### PR TITLE
feat(cli): add "api" as alias for "apis" command

### DIFF
--- a/cli/internal/cmd/apis.go
+++ b/cli/internal/cmd/apis.go
@@ -22,7 +22,7 @@ func newApisCmd(app *App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "apis",
 		Aliases: []string{"api"},
-		Short: "Browse and manage APIs in the local registry",
+		Short:   "Browse and manage APIs in the local registry",
 		Long: "apis inspects and manages the APIs imported into this deployment's local\n" +
 			"registry — the other half of `jentic catalog import`. Run bare on a\n" +
 			"terminal to open an interactive browser (list, preview operations, manage\n" +

--- a/cli/internal/cmd/apis.go
+++ b/cli/internal/cmd/apis.go
@@ -20,7 +20,8 @@ import (
 func newApisCmd(app *App) *cobra.Command {
 	ident := &identityOptions{}
 	cmd := &cobra.Command{
-		Use:   "apis",
+		Use:     "apis",
+		Aliases: []string{"api"},
 		Short: "Browse and manage APIs in the local registry",
 		Long: "apis inspects and manages the APIs imported into this deployment's local\n" +
 			"registry — the other half of `jentic catalog import`. Run bare on a\n" +

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -418,6 +418,9 @@
           "use": "apis",
           "short": "Browse and manage APIs in the local registry",
           "long": "apis inspects and manages the APIs imported into this deployment's local\nregistry — the other half of `jentic catalog import`. Run bare on a\nterminal to open an interactive browser (list, preview operations, manage\nrevisions); the subcommands (list/show/revisions/operations/inspect/\npromote/archive/rm/spec) are script-friendly.\nRequires a registered agent (run `jentic register` first).",
+          "aliases": [
+            "api"
+          ],
           "group_title": "APIs",
           "flags": [
             {


### PR DESCRIPTION
feat(cli): add "api" as alias for "apis" command

Cobra supports native command aliases. Users can now type either "jentic api" or "jentic apis" interchangeably.

## Summary

Adds `"api"` as a Cobra alias for the `apis` command so both `jentic api` and `jentic apis` work identically.

## Related issue

## Changes

- Add `Aliases: []string{"api"}` to `newApisCmd` in `cli/internal/cmd/apis.go`

## Testing

- `cd cli && make check` passes (lint, vet, race tests)
- `jentic api --help` and `jentic apis --help` produce identical output

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [x] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included
