### PR TITLE
docs(readme): align setup and security guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,16 +10,20 @@ rest of this file is for changing the codebase.
 
 **Install.** Two supported paths:
 
-1. Signed release binary, from https://github.com/jentic/jentic-one/releases/latest. Verify
-   against `checksums.txt` (signature: `checksums.txt.sig`, certificate: `checksums.txt.pem`),
-   then run `jenticctl install`. Prefer this path: it is verifiable before execution, and a
-   sandboxed agent will usually be refused permission to pipe a script to a shell.
+1. Signed release binaries, from https://github.com/jentic/jentic-one/releases/latest.
+   Download `jentic` and, for a local stack, `jenticctl`. Verify the archives against
+   `checksums.txt` (signature: `checksums.txt.sig`, certificate: `checksums.txt.pem`), then run
+   `jenticctl install`. Prefer this path: it is verifiable before execution, and a sandboxed
+   agent will usually be refused permission to pipe a script to a shell.
 2. Bootstrap script:
-   `curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh`
-   This downloads a Go toolchain if none is present, clones this repository, builds `jenticctl`
-   and `jentic`, then runs `jenticctl install`. Set `JENTIC_NO_INSTALL=1` to stop after the
-   binaries are installed — do that on the agent machine, which needs only the binaries, not a
-   second deployment.
+   `curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh |
+   env JENTIC_INSTALL_BINARIES=both sh`
+   This prefers verified release archives and falls back to building from source, then runs
+   `jenticctl install` in an interactive terminal. Add `JENTIC_NO_INSTALL=1` to the `env`
+   command to stop after both binaries are installed. On an agent machine that will use a
+   remote deployment, use `JENTIC_INSTALL_METHOD=binary` instead of
+   `JENTIC_INSTALL_BINARIES=both`; that installs only `jentic` and fails rather than falling
+   back to a source build.
 
 **Run Jentic One on a different machine from the agent.** An agent running as the same OS user
 can read the credential database and encryption key from disk, whatever the API-level controls
@@ -34,11 +38,12 @@ allow. See `docs/security/hardening.md` before using real credentials.
    `http://127.0.0.1:8000`, and prompt for it on an interactive terminal.)
    Report the wait to the user: on a single-operator install they are the operator, and they
    approve the agent in the UI at `/app`.
-2. If no admin account exists yet, point the user to `/setup` (browser) or `jenticctl setup`
+2. If no admin account exists yet, point the user to `/app/setup` (browser) or `jenticctl setup`
    (terminal). This is a one-time step.
 3. Import an API from https://github.com/jentic/jentic-public-apis (e.g. `httpbin.org`, used in
    step 6), or register a private OpenAPI description of the user's own service.
-4. Store a credential for that API, once. It is encrypted at rest and is never returned.
+4. Store a credential for that API. It is encrypted at rest. Cleartext secret material is
+   returned once in the create response; subsequent reads and rotation responses are redacted.
 5. Request access: `jentic access request --toolkit <vendor/name>` files a reviewable request;
    granting is always a human action. The operator binds the agent to a toolkit — access is
    default-deny, and a rule-less binding still blocks everything.
@@ -55,7 +60,9 @@ allow. See `docs/security/hardening.md` before using real credentials.
   skill it generates, or plain HTTP against the deployment's own API.
 - A running instance serves `/llms.txt` and `/.well-known/llms.txt` with that deployment's base
   URL. Once an instance exists, prefer those over this file for anything at runtime.
-- Never print, log or echo a stored credential. The Broker does not return them.
+- Never print, log or echo a stored credential. Credential read APIs return redacted data, but
+  the creation response contains cleartext secret material once. Broker responses are upstream
+  passthrough responses, so a trusted upstream is part of the credential boundary.
 
 **If a step is blocked by your own sandbox or by network egress rules, say so and stop.** Do
 not work around a security control. Issue #994 tracks the install paths available to a

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 </p>
 
 <p align="center">
-  <strong>A self-hosted execution layer for AI agents.</strong><br>
-  Connect an agent to any API you need, and enforce exactly what it is allowed to call.
+  <strong>A self-hosted credential broker for AI agents.</strong><br>
+  Register HTTP APIs, approve the operations an agent may call, and inject credentials after access checks.
 </p>
 
 <p align="center">
@@ -19,7 +19,7 @@
   <a href="https://github.com/jentic/jentic-one/actions/workflows/ci.yml"><img src="https://github.com/jentic/jentic-one/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-A3CACC.svg" alt="License: Apache 2.0"></a>
   <img src="https://img.shields.io/badge/Python-3.12-68BAEC.svg?logo=python&logoColor=white" alt="Python 3.12">
-  <img src="https://img.shields.io/badge/Go-1.26-5EDEB9.svg?logo=go&logoColor=white" alt="Go 1.26">
+  <img src="https://img.shields.io/badge/Go-1.25.7-5EDEB9.svg?logo=go&logoColor=white" alt="Go 1.25.7">
   <img src="https://img.shields.io/badge/PostgreSQL-16-A3CACC.svg?logo=postgresql&logoColor=white" alt="PostgreSQL">
   <img src="https://img.shields.io/badge/SQLite-3-A3CACC.svg?logo=sqlite&logoColor=white" alt="SQLite">
   <br>
@@ -30,21 +30,23 @@
 
 > [!NOTE]
 > **Public Beta.** Schemas and CLI commands can change between 0.x releases. Pin a version if
-> you need stability. Contributions are welcome: see [CONTRIBUTING.md](CONTRIBUTING.md) and the
-> [open issues](https://github.com/jentic/jentic-one/issues).
+> you need stability. Production use is not yet recommended. Contributions are welcome: see
+> [CONTRIBUTING.md](CONTRIBUTING.md) and the [open issues](https://github.com/jentic/jentic-one/issues).
 
 ## What Jentic One is
 
 <p align="center">
-  <img src="docs/assets/how-it-works.gif" alt="Any agent calls Jentic One, which applies default-deny policies, injects credentials at execution time, and logs every call on your own instance, before reaching any public or private API. One call is allowed and returns 201; a second is denied by rule and never leaves the layer." width="100%">
+  <img src="docs/assets/how-it-works.gif" alt="An agent calls a registered API through Jentic One, which applies default-deny policies, injects credentials at execution time, and logs each call. One call is allowed and returns 201; a second is denied by rule and never reaches the upstream." width="100%">
 </p>
 
 Giving an agent API access normally means giving it an API key. Jentic One removes that step.
 Register the APIs an agent may use, store the credentials once, and the agent makes its calls
 through the Broker. The Broker checks the agent's permissions, attaches the credential at
-execution time, and writes an audit record. Your agent never sees your keys.
+execution time, and writes an audit record. Credential read APIs return redacted data; cleartext
+secret material is shown only in the create response. Rotation accepts a new secret but returns
+redacted data.
 
-Self-hosted and Apache-2.0. The open-source build is the real thing, not a trial.
+Jentic One is self-hosted and licensed under Apache-2.0.
 
 **Who it's for**
 
@@ -52,7 +54,7 @@ Self-hosted and Apache-2.0. The open-source build is the real thing, not a trial
   one you built — that needs access to real APIs.
 - Small teams running an agent in a private network or VPC, with the agent calling Jentic One
   over private DNS.
-- Anyone who needs to pass a security review before an agent touches production credentials.
+- Teams that need reviewable access controls and audit records before agents call protected APIs.
 
 **What it is not**
 
@@ -60,42 +62,57 @@ Self-hosted and Apache-2.0. The open-source build is the real thing, not a trial
 | --- | ------ |
 | A workflow or orchestration engine | The Broker makes one governed upstream call per execution. An agent that needs multi-step orchestration composes calls itself. |
 | A secrets manager | It stores and injects the credentials it brokers. It does not replace Vault for your wider infrastructure. |
-| A hosted service | You run it. No tier exists in which Jentic holds your keys. |
-| Safe to run as the same OS user as your agent, with real credentials | The network guarantee holds. The same-OS-user guarantee does not. See [Security](#security--telemetry). |
+| A hosted service | The open-source product runs in infrastructure you operate. |
+| Safe to run as the same OS user as your agent, with real credentials | API controls cannot stop a same-user process from reading the encryption key and database. See [Security](#security--telemetry). |
 
 ## Why self-hosted
 
 Most tools in this category are hosted: the credentials live in the vendor's infrastructure.
-Jentic One runs on infrastructure you control. Credentials are encrypted at rest in your own
-database and are decrypted only inside the Broker, at execution time.
+Jentic One runs on infrastructure you control. Credentials are encrypted at rest in your
+database. The Broker decrypts them for execution; Control also handles secret material during
+credential creation, rotation, and managed OAuth connect or refresh flows.
 
-Jentic One exposes no MCP endpoint. An MCP server running beside an agent gives that agent a
-credential-bearing surface to call, which is what the Broker exists to avoid. Agents integrate
-through the `jentic` CLI, a generated skill, or plain HTTP.
+Jentic One exposes no MCP endpoint. Agents integrate through the `jentic` CLI, a generated
+skill, or the deployment's HTTP APIs.
 
 ## Quickstart
 
-**Prerequisites:** `git`, [`uv`](https://docs.astral.sh/uv/), and Docker running. Node is
-required only to build the UI from source.
+The bootstrap script supports macOS and Linux. The `jentic` release binary also supports native
+Windows; use WSL for local-stack workflows. A source checkout requires `git` and
+[`uv`](https://docs.astral.sh/uv/). Docker is required for the default development database,
+and Node is optional when building the UI.
 
-### Option A — signed release binary
+### Option A — signed release binaries
 
-Download the binary for your platform from the
-[latest release](https://github.com/jentic/jentic-one/releases/latest), verify it against
-`checksums.txt` (signed: `checksums.txt.sig`, `checksums.txt.pem`), then run
-`jenticctl install`. Each release also ships an SBOM. Use this path where the binary must be
-verified before it runs.
+Download `jentic` and, for a local stack, `jenticctl` from the
+[latest release](https://github.com/jentic/jentic-one/releases/latest). Verify each archive
+against `checksums.txt`, then verify that file with `checksums.txt.sig` and
+`checksums.txt.pem`. Run `jenticctl install` to configure and start the local stack. Each
+release also ships an SBOM. The [CLI guide](cli/README.md#3-manual-download--verify) has the
+complete verification commands.
 
 ### Option B — bootstrap script
 
+To install only the agent CLI from a published release for use with an existing remote
+deployment:
+
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh \
+  | env JENTIC_INSTALL_METHOD=binary sh
 ```
 
-The script checks for a suitable Go toolchain and downloads Go 1.26.2 if it does not find one,
-clones this repository, builds the two CLI binaries (`jenticctl` and `jentic`), then runs
-`jenticctl install`, which configures and starts a local stack. Set `JENTIC_NO_INSTALL=1` to
-stop after the binaries are installed.
+To install both binaries and start the local-stack wizard:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh \
+  | env JENTIC_INSTALL_BINARIES=both sh
+```
+
+The script prefers checksummed release archives and falls back to a source build when no
+matching release asset exists. The default download installs only `jentic`; setting
+`JENTIC_INSTALL_BINARIES=both` adds `jenticctl` and, in an interactive terminal, starts
+`jenticctl install`. Add `JENTIC_NO_INSTALL=1` to the `env` command to install both binaries
+without starting the stack wizard.
 
 ### Option C — from source
 
@@ -104,23 +121,26 @@ make install   # install dependencies and git hooks
 make dev       # idempotent local bring-up: fixtures + migrations + UI, then run the app
 ```
 
-`make dev` is the one-command local flow and is safe to re-run, including after a reboot. See
-[Local development setup](docs/development/local-setup.md).
+`make dev` is the one-command local flow and is safe to re-run, including after a reboot. It
+builds the UI when Node is available and otherwise starts the backend without rebuilding the
+UI. See [Local development setup](docs/development/local-setup.md).
 
 ## First brokered call
 
 Six steps from a running instance to a response from a real API.
 
-1. **Create your admin account** at `/setup` (the wizard opens this automatically, or run
+1. **Create your admin account** at `/app/setup` (the wizard opens this automatically, or run
    `jenticctl setup` to do it from the terminal).
 2. **Import an API** from the [Jentic API Directory](https://github.com/jentic/jentic-public-apis)
    (e.g. `httpbin.org`, used in step 6), or upload your own specification.
-3. **Store a credential** for that API. It is encrypted at rest and is never returned to a
-   caller.
-4. **Register the agent:** `jentic register` (add `--base-url <URL>` when the agent runs on a
-   different machine). Registration waits for an operator to approve the
-   agent. On a single-operator install, approve it in the UI and the command completes.
-5. **Grant access** by binding the agent to a toolkit. A rule-less binding blocks everything;
+3. **Store a credential** for that API. Cleartext secret material is returned once in the
+   create response; subsequent reads and rotation responses are redacted.
+4. **Register the agent:** run `jentic setup` for a coding agent, or `jentic register` for
+   identity-only onboarding. For a remote deployment, pass both `--url <control-plane URL>`
+   and `--broker-url <broker URL>`. Registration waits for an operator to approve the agent.
+   On a single-operator install, approve it in the UI and the command completes.
+5. **Request access:** `jentic access request --toolkit <vendor/name>`. The operator grants
+   the request by binding the agent to the toolkit. A rule-less binding blocks everything;
    the default is deny.
 6. **Make the call:** `jentic execute GET:https://httpbin.org/get --json` — the operation's
    full URL, as returned by `jentic search`/`jentic inspect`.
@@ -132,34 +152,42 @@ of these docs for assistants evaluating the project.
 ## How it works
 
 Jentic One handles secure third-party API execution for agents. It deploys as two peer units
-above a shared database. **App** is the control plane and contains the Registry, Control and
-Admin surfaces. **Broker** is the data plane. Configuration happens through App; the agent
-talks only to the Broker.
+above shared persistence. **App** is the control plane and contains the Registry, Control,
+Admin, and Auth surfaces. **Broker** is the data plane. Agents use App for registration,
+discovery, and access requests, and Broker for governed execution.
 
-<p align="center">
-  <img src="docs/assets/architecture.png" alt="Two peer units above one database. App is the control plane, containing the Registry, Control and Admin surfaces, and is where the operator configures the instance. Broker is the data plane: a stateless credential-injecting HTTP proxy, and the only surface that touches a secret. Both sit above PostgreSQL or SQLite with registry, control and admin schemas." width="100%">
-</p>
+```mermaid
+flowchart TB
+    Operator[Operator] --> App[App: Registry, Control, Admin, Auth]
+    Agent[Agent or jentic CLI] --> App
+    Agent --> Broker[Broker: governed HTTP execution]
+    App --> Data[(PostgreSQL or per-surface SQLite)]
+    Broker --> Data
+    Broker --> Upstream[Registered upstream HTTP API]
+```
 
 On each call the Broker checks the agent's permissions, attaches the stored credential,
-forwards the request, and writes an audit record. The credential is added inside the Broker,
-after the permission check, and is never returned to the caller.
+forwards the request, and writes an audit record. The upstream status, headers, and body are
+relayed to the caller. Use trusted upstreams: an upstream can reflect request data, including
+an injected credential, in its response.
 
 ## Components
 
 | Component | Responsibility |
 | --------- | -------------- |
-| **Broker** | A stateless Broker: a credential-injecting HTTP proxy. Receives an HTTP request with the upstream URL as the path, injects the caller's stored credentials, forwards method/headers/body, and returns the upstream response. Secrets never leave the Broker. |
+| **Broker** | A stateless credential-injecting HTTP proxy. Receives an HTTP request with the upstream URL as the path, resolves permissions and credentials, forwards method/headers/body, and relays the upstream response. |
 | **Registry** | API specification directory. Stores registered APIs with immutable revisions, operations, security schemes, and server definitions. Owns what APIs are available and at which version. |
-| **Control** | Credential storage. Manages polymorphic API credentials (API key in header, query or cookie; basic; static bearer; session token; OAuth2 in client-credentials, authorization-code and implicit flows) used by the Broker at execution time. |
-| **Admin** | Permissions, jobs, audit, and execution telemetry. Owns the operator account, role-based access grants, async job lifecycle, append-only audit log, and execution records. |
+| **Control** | Credential storage, toolkit bindings, permission rules, and access requests. Supports API keys, basic and bearer authentication, OAuth2 client-credentials and authorization-code flows, no-auth bindings, and AWS SigV4. |
+| **Admin** | Operator administration, jobs, audit, and execution telemetry. Owns role grants, async job lifecycle, the append-only audit log, and execution records. |
+| **Auth** | Operator and agent authentication. Owns agent registration, token minting, OAuth clients, service accounts, and identity discovery. |
 | **Shared** | Internal infrastructure layer: configuration loading, async database sessions, structured logging, metrics facade, and the multi-surface application factory. |
-| **CLI** | Two Go binaries: `jenticctl` onboards and operates the platform (`jenticctl install`), and `jentic` registers agent identities (`jentic register`) and drives the catalog/broker (`jentic catalog`, `jentic execute`). See [`cli/`](cli/README.md). |
+| **CLI** | Two Go binaries: `jenticctl` installs and operates the platform, while `jentic` onboards agents, manages the catalog and access requests, and executes operations. See [`cli/`](cli/README.md). |
 
 Agent identity is per-agent. Each agent registers with its own Ed25519 keypair through dynamic
 client registration, and an operator approves it before it can call anything. Revoking one
 agent does not affect the others.
 
-Both PostgreSQL and SQLite are supported production backends.
+Both PostgreSQL and SQLite are supported persistence backends.
 
 ## Does Jentic One replace my API gateway?
 
@@ -168,10 +196,9 @@ which agent may make a given call, which stored credential is attached to it, an
 recorded afterwards. Both sit on the same request path and address different concerns, so
 Jentic One runs alongside an existing gateway.
 
-Jentic One works with any API you can reach, public or private, third-party or your own.
-Registering internal services is a supported path: the same credential custody, per-agent
-permissions and audit trail apply whether the upstream is Stripe or an API that exists only
-inside your network. The public
+Jentic One works with registered HTTP APIs the deployment can reach, whether public, private,
+third-party, or internal. The same credential custody, per-agent permissions, and audit trail
+apply whether the upstream is Stripe or an API that exists only inside your network. The public
 [Jentic API Directory](https://github.com/jentic/jentic-public-apis) supplies specifications
 for APIs that already have one.
 
@@ -179,7 +206,8 @@ for APIs that already have one.
 
 ```bash
 jenticctl install                                    # interactive wizard: config + install (local venv or Docker)
-jentic register                                      # mint an agent identity, then wait for operator approval
+jentic setup                                         # coding-agent setup: identity, skill, optional isolation
+jentic register                                      # identity-only onboarding, then wait for operator approval
 jentic catalog search stripe                         # find an API in the directory
 jentic execute GET:https://httpbin.org/get --json    # run a call through the Broker with the credential injected
 ```
@@ -197,7 +225,7 @@ Full reference: [`cli/README.md`](cli/README.md).
 | [Local coding agents](docs/local-agent.md) | Run Claude Code, Codex, Cursor, or Hermes as an isolated Unix user with `jentic run` — flow, examples, grants, and troubleshooting |
 | [CLI reference](cli/README.md) | Every `jenticctl` and `jentic` command |
 
-**Running it somewhere real**
+**Deployment and security**
 
 | Guide | Covers |
 | ----- | ------ |
@@ -216,13 +244,17 @@ Full reference: [`cli/README.md`](cli/README.md).
 
 ## Security & telemetry
 
-- **Credentials stay local.** Stored credentials are encrypted at rest and are only ever
-  decrypted inside the Broker at execution time. They are never returned to callers, logged in
-  cleartext, or exposed to the agent.
-- **Run Jentic One separately from your agent.** The guarantee above holds on the network path,
-  but a process running as the same OS user as Jentic One can read the key and credential
-  database directly. For real credentials, do not run Jentic One in the same trust boundary as
-  your agent: sandbox the agent, or run Jentic One on a separate host or network. The
+- **Credential custody is self-hosted.** Stored credentials are encrypted at rest. The create
+  response returns cleartext secret material once; later reads and rotation responses are
+  redacted. The Broker decrypts credentials for execution, and Control handles managed OAuth
+  connect and refresh flows. Secret values are not intentionally written to application logs.
+- **Use trusted upstreams.** The Broker injects a credential only after its access check, but
+  it relays the upstream response. A reflective or malicious upstream can return request data,
+  including the injected credential, to the caller.
+- **Run Jentic One separately from your agent.** A process running as the same OS user as
+  Jentic One can read the key and credential database directly. For real credentials, do not
+  run Jentic One in the same trust boundary as your agent: sandbox the agent, or run Jentic One
+  on a separate host or network. The
   [security hardening guide](docs/security/hardening.md) contains the deployment-tier ladder
   and a production checklist.
 - **Access is default-deny.** A rule-less binding blocks everything. Permissions are
@@ -247,7 +279,7 @@ Common `make` targets (run `make help` for the full list):
 | ------ | ----------- |
 | `make install` | Full dev setup: sync deps + install git hooks |
 | `make dev` | One-command local bring-up (idempotent): fixtures + migrations + UI, then start the app |
-| `make check` | Lint, score, secrets audit, unit + arch tests |
+| `make check` | Lint, API score, secrets audit, and architecture tests |
 | `make fix` | Auto-fix lint issues and reformat code |
 | `make test` | Run unit tests |
 | `make start-app` | Start the combined app (all surfaces) |
@@ -259,18 +291,14 @@ Tests are split into tiers:
 - **Architecture** — enforcement of layering and conventions (`make test-arch`).
 - **Smoke** — liveness against running services (`make test-smoke`).
 
-Commits follow [Conventional Commits](https://www.conventionalcommits.org/) with a mandatory
-scope, enforced repo-wide by a `commit-msg` hook. The architecture tests run against a small
-vendored subset of rule facts ([`tests/arch/vendored/`](tests/arch/vendored/)), so a plain clone
-requires no additional setup. [CONTRIBUTING.md](CONTRIBUTING.md) covers pointing them at a
-fuller set.
-
 ## Contributing
 
-Commit messages follow Conventional Commits, and `make check` must pass before opening a pull
-request. [CONTRIBUTING.md](CONTRIBUTING.md) has the full workflow, the
-[open issues](https://github.com/jentic/jentic-one/issues) list where help is wanted, and the
-Jentic [Code of Conduct](https://github.com/jentic/.github/blob/main/CODE_OF_CONDUCT.md)
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) with a
+mandatory scope, enforced by the `commit-msg` hook. Run `make check` before opening a pull
+request. The architecture tests use a vendored subset of rule facts
+([`tests/arch/vendored/`](tests/arch/vendored/)), so a plain clone requires no additional
+setup. [CONTRIBUTING.md](CONTRIBUTING.md) has the full workflow and links to issues where help
+is wanted. The Jentic [Code of Conduct](https://github.com/jentic/.github/blob/main/CODE_OF_CONDUCT.md)
 applies.
 
 Use [Discussions](https://github.com/jentic/jentic-one/discussions) for questions and proposals.
@@ -278,14 +306,15 @@ Use [Discussions](https://github.com/jentic/jentic-one/discussions) for question
 ## Migrating from the hosted platform or Jentic Mini
 
 Read [Cloud vs self-hosted](docs/cloud-vs-self-hosted.md) before running Jentic One alongside
-the hosted Jentic platform or a self-hosted Jentic Mini instance: the failure mode is silent
-wrong answers, not errors. New installations should start with Jentic One.
+the hosted Jentic platform or a self-hosted Jentic Mini instance. The CLI and cloud MCP can
+query different backends, making APIs or credentials appear missing. New installations should
+start with Jentic One.
 
 ## Enterprise & commercial support
 
-Jentic One is fully open source (Apache-2.0) and free to self-host. For help operating a
-credential broker at scale — security hardening reviews, deployment architecture, SLAs, or a
-managed option — contact [jentic.com/contact](https://jentic.com/contact).
+Jentic One is licensed under Apache-2.0 and is free to self-host. For security hardening
+reviews, deployment architecture, SLAs, or managed operation, contact
+[jentic.com/contact](https://jentic.com/contact).
 [SUPPORT.md](SUPPORT.md) lists community and commercial support options.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@
 Giving an agent API access normally means giving it an API key. Jentic One removes that step.
 Register the APIs an agent may use, store the credentials once, and the agent makes its calls
 through the Broker. The Broker checks the agent's permissions, attaches the credential at
-execution time, and writes an audit record. Credential read APIs return redacted data; cleartext
-secret material is shown only in the create response. Rotation accepts a new secret but returns
-redacted data.
+execution time, and writes an audit record. The agent never sees your keys.
 
 Jentic One is self-hosted and licensed under Apache-2.0.
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@
 
 > [!NOTE]
 > **Public Beta.** Schemas and CLI commands can change between 0.x releases. Pin a version if
-> you need stability. Production use is not yet recommended. Contributions are welcome: see
-> [CONTRIBUTING.md](CONTRIBUTING.md) and the [open issues](https://github.com/jentic/jentic-one/issues).
+> you need stability. Contributions are welcome: see [CONTRIBUTING.md](CONTRIBUTING.md) and the
+> [open issues](https://github.com/jentic/jentic-one/issues).
 
 ## What Jentic One is
 
@@ -61,7 +61,7 @@ Jentic One is self-hosted and licensed under Apache-2.0.
 | Not | Reason |
 | --- | ------ |
 | A workflow or orchestration engine | The Broker makes one governed upstream call per execution. An agent that needs multi-step orchestration composes calls itself. |
-| A secrets manager | It stores and injects the credentials it brokers. It does not replace Vault for your wider infrastructure. |
+| A general-purpose secrets manager | It stores credentials used for brokered API calls, not arbitrary application or infrastructure secrets. |
 | A hosted service | The open-source product runs in infrastructure you operate. |
 | Safe to run as the same OS user as your agent, with real credentials | API controls cannot stop a same-user process from reading the encryption key and database. See [Security](#security--telemetry). |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,13 +30,21 @@ We follow coordinated disclosure. We ask that you:
 
 We will credit reporters in release notes unless anonymity is requested.
 
-## Security Model — what you should know as an operator
+## Security Model — what operators should know
 
-Jentic One is designed so that **credentials never leave the data plane**:
+Jentic One keeps credential custody within the operator's deployment:
 
-- Stored credentials are **encrypted at rest** and are only decrypted inside the
-  Broker at execution time. They are never returned to callers, never logged in
-  cleartext, and never exposed to the agent.
+- Stored credentials are **encrypted at rest**. The credential creation response
+  returns cleartext secret material once; subsequent reads and rotation responses
+  are redacted.
+- The Broker decrypts credentials for governed execution. Control also handles
+  cleartext secret material during creation and rotation and decrypts managed
+  OAuth secrets during connect and refresh flows.
+- The intended upstream receives the injected credential. Broker responses are
+  passthrough responses, so a reflective or malicious upstream can return
+  request data, including an injected credential, to the caller. Register only
+  trusted upstreams for credentialed execution.
+- Jentic One does not intentionally write secret values to application logs.
 - The credential-at-rest encryption keyset is **required** and must be supplied
   by the operator (environment variable or secret manager). Never commit a real
   key to source control.
@@ -48,13 +56,12 @@ Jentic One is designed so that **credentials never leave the data plane**:
   `event`/`actor_type` are fixed enums and `tags` are fixed labels — with no
   credentials, request data, or PII. Observability exporters are self-hosted.
 
-> **Most important operator guidance:** the "credentials never leave the data
-> plane" guarantee holds on the network, but **not** when the agent runs as the
-> same OS user as the broker — a same-user process can read the key and database
-> directly. Do not run the broker in the same trust boundary as your agent for
-> real credentials. See **[docs/security/hardening.md](docs/security/hardening.md)**
-> for the deployment-tier ladder, agent-sandboxing options, and a production
-> checklist.
+> **Most important operator guidance:** API-level controls do not protect
+> credentials from an agent running as the same OS user as Jentic One. A
+> same-user process can read the encryption key and database directly. Do not
+> run the broker in the same trust boundary as your agent for real credentials.
+> See **[docs/security/hardening.md](docs/security/hardening.md)** for the
+> deployment-tier ladder, agent-sandboxing options, and a production checklist.
 
 ## Secrets in the Repository
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -41,7 +41,8 @@ building, onboarding, and operating; it does not duplicate per-flag docs.
 # 1. Install the CLI + stand up the local stack. The one-liner installs the
 #    binaries and flows straight into the `jenticctl install` wizard, which
 #    brings the server up on http://127.0.0.1:8000:
-curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh \
+  | env JENTIC_INSTALL_BINARIES=both sh
 
 # 2. Connect this machine — that's it. `register` defaults to the local install
 #    (http://127.0.0.1:8000) and seeds the local broker for you, so just confirm:
@@ -49,8 +50,8 @@ jentic register
 ```
 
 (Setting up a local **coding agent**? Run `jentic setup` instead of `jentic
-register` — it does the registration above *plus* an isolated account and the
-agent skills.)
+register` — it does the registration above, installs the agent skills, and
+offers to configure an isolated account.)
 
 **Remote server** (connect to a Jentic server someone else is running): you
 don't need `jenticctl` or a local install at all — the `jentic` binary is
@@ -82,12 +83,12 @@ The cask installs both `jentic` and `jenticctl`.
 
 ```bash
 # jentic only (default) — for talking to a remote jentic server:
-JENTIC_INSTALL_METHOD=binary \
-  curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh \
+  | env JENTIC_INSTALL_METHOD=binary sh
 
 # both binaries (also install jenticctl to run the stack locally):
-JENTIC_INSTALL_METHOD=binary JENTIC_INSTALL_BINARIES=both \
-  curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh \
+  | env JENTIC_INSTALL_METHOD=binary JENTIC_INSTALL_BINARIES=both sh
 ```
 
 This downloads the released archive for your OS/arch from the GitHub Releases

--- a/docs/cloud-vs-self-hosted.md
+++ b/docs/cloud-vs-self-hosted.md
@@ -9,7 +9,7 @@ especially for an AI agent (or its operator) that has used both:
 | How agents connect | Remote **MCP server** (`https://api.jentic.com/mcp`) configured in the agent runtime with a workspace API key | **`jentic` CLI + generated skill** (or the raw HTTP flow) — see below |
 | Agent identity | Workspace API key | Per-agent Ed25519 keypair via dynamic client registration (`jentic register` / `jentic setup`) |
 | Dashboard | `app.jentic.com` | The bundled UI on your deployment (`/app`) |
-| Data | Jentic-hosted workspace | Stays on your infrastructure; stored secrets are decrypted only inside your Broker at execution time |
+| Data | Jentic-hosted workspace | Stored in your infrastructure; the Broker decrypts credentials for execution, while Control handles creation, rotation, and managed OAuth flows |
 
 They do not share state: an API imported or a credential stored in one is
 invisible to the other.
@@ -41,8 +41,8 @@ If you used the cloud platform first and later installed Jentic One, you end
 up with a **dual setup**: the agent runtime's MCP tools (`search_apis`,
 `list_credentials`, `execute`, …) still point at the cloud workspace, while
 the `jentic` CLI points at the local install. Nothing in any tool response
-says which backend replied, so the failure mode is *silent wrong answers*,
-not errors:
+says which backend replied, so a request can succeed against the wrong
+backend:
 
 - an API you just imported locally "doesn't exist" (the MCP search answered
   from the cloud workspace),
@@ -70,11 +70,13 @@ answer from the wrong backend.
 
 ## Migrating from the cloud MCP to a self-hosted install
 
-1. Install the stack: `curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh`, then `jenticctl install`.
+1. Install the stack:
+   `curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh |
+   env JENTIC_INSTALL_BINARIES=both sh`.
 2. Re-import the APIs you need (`jentic catalog import`, or the dashboard) —
    catalog state does not transfer from the cloud workspace.
-3. Re-enter credentials in your deployment's dashboard — secrets cannot be
-   exported from the cloud platform (nor from Jentic One; that's the point).
+3. Re-enter credentials in your deployment's dashboard. Jentic One credential
+   read APIs return redacted data and do not provide a secret-export operation.
 4. Register your agents against the local install (`jentic setup`).
 5. Remove the cloud MCP server entry from your agent runtime's config to
    avoid the split-brain scenario above.

--- a/docs/credentials-and-toolkits.md
+++ b/docs/credentials-and-toolkits.md
@@ -12,7 +12,9 @@ resolution unambiguous.
   **toolkit-credential binding** (`toolkit_credential_bindings`) associates a
   toolkit with a credential.
 - At execution time the Broker resolves the **single active** credential for the
-  requested API and injects its secret — the secret never reaches the agent.
+  requested API and injects its secret after the access check. Credential read
+  APIs are redacted; upstream responses pass through the Broker, so the
+  registered upstream remains part of the credential boundary.
 
 Registry (the `apis` table) and Control (`credentials`,
 `toolkit_credential_bindings`) are **separate databases** with no foreign key

--- a/docs/product-scope.md
+++ b/docs/product-scope.md
@@ -13,8 +13,8 @@
 
 Jentic One is a **self-hosted gateway for secure third-party API execution by AI
 agents**: you register the APIs an agent may use, store the credentials once, and
-the agent calls out through a credential-injecting Broker so **secrets never leave
-your infrastructure and never reach the agent** (`README.md`, `SECURITY.md`).
+the agent calls out through a credential-injecting Broker with default-deny access
+checks and redacted credential reads (`README.md`, `SECURITY.md`).
 
 ## Who it's for
 
@@ -33,9 +33,9 @@ Deployment personas the public docs call out (`docs/security/hardening.md`):
 - **Issue filer / contributor** — including AI agents filing issues (this harness's
   own audience; see `CONTRIBUTING.md`).
 
-**Commercial-support boundary:** self-hosting is free and is the real product;
-"host it for me / run it at scale / SLAs / managed edition" is a commercial
-conversation, **not** a product issue (`README.md` Enterprise section, `SUPPORT.md`).
+**Commercial-support boundary:** self-hosting is free; managed operation, deployment
+reviews, and SLAs are commercial support requests rather than product issues
+(`README.md` Enterprise section, `SUPPORT.md`).
 
 ## What's in scope (the product is about this)
 
@@ -63,8 +63,8 @@ Supported specifics worth knowing (so the harness doesn't mis-score them as out 
 scope):
 
 - **Credential schemes:** API key (header/query/cookie), basic, static bearer,
-  session token, and OAuth2 (client-credentials, authorization-code, implicit), plus
-  no-auth (`shared/models/credentials.py`).
+  OAuth2 (client-credentials and authorization-code), no-auth, and AWS SigV4
+  (`control/web/schemas/credentials.py`).
 - **Database backends:** Postgres **and** SQLite — SQLite is a supported *production*
   target, not dev-only (`shared/db/backends/sqlite.py`).
 - **ML/embeddings** exist but are **registry-search-only**; core surfaces don't use
@@ -80,12 +80,11 @@ usability, or operability of one of these surfaces for the audience above.
   governed upstream call per execution, not branching multi-step workflows. An agent
   that needs multi-step orchestration composes broker calls itself.
 - **Not co-located with the agent for _real / high-value credentials_.** *(Grounded —
-  security model.)* The "credentials never leave the data plane" guarantee does not
-  hold when the agent runs as the same OS user / same host as the broker
-  (`SECURITY.md`, `docs/security/hardening.md`). **Nuance:** same-host use *is*
-  supported for trying it out / non-real credentials — so a local/dev-mode request is
-  **not** automatically out of scope; only "use real credentials in the agent's trust
-  boundary" is.
+  security model.)* API-level controls cannot protect the key or database from an
+  agent running as the same OS user as Jentic One (`SECURITY.md`,
+  `docs/security/hardening.md`). **Nuance:** same-host use *is* supported for trying
+  it out / non-real credentials — so a local/dev-mode request is **not** automatically
+  out of scope; only "use real credentials in the agent's trust boundary" is.
 - **Not a general-purpose API gateway for _non-agent_ traffic** (Kong/NGINX). The
   Broker governs credential-injecting **agent** calls, not arbitrary traffic
   management.
@@ -106,11 +105,12 @@ usability, or operability of one of these surfaces for the audience above.
 
 Ordered by how strongly the public docs emphasize each.
 
-1. **Secrets never leave / never reach the agent.** The most-repeated value across
-   the tagline, `README.md`, `SECURITY.md`, and the hardening threat model, and
-   enforced in code (credentials "never returned after create"; central redaction).
-   Anything risking credential exposure is at least `severity:major` regardless of
-   size.
+1. **Credential confidentiality.** Stored credentials are encrypted, read APIs are
+   redacted, and the Broker injects credentials only after access checks. Creation
+   responses expose cleartext once, while rotation responses are redacted. Upstream
+   responses pass through the Broker, so both response handling and upstream trust
+   are part of the boundary. Anything risking unintended credential exposure is at
+   least `severity:major` regardless of size.
 2. **Secure & auditable by default.** Default-deny permissions (a rule-less binding
    blocks everything); append-only audit log; operator-supplied encryption keyset
    required (`SECURITY.md`, `control/web/schemas/toolkits.py`).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 This is the full walkthrough behind the six steps in the
 [README](../README.md#first-brokered-call): from a running Jentic One instance
-to a response from a real API, with the agent never seeing your credentials.
+to a governed response from a registered API.
 
 If you do not have an instance yet, install one first — see
 [Quickstart → install options](../README.md#quickstart) (signed release binary,
@@ -18,7 +18,7 @@ the Broker are running and reachable (the local default is
 
 ## 1. Create your admin account
 
-Open `/setup` in the operator UI and create the first administrator. This is a
+Open `/app/setup` in the operator UI and create the first administrator. This is a
 one-time step: once the account exists, this page redirects to login. The account
 you create here is the operator: it configures the instance, imports APIs, stores
 credentials, and approves agents.
@@ -48,9 +48,9 @@ imported description needs correcting without editing the original, see
 ## 3. Store a credential
 
 Store the credential the API needs (an API key, bearer token, basic auth, or an
-OAuth2 flow). It is encrypted at rest and is **never** returned to a caller,
-logged in cleartext, or exposed to the agent — it is decrypted only inside the
-Broker, at execution time. See
+OAuth2 flow). It is encrypted at rest. Cleartext secret material is returned
+once in the create response; later credential reads and rotation responses
+return redacted data. See
 [Credentials and toolkits](credentials-and-toolkits.md) for how a credential is
 stored and how one credential is shared across an API's operations.
 
@@ -74,6 +74,10 @@ agent in the UI at `/app`, and the command completes automatically once the
 agent is active. Re-running `register` is idempotent. (Registering with a
 **remote** deployment instead? Pass `--url` and `--broker-url` — see the
 [CLI README](../cli/README.md#usage).)
+
+For a local coding agent, use `jentic setup` instead. It runs the same
+registration flow, installs the Jentic skill, and offers to configure agent
+isolation.
 
 ## 5. Grant access
 
@@ -102,8 +106,10 @@ and `inspect` report) or its operation_id — the Broker is a forward proxy, not
 path router.
 
 The Broker checks the agent's permissions, attaches the stored credential after
-the permission check, forwards the request, and writes an audit record. The
-credential is added inside the Broker and is never returned to the caller.
+the permission check, forwards the request, and writes an audit record. It
+relays the upstream status, headers, and body, so use trusted upstreams: an
+upstream can reflect request data, including an injected credential, in its
+response.
 
 ## Where to go next
 
@@ -116,5 +122,5 @@ credential is added inside the Broker and is never returned to the caller.
   Swagger and `/redoc` the rendered reference — both generated from code.
 - **Endpoint & scope reference.** Every HTTP route and the scope it requires:
   [endpoint reference](reference/endpoints.md).
-- **Run it somewhere real.** [Build & deploy](../deploy/README.md) and the
+- **Deploy and harden it.** [Build & deploy](../deploy/README.md) and the
   [security hardening guide](security/hardening.md).

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -5,29 +5,33 @@ model and gives a tiered set of deployment postures — from "fine for trying it
 out" to "handling real production credentials" — so you can pick the right level
 of isolation for your use case.
 
-> **TL;DR:** Jentic One keeps your credentials off the
-> *network* path (the Broker injects them; the agent only ever sees responses).
-> To also keep them off the *host* path, **don't run Jentic One as the same OS
-> user as your agent** — sandbox the agent, or run Jentic One on a separate
-> host/network. The agent and CLI reach Jentic One over its HTTP API, so a
-> remote or private-network deployment is reached the same way you'd reach any
-> private service (VPN / private DNS / authenticated proxy) — see below.
+> **TL;DR:** Jentic One stores credentials in the operator's deployment and
+> injects them into governed upstream requests. Credential read APIs are
+> redacted, but upstream responses pass through the Broker; use trusted
+> upstreams. To protect the encryption key and database from a local agent,
+> **don't run Jentic One as the same OS user as your agent** — sandbox the
+> agent, or run Jentic One on a separate host/network. The agent and CLI reach
+> Jentic One over HTTP, so a remote or private-network deployment is reached
+> through the usual private-service controls (VPN / private DNS / authenticated
+> proxy).
 >
 > The strongly recommended pattern is to run Jentic One on a separate
 > host or network.
 
 ## Threat model
 
-The Broker's core guarantee is that a secret is injected into the outbound
-request inside the data plane and is **never returned to the caller and never
-seen by the agent**. That guarantee holds on the network.
+The Broker injects a secret into the outbound request only after its access
+check. Credential read APIs do not expose the stored value. The upstream
+response is relayed to the caller, however, so a reflective or malicious
+upstream can return request data, including the injected credential. Trust in
+the registered upstream is part of the credential boundary.
 
-It does **not** hold on the host when the agent runs on the **same machine and
-as the same OS user** as Jentic One — the default when you run a local install
-next to a coding agent (e.g. Claude Code, Cursor). A same-user process can read
-the credential database and the encryption key directly off disk or out of
-memory, regardless of the API-level controls. This is the single most important
-thing to understand before you point Jentic One at real credentials.
+API-level controls also do **not** protect the host when the agent runs on the
+**same machine and as the same OS user** as Jentic One — the default when you
+run a local install next to a coding agent (e.g. Claude Code, Cursor). A
+same-user process can read the credential database and encryption key directly
+off disk or out of memory. This is the single most important thing to
+understand before you point Jentic One at real credentials.
 
 ## Two independent decisions
 
@@ -51,9 +55,9 @@ secured*. (See "How the agent and CLI connect" below.)
 
 Everything that uses Jentic One — a coding agent, a running service, and the
 `jentic` CLI (`register`, `catalog`, `execute`) — reaches Jentic One over HTTPS
-at a configurable base URL (e.g. the CLI's `--broker-scheme` / `--broker-host`,
-or the equivalent config/profile) plus a scoped bearer token. There is **no
-requirement that any of them run on the same machine as Jentic One.**
+at configurable control-plane and Broker URLs (the CLI's `--url` and
+`--broker-url`) plus a scoped bearer token. There is **no requirement that any
+of them run on the same machine as Jentic One.**
 
 So when Jentic One is remote or inside a private network/VPC, clients reach it
 the normal way you'd reach any private service:

--- a/docs/security/local-agent/README.md
+++ b/docs/security/local-agent/README.md
@@ -4,12 +4,13 @@
 > `jentic run` with per-session confinement, directory grants, and `jentic
 > reset`). Two follow-ups remain deferred and are called out as such below.
 
-Jentic One keeps third-party credentials off the *network* path (the Broker
-injects them; the agent only sees responses). But the one-line install lands most
-users with the agent and Jentic One running as the **same OS user on the same
-machine**, where that guarantee doesn't hold — a compromised or prompt-injected
-agent can read the keys straight off disk. These docs work through isolating the
-agent as its own unprivileged Unix user so the isolated posture is the default.
+Jentic One keeps stored credentials out of credential read APIs and injects them
+inside the Broker. Upstream responses pass through, so upstream trust remains
+part of the boundary. The one-line install can place the agent and Jentic One
+under the **same OS user on the same machine**, where a compromised or
+prompt-injected agent can read the keys straight off disk. These docs work
+through isolating the agent as its own unprivileged Unix user so the isolated
+posture is the default.
 
 > **Just want to use it?** The operator-facing guide — flow, examples, and
 > troubleshooting for `jentic setup` / `jentic run` / `jentic reset` — is

--- a/docs/security/local-agent/analysis.md
+++ b/docs/security/local-agent/analysis.md
@@ -7,10 +7,11 @@
 
 ## The problem in one sentence
 
-Jentic One's promise — *the agent never sees the credential* — is a
-**network-path** guarantee, but the one-line install lands most users with the
-agent and Jentic One running as the **same OS user on the same machine**, where
-that guarantee does not hold.
+Jentic One's API boundary keeps stored credentials out of credential read
+responses and injects them inside the Broker. The one-line install can place the
+agent and Jentic One under the **same OS user on the same machine**, where that
+boundary does not protect the key or database. Upstream responses also pass
+through the Broker, so upstream trust is a separate part of the boundary.
 
 In that posture the boundary is defeated not by breaking the Broker but by going
 around it. Everything the boundary depends on — the AES-256 encryption key, the

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -17190,7 +17190,7 @@ servers:
 - description: Same-origin (relative)
   url: /
 tags:
-- description: Part of the **Core / Access** bounded context — the authoritative record of "who can call what, with which secret". A `Credential` is the auth secret + header configuration the Broker injects on the way out to an upstream API. Credentials reference registry content via the loose `(vendor, name, version)` identity tuple (see `APIReference`) — there is no foreign key between Core and Registry, by design. Cleartext secret material is returned **exactly once** at creation (and on rotation via `PATCH`). Read paths return a redacted projection — last-N characters, hints, never the secret itself.
+- description: Part of the **Core / Access** bounded context — the authoritative record of "who can call what, with which secret". A `Credential` is the auth secret + header configuration the Broker injects on the way out to an upstream API. Credentials reference registry content via the loose `(vendor, name, version)` identity tuple (see `APIReference`) — there is no foreign key between Core and Registry, by design. Cleartext secret material is returned **exactly once**, in the creation response. Read and rotation paths return a redacted projection — last-N characters, hints, never the secret itself.
   name: Credentials
 - description: |-
     Part of the **Core / Access** bounded context — a `Toolkit` is a scoped bundle of credentials and permissions issued to an agent or service. This tag covers **toolkit lifecycle**: list, create, read, update, delete. Sub-resources (keys, credential bindings, per-binding permission rules) live under the sibling tags `Toolkit Keys`, `Toolkit Credentials`, and `Toolkit Permissions`.

--- a/src/jentic_one/shared/web/openapi_meta.py
+++ b/src/jentic_one/shared/web/openapi_meta.py
@@ -221,9 +221,9 @@ OPENAPI_TAGS: list[dict[str, str]] = [
             "header configuration the Broker injects on the way out to an upstream API. "
             "Credentials reference registry content via the loose `(vendor, name, version)` "
             "identity tuple (see `APIReference`) — there is no foreign key between Core and "
-            "Registry, by design. Cleartext secret material is returned **exactly once** at "
-            "creation (and on rotation via `PATCH`). Read paths return a redacted projection "
-            "— last-N characters, hints, never the secret itself."
+            "Registry, by design. Cleartext secret material is returned **exactly once**, in "
+            "the creation response. Read and rotation paths return a redacted projection — "
+            "last-N characters, hints, never the secret itself."
         ),
     },
     {

--- a/tools/install-README.md
+++ b/tools/install-README.md
@@ -1,22 +1,26 @@
 # Jentic CLI installer
 
 [`install.sh`](install.sh) is a self-contained shell script that builds the
-Jentic CLIs from source and installs them onto your PATH. It builds **two
-binaries** — `jenticctl` (install/lifecycle) and `jentic` (API catalog) — that
-share the same module and `~/.jentic` state. It detects your OS/arch, makes sure
-a suitable Go toolchain is available (downloading one if needed), fetches just
-the `cli/` source from GitHub, builds the binaries, and verifies them.
+Jentic CLIs from signed release archives or source and installs them onto your
+`PATH`. The default download installs `jentic`, the agent CLI. Set
+`JENTIC_INSTALL_BINARIES=both` to also install `jenticctl`, the local-stack
+installer and lifecycle CLI.
 
 ## Quick start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
+# Install only jentic from a published release for use with a remote deployment.
+curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh \
+  | env JENTIC_INSTALL_METHOD=binary sh
+
+# Install both binaries and start the local-stack wizard.
+curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh \
+  | env JENTIC_INSTALL_BINARIES=both sh
 ```
 
-This clones the public repo anonymously — no token required. If you're building
-from a **private fork** (or a repo you must authenticate to), pass a GitHub token
-with read access. The token is needed twice: once for `curl` to fetch the script,
-and once (as an env var) for the script to clone the source:
+The public release and source repository need no token. If you're installing
+from a **private fork**, pass a GitHub token with read access. The token is
+needed twice: once for `curl` to fetch the script and once by the script:
 
 ```bash
 curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -32,35 +36,38 @@ You can also run it from a checkout:
 
 ## What it does
 
-1. Checks prerequisites (`git`, `curl`, `tar`, `mktemp`).
-2. Detects your platform (`linux`/`darwin`, `amd64`/`arm64`). Windows is not
-   supported directly — use WSL.
-3. Ensures Go: uses your existing `go` if it's new enough, otherwise downloads a
-   pinned Go into `~/.jentic/toolchain` (reused on subsequent runs).
-4. Resolves the ref to build: unless you set `JENTIC_REF`, it queries the repo's
-   tags and builds the **latest release** (`vX.Y.Z`), falling back to `main` if
-   no release tag is found. Set `JENTIC_REF` to build `main` or a dev branch.
-5. Shallow + sparse clones only the `cli/` subtree of the repo into a temp dir.
-6. Builds both binaries with version metadata stamped in via `-ldflags`.
-7. Installs them to `~/.jentic/bin/{jenticctl,jentic}` and makes them reachable
-   by name (see [PATH handling](#path-handling) below).
-8. Runs `jenticctl --version` and `jentic --version` to verify.
+1. Checks prerequisites (`git`, `curl`, `tar`, `mktemp`) and detects the
+   platform (`linux`/`darwin`, `amd64`/`arm64`). Windows is supported through
+   WSL.
+2. Resolves the requested ref, using the latest release when `JENTIC_REF` is
+   unset.
+3. In the default `auto` mode, downloads the matching release archive and
+   verifies its SHA-256 checksum. If `cosign` is available, it also verifies
+   the signed checksum file. If no matching release asset exists, it falls back
+   to a source build.
+4. Downloads `jentic` by default. `JENTIC_INSTALL_BINARIES=both` also downloads
+   `jenticctl`. The source-build path always builds both binaries.
+5. For a source build, uses a suitable Go toolchain or downloads the pinned
+   fallback, then shallow-clones the `cli/` subtree and builds both binaries.
+6. Installs the selected binaries under `~/.jentic/bin`, verifies that they
+   respond to `--version`, and records the install manifest.
+7. If `jenticctl` was installed and a terminal is available, starts
+   `jenticctl install`. Set `JENTIC_NO_INSTALL=1` to skip this hand-off.
 
-The temp clone/build directory is removed on exit; the only things left behind
-are the binaries (and the cached Go toolchain, if it was downloaded).
+Temporary download or build directories are removed on exit. A downloaded Go
+toolchain is cached for later source builds.
 
 ## PATH handling
 
-The binaries install into `~/.jentic/bin`. So `jenticctl` / `jentic` work by
-name, the installer makes that directory reachable using the first of these
-that applies:
+The binaries install into `~/.jentic/bin`. The installer makes that directory
+reachable using the first of these that applies:
 
 1. **Already on `PATH`** — if `~/.jentic/bin` is already on your `PATH`, nothing
    is changed and nothing extra is printed.
 2. **Symlink into an on-`PATH` dir** — if a conventional directory that's
    already on your `PATH` is writable (`/usr/local/bin`, then `~/.local/bin`),
-   both binaries are symlinked there. This takes effect immediately, no shell
-   restart needed.
+   the selected binaries are symlinked there. This takes effect immediately,
+   with no shell restart needed.
 3. **Append to your shell profile** — otherwise the installer appends a single
    guarded block to the right rc file for your login shell and prints the exact
    `export` line to use right now:
@@ -83,22 +90,25 @@ All optional, set as environment variables:
 | Variable | Default | Description |
 | --- | --- | --- |
 | `JENTIC_REPO` | `jentic/jentic-one` | `owner/name` of the source repo |
-| `JENTIC_REF` | _latest release tag_ | Branch, tag, or commit to build (also used as the reported version). When unset, the installer resolves the highest `vX.Y.Z` release tag and builds that, falling back to `main` if none is found. Set it to build `main` or a dev branch. |
+| `JENTIC_REF` | _latest release tag_ | Release tag to download, or branch/tag/commit to build. When unset, the installer resolves the latest release. |
 | `JENTIC_INSTALL_DIR` | `~/.jentic/bin` | Where the binaries are installed |
 | `JENTIC_GO_VERSION` | `1.26.2` | Go version to download if no suitable `go` is found |
+| `JENTIC_INSTALL_METHOD` | `auto` | `auto` prefers a release archive and falls back to source; `binary` requires a matching release archive; `source` forces a source build. |
+| `JENTIC_INSTALL_BINARIES` | `jentic` | Download `jentic` only, or `both` to also download `jenticctl`. Source builds always build both. |
+| `JENTIC_NO_INSTALL` | `0` | Set to `1` to skip the `jenticctl install` hand-off. |
 | `GITHUB_TOKEN` | _(unset)_ | Only needed to clone a **private fork** — a token with repo read access (HTTP Basic, never written to disk). Not needed for the public repo. |
 
 Examples:
 
 ```bash
-# Default: build the latest release tag
+# Default: install the jentic release archive, falling back to source
 ./tools/install.sh
 
-# Build the bleeding-edge main branch instead of the latest release
-JENTIC_REF=main ./tools/install.sh
+# Install both release binaries without starting the local-stack wizard
+JENTIC_INSTALL_BINARIES=both JENTIC_NO_INSTALL=1 ./tools/install.sh
 
-# Build a specific branch into /usr/local/bin
-JENTIC_REF=feat/my-branch JENTIC_INSTALL_DIR=/usr/local/bin ./tools/install.sh
+# Build the main branch instead of downloading a release
+JENTIC_INSTALL_METHOD=source JENTIC_REF=main ./tools/install.sh
 
 # Pin an exact release tag
 JENTIC_REF=v0.24.0 ./tools/install.sh
@@ -110,26 +120,26 @@ JENTIC_GO_VERSION=1.26.2 ./tools/install.sh
 ## Verifying the install
 
 ```bash
-jenticctl --version
-# jenticctl v0.24.0 (commit a1b2c3d, built 2026-06-19T14:00:00Z)
-
 jentic --version
 # jentic v0.24.0 (commit a1b2c3d, built 2026-06-19T14:00:00Z)
 
-jenticctl --help
 jentic --help
+
+# If you installed both binaries:
+jenticctl --version
+jenticctl --help
 ```
 
 ## Troubleshooting
 
-- **`clone failed ...`** — the public repo clones anonymously, so this usually
+- **`clone failed ...`** — source builds clone the public repo anonymously, so this usually
   means a network/proxy issue or a bad `JENTIC_REF` (the ref must be a branch,
   tag, or commit that exists in the repo). If you're building from a
   **private fork**, it means no token was provided (or the token lacks access) —
   create a token with repo read scope and re-run with `GITHUB_TOKEN=...`.
-- **`Found go1.xx but Go 1.26+ is required`** — your system Go is too old. The
+- **`Found go1.xx but Go 1.25+ is required`** — your system Go is too old. The
   script downloads a newer Go automatically; if you'd rather use your own, update
-  Go to 1.26 or newer.
+  Go to 1.25 or newer.
 - **`~/.jentic/bin is not on your PATH`** — the installer appends a guarded
   `export PATH=...` block to your shell profile (`~/.zshrc`/`~/.bashrc`); restart
   your terminal (or `source` the rc file) to pick it up. To use the CLIs in the
@@ -139,10 +149,10 @@ jentic --help
 
 ## Notes
 
-- This builds from source, so it needs network access to GitHub and the Go
-  module proxy. Prebuilt signed binaries are published with each
-  [GitHub release](https://github.com/jentic/jentic-one/releases) (verify
-  against `checksums.txt`, signature `checksums.txt.sig`, certificate
-  `checksums.txt.pem`); this script is the build-from-source alternative.
+- Binary mode downloads release archives from GitHub. Source mode additionally
+  needs access to the Go module proxy.
+- Release archives are checked against `checksums.txt`. If `cosign` is
+  installed, the script also verifies `checksums.txt.sig` with
+  `checksums.txt.pem`.
 - The script honors Go's `GOTOOLCHAIN=auto`, so even if the resolved Go is a bit
   older than the one named in `cli/go.mod`, the build can self-upgrade.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -2,12 +2,17 @@
 #
 # Jentic CLI installer.
 #
-# Detects your OS/arch, ensures a Go toolchain, fetches the `cli/` source from
-# GitHub, builds the `jenticctl` (installer/lifecycle) and `jentic` (API-spec)
-# binaries, and installs both onto your PATH.
+# Detects your OS/arch, installs release binaries when available, and falls
+# back to building the CLI from source. Release downloads install `jentic` by
+# default; set JENTIC_INSTALL_BINARIES=both to add `jenticctl`.
 #
-# Quick start:
-#   curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
+# Quick start (agent CLI for an existing remote deployment):
+#   curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh \
+#     | JENTIC_INSTALL_METHOD=binary sh
+#
+# Local stack (both binaries + interactive install wizard):
+#   curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh \
+#     | JENTIC_INSTALL_BINARIES=both sh
 #
 # For a private fork or a repo you must authenticate to, pass a GitHub token
 # with `repo` (read) scope:
@@ -17,12 +22,15 @@
 #
 # Configuration (environment variables, all optional):
 #   JENTIC_REPO         owner/name of the source repo   (default: jentic/jentic-one)
-#   JENTIC_REF          branch, tag, or commit to build  (default: latest release
-#                       tag, e.g. v0.24.0; falls back to main if none is found.
-#                       Set explicitly to build main or a dev branch.)
+#   JENTIC_REF          release tag to download, or branch/tag/commit to build
+#                       (default: latest release tag)
 #   JENTIC_INSTALL_DIR  where to install the binaries     (default: ~/.jentic/bin)
 #   JENTIC_GO_VERSION   Go to download if none suitable   (default: 1.26.2)
 #   GITHUB_TOKEN        token for cloning a private fork  (default: unset/anonymous)
+#   JENTIC_INSTALL_METHOD
+#                       auto | binary | source             (default: auto)
+#   JENTIC_INSTALL_BINARIES
+#                       jentic | both                      (default: jentic)
 #   JENTIC_NO_INSTALL   set to 1 to stop after installing the binaries, skipping
 #                       the automatic hand-off into `jenticctl install`
 #   JENTIC_INSTALL_SOURCE_URL

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -33079,7 +33079,7 @@
   ],
   "tags": [
     {
-      "description": "Part of the **Core / Access** bounded context — the authoritative record of \"who can call what, with which secret\". A `Credential` is the auth secret + header configuration the Broker injects on the way out to an upstream API. Credentials reference registry content via the loose `(vendor, name, version)` identity tuple (see `APIReference`) — there is no foreign key between Core and Registry, by design. Cleartext secret material is returned **exactly once** at creation (and on rotation via `PATCH`). Read paths return a redacted projection — last-N characters, hints, never the secret itself.",
+      "description": "Part of the **Core / Access** bounded context — the authoritative record of \"who can call what, with which secret\". A `Credential` is the auth secret + header configuration the Broker injects on the way out to an upstream API. Credentials reference registry content via the loose `(vendor, name, version)` identity tuple (see `APIReference`) — there is no foreign key between Core and Registry, by design. Cleartext secret material is returned **exactly once**, in the creation response. Read and rotation paths return a redacted projection — last-N characters, hints, never the secret itself.",
       "name": "Credentials"
     },
     {


### PR DESCRIPTION
## Summary

- align the README quickstart with the current release installer, `jentic setup` / `jentic register` flags, `/app/setup`, and the real `make check` target
- replace absolute credential claims with the implemented lifecycle: the create response shows cleartext once, later reads and rotations are redacted, Control handles managed OAuth secrets, and upstream responses pass through the Broker
- update the component model for Auth, current credential types, and agent interactions; replace the stale architecture PNG embed with a maintainable Mermaid diagram
- remove marketing-heavy and ambiguous wording, consolidate repeated contributing guidance, and propagate factual corrections through linked operator, security, CLI, and agent docs
- regenerate the committed OpenAPI artifacts after correcting the credential tag description

## Verification

- `make openapi`
- Ruff lint and format checks
- strict mypy check
- `make detect-secrets`
- `make test-arch` — 150 passed, 1 skipped
- `bash -n tools/install.sh`
- local-link validation across all changed Markdown files
- `git diff --check`

`make check` reaches the API scorecard after lint, formatting, and mypy, but the scorecard cannot run here without `JENTIC_API_KEY`. The remaining local checks were run separately and passed.
