### PR TITLE
fix(registry): include auth requirements in operation inspect response

### DIFF
--- a/src/jentic_one/registry/services/inspect/models.py
+++ b/src/jentic_one/registry/services/inspect/models.py
@@ -17,7 +17,7 @@ class InspectLoadOptions:
     load_server: bool
 
 
-SUMMARY_LOAD_OPTIONS = InspectLoadOptions(load_spec=False, load_auth=False, load_server=True)
+SUMMARY_LOAD_OPTIONS = InspectLoadOptions(load_spec=False, load_auth=True, load_server=True)
 
 
 class TagDescription(BaseModel):


### PR DESCRIPTION
fix(registry): include auth requirements in operation inspect response

SUMMARY_LOAD_OPTIONS had load_auth=False, so the /inspect endpoint never populated the auth field despite the model and loader already supporting it. Agents inspecting an operation saw no authentication requirements.

## Summary

The `/inspect` endpoint's `SUMMARY_LOAD_OPTIONS` had `load_auth=False`, meaning auth requirements were never included in inspect responses. The model (`OperationInspectResult.auth`), the loader (`_load_security_schemes()`), and the CLI renderer (`apis.go:385`) all already support auth data — it just wasn't being loaded.

## Related issue

## Changes

- Flip `load_auth=False` → `load_auth=True` in `SUMMARY_LOAD_OPTIONS` (`src/jentic_one/registry/services/inspect/models.py`)

## Testing

- `make check` passes
- `jentic apis inspect <operation_id>` now includes auth/security scheme details in output

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [x] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included
