### PR TITLE
feat(telemetry): add Origin.MCP + MCP session/config events

### DIFF
--- a/src/jentic_one/admin/core/schema/events.py
+++ b/src/jentic_one/admin/core/schema/events.py
@@ -32,6 +32,22 @@ class Event(AuditableMixin, AdminBase):
             postgresql_where=text("trace_id IS NOT NULL"),
         ),
         Index("ix_events_actor", "actor_id", "actor_type"),
+        # Cross-worker exactly-once backstop for mcp.session_started: the emit
+        # path (shared/events/mcp_session.py) is check-then-insert, so two
+        # workers can both pass the dedupe lookup before either commits. This
+        # partial unique index turns the loser's insert into an IntegrityError
+        # (tolerated there), and doubles as the read-path index for
+        # EventRepository.exists_with_data_value on Postgres. Scoped to the one
+        # event type so other events carrying a session_id stay unconstrained.
+        # The SQLite migration (f2a3b4c5d6e7) creates the same index with
+        # json_extract(data, '$.session_id') instead of the Postgres operator.
+        Index(
+            "uq_events_mcp_session_started_session",
+            "type",
+            text("(data ->> 'session_id')"),
+            unique=True,
+            postgresql_where=text("type = 'mcp.session_started'"),
+        ),
     )
 
     id: Mapped[str] = mapped_column(

--- a/src/jentic_one/admin/repos/event_repo.py
+++ b/src/jentic_one/admin/repos/event_repo.py
@@ -66,8 +66,15 @@ class EventRepository:
 
         One narrow lookup used for table-backed dedupe (e.g. one
         ``mcp.session_started`` per ``data.session_id`` across workers and
-        surfaces). The ``type`` predicate rides the ``ix_events_type_created``
-        index; the JSON comparison then filters the (small) per-type slice.
+        surfaces — a pair additionally *enforced* by the partial unique index
+        ``uq_events_mcp_session_started_session``; this lookup is the cheap
+        first check, the index is the guarantee). On Postgres that same index
+        covers the ``(type, data->>'session_id')`` read here. For other
+        type/key pairs the ``type`` predicate rides ``ix_events_type_created``
+        and the JSON comparison filters the (small) per-type slice. On SQLite
+        the JSON comparison compiles to a ``json_extract`` path form that does
+        not match the index expression, so the lookup stays a per-type scan —
+        acceptable for the embedded single-file target.
         """
         stmt = (
             select(Event.id)

--- a/src/jentic_one/admin/repos/event_repo.py
+++ b/src/jentic_one/admin/repos/event_repo.py
@@ -55,6 +55,30 @@ class EventRepository:
         return await session.get(Event, event_id)
 
     @staticmethod
+    async def exists_with_data_value(
+        session: AsyncSession,
+        *,
+        event_type: str,
+        key: str,
+        value: str,
+    ) -> bool:
+        """Return whether any event of ``event_type`` has ``data[key] == value``.
+
+        One narrow lookup used for table-backed dedupe (e.g. one
+        ``mcp.session_started`` per ``data.session_id`` across workers and
+        surfaces). The ``type`` predicate rides the ``ix_events_type_created``
+        index; the JSON comparison then filters the (small) per-type slice.
+        """
+        stmt = (
+            select(Event.id)
+            .where(Event.type == event_type)
+            .where(Event.data[key].as_string() == value)
+            .limit(1)
+        )
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none() is not None
+
+    @staticmethod
     async def list_all(
         session: AsyncSession,
         *,

--- a/src/jentic_one/broker/services/execution/service.py
+++ b/src/jentic_one/broker/services/execution/service.py
@@ -35,6 +35,7 @@ from jentic_one.shared.events.repeated_failure import maybe_emit_repeated_failur
 from jentic_one.shared.executions import record_execution
 from jentic_one.shared.metrics import get_meter
 from jentic_one.shared.models import ExecutionStatus
+from jentic_one.shared.models.actors import origin_or_none
 from jentic_one.shared.models.events import ErrorSource, EventSeverity, EventTag, EventType
 from jentic_one.shared.schemas import APIReference
 from jentic_one.shared.tracing import jentic_tracestate, pack_jentic_tracestate
@@ -210,6 +211,7 @@ async def run_execution(
             toolkit_id=ctx_req.toolkit_id,
             operation_id=ctx_req.operation_id,
             security_config=security_config,
+            origin=origin,
         )
         if isinstance(exc, CircuitOpenError):
             host = urlparse(ctx_req.upstream_url).netloc or "<unknown>"
@@ -290,6 +292,7 @@ async def run_execution(
         operation_id=ctx_req.operation_id,
         security_config=security_config,
         error_tags=error_tags,
+        origin=origin,
     )
 
     return outcome
@@ -402,6 +405,7 @@ async def persist_streaming_execution(
         operation_id=ctx_req.operation_id,
         security_config=security_config,
         error_tags=error_tags,
+        origin=origin,
     )
 
 
@@ -455,6 +459,7 @@ async def _emit_execution_lifecycle(
     operation_id: str | None = None,
     security_config: SecurityConfig | None = None,
     error_tags: set[EventTag] | None = None,
+    origin: str | None = None,
 ) -> None:
     """Emit EXECUTION_COMPLETED/EXECUTION_FAILED events for the sync and streaming paths.
 
@@ -467,8 +472,14 @@ async def _emit_execution_lifecycle(
     so ``broker_execution_failed`` telemetry carries the auth split *without* a
     separate ``auth_failure`` event that the flat, correlation-id-free payload
     could never dedupe downstream.
+
+    ``origin`` (the request-derived ``Origin`` string the callers already thread
+    for the execution record) rides both events as a closed-enum ``Origin`` tag,
+    so telemetry can split executions by surface (the MCP adoption metric)
+    without any free-form property; an unrecognised value is simply not tagged.
     """
     event_trace_id = valid_trace_id_or_none(trace_id)
+    origin_tag = origin_or_none(origin)
     try:
         if status == ExecutionStatus.COMPLETED:
             await emit_event(
@@ -481,9 +492,13 @@ async def _emit_execution_lifecycle(
                 created_by=actor_id,
                 actor_id=actor_id,
                 actor_type=actor_type,
+                tags={origin_tag} if origin_tag is not None else None,
             )
         else:
             sanitized = (error_msg or "unknown")[:_MAX_EVENT_SUMMARY_LEN]
+            failed_tags: set[EventTag] = set(error_tags or ())
+            if origin_tag is not None:
+                failed_tags.add(origin_tag)
             await emit_event(
                 session,
                 type=EventType.EXECUTION_FAILED,
@@ -495,7 +510,7 @@ async def _emit_execution_lifecycle(
                 created_by=actor_id,
                 actor_id=actor_id,
                 actor_type=actor_type,
-                tags=error_tags or None,
+                tags=failed_tags or None,
             )
     except Exception:
         logger.warning("emit_execution_event_failed", execution_id=execution_id)

--- a/src/jentic_one/broker/web/deps.py
+++ b/src/jentic_one/broker/web/deps.py
@@ -27,6 +27,7 @@ from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.broker.protocols import RuleEvaluatorProtocol, ToolkitDeriverProtocol
 from jentic_one.shared.context import Context
 from jentic_one.shared.events import emit_event
+from jentic_one.shared.events.mcp_session import SESSION_ID_HEADER, schedule_mcp_session_emit
 from jentic_one.shared.metrics import get_meter
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.resilience import RateLimiter
@@ -114,6 +115,17 @@ async def require_broker_identity(request: Request) -> Identity:
         ) from exc
 
     resolved.origin = derive_origin(request.headers.get("user-agent"))
+
+    # Broker half of the two-plane ``mcp.session_started`` emit: an MCP session
+    # whose only traffic is ``execute`` never touches the control plane, so it
+    # must be detected here too (table-backed dedupe keeps it to one event).
+    schedule_mcp_session_emit(
+        getattr(request.app.state, "ctx", None),
+        user_agent=request.headers.get("user-agent"),
+        session_id=request.headers.get(SESSION_ID_HEADER),
+        actor_id=resolved.sub,
+        actor_type=resolved.actor_type.value,
+    )
     return resolved
 
 

--- a/src/jentic_one/migrations/admin/versions/f2a3b4c5d6e7_add_mcp_session_started_dedup_index.py
+++ b/src/jentic_one/migrations/admin/versions/f2a3b4c5d6e7_add_mcp_session_started_dedup_index.py
@@ -1,0 +1,48 @@
+"""add unique dedupe index for mcp.session_started
+
+Backstop for the check-then-insert race in ``shared/events/mcp_session.py``:
+two workers can both pass the ``exists_with_data_value`` lookup before either
+commits, emitting duplicate ``mcp.session_started`` events. This partial
+unique index on ``(type, (data->>'session_id'))``, scoped to that one event
+type, makes the losing insert fail with ``IntegrityError`` (which the emit
+path tolerates), so the table holds exactly one row per session id. On
+Postgres it also serves the dedupe lookup's read path. Scoped so other event
+types carrying a ``session_id`` in ``data`` stay unconstrained.
+
+No data cleanup is needed: ``mcp.session_started`` ships in the same release
+as this index, so upgraded deployments cannot hold rows of this type yet.
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1f2a3b4c5d6
+Create Date: 2026-08-31
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f2a3b4c5d6e7"
+down_revision: str | None = "e1f2a3b4c5d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pg = op.get_bind().dialect.name == "postgresql"
+    session_id_expr = (
+        sa.text("(data ->> 'session_id')") if pg else sa.text("json_extract(data, '$.session_id')")
+    )
+    op.create_index(
+        "uq_events_mcp_session_started_session",
+        "events",
+        ["type", session_id_expr],
+        unique=True,
+        postgresql_where=sa.text("type = 'mcp.session_started'"),
+        sqlite_where=sa.text("type = 'mcp.session_started'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_events_mcp_session_started_session", table_name="events")

--- a/src/jentic_one/shared/events/__init__.py
+++ b/src/jentic_one/shared/events/__init__.py
@@ -53,7 +53,9 @@ def valid_trace_id_or_minted(trace_id: str | None) -> str:
 def _validate_tags(type: str, tags: set[EventTag] | None) -> list[EventTag]:
     """Drop tags whose closed-enum type is not allowed for this event.
 
-    Invalid tags are logged and discarded; the event still emits (never raises).
+    ``EVENT_TAGS`` maps each event to a *tuple* of allowed tag types (an event
+    may split along more than one closed enum). Invalid tags are logged and
+    discarded; the event still emits (never raises).
     """
     if not tags:
         return []

--- a/src/jentic_one/shared/events/mcp_session.py
+++ b/src/jentic_one/shared/events/mcp_session.py
@@ -17,9 +17,16 @@ The event is emitted **once per session id**, on the first authenticated
 request that shows both, from **both planes** (the control plane's
 ``resolve_identity`` and the broker's ``require_broker_identity`` — a session
 whose only traffic is ``execute`` never touches the control plane). Dedupe is
-two-layered per the lane-D plan: a per-process seen-set short-circuit, backed
-by one indexed events-table lookup on ``data.session_id`` (the table is the
-store shared across workers/services). Emission is fire-and-forget in a
+three-layered (the lane-D plan's two layers, hardened against races): a
+synchronous per-process short-circuit (the seen-set plus an in-flight set
+checked before any task is scheduled, so concurrent first requests on one
+worker schedule at most one emit), one indexed events-table lookup on
+``data.session_id`` (the table is the store shared across workers/services),
+and — because the lookup is check-then-insert and two workers can race past
+it — a partial unique index on ``(type, data->>'session_id')`` scoped to this
+event type (``uq_events_mcp_session_started_session``). The loser of a
+cross-worker race gets an ``IntegrityError`` and skips, so the store holds
+exactly one row per session id. Emission is fire-and-forget in a
 background task so the auth path never waits on it, and it rides
 ``emit_event``'s existing consent gate — the telemetry wire carries at most
 the closed ``McpClient`` tag, while the internal event's ``data`` holds the
@@ -34,9 +41,11 @@ import re
 from dataclasses import dataclass
 
 import structlog
+from sqlalchemy.exc import IntegrityError
 
 from jentic_one.admin.repos.event_repo import EventRepository
 from jentic_one.shared.context import Context
+from jentic_one.shared.db.errors import DatabaseIntegrityError
 from jentic_one.shared.events import emit_event
 from jentic_one.shared.models.events import EventSeverity, EventType, McpClient
 
@@ -63,12 +72,25 @@ _MCP_UA_RE = re.compile(
 #: once-per-session-id path.
 _STDIO_TRANSPORT = "stdio"
 
+#: Longest UA-derived field persisted to event ``data``. The User-Agent is
+#: untrusted input; without a cap a hostile client could grow every
+#: ``mcp.session_started`` row by kilobytes of junk.
+_UA_FIELD_MAX = 128
+
 #: Per-process short-circuit: session ids already confirmed emitted (here or
 #: by another worker, via the table lookup). Bounded so a long-lived process
 #: fed unique ids can't grow it without limit — clearing only costs one extra
 #: table lookup per session, never a duplicate event.
 _seen_sessions: set[str] = set()
 _SEEN_SESSIONS_MAX = 4096
+
+#: Session ids with an emit task currently in flight on this process. Checked
+#: and added *synchronously* in :func:`schedule_mcp_session_emit`, before the
+#: task is created, so two concurrent first requests on one worker can never
+#: both schedule an emit. Entries are discarded in the task's done callback —
+#: on failure the session is not in the seen-set either, so the next request
+#: retries.
+_in_flight: set[str] = set()
 
 _background_tasks: set[asyncio.Task[None]] = set()
 
@@ -87,7 +109,8 @@ def parse_mcp_user_agent(user_agent: str | None) -> McpUserAgent | None:
 
     Returns ``None`` for anything that is not MCP-server traffic. A UA with the
     prefix but a malformed tail still identifies MCP traffic — it degrades to
-    "client unknown" rather than dropping the session event.
+    "client unknown" rather than dropping the session event. Parsed fields are
+    capped at ``_UA_FIELD_MAX`` chars — they end up persisted in event ``data``.
     """
     if not user_agent or not user_agent.lower().startswith(MCP_USER_AGENT_PREFIX):
         return None
@@ -97,9 +120,9 @@ def parse_mcp_user_agent(user_agent: str | None) -> McpUserAgent | None:
     client = match.group("client")
     client_version = match.group("client_version")
     return McpUserAgent(
-        server_version=match.group("version"),
-        client_name=client.strip() if client else None,
-        client_version=client_version.strip() if client_version else None,
+        server_version=match.group("version")[:_UA_FIELD_MAX],
+        client_name=client.strip()[:_UA_FIELD_MAX] if client else None,
+        client_version=client_version.strip()[:_UA_FIELD_MAX] if client_version else None,
     )
 
 
@@ -127,9 +150,12 @@ async def record_mcp_session_started(
     """Emit ``mcp.session_started`` for ``session_id`` unless already emitted.
 
     Opens its own admin-DB transaction (callers run this off the request path).
-    The table lookup keeps the once-per-session guarantee across processes;
-    failures are logged and the seen-set is left untouched so the next request
-    for the session retries.
+    The table lookup short-circuits sessions already recorded by another
+    process; the once-per-session guarantee itself is held by the partial
+    unique index ``uq_events_mcp_session_started_session`` — losing a
+    cross-worker check-then-insert race raises ``IntegrityError``, which is
+    treated as "already emitted". Other failures are logged and the seen-set
+    is left untouched so the next request for the session retries.
     """
     try:
         async with ctx.admin_db.transaction() as session:
@@ -158,6 +184,13 @@ async def record_mcp_session_started(
                     tags={client_tag},
                 )
         _remember(session_id)
+    except (DatabaseIntegrityError, IntegrityError):
+        # Lost the cross-worker insert race: another worker/plane committed the
+        # row between our lookup and our insert, and the unique index rejected
+        # the duplicate (``transaction()`` maps the raw ``IntegrityError`` to
+        # ``DatabaseIntegrityError``). The event exists — the desired end state.
+        logger.debug("mcp_session_started_already_emitted", actor_id=actor_id)
+        _remember(session_id)
     except Exception:
         logger.warning("emit_mcp_session_started_failed", actor_id=actor_id)
 
@@ -175,21 +208,31 @@ def schedule_mcp_session_emit(
     Called by both planes' identity dependencies on every request; the
     non-MCP fast path is two header checks. Never raises and never blocks the
     caller — the DB work runs in a background task (matching the broker's
-    auth-failure event pattern).
+    auth-failure event pattern). The in-flight check-and-add happens
+    synchronously here, before the task is created, so concurrent first
+    requests for one session schedule exactly one emit on this process.
     """
     ua = parse_mcp_user_agent(user_agent)
     if ua is None:
         return
     sid = valid_session_id_or_none(session_id)
-    if sid is None or sid in _seen_sessions:
+    if sid is None or sid in _seen_sessions or sid in _in_flight:
         return
     if ctx is None:
         return
 
+    _in_flight.add(sid)
     task = asyncio.create_task(
         record_mcp_session_started(
             ctx, ua=ua, session_id=sid, actor_id=actor_id, actor_type=actor_type
         )
     )
     _background_tasks.add(task)
-    task.add_done_callback(_background_tasks.discard)
+
+    def _cleanup(done: asyncio.Task[None]) -> None:
+        _background_tasks.discard(done)
+        # On failure the session is not in the seen-set, so dropping the
+        # in-flight entry lets the next request retry.
+        _in_flight.discard(sid)
+
+    task.add_done_callback(_cleanup)

--- a/src/jentic_one/shared/events/mcp_session.py
+++ b/src/jentic_one/shared/events/mcp_session.py
@@ -1,0 +1,195 @@
+"""``mcp.session_started`` emission — first authenticated request per MCP session.
+
+Local-MCP lane D (issue #1177). The stdio MCP server (Go, ``jentic mcp``)
+terminates all MCP protocol traffic; the backend only ever sees plain HTTP
+calls. Two request properties identify an MCP session:
+
+- ``User-Agent: jentic-mcp/<version> (<client>/<clientversion>)`` — the UA
+  prefix (not the header below) is what marks the traffic as MCP; the
+  parenthetical clientInfo is optional (a SHOULD in the MCP spec), so an
+  absent clientInfo means "client unknown".
+- ``X-Jentic-Session-Id: <session-uuid>`` — the shipped correlation seam. An
+  orchestrator-set ``$JENTIC_SESSION_ID`` groups several server processes into
+  one logical session; the Go server's per-process UUID is the fallback. Plain
+  CLI calls carry this header too — which is why the UA gates.
+
+The event is emitted **once per session id**, on the first authenticated
+request that shows both, from **both planes** (the control plane's
+``resolve_identity`` and the broker's ``require_broker_identity`` — a session
+whose only traffic is ``execute`` never touches the control plane). Dedupe is
+two-layered per the lane-D plan: a per-process seen-set short-circuit, backed
+by one indexed events-table lookup on ``data.session_id`` (the table is the
+store shared across workers/services). Emission is fire-and-forget in a
+background task so the auth path never waits on it, and it rides
+``emit_event``'s existing consent gate — the telemetry wire carries at most
+the closed ``McpClient`` tag, while the internal event's ``data`` holds the
+full clientInfo, the transport, and the session id for the UI (two-plane
+pattern).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass
+
+import structlog
+
+from jentic_one.admin.repos.event_repo import EventRepository
+from jentic_one.shared.context import Context
+from jentic_one.shared.events import emit_event
+from jentic_one.shared.models.events import EventSeverity, EventType, McpClient
+
+logger = structlog.get_logger(__name__)
+
+MCP_USER_AGENT_PREFIX = "jentic-mcp/"
+SESSION_ID_HEADER = "x-jentic-session-id"
+
+#: Mirrors the Go client's ``SanitizeSessionID`` charset + length bound
+#: (``cli/client/client.go``) — but the header is untrusted input, so the
+#: backend re-validates rather than assuming the sender sanitised.
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+#: ``jentic-mcp/<version>`` optionally followed by ``(<client>/<clientversion>)``.
+#: The client version segment is itself optional (``(cursor)`` parses too).
+_MCP_UA_RE = re.compile(
+    r"^jentic-mcp/(?P<version>\S+)"
+    r"(?:\s+\((?P<client>[^/()]+?)(?:/(?P<client_version>[^()]*))?\))?\s*$",
+    re.IGNORECASE,
+)
+
+#: Transport for the header-seam path. Phase-3's mounted HTTP app emits with
+#: its own transport value and windowed dedupe key — not through this module's
+#: once-per-session-id path.
+_STDIO_TRANSPORT = "stdio"
+
+#: Per-process short-circuit: session ids already confirmed emitted (here or
+#: by another worker, via the table lookup). Bounded so a long-lived process
+#: fed unique ids can't grow it without limit — clearing only costs one extra
+#: table lookup per session, never a duplicate event.
+_seen_sessions: set[str] = set()
+_SEEN_SESSIONS_MAX = 4096
+
+_background_tasks: set[asyncio.Task[None]] = set()
+
+
+@dataclass(frozen=True, slots=True)
+class McpUserAgent:
+    """Parsed ``jentic-mcp/…`` User-Agent."""
+
+    server_version: str
+    client_name: str | None
+    client_version: str | None
+
+
+def parse_mcp_user_agent(user_agent: str | None) -> McpUserAgent | None:
+    """Parse a ``jentic-mcp/<version> (<client>/<clientversion>)`` User-Agent.
+
+    Returns ``None`` for anything that is not MCP-server traffic. A UA with the
+    prefix but a malformed tail still identifies MCP traffic — it degrades to
+    "client unknown" rather than dropping the session event.
+    """
+    if not user_agent or not user_agent.lower().startswith(MCP_USER_AGENT_PREFIX):
+        return None
+    match = _MCP_UA_RE.match(user_agent.strip())
+    if match is None:
+        return McpUserAgent(server_version="", client_name=None, client_version=None)
+    client = match.group("client")
+    client_version = match.group("client_version")
+    return McpUserAgent(
+        server_version=match.group("version"),
+        client_name=client.strip() if client else None,
+        client_version=client_version.strip() if client_version else None,
+    )
+
+
+def valid_session_id_or_none(session_id: str | None) -> str | None:
+    """Return the header value when it is a plausible session id, else ``None``."""
+    if session_id is not None and _SESSION_ID_RE.match(session_id):
+        return session_id
+    return None
+
+
+def _remember(session_id: str) -> None:
+    if len(_seen_sessions) >= _SEEN_SESSIONS_MAX:
+        _seen_sessions.clear()
+    _seen_sessions.add(session_id)
+
+
+async def record_mcp_session_started(
+    ctx: Context,
+    *,
+    ua: McpUserAgent,
+    session_id: str,
+    actor_id: str,
+    actor_type: str,
+) -> None:
+    """Emit ``mcp.session_started`` for ``session_id`` unless already emitted.
+
+    Opens its own admin-DB transaction (callers run this off the request path).
+    The table lookup keeps the once-per-session guarantee across processes;
+    failures are logged and the seen-set is left untouched so the next request
+    for the session retries.
+    """
+    try:
+        async with ctx.admin_db.transaction() as session:
+            already_emitted = await EventRepository.exists_with_data_value(
+                session,
+                event_type=EventType.MCP_SESSION_STARTED,
+                key="session_id",
+                value=session_id,
+            )
+            if not already_emitted:
+                client_tag = McpClient.from_client_name(ua.client_name)
+                await emit_event(
+                    session,
+                    type=EventType.MCP_SESSION_STARTED,
+                    severity=EventSeverity.INFO,
+                    summary=f"MCP session started for {actor_id}",
+                    created_by=actor_id,
+                    actor_id=actor_id,
+                    actor_type=actor_type,
+                    data={
+                        "session_id": session_id,
+                        "transport": _STDIO_TRANSPORT,
+                        "client_name": ua.client_name,
+                        "client_version": ua.client_version,
+                    },
+                    tags={client_tag},
+                )
+        _remember(session_id)
+    except Exception:
+        logger.warning("emit_mcp_session_started_failed", actor_id=actor_id)
+
+
+def schedule_mcp_session_emit(
+    ctx: Context | None,
+    *,
+    user_agent: str | None,
+    session_id: str | None,
+    actor_id: str,
+    actor_type: str,
+) -> None:
+    """Fire-and-forget ``mcp.session_started`` from an authenticated request.
+
+    Called by both planes' identity dependencies on every request; the
+    non-MCP fast path is two header checks. Never raises and never blocks the
+    caller — the DB work runs in a background task (matching the broker's
+    auth-failure event pattern).
+    """
+    ua = parse_mcp_user_agent(user_agent)
+    if ua is None:
+        return
+    sid = valid_session_id_or_none(session_id)
+    if sid is None or sid in _seen_sessions:
+        return
+    if ctx is None:
+        return
+
+    task = asyncio.create_task(
+        record_mcp_session_started(
+            ctx, ua=ua, session_id=sid, actor_id=actor_id, actor_type=actor_type
+        )
+    )
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)

--- a/src/jentic_one/shared/jobs/execution_handler.py
+++ b/src/jentic_one/shared/jobs/execution_handler.py
@@ -38,7 +38,8 @@ from jentic_one.shared.jobs.protocols import (
 )
 from jentic_one.shared.models import ActorType as ActorTypeEnum
 from jentic_one.shared.models import ExecutionStatus
-from jentic_one.shared.models.events import EventSeverity, EventType
+from jentic_one.shared.models.actors import origin_or_none
+from jentic_one.shared.models.events import EventSeverity, EventTag, EventType
 from jentic_one.shared.url import apply_server_variables
 from jentic_one.shared.url_validation import validate_upstream_url
 
@@ -196,6 +197,7 @@ class ExecutionHandler:
             actor_type=actor_type,
             toolkit_id=payload.get("toolkit_id"),
             operation_id=payload.get("operation_id"),
+            origin=origin,
         )
 
         result_body: dict[str, Any] = {
@@ -222,7 +224,13 @@ class ExecutionHandler:
         actor_type: str,
         toolkit_id: str | None = None,
         operation_id: str | None = None,
+        origin: str | None = None,
     ) -> None:
+        # The enqueue path persisted the request-derived Origin string in the
+        # job payload; it rides the lifecycle events as a closed-enum tag so
+        # the async path splits telemetry by surface like the sync path does.
+        origin_tag = origin_or_none(origin)
+        origin_tags: set[EventTag] | None = {origin_tag} if origin_tag is not None else None
         event_trace_id = valid_trace_id_or_none(trace_id)
         try:
             if status == ExecutionStatus.COMPLETED:
@@ -237,6 +245,7 @@ class ExecutionHandler:
                     created_by=created_by,
                     actor_id=created_by,
                     actor_type=actor_type,
+                    tags=origin_tags,
                 )
             else:
                 sanitized = (error_msg or "unknown")[:_MAX_EVENT_SUMMARY_LEN]
@@ -252,6 +261,7 @@ class ExecutionHandler:
                     created_by=created_by,
                     actor_id=created_by,
                     actor_type=actor_type,
+                    tags=origin_tags,
                 )
         except Exception:
             logger.warning("emit_event_failed", job_id=job_id, execution_id=execution_id)

--- a/src/jentic_one/shared/models/actors.py
+++ b/src/jentic_one/shared/models/actors.py
@@ -20,6 +20,22 @@ class Origin(StrEnum):
     API = "api"
     AGENT = "agent"
     SYSTEM = "system"
+    MCP = "mcp"
+
+
+def origin_or_none(value: str | None) -> Origin | None:
+    """Coerce a persisted/threaded origin string back to the enum.
+
+    Emit sites receive the origin as a plain string (job payloads, persisted
+    execution rows); an absent or unrecognised value degrades to ``None`` so a
+    garbage origin can never become an event tag.
+    """
+    if not value:
+        return None
+    try:
+        return Origin(value)
+    except ValueError:
+        return None
 
 
 _PREFIX_TO_ACTOR_TYPE: dict[str, ActorType] = {

--- a/src/jentic_one/shared/models/events.py
+++ b/src/jentic_one/shared/models/events.py
@@ -3,6 +3,8 @@
 import platform
 from enum import StrEnum
 
+from jentic_one.shared.models.actors import Origin
+
 
 class EventSeverity(StrEnum):
     """Severity level for platform events."""
@@ -91,6 +93,20 @@ class EventType:
     # ``AccessRequestService._advise_unserved_bind_references``).
     TOOLKIT_BINDING_UNSERVED = "broker.toolkit_binding_unserved"
 
+    # --- Local-MCP transport events (issue #1177) -------------------------
+    # Emitted once per MCP session UUID on the first authenticated request
+    # that carries both the X-Jentic-Session-Id header and a `jentic-mcp/`
+    # User-Agent (the UA — not the header — marks the session as MCP: plain
+    # CLI calls carry the header too). The internal event's `data` holds the
+    # full clientInfo name/version, the transport, and the session UUID (the
+    # dedupe key); the telemetry wire carries at most the closed McpClient tag.
+    MCP_SESSION_STARTED = "mcp.session_started"
+    # Emitted when an MCP config entry is written for an agent runtime
+    # (`jentic setup` / `jentic skill init`). Runtime rides as the closed
+    # McpConfigRuntime tag. The emit path is landed separately (see the
+    # lane-D plan): this constant + the tag enum land first.
+    MCP_CONFIG_REGISTERED = "mcp.config_registered"
+
     ALL: frozenset[str] = frozenset(
         {
             IMPORT_COMPLETED,
@@ -132,6 +148,8 @@ class EventType:
             AGENT_REGISTRATION_DENIED,
             PBAC_DENIED,
             TOOLKIT_BINDING_UNSERVED,
+            MCP_SESSION_STARTED,
+            MCP_CONFIG_REGISTERED,
         }
     )
 
@@ -239,19 +257,76 @@ class HostOs(StrEnum):
             return cls.OTHER
 
 
+class McpClient(StrEnum):
+    """Closed-enum tag naming the MCP client runtime behind a session.
+
+    Attached only to ``mcp_session_started``. Classified from the clientInfo
+    name the MCP server relays in its User-Agent
+    (``jentic-mcp/<version> (<client>/<clientversion>)``) — the raw string
+    never reaches the telemetry wire: anything outside the closed set (or an
+    absent clientInfo — it is a SHOULD in the MCP spec) collapses to ``OTHER``.
+    The full name/version still lands in the internal event's ``data`` for the
+    UI (two-plane pattern).
+    """
+
+    CLAUDE = "claude"
+    CURSOR = "cursor"
+    CODEX = "codex"
+    OTHER = "other"
+
+    @classmethod
+    def from_client_name(cls, name: str | None) -> "McpClient":
+        """Classify a raw clientInfo name into the closed set.
+
+        Substring matching (lowercased) so vendor variants ("Claude Desktop",
+        "claude-code", "Cursor IDE") map to their family without an ever-growing
+        alias table; unknowns collapse to ``OTHER``.
+        """
+        if not name:
+            return cls.OTHER
+        lowered = name.strip().lower()
+        for member in (cls.CLAUDE, cls.CURSOR, cls.CODEX):
+            if member.value in lowered:
+                return member
+        return cls.OTHER
+
+
+class McpConfigRuntime(StrEnum):
+    """Closed-enum tag naming the agent runtime an MCP config entry targets.
+
+    Attached only to ``mcp_config_registered`` — one event per runtime whose
+    config file/entry ``jentic setup``/``jentic skill init`` writes. A closed
+    set (never the raw runtime string) so the config-written → first-session →
+    first-execute funnel stays property-free on the wire.
+    """
+
+    CLAUDE_DESKTOP = "claude_desktop"
+    CLAUDE_CODE = "claude_code"
+    CURSOR = "cursor"
+    CODEX = "codex"
+    OTHER = "other"
+
+
 #: Union of every closed-enum tag type. A tag on the wire is always a member of
 #: one of these — there is deliberately no free-form variant.
-EventTag = ErrorSource | SpecSource | ImportFailReason | HostOs
+EventTag = (
+    ErrorSource | SpecSource | ImportFailReason | HostOs | Origin | McpClient | McpConfigRuntime
+)
 
 
-#: Which closed-enum tag type each event may carry. ``emit_event`` validates
-#: supplied tags against this map: a tag whose type is not allowed for the event
+#: Which closed-enum tag types each event may carry. ``emit_event`` validates
+#: supplied tags against this map: a tag whose type is not in the event's tuple
 #: is dropped (with a logged warning) and the event still emits. An event absent
-#: from this map accepts no tags.
-EVENT_TAGS: dict[str, type[StrEnum]] = {
-    EventType.EXECUTION_FAILED: ErrorSource,
-    EventType.CREDENTIAL_REFRESH_FAILED: ErrorSource,
-    EventType.IMPORT_COMPLETED: SpecSource,
-    EventType.IMPORT_FAILED: ImportFailReason,
-    EventType.INSTANCE_BOOTED: HostOs,
+#: from this map accepts no tags. Values are tuples so an event can carry tags
+#: from more than one closed enum (e.g. ``EXECUTION_FAILED`` splits by both
+#: error source and request origin); ``isinstance`` accepts the tuple directly.
+EVENT_TAGS: dict[str, tuple[type[StrEnum], ...]] = {
+    EventType.EXECUTION_COMPLETED: (Origin,),
+    EventType.EXECUTION_FAILED: (ErrorSource, Origin),
+    EventType.CREDENTIAL_REFRESH_FAILED: (ErrorSource,),
+    EventType.IMPORT_COMPLETED: (SpecSource,),
+    EventType.IMPORT_FAILED: (ImportFailReason,),
+    EventType.INSTANCE_BOOTED: (HostOs,),
+    EventType.MCP_SESSION_STARTED: (McpClient,),
+    EventType.MCP_CONFIG_REGISTERED: (McpConfigRuntime,),
 }

--- a/src/jentic_one/shared/telemetry/events.py
+++ b/src/jentic_one/shared/telemetry/events.py
@@ -56,6 +56,9 @@ class TelemetryEventName(StrEnum):
     CREDENTIAL_CONNECTION_FAILED = "credential_connection_failed"
     CREDENTIAL_REFRESH_FAILED = "credential_refresh_failed"
     CREDENTIAL_UNDECRYPTABLE = "credential_undecryptable"
+    # Local-MCP transport adoption (issue #1177)
+    MCP_SESSION_STARTED = "mcp_session_started"
+    MCP_CONFIG_REGISTERED = "mcp_config_registered"
 
 
 #: Allowlist: internal ``EventType`` → wire ``TelemetryEventName``. Only events
@@ -89,6 +92,8 @@ TELEMETRY_EVENTS: dict[str, TelemetryEventName] = {
     EventType.EXECUTION_COMPLETED: TelemetryEventName.BROKER_EXECUTION,
     EventType.EXECUTION_FAILED: TelemetryEventName.BROKER_EXECUTION_FAILED,
     EventType.PBAC_DENIED: TelemetryEventName.PBAC_DENIED,
+    EventType.MCP_SESSION_STARTED: TelemetryEventName.MCP_SESSION_STARTED,
+    EventType.MCP_CONFIG_REGISTERED: TelemetryEventName.MCP_CONFIG_REGISTERED,
 }
 
 

--- a/src/jentic_one/shared/web/deps.py
+++ b/src/jentic_one/shared/web/deps.py
@@ -11,6 +11,7 @@ from jentic.problem_details import Forbidden, Unauthorized
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.auth.permission_catalog import compute_effective
 from jentic_one.shared.context import Context
+from jentic_one.shared.events.mcp_session import SESSION_ID_HEADER, schedule_mcp_session_emit
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.models.actors import Origin
 from jentic_one.shared.web.auth import extract_credential
@@ -30,6 +31,8 @@ def derive_origin(user_agent: str | None) -> Origin:
     if not user_agent:
         return Origin.API
     ua_lower = user_agent.lower()
+    if ua_lower.startswith("jentic-mcp/"):
+        return Origin.MCP
     if ua_lower.startswith("jentic-cli/"):
         return Origin.CLI
     if ua_lower.startswith("mozilla/") or ua_lower.startswith("applewebkit/"):
@@ -60,6 +63,18 @@ async def resolve_identity(request: Request) -> Identity:
         ) from None
 
     identity.origin = derive_origin(request.headers.get("user-agent"))
+
+    # First authenticated MCP request per session emits ``mcp.session_started``
+    # (fire-and-forget; two header checks on the non-MCP fast path). This is the
+    # control-plane half of the two-plane emit — the broker's identity
+    # dependency mirrors it for execute-only sessions.
+    schedule_mcp_session_emit(
+        getattr(request.app.state, "ctx", None),
+        user_agent=request.headers.get("user-agent"),
+        session_id=request.headers.get(SESSION_ID_HEADER),
+        actor_id=identity.sub,
+        actor_type=identity.actor_type.value,
+    )
     return identity
 
 

--- a/tests/integration/admin/test_events_emission.py
+++ b/tests/integration/admin/test_events_emission.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 
 import pytest
-from sqlalchemy import delete
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.admin.core.schema.events import Event
 from jentic_one.admin.core.schema.jobs import Job
 from jentic_one.admin.repos import EventRepository
+from jentic_one.shared.db.errors import DatabaseIntegrityError
 from jentic_one.shared.db.session import DatabaseSession
 from jentic_one.shared.events import emit_credential_access, emit_event
 from jentic_one.shared.models.events import EventSeverity, EventType
@@ -281,3 +283,78 @@ async def test_exists_with_data_value_dedupes_mcp_session(
             key="session_id",
             value="sess-abc123",
         )
+
+
+async def _emit_session_started(session: AsyncSession, session_id: str) -> None:
+    await emit_event(
+        session,
+        type=EventType.MCP_SESSION_STARTED,
+        severity=EventSeverity.INFO,
+        summary="MCP session started for agnt_test",
+        created_by="agnt_test",
+        actor_id="agnt_test",
+        actor_type="agent",
+        data={"session_id": session_id, "transport": "stdio"},
+    )
+
+
+async def test_mcp_session_started_duplicate_insert_rejected_by_unique_index(
+    admin_db: DatabaseSession, clean_events: None
+) -> None:
+    """The partial unique index makes the emit idempotent at the store.
+
+    Two workers racing past the exists_with_data_value lookup both insert;
+    uq_events_mcp_session_started_session must reject the second commit so the
+    table can never hold two mcp.session_started rows for one session id.
+    ``transaction()`` maps the raw IntegrityError to DatabaseIntegrityError.
+    """
+    async with admin_db.transaction() as session:
+        await _emit_session_started(session, "sess-race")
+
+    with pytest.raises(DatabaseIntegrityError):
+        async with admin_db.transaction() as session:
+            await _emit_session_started(session, "sess-race")
+
+    async with admin_db.session() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(Event.id).where(Event.type == EventType.MCP_SESSION_STARTED)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+
+
+async def test_mcp_session_started_index_scoped_to_one_event_type(
+    admin_db: DatabaseSession, clean_events: None
+) -> None:
+    """Other event types (and other session ids) are not constrained by the index."""
+    async with admin_db.transaction() as session:
+        await _emit_session_started(session, "sess-scoped")
+        # A second session id of the same type is fine.
+        await _emit_session_started(session, "sess-scoped-2")
+        # A different event type reusing the same session id is fine too —
+        # the unique index is partial, scoped to mcp.session_started.
+        await emit_event(
+            session,
+            type=EventType.MCP_CONFIG_REGISTERED,
+            severity=EventSeverity.INFO,
+            summary="MCP config registered",
+            created_by="agnt_test",
+            data={"session_id": "sess-scoped"},
+        )
+        await emit_event(
+            session,
+            type=EventType.MCP_CONFIG_REGISTERED,
+            severity=EventSeverity.INFO,
+            summary="MCP config registered again",
+            created_by="agnt_test",
+            data={"session_id": "sess-scoped"},
+        )
+
+    async with admin_db.session() as session:
+        rows = (await session.execute(select(Event.id))).scalars().all()
+        assert len(rows) == 4

--- a/tests/integration/admin/test_events_emission.py
+++ b/tests/integration/admin/test_events_emission.py
@@ -237,3 +237,47 @@ async def test_emit_declared_event_round_trips(
 
         by_severity = await EventRepository.list_all(session, severity=[severity.value])
         assert event_id in [e.id for e in by_severity]
+
+
+async def test_exists_with_data_value_dedupes_mcp_session(
+    admin_db: DatabaseSession, clean_events: None
+) -> None:
+    """The mcp.session_started dedupe lookup matches on type + data.session_id."""
+    async with admin_db.transaction() as session:
+        await emit_event(
+            session,
+            type=EventType.MCP_SESSION_STARTED,
+            severity=EventSeverity.INFO,
+            summary="MCP session started for agnt_test",
+            created_by="agnt_test",
+            actor_id="agnt_test",
+            actor_type="agent",
+            data={
+                "session_id": "sess-abc123",
+                "transport": "stdio",
+                "client_name": "cursor",
+                "client_version": "1.0",
+            },
+        )
+
+    async with admin_db.session() as session:
+        assert await EventRepository.exists_with_data_value(
+            session,
+            event_type=EventType.MCP_SESSION_STARTED,
+            key="session_id",
+            value="sess-abc123",
+        )
+        # A different session id does not match.
+        assert not await EventRepository.exists_with_data_value(
+            session,
+            event_type=EventType.MCP_SESSION_STARTED,
+            key="session_id",
+            value="sess-other",
+        )
+        # The same data value under a different event type does not match.
+        assert not await EventRepository.exists_with_data_value(
+            session,
+            event_type=EventType.EXECUTION_COMPLETED,
+            key="session_id",
+            value="sess-abc123",
+        )

--- a/tests/unit/broker/test_execution_events.py
+++ b/tests/unit/broker/test_execution_events.py
@@ -16,6 +16,7 @@ from jentic_one.broker.services.execution.service import (
     run_execution,
 )
 from jentic_one.shared.models import ExecutionStatus
+from jentic_one.shared.models.actors import Origin
 from jentic_one.shared.models.events import ErrorSource, EventSeverity, EventType
 
 
@@ -487,3 +488,142 @@ async def test_run_execution_no_auth_tag_without_vendor() -> None:
     ]
     assert len(failed_calls) == 1
     assert not failed_calls[0].kwargs.get("tags")
+
+
+# --- Origin tagging (lane D, #1177) --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_execution_tags_completed_event_with_origin() -> None:
+    """The request-derived origin rides EXECUTION_COMPLETED as a closed-enum tag."""
+    session = AsyncMock()
+    broker = default_broker(_SuccessRunner())
+
+    with (
+        patch(
+            "jentic_one.broker.services.execution.service.record_execution",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "jentic_one.broker.services.execution.service.emit_event",
+            new_callable=AsyncMock,
+        ) as mock_emit,
+    ):
+        await run_execution(
+            _ctx_req(),
+            body=None,
+            headers=None,
+            session=session,
+            broker=broker,
+            actor_id="agt_abc",
+            actor_type="agent",
+            origin="mcp",
+        )
+
+    mock_emit.assert_called_once()
+    call_kwargs = mock_emit.call_args.kwargs
+    assert call_kwargs["type"] == EventType.EXECUTION_COMPLETED
+    assert call_kwargs["tags"] == {Origin.MCP}
+
+
+@pytest.mark.asyncio
+async def test_run_execution_failed_carries_origin_and_error_source_tags() -> None:
+    """An MCP-origin upstream 401 tags the failure with both closed enums."""
+    session = AsyncMock()
+    broker = default_broker(_StatusRunner(401))
+
+    with (
+        patch(
+            "jentic_one.broker.services.execution.service.record_execution",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "jentic_one.broker.services.execution.service.emit_event",
+            new_callable=AsyncMock,
+        ) as mock_emit,
+    ):
+        await run_execution(
+            _ctx_req(),
+            body=None,
+            headers=None,
+            session=session,
+            broker=broker,
+            actor_id="agt_abc",
+            actor_type="agent",
+            origin="mcp",
+        )
+
+    failed_calls = [
+        c for c in mock_emit.call_args_list if c.kwargs.get("type") == EventType.EXECUTION_FAILED
+    ]
+    assert len(failed_calls) == 1
+    assert failed_calls[0].kwargs["tags"] == {
+        ErrorSource.AUTH_THIRDPARTY_UNAUTHORIZED,
+        Origin.MCP,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_execution_unknown_origin_is_not_tagged() -> None:
+    """A garbage origin string never becomes a tag (and never raises)."""
+    session = AsyncMock()
+    broker = default_broker(_SuccessRunner())
+
+    with (
+        patch(
+            "jentic_one.broker.services.execution.service.record_execution",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "jentic_one.broker.services.execution.service.emit_event",
+            new_callable=AsyncMock,
+        ) as mock_emit,
+    ):
+        await run_execution(
+            _ctx_req(),
+            body=None,
+            headers=None,
+            session=session,
+            broker=broker,
+            actor_id="agt_abc",
+            actor_type="agent",
+            origin="carrier-pigeon",
+        )
+
+    call_kwargs = mock_emit.call_args.kwargs
+    assert call_kwargs["type"] == EventType.EXECUTION_COMPLETED
+    assert call_kwargs["tags"] is None
+
+
+@pytest.mark.asyncio
+async def test_persist_streaming_execution_tags_events_with_origin() -> None:
+    """The streaming path threads the same origin tag onto its lifecycle event."""
+    session = AsyncMock()
+
+    with (
+        patch(
+            "jentic_one.broker.services.execution.service.record_execution",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "jentic_one.broker.services.execution.service.emit_event",
+            new_callable=AsyncMock,
+        ) as mock_emit,
+    ):
+        await persist_streaming_execution(
+            session,
+            execution_id="exec_stream_origin",
+            started_at=datetime.now(UTC),
+            status=ExecutionStatus.COMPLETED,
+            http_status=200,
+            duration_ms=10,
+            error=None,
+            ctx_req=_ctx_req(),
+            actor_id="agt_stream",
+            actor_type="agent",
+            origin="cli",
+        )
+
+    call_kwargs = mock_emit.call_args.kwargs
+    assert call_kwargs["type"] == EventType.EXECUTION_COMPLETED
+    assert call_kwargs["tags"] == {Origin.CLI}

--- a/tests/unit/shared/events/test_emit_tags.py
+++ b/tests/unit/shared/events/test_emit_tags.py
@@ -2,20 +2,25 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from jentic_one.shared.events import emit_event
+from jentic_one.shared.models.actors import Origin
 from jentic_one.shared.models.events import (
+    EVENT_TAGS,
     ErrorSource,
     EventSeverity,
+    EventTag,
     EventType,
     HostOs,
+    McpClient,
+    McpConfigRuntime,
     SpecSource,
 )
-from jentic_one.shared.telemetry.events import TelemetryEventName
+from jentic_one.shared.telemetry.events import TELEMETRY_EVENTS, TelemetryEventName
 
 
 class _RecordingSink:
@@ -139,6 +144,185 @@ async def test_invalid_tag_dropped_with_warning_event_still_emits() -> None:
     warn.assert_called_once()
     # No valid tag → forwarded with no tags.
     assert sink.records == [(TelemetryEventName.BROKER_EXECUTION_FAILED, (), None)]
+
+
+# --- Regression suite over the widened EVENT_TAGS map (lane D, #1177) ---------
+# EVENT_TAGS values are now tuples of allowed tag types; the widening touches
+# _validate_tags for every tagged event, so pin every (event, allowed-type)
+# pair: a representative member of each allowed enum must be stored + forwarded.
+
+_TAGGED_EVENT_CASES: list[tuple[str, EventTag]] = [
+    (event_type, cast("EventTag", next(iter(allowed_type))))
+    for event_type, allowed_types in sorted(EVENT_TAGS.items())
+    for allowed_type in allowed_types
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "tag"),
+    _TAGGED_EVENT_CASES,
+    ids=[f"{e}:{type(t).__name__}" for e, t in _TAGGED_EVENT_CASES],
+)
+async def test_every_tagged_event_accepts_each_allowed_tag_type(
+    event_type: str, tag: EventTag
+) -> None:
+    """Each event in EVENT_TAGS stores + forwards a member of every allowed type."""
+    sink = _RecordingSink(enabled=True)
+    create = _fake_create()
+
+    with (
+        patch("jentic_one.shared.events.EventRepository.create", create),
+        patch("jentic_one.shared.events.get_active_sink", return_value=sink),
+        patch("jentic_one.shared.events.logger.warning") as warn,
+    ):
+        await emit_event(
+            session=AsyncMock(),
+            type=event_type,
+            severity=EventSeverity.INFO,
+            summary="tagged event",
+            created_by="usr_1",
+            tags={tag},
+        )
+
+    warn.assert_not_called()
+    assert create.call_args.kwargs["data"]["tags"] == [str(tag)]
+    # Every tagged event happens to be on the telemetry allowlist today; the
+    # validated tag must ride the forwarded record.
+    assert event_type in TELEMETRY_EVENTS
+    assert sink.records == [(TELEMETRY_EVENTS[event_type], (tag,), None)]
+
+
+@pytest.mark.asyncio
+async def test_execution_failed_carries_error_source_and_origin_together() -> None:
+    """The widened map lets EXECUTION_FAILED split by both source and origin."""
+    sink = _RecordingSink(enabled=True)
+    create = _fake_create()
+
+    with (
+        patch("jentic_one.shared.events.EventRepository.create", create),
+        patch("jentic_one.shared.events.get_active_sink", return_value=sink),
+        patch("jentic_one.shared.events.logger.warning") as warn,
+    ):
+        await emit_event(
+            session=AsyncMock(),
+            type=EventType.EXECUTION_FAILED,
+            severity=EventSeverity.ERROR,
+            summary="execution failed",
+            created_by="agt_1",
+            tags={ErrorSource.AUTH_THIRDPARTY_UNAUTHORIZED, Origin.MCP},
+        )
+
+    warn.assert_not_called()
+    stored_data = create.call_args.kwargs["data"]
+    assert set(stored_data["tags"]) == {"auth_thirdparty_unauthorized", "mcp"}
+    assert len(sink.records) == 1
+    _name, forwarded, _actor = sink.records[0]
+    assert set(forwarded) == {ErrorSource.AUTH_THIRDPARTY_UNAUTHORIZED, Origin.MCP}
+
+
+@pytest.mark.asyncio
+async def test_execution_completed_carries_origin_tag() -> None:
+    """EXECUTION_COMPLETED (previously tag-less) now accepts the Origin tag."""
+    sink = _RecordingSink(enabled=True)
+    create = _fake_create()
+
+    with (
+        patch("jentic_one.shared.events.EventRepository.create", create),
+        patch("jentic_one.shared.events.get_active_sink", return_value=sink),
+    ):
+        await emit_event(
+            session=AsyncMock(),
+            type=EventType.EXECUTION_COMPLETED,
+            severity=EventSeverity.INFO,
+            summary="execution completed",
+            created_by="agt_1",
+            tags={Origin.MCP},
+        )
+
+    assert create.call_args.kwargs["data"]["tags"] == ["mcp"]
+    assert sink.records == [(TelemetryEventName.BROKER_EXECUTION, (Origin.MCP,), None)]
+
+
+@pytest.mark.asyncio
+async def test_origin_tag_dropped_on_event_that_does_not_allow_it() -> None:
+    """event_tag_dropped fallback: Origin on IMPORT_COMPLETED is discarded, event emits."""
+    sink = _RecordingSink(enabled=True)
+    create = _fake_create()
+
+    with (
+        patch("jentic_one.shared.events.EventRepository.create", create),
+        patch("jentic_one.shared.events.get_active_sink", return_value=sink),
+        patch("jentic_one.shared.events.logger.warning") as warn,
+    ):
+        await emit_event(
+            session=AsyncMock(),
+            type=EventType.IMPORT_COMPLETED,
+            severity=EventSeverity.INFO,
+            summary="import completed",
+            created_by="usr_1",
+            tags={Origin.MCP, SpecSource.CATALOG},
+        )
+
+    warn.assert_called_once()
+    # Only the allowed SpecSource tag survives; the event still emits + forwards.
+    assert create.call_args.kwargs["data"]["tags"] == ["catalog"]
+    assert sink.records == [(TelemetryEventName.SPEC_IMPORTED, (SpecSource.CATALOG,), None)]
+
+
+@pytest.mark.asyncio
+async def test_mcp_session_started_forwards_only_closed_client_tag() -> None:
+    """mcp_session_started telemetry carries the McpClient tag; data stays internal."""
+    sink = _RecordingSink(enabled=True)
+    create = _fake_create()
+
+    with (
+        patch("jentic_one.shared.events.EventRepository.create", create),
+        patch("jentic_one.shared.events.get_active_sink", return_value=sink),
+    ):
+        await emit_event(
+            session=AsyncMock(),
+            type=EventType.MCP_SESSION_STARTED,
+            severity=EventSeverity.INFO,
+            summary="MCP session started",
+            created_by="agt_1",
+            actor_id="agt_1",
+            actor_type="agent",
+            data={"session_id": "sess-1", "client_name": "Cursor IDE"},
+            tags={McpClient.CURSOR},
+        )
+
+    assert sink.records == [(TelemetryEventName.MCP_SESSION_STARTED, (McpClient.CURSOR,), "agent")]
+    # The full-fidelity clientInfo stays on the internal event's data.
+    stored_data = create.call_args.kwargs["data"]
+    assert stored_data["client_name"] == "Cursor IDE"
+    assert stored_data["tags"] == ["cursor"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_config_registered_forwards_runtime_tag() -> None:
+    sink = _RecordingSink(enabled=True)
+
+    with (
+        patch("jentic_one.shared.events.EventRepository.create", _fake_create()),
+        patch("jentic_one.shared.events.get_active_sink", return_value=sink),
+    ):
+        await emit_event(
+            session=AsyncMock(),
+            type=EventType.MCP_CONFIG_REGISTERED,
+            severity=EventSeverity.INFO,
+            summary="MCP config registered",
+            created_by="usr_1",
+            tags={McpConfigRuntime.CLAUDE_DESKTOP},
+        )
+
+    assert sink.records == [
+        (
+            TelemetryEventName.MCP_CONFIG_REGISTERED,
+            (McpConfigRuntime.CLAUDE_DESKTOP,),
+            None,
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/shared/events/test_mcp_session.py
+++ b/tests/unit/shared/events/test_mcp_session.py
@@ -1,18 +1,21 @@
 """Unit tests for ``mcp.session_started`` emission (lane D, issue #1177).
 
-Covers the User-Agent parser, the session-id header validation, the two-layer
-dedupe (per-process seen-set + events-table lookup), and the shape of the
-emitted internal event vs. the closed-enum telemetry tag.
+Covers the User-Agent parser, the session-id header validation, the layered
+dedupe (synchronous in-flight/seen-set short-circuits + events-table lookup +
+unique-index race tolerance), and the shape of the emitted internal event vs.
+the closed-enum telemetry tag.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import jentic_one.shared.events.mcp_session as mcp_session
+from jentic_one.shared.db.errors import DatabaseIntegrityError
 from jentic_one.shared.events.mcp_session import (
     McpUserAgent,
     parse_mcp_user_agent,
@@ -27,8 +30,10 @@ from jentic_one.shared.models.events import EventSeverity, EventType, McpClient
 def _clear_seen_sessions():
     """Isolate the module-level dedupe state per test."""
     mcp_session._seen_sessions.clear()
+    mcp_session._in_flight.clear()
     yield
     mcp_session._seen_sessions.clear()
+    mcp_session._in_flight.clear()
 
 
 def _fake_ctx() -> MagicMock:
@@ -94,6 +99,16 @@ def test_parse_mcp_user_agent_malformed_tail_degrades_to_unknown_client() -> Non
     assert parsed is not None
     assert parsed.client_name is None
     assert McpClient.from_client_name(parsed.client_name) is McpClient.OTHER
+
+
+def test_parse_mcp_user_agent_truncates_oversized_fields() -> None:
+    """Untrusted UA fields are capped before they can reach persisted event data."""
+    ua = f"jentic-mcp/{'v' * 300} ({'c' * 300}/{'x' * 300})"
+    parsed = parse_mcp_user_agent(ua)
+    assert parsed is not None
+    assert parsed.server_version == "v" * 128
+    assert parsed.client_name == "c" * 128
+    assert parsed.client_version == "x" * 128
 
 
 # --- Session-id validation -----------------------------------------------------
@@ -196,6 +211,32 @@ async def test_record_failure_is_swallowed_and_retryable() -> None:
     assert "sess-err" not in mcp_session._seen_sessions
 
 
+@pytest.mark.asyncio
+async def test_record_lost_insert_race_treated_as_already_emitted() -> None:
+    """A unique-index IntegrityError means another worker won — skip, don't retry."""
+    ctx = _fake_ctx()
+    ua = McpUserAgent(server_version="1.0", client_name=None, client_version=None)
+
+    with (
+        patch(
+            "jentic_one.shared.events.mcp_session.EventRepository.exists_with_data_value",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "jentic_one.shared.events.mcp_session.emit_event",
+            # transaction() maps the raw IntegrityError to this domain error.
+            AsyncMock(side_effect=DatabaseIntegrityError("UNIQUE constraint failed")),
+        ),
+    ):
+        await record_mcp_session_started(
+            ctx, ua=ua, session_id="sess-race", actor_id="agnt_abc", actor_type="agent"
+        )
+
+    # The row exists (written by the race winner) — remember so this process
+    # never re-schedules the emit for this session.
+    assert "sess-race" in mcp_session._seen_sessions
+
+
 # --- schedule_mcp_session_emit -------------------------------------------------
 
 
@@ -271,6 +312,67 @@ async def test_schedule_seen_set_short_circuits() -> None:
             await task
 
     record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_schedule_concurrent_first_requests_emit_once() -> None:
+    """Two concurrent first requests for one session schedule exactly one emit.
+
+    Reproduces the reviewed race: before the in-flight set, both schedules
+    passed the seen-set check (it is only populated after the background task
+    commits) and both created tasks. The in-flight check-and-add is synchronous
+    in schedule_mcp_session_emit, so the second schedule must no-op even while
+    the first task is still mid-transaction.
+    """
+    release = asyncio.Event()
+    calls = 0
+
+    async def slow_record(*args: Any, **kwargs: Any) -> None:
+        nonlocal calls
+        calls += 1
+        await release.wait()
+
+    with patch(
+        "jentic_one.shared.events.mcp_session.record_mcp_session_started",
+        AsyncMock(side_effect=slow_record),
+    ):
+        _schedule(_fake_ctx())
+        _schedule(_fake_ctx())  # concurrent duplicate — same session id
+        assert "sess-1" in mcp_session._in_flight
+        # A third request arriving while the emit is still in flight also skips.
+        await asyncio.sleep(0)
+        _schedule(_fake_ctx())
+        release.set()
+        for task in list(mcp_session._background_tasks):
+            await task
+        # Let the done callbacks run.
+        await asyncio.sleep(0)
+
+    assert calls == 1
+    assert "sess-1" not in mcp_session._in_flight
+    assert not mcp_session._background_tasks
+
+
+@pytest.mark.asyncio
+async def test_schedule_retries_after_failed_emit() -> None:
+    """A failed emit clears the in-flight entry so the next request retries."""
+    with patch(
+        "jentic_one.shared.events.mcp_session.record_mcp_session_started",
+        new_callable=AsyncMock,
+    ) as record:
+        _schedule(_fake_ctx())
+        for task in list(mcp_session._background_tasks):
+            await task
+        await asyncio.sleep(0)
+
+        # The emit failed (record swallows errors and does not touch the
+        # seen-set), so a later request for the same session schedules again.
+        assert "sess-1" not in mcp_session._in_flight
+        _schedule(_fake_ctx())
+        for task in list(mcp_session._background_tasks):
+            await task
+
+    assert record.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/shared/events/test_mcp_session.py
+++ b/tests/unit/shared/events/test_mcp_session.py
@@ -1,0 +1,295 @@
+"""Unit tests for ``mcp.session_started`` emission (lane D, issue #1177).
+
+Covers the User-Agent parser, the session-id header validation, the two-layer
+dedupe (per-process seen-set + events-table lookup), and the shape of the
+emitted internal event vs. the closed-enum telemetry tag.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import jentic_one.shared.events.mcp_session as mcp_session
+from jentic_one.shared.events.mcp_session import (
+    McpUserAgent,
+    parse_mcp_user_agent,
+    record_mcp_session_started,
+    schedule_mcp_session_emit,
+    valid_session_id_or_none,
+)
+from jentic_one.shared.models.events import EventSeverity, EventType, McpClient
+
+
+@pytest.fixture(autouse=True)
+def _clear_seen_sessions():
+    """Isolate the module-level dedupe state per test."""
+    mcp_session._seen_sessions.clear()
+    yield
+    mcp_session._seen_sessions.clear()
+
+
+def _fake_ctx() -> MagicMock:
+    """A Context whose admin_db.transaction() yields an AsyncMock session."""
+    ctx = MagicMock()
+    session = AsyncMock()
+    transaction = MagicMock()
+    transaction.__aenter__ = AsyncMock(return_value=session)
+    transaction.__aexit__ = AsyncMock(return_value=False)
+    ctx.admin_db.transaction.return_value = transaction
+    return ctx
+
+
+# --- User-Agent parsing --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ua", "expected"),
+    [
+        (
+            "jentic-mcp/1.2.3 (cursor/0.42.0)",
+            McpUserAgent(server_version="1.2.3", client_name="cursor", client_version="0.42.0"),
+        ),
+        (
+            "jentic-mcp/1.2.3 (Claude Desktop/2.1)",
+            McpUserAgent(
+                server_version="1.2.3", client_name="Claude Desktop", client_version="2.1"
+            ),
+        ),
+        # Parenthetical is optional (clientInfo is a SHOULD) → client unknown.
+        (
+            "jentic-mcp/1.2.3",
+            McpUserAgent(server_version="1.2.3", client_name=None, client_version=None),
+        ),
+        # Client without a version parses too.
+        (
+            "jentic-mcp/1.2.3 (codex)",
+            McpUserAgent(server_version="1.2.3", client_name="codex", client_version=None),
+        ),
+        # Prefix match is case-insensitive, mirroring derive_origin.
+        (
+            "Jentic-MCP/2.0.0 (Cursor/1.0)",
+            McpUserAgent(server_version="2.0.0", client_name="Cursor", client_version="1.0"),
+        ),
+    ],
+)
+def test_parse_mcp_user_agent_valid(ua: str, expected: McpUserAgent) -> None:
+    assert parse_mcp_user_agent(ua) == expected
+
+
+@pytest.mark.parametrize(
+    "ua",
+    [None, "", "jentic-cli/1.0.0", "Mozilla/5.0", "curl/8.0", "jentic-mcpX/1.0"],
+)
+def test_parse_mcp_user_agent_non_mcp(ua: str | None) -> None:
+    """Non-MCP traffic parses to None — the fast path for every normal request."""
+    assert parse_mcp_user_agent(ua) is None
+
+
+def test_parse_mcp_user_agent_malformed_tail_degrades_to_unknown_client() -> None:
+    """A jentic-mcp/ UA with a garbled tail still counts as MCP, client unknown."""
+    parsed = parse_mcp_user_agent("jentic-mcp/1.0 (((broken")
+    assert parsed is not None
+    assert parsed.client_name is None
+    assert McpClient.from_client_name(parsed.client_name) is McpClient.OTHER
+
+
+# --- Session-id validation -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sid",
+    ["sess-1", "a" * 128, "0123e4567-e89b:12d3", "run_7.retry"],
+)
+def test_valid_session_id_accepted(sid: str) -> None:
+    assert valid_session_id_or_none(sid) == sid
+
+
+@pytest.mark.parametrize(
+    "sid",
+    [None, "", "a" * 129, "bad session", "id\nnewline", "emoji🎉"],
+)
+def test_invalid_session_id_rejected(sid: str | None) -> None:
+    """The header is untrusted input — anything outside the charset is ignored."""
+    assert valid_session_id_or_none(sid) is None
+
+
+# --- record_mcp_session_started ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_emits_event_with_full_data_and_closed_tag() -> None:
+    """First sighting of a session id emits with actor, data, and McpClient tag."""
+    ctx = _fake_ctx()
+    ua = McpUserAgent(server_version="1.2.3", client_name="Cursor IDE", client_version="0.42")
+
+    with (
+        patch(
+            "jentic_one.shared.events.mcp_session.EventRepository.exists_with_data_value",
+            AsyncMock(return_value=False),
+        ) as exists,
+        patch("jentic_one.shared.events.mcp_session.emit_event", new_callable=AsyncMock) as emit,
+    ):
+        await record_mcp_session_started(
+            ctx, ua=ua, session_id="sess-1", actor_id="agnt_abc", actor_type="agent"
+        )
+
+    exists.assert_awaited_once()
+    assert exists.call_args.kwargs["event_type"] == EventType.MCP_SESSION_STARTED
+    assert exists.call_args.kwargs["key"] == "session_id"
+    assert exists.call_args.kwargs["value"] == "sess-1"
+
+    emit.assert_awaited_once()
+    kwargs = emit.call_args.kwargs
+    assert kwargs["type"] == EventType.MCP_SESSION_STARTED
+    assert kwargs["severity"] == EventSeverity.INFO
+    # actor_id is mandatory here — it's what the per-agent UI read keys on.
+    assert kwargs["actor_id"] == "agnt_abc"
+    assert kwargs["actor_type"] == "agent"
+    assert kwargs["data"] == {
+        "session_id": "sess-1",
+        "transport": "stdio",
+        "client_name": "Cursor IDE",
+        "client_version": "0.42",
+    }
+    # Telemetry side: at most the closed McpClient tag — never the raw string.
+    assert kwargs["tags"] == {McpClient.CURSOR}
+
+    assert "sess-1" in mcp_session._seen_sessions
+
+
+@pytest.mark.asyncio
+async def test_record_short_circuits_on_existing_table_row() -> None:
+    """A row already written (by another worker/plane) suppresses the emit."""
+    ctx = _fake_ctx()
+    ua = McpUserAgent(server_version="1.0", client_name=None, client_version=None)
+
+    with (
+        patch(
+            "jentic_one.shared.events.mcp_session.EventRepository.exists_with_data_value",
+            AsyncMock(return_value=True),
+        ),
+        patch("jentic_one.shared.events.mcp_session.emit_event", new_callable=AsyncMock) as emit,
+    ):
+        await record_mcp_session_started(
+            ctx, ua=ua, session_id="sess-dup", actor_id="agnt_abc", actor_type="agent"
+        )
+
+    emit.assert_not_awaited()
+    # The seen-set is primed so subsequent requests skip the table lookup too.
+    assert "sess-dup" in mcp_session._seen_sessions
+
+
+@pytest.mark.asyncio
+async def test_record_failure_is_swallowed_and_retryable() -> None:
+    """A DB failure never propagates, and the session stays unremembered (retry)."""
+    ctx = _fake_ctx()
+    ctx.admin_db.transaction.side_effect = RuntimeError("db down")
+    ua = McpUserAgent(server_version="1.0", client_name=None, client_version=None)
+
+    await record_mcp_session_started(
+        ctx, ua=ua, session_id="sess-err", actor_id="agnt_abc", actor_type="agent"
+    )
+
+    assert "sess-err" not in mcp_session._seen_sessions
+
+
+# --- schedule_mcp_session_emit -------------------------------------------------
+
+
+def _schedule(
+    ctx: Any,
+    *,
+    user_agent: str | None = "jentic-mcp/1.0 (cursor/1.0)",
+    session_id: str | None = "sess-1",
+) -> None:
+    schedule_mcp_session_emit(
+        ctx,
+        user_agent=user_agent,
+        session_id=session_id,
+        actor_id="agnt_abc",
+        actor_type="agent",
+    )
+
+
+@pytest.mark.asyncio
+async def test_schedule_creates_task_for_mcp_request() -> None:
+    with patch(
+        "jentic_one.shared.events.mcp_session.record_mcp_session_started",
+        new_callable=AsyncMock,
+    ) as record:
+        _schedule(_fake_ctx())
+        # Let the created task run.
+        for task in list(mcp_session._background_tasks):
+            await task
+
+    record.assert_awaited_once()
+    assert record.call_args.kwargs["session_id"] == "sess-1"
+    assert record.call_args.kwargs["actor_id"] == "agnt_abc"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("user_agent", "session_id"),
+    [
+        # Plain CLI calls carry the header too — the UA, not the header, gates.
+        ("jentic-cli/1.0.0", "sess-1"),
+        # Browser traffic.
+        ("Mozilla/5.0", "sess-1"),
+        # MCP UA without the session header: nothing to key the dedupe on.
+        ("jentic-mcp/1.0 (cursor/1.0)", None),
+        # MCP UA with a garbage header value.
+        ("jentic-mcp/1.0 (cursor/1.0)", "bad session\n"),
+    ],
+)
+async def test_schedule_ignores_non_qualifying_requests(
+    user_agent: str | None, session_id: str | None
+) -> None:
+    with patch(
+        "jentic_one.shared.events.mcp_session.record_mcp_session_started",
+        new_callable=AsyncMock,
+    ) as record:
+        _schedule(_fake_ctx(), user_agent=user_agent, session_id=session_id)
+        for task in list(mcp_session._background_tasks):
+            await task
+
+    record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_schedule_seen_set_short_circuits() -> None:
+    """Once a session id is remembered, no further task (or lookup) is scheduled."""
+    mcp_session._seen_sessions.add("sess-1")
+    with patch(
+        "jentic_one.shared.events.mcp_session.record_mcp_session_started",
+        new_callable=AsyncMock,
+    ) as record:
+        _schedule(_fake_ctx())
+        for task in list(mcp_session._background_tasks):
+            await task
+
+    record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_schedule_without_ctx_is_a_noop() -> None:
+    """Apps without a wired Context (some test harnesses) never crash the auth path."""
+    with patch(
+        "jentic_one.shared.events.mcp_session.record_mcp_session_started",
+        new_callable=AsyncMock,
+    ) as record:
+        _schedule(None)
+
+    record.assert_not_awaited()
+
+
+def test_seen_set_is_bounded() -> None:
+    """The per-process seen-set can never grow past its cap."""
+    for i in range(mcp_session._SEEN_SESSIONS_MAX):
+        mcp_session._remember(f"sess-{i}")
+    assert len(mcp_session._seen_sessions) == mcp_session._SEEN_SESSIONS_MAX
+    mcp_session._remember("one-more")
+    assert len(mcp_session._seen_sessions) == 1
+    assert "one-more" in mcp_session._seen_sessions

--- a/tests/unit/shared/test_event_types.py
+++ b/tests/unit/shared/test_event_types.py
@@ -1,10 +1,19 @@
-"""Unit tests for EventType constants and the HostOs closed-enum tag."""
+"""Unit tests for EventType constants and the closed-enum event tags."""
 
 from unittest.mock import patch
 
 import pytest
 
-from jentic_one.shared.models.events import EVENT_TAGS, EventType, HostOs
+from jentic_one.shared.models.actors import Origin
+from jentic_one.shared.models.events import (
+    EVENT_TAGS,
+    ErrorSource,
+    EventType,
+    HostOs,
+    McpClient,
+    McpConfigRuntime,
+)
+from jentic_one.shared.telemetry.events import TELEMETRY_EVENTS, TelemetryEventName
 
 
 def test_new_event_types_in_all() -> None:
@@ -14,11 +23,30 @@ def test_new_event_types_in_all() -> None:
     assert EventType.UNAUTHORIZED_ACCESS_ATTEMPT in EventType.ALL
 
 
+def test_mcp_event_types_in_all() -> None:
+    """The lane-D MCP event types are registered in EventType.ALL."""
+    assert EventType.MCP_SESSION_STARTED in EventType.ALL
+    assert EventType.MCP_CONFIG_REGISTERED in EventType.ALL
+
+
 def test_event_type_values() -> None:
     """Event type string values match the namespaced convention."""
     assert EventType.UPSTREAM_CIRCUIT_OPEN == "upstream.circuit_open"
     assert EventType.JOB_FAILED_PERMANENTLY == "job.failed_permanently"
     assert EventType.UNAUTHORIZED_ACCESS_ATTEMPT == "security.unauthorized_access_attempt"
+    assert EventType.MCP_SESSION_STARTED == "mcp.session_started"
+    assert EventType.MCP_CONFIG_REGISTERED == "mcp.config_registered"
+
+
+def test_mcp_events_on_telemetry_allowlist() -> None:
+    """The MCP events forward to the telemetry wire under their snake_case names."""
+    assert TELEMETRY_EVENTS[EventType.MCP_SESSION_STARTED] is TelemetryEventName.MCP_SESSION_STARTED
+    assert (
+        TELEMETRY_EVENTS[EventType.MCP_CONFIG_REGISTERED]
+        is TelemetryEventName.MCP_CONFIG_REGISTERED
+    )
+    assert TelemetryEventName.MCP_SESSION_STARTED.value == "mcp_session_started"
+    assert TelemetryEventName.MCP_CONFIG_REGISTERED.value == "mcp_config_registered"
 
 
 def test_all_contains_every_class_constant() -> None:
@@ -83,6 +111,65 @@ def test_host_os_resolve_falls_back_to_runtime_detection(absent: str | None) -> 
 
 def test_host_os_allowed_only_on_instance_booted() -> None:
     """HostOs is the tag type for the per-boot instance_booted event only."""
-    assert EVENT_TAGS[EventType.INSTANCE_BOOTED] is HostOs
+    assert EVENT_TAGS[EventType.INSTANCE_BOOTED] == (HostOs,)
     others = {k: v for k, v in EVENT_TAGS.items() if k != EventType.INSTANCE_BOOTED}
-    assert HostOs not in others.values()
+    assert all(HostOs not in allowed for allowed in others.values())
+
+
+def test_execution_events_carry_origin_tag_type() -> None:
+    """The adoption split: both execution lifecycle events accept Origin tags.
+
+    EXECUTION_FAILED keeps its ErrorSource split alongside — the tuple widening
+    is exactly what lets one event carry both closed enums.
+    """
+    assert EVENT_TAGS[EventType.EXECUTION_COMPLETED] == (Origin,)
+    assert EVENT_TAGS[EventType.EXECUTION_FAILED] == (ErrorSource, Origin)
+
+
+def test_event_tags_values_are_tuples_of_enums() -> None:
+    """Every EVENT_TAGS value is a tuple of StrEnum types (isinstance-compatible)."""
+    for event_type, allowed in EVENT_TAGS.items():
+        assert isinstance(allowed, tuple), event_type
+        assert allowed, f"{event_type} maps an empty tuple — remove the entry instead"
+        assert all(isinstance(t, type) for t in allowed), event_type
+
+
+def test_mcp_session_started_carries_only_mcp_client_tag() -> None:
+    """The telemetry side of mcp_session_started is at most the closed McpClient tag."""
+    assert EVENT_TAGS[EventType.MCP_SESSION_STARTED] == (McpClient,)
+
+
+def test_mcp_config_registered_carries_only_runtime_tag() -> None:
+    assert EVENT_TAGS[EventType.MCP_CONFIG_REGISTERED] == (McpConfigRuntime,)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("claude", McpClient.CLAUDE),
+        ("Claude Desktop", McpClient.CLAUDE),
+        ("claude-code", McpClient.CLAUDE),
+        ("cursor", McpClient.CURSOR),
+        ("Cursor IDE", McpClient.CURSOR),
+        ("codex", McpClient.CODEX),
+        ("Codex CLI", McpClient.CODEX),
+        # Unknowns and absent clientInfo collapse to OTHER — a raw client name
+        # can never become a tag value.
+        ("windsurf", McpClient.OTHER),
+        ("", McpClient.OTHER),
+        (None, McpClient.OTHER),
+    ],
+)
+def test_mcp_client_classifies_into_closed_set(name: str | None, expected: McpClient) -> None:
+    assert McpClient.from_client_name(name) is expected
+
+
+def test_mcp_config_runtime_members() -> None:
+    """The runtime tag set matches the runtimes auto-registration writes (2-E3)."""
+    assert {m.value for m in McpConfigRuntime} == {
+        "claude_desktop",
+        "claude_code",
+        "cursor",
+        "codex",
+        "other",
+    }

--- a/tests/unit/shared/test_execution_handler.py
+++ b/tests/unit/shared/test_execution_handler.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -23,6 +24,8 @@ from jentic_one.shared.jobs.protocols import (
     UpstreamExecRequest,
     UpstreamExecResult,
 )
+from jentic_one.shared.models.actors import Origin
+from jentic_one.shared.models.events import EventType
 
 
 class _FakeSession:
@@ -313,3 +316,58 @@ async def test_handler_rejects_missing_actor_fields() -> None:
 
     with pytest.raises(ValueError, match="created_by and actor_type are required"):
         await handler.execute("job7", _FakeSession(), payload=_payload())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "expected_type"),
+    [(200, EventType.EXECUTION_COMPLETED), (503, EventType.EXECUTION_FAILED)],
+)
+async def test_handler_tags_lifecycle_events_with_payload_origin(
+    status_code: int, expected_type: str
+) -> None:
+    """The origin persisted in the job payload rides both lifecycle events as a
+    closed-enum tag, so async executions split telemetry by surface like the
+    sync path (lane D, #1177)."""
+    executor = _RecordingExecutor(
+        UpstreamExecResult(status_code=status_code, body=b"", content_type=None, duration_ms=1)
+    )
+    handler = ExecutionHandler(executor=executor)
+
+    with patch(
+        "jentic_one.shared.jobs.execution_handler.emit_event", new_callable=AsyncMock
+    ) as mock_emit:
+        await handler.execute(
+            "job10",
+            _FakeSession(),
+            payload=_payload(origin="mcp"),
+            created_by="agt_abc123",
+            actor_type="agent",
+        )
+
+    mock_emit.assert_awaited_once()
+    kwargs = mock_emit.call_args.kwargs
+    assert kwargs["type"] == expected_type
+    assert kwargs["tags"] == {Origin.MCP}
+
+
+@pytest.mark.asyncio
+async def test_handler_missing_origin_emits_untagged_event() -> None:
+    """Payloads without an origin (or with garbage) emit untagged, never raise."""
+    executor = _RecordingExecutor(
+        UpstreamExecResult(status_code=200, body=b"", content_type=None, duration_ms=1)
+    )
+    handler = ExecutionHandler(executor=executor)
+
+    with patch(
+        "jentic_one.shared.jobs.execution_handler.emit_event", new_callable=AsyncMock
+    ) as mock_emit:
+        await handler.execute(
+            "job11",
+            _FakeSession(),
+            payload=_payload(),
+            created_by="agt_abc123",
+            actor_type="agent",
+        )
+
+    assert mock_emit.call_args.kwargs["tags"] is None

--- a/tests/unit/shared/test_origin.py
+++ b/tests/unit/shared/test_origin.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from jentic_one.shared.models.actors import Origin
+from jentic_one.shared.models.actors import Origin, origin_or_none
 from jentic_one.shared.web.deps import derive_origin
 
 
@@ -12,11 +12,13 @@ def test_origin_values() -> None:
     assert Origin.API.value == "api"
     assert Origin.AGENT.value == "agent"
     assert Origin.SYSTEM.value == "system"
+    assert Origin.MCP.value == "mcp"
 
 
 def test_origin_string_serialization() -> None:
     assert str(Origin.CLI) == "cli"
     assert str(Origin.DASHBOARD) == "dashboard"
+    assert str(Origin.MCP) == "mcp"
 
 
 def test_origin_all_members() -> None:
@@ -26,7 +28,35 @@ def test_origin_all_members() -> None:
         Origin.API,
         Origin.AGENT,
         Origin.SYSTEM,
+        Origin.MCP,
     }
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("mcp", Origin.MCP),
+        ("cli", Origin.CLI),
+        (None, None),
+        ("", None),
+        ("carrier-pigeon", None),
+    ],
+)
+def test_origin_or_none(value: str | None, expected: Origin | None) -> None:
+    """Persisted origin strings coerce back to the enum; garbage degrades to None."""
+    assert origin_or_none(value) is expected
+
+
+def test_derive_origin_mcp_prefix() -> None:
+    assert derive_origin("jentic-mcp/1.2.3") == Origin.MCP
+
+
+def test_derive_origin_mcp_prefix_with_client_info() -> None:
+    assert derive_origin("jentic-mcp/1.2.3 (cursor/0.42.0)") == Origin.MCP
+
+
+def test_derive_origin_mcp_prefix_case_insensitive() -> None:
+    assert derive_origin("Jentic-MCP/2.0.0") == Origin.MCP
 
 
 def test_derive_origin_cli_prefix() -> None:


### PR DESCRIPTION
## Summary

Lane D of the local-MCP theme (`themes/local-mcp/phase-2.md`): telemetry & events groundwork for the upcoming MCP transport.

- **`Origin.MCP`**: new enum member; `derive_origin` (shared) and the broker's origin derivation now map a `jentic-mcp/` User-Agent prefix to it. `execution_records.origin` already persists the value — no schema work.
- **Execution-event origin tag**: `EVENT_TAGS` values widened to tuples of allowed tag types (`_validate_tags`'s isinstance loop already handles tuples). `EXECUTION_FAILED` now allows `(ErrorSource, Origin)`, `EXECUTION_COMPLETED` allows `(Origin,)`; `Origin` added to the `EventTag` union. All three execution emit sites (broker sync path, broker streaming persist, async worker handler) tag lifecycle events with the request-derived origin via a new `origin_or_none` coercion helper (garbage/absent origins degrade to no tag, never an error).
- **`mcp.session_started`**: new `EventType` + `TelemetryEventName` + closed `McpClient` tag enum (`claude|cursor|codex|other`). Emitted once per session UUID on the first authenticated request carrying both the `X-Jentic-Session-Id` header **and** a `jentic-mcp/` User-Agent (the UA marks it MCP; plain CLI calls carry the header too). Internal event `data`: full parsed clientInfo (name/version from `jentic-mcp/<version> (<client>/<clientversion>)`, parenthetical optional → client `unknown`), `transport: "stdio"`, `session_id`; `actor_id`/`actor_type` = the authenticated agent. Telemetry wire carries only the closed `McpClient` tag.
- **Dedupe**: per-process bounded seen-set short-circuit backed by one indexed events-table lookup (`EventRepository.exists_with_data_value`, riding `ix_events_type_created` on the `type` predicate). Both planes emit (shared `resolve_identity` and broker `require_broker_identity`) and share the table-backed dedupe, so execute-only sessions are still counted exactly once.
- **`mcp.config_registered`**: `EventType` + `TelemetryEventName` + closed `McpConfigRuntime` tag enum (`claude_code|cursor|codex|generic`) landed.

### Emit-path decision for `mcp.config_registered` (reviewer input wanted)

The plan leaves open: a small authenticated report-registration endpoint the CLI calls (per-runtime fidelity) vs a server-side emit from an existing bootstrap call. **This PR lands only the enum/event entries and defers the emit wiring.** Recommendation: a dedicated `POST /events/mcp-config-registered`-style authenticated endpoint is the cleaner fit — config registration happens client-side in the CLI (`jentic mcp install`-type flows), so only the CLI knows which runtime's config file was actually written; a server-side emit from bootstrap would have to guess the runtime and would fire on re-bootstraps rather than registrations. That endpoint touches the Go CLI (out of scope for this lane) and deserves its own small PR alongside the CLI change, per the `web-layer` rule's one-concern-per-endpoint guidance.

### Consent & wire discipline

All new events ride `emit_event`'s existing consent gate — no MCP-specific consent plumbing. Telemetry wire stays property-free: closed enums only, raw client strings live only in the internal event `data`.

### Tests

- Tag-validation regression suite over every (event, allowed-tag-type) pair in the widened `EVENT_TAGS` map + an `event_tag_dropped` case pinning the fallback.
- Origin derivation (shared + broker), `origin_or_none` coercion, execution-lifecycle tagging in broker service and async worker.
- MCP UA parsing, session-ID validation, seen-set + table-backed dedupe, both-plane emit wiring.
- Integration test for `EventRepository.exists_with_data_value` (SQLite + Postgres backends).

`uv run pytest tests/unit tests/arch`, integration suite (both backends), `make lint`, `make detect-secrets`, mypy: all green. (`make check`'s `score` target needs a `JENTIC_API_KEY` not available locally; no OpenAPI surface changed.)

Closes #1177

Made with [Cursor](https://cursor.com)