### PR TITLE
refactor(cli): extract agentops from cmd for reuse

### DIFF
--- a/cli/internal/agentops/classify.go
+++ b/cli/internal/agentops/classify.go
@@ -1,0 +1,91 @@
+package agentops
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// IsBrokerDenial reports whether a result is one the broker itself emitted to
+// deny a call the agent can recover from: missing toolkit binding → 403,
+// ambiguous toolkit → 409, credential needs reconnect → 401, no credential →
+// 424. Each carries an agent_directive (see broker/web/errors.STATUS_BY_ERROR).
+//
+// Status alone is NOT sufficient: the broker is a transparent forward proxy, so
+// an *upstream* API can return these same 4xx codes on a call the broker
+// successfully proxied (the upstream auth failed, the resource is forbidden,
+// etc.). Treating those as broker denials would exit 2 and print a misleading
+// "recovery required" for a call that actually ran. The broker disambiguates
+// with the Jentic-Error-Origin response header (broker/core/headers): it stamps
+// "broker" on its own errors and "upstream" on mirrored pass-through 4xx/5xx
+// (broker/services/execution/pipeline.enrich_error_origin). So a denial-class
+// status is a broker denial only when the origin is not "upstream" (a missing
+// header is treated as broker, since the loopback broker always sets it on its
+// own errors and only a non-conformant proxy would omit it).
+func IsBrokerDenial(r *ExecuteResult) bool {
+	if r == nil {
+		return false
+	}
+	if errorOrigin(r) == errorOriginUpstream {
+		return false
+	}
+	switch r.Status {
+	case http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusConflict,
+		http.StatusFailedDependency:
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseAgentDirective extracts an agent_directive from a denial result's body.
+// It only treats recoverable broker-denial responses as directives so a normal
+// 4xx (including an upstream pass-through with an incidental
+// "agent_directive"-shaped body) can't trip the caller's exit code.
+func ParseAgentDirective(r *ExecuteResult) (ux.Directive, bool) {
+	if !IsBrokerDenial(r) {
+		return ux.Directive{}, false
+	}
+	var envelope struct {
+		Directive *ux.Directive `json:"agent_directive"`
+	}
+	if err := json.Unmarshal(r.Body, &envelope); err != nil || envelope.Directive == nil {
+		return ux.Directive{}, false
+	}
+	return *envelope.Directive, true
+}
+
+// Classify is the unfused classification step (response → denial-or-not) the
+// old executeOutput performed inline with printing: nil for every non-denial
+// result (2xx, upstream pass-through 4xx/5xx), else the Denial carrying the
+// denying status and the parsed directive (nil Directive when the body carried
+// none — the caller synthesizes a status-keyed recovery hint). The exit code
+// keys off the *status*, not the presence of an agent_directive: some denials
+// (e.g. action_denied from a permission rule) carry no directive, and gating
+// on a parsed directive would let those silently exit 0.
+func Classify(r *ExecuteResult) *Denial {
+	if !IsBrokerDenial(r) {
+		return nil
+	}
+	d := &Denial{Status: r.Status}
+	if directive, ok := ParseAgentDirective(r); ok {
+		d.Directive = &directive
+	}
+	return d
+}
+
+// errorOriginUpstream is the Jentic-Error-Origin value the broker stamps on a
+// mirrored upstream response (broker ErrorOrigin.UPSTREAM). The matching header
+// name mirrors broker/core/headers.JenticHeader.ERROR_ORIGIN.
+const errorOriginUpstream = "upstream"
+
+func errorOrigin(r *ExecuteResult) string {
+	if r == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(r.Headers.Get("Jentic-Error-Origin")))
+}

--- a/cli/internal/agentops/execute.go
+++ b/cli/internal/agentops/execute.go
@@ -1,0 +1,308 @@
+package agentops
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	sdkclient "github.com/jentic/jentic-one/cli/client"
+	"github.com/jentic/jentic-one/cli/client/auth"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// ErrInspectMissingFields reports an inspect document that resolved but carries
+// no usable method/url pair.
+var ErrInspectMissingFields = errors.New("inspect response missing method or url")
+
+// ParseMethodPath checks if target is in METHOD:/path format (a broker-relative
+// path, e.g. GET:/v1/pets). Returns the method and path if valid, or empty
+// strings if not in this format. A METHOD:URL absolute form (GET:https://…) is
+// deliberately NOT matched here — that is handled as an inspectable identifier.
+func ParseMethodPath(target string) (method, path string) {
+	idx := strings.IndexByte(target, ':')
+	if idx < 1 || idx >= len(target)-1 || target[idx+1] != '/' {
+		return "", ""
+	}
+	// Reject the scheme separator of an absolute URL (https://…): the char
+	// after ':' is '/', but it's followed by another '/'.
+	if idx+2 < len(target) && target[idx+2] == '/' {
+		return "", ""
+	}
+	m := strings.ToUpper(target[:idx])
+	switch m {
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodDelete, http.MethodHead, http.MethodOptions:
+		return m, target[idx+1:]
+	default:
+		return "", ""
+	}
+}
+
+// ResolveOperation resolves an execute target to its method and destination:
+// METHOD:/path short-circuits to a broker-relative Operation with no network
+// call; METHOD:URL (absolute) and opaque operation_ids resolve via the
+// Inspector, which returns the absolute upstream URL to send to. Failures are
+// coded RESOLVE_FAILED so the caller's exit taxonomy maps them to exit 2.
+func ResolveOperation(ctx context.Context, ins Inspector, target, revision string) (*Operation, error) {
+	if method, path := ParseMethodPath(target); method != "" {
+		return &Operation{Method: method, Path: path}, nil
+	}
+
+	inspectBody, err := ins.Inspect(ctx, target, revision, "json")
+	if err != nil {
+		var he *HTTPError
+		if errors.As(err, &he) && he.StatusCode == http.StatusNotFound {
+			// AGT-23: single-source the failure on stderr (the coded envelope
+			// below). No unversioned {error,status:0} on stdout.
+			return nil, &ux.CodedError{
+				Code:       ux.CodeResolveFailed,
+				Msg:        fmt.Sprintf("operation %q not found", target),
+				Actionable: "jentic search \"<what you want to do>\"",
+			}
+		}
+		// A non-404 inspect failure (transport, 5xx, malformed) still exits 2,
+		// but surface the cause so the agent isn't left with a bare exit code.
+		return nil, &ux.CodedError{
+			Code: ux.CodeResolveFailed,
+			Msg:  fmt.Sprintf("resolve %q failed: %v", target, err),
+		}
+	}
+
+	var op Operation
+	if err := json.Unmarshal(inspectBody, &op); err != nil {
+		return nil, fmt.Errorf("decode inspect response: %w", err)
+	}
+	if op.Method == "" || op.URL == "" {
+		return nil, ErrInspectMissingFields
+	}
+	return &op, nil
+}
+
+// BuildRequest assembles the outbound broker request from a resolved
+// ExecuteRequest: path-parameter substitution, query append, the broker
+// catch-all URL, the SEC-1 secure-transport guard, bearer/correlation/
+// idempotency headers. It does NOT send — the CLI's --dry-run/--export-plan
+// hook renders the built request and stops before firing.
+//
+// All traffic goes through the Jentic broker so the agent authenticates to
+// the broker with its own token (Authorization: Bearer) and the broker
+// injects the stored upstream credential. We never send the agent token to
+// the upstream API directly. The broker is addressed as a catch-all proxy:
+// {brokerScheme}://{brokerHost}/{upstreamURL} (mirroring the broker's
+// /{upstream_url:path} route).
+//
+//   - r.URL (absolute upstream URL, from inspect / METHOD:url) is prefixed
+//     with the broker host.
+//   - r.Path (broker-relative METHOD:/path) is sent to the broker host
+//     verbatim — the caller supplied the broker path themselves.
+func BuildRequest(ctx context.Context, r ExecuteRequest) (*http.Request, error) {
+	var upstream string
+	brokerRelative := r.URL == ""
+	if brokerRelative {
+		upstream = r.Path
+	} else {
+		upstream = r.URL
+	}
+	for _, kv := range r.PathParams {
+		upstream = strings.ReplaceAll(upstream, "{"+kv.Key+"}", url.PathEscape(kv.Value))
+	}
+
+	// Append query params to the upstream URL (before broker-wrapping).
+	if len(r.QueryParams) > 0 {
+		qv := url.Values{}
+		for _, kv := range r.QueryParams {
+			qv.Add(kv.Key, kv.Value)
+		}
+		sep := "?"
+		if strings.Contains(upstream, "?") {
+			sep = "&"
+		}
+		upstream += sep + qv.Encode()
+	}
+
+	var brokerURL string
+	if brokerRelative {
+		brokerURL = r.BrokerScheme + "://" + r.BrokerHost + upstream
+	} else {
+		brokerURL = r.BrokerScheme + "://" + r.BrokerHost + "/" + upstream
+	}
+
+	req, err := http.NewRequestWithContext(ctx, r.Method, brokerURL, r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	// Forward the agent bearer token to the broker.
+	// SEC-1: never send the bearer over plaintext to a non-loopback broker.
+	if err := auth.RequireSecureURL(brokerURL); err != nil {
+		return nil, &ux.CodedError{
+			Code:       ux.CodeTransportError,
+			Msg:        err.Error(),
+			Actionable: "Use an https broker URL, or a loopback (127.0.0.1/localhost) http broker for local installs.",
+		}
+	}
+	req.Header.Set("Authorization", "Bearer "+r.Token)
+
+	// Auto-set Content-Type for body requests.
+	hasContentType := false
+	for _, kv := range r.Headers {
+		if strings.EqualFold(strings.TrimSpace(kv.Key), "content-type") {
+			hasContentType = true
+			break
+		}
+	}
+	if r.Body != nil && !hasContentType {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Merge custom headers.
+	for _, kv := range r.Headers {
+		req.Header.Set(strings.TrimSpace(kv.Key), strings.TrimSpace(kv.Value))
+	}
+
+	// Correlation (P5.2, F8-6). execute builds a bare request outside the SDK
+	// editor chain, so the SDK's session/trace editors never run on this path —
+	// we attach the same headers here so a broker-side trace can be joined back
+	// to this invocation:
+	//   - X-Jentic-Session-Id groups every call of one agent run/batch (the
+	//     caller resolves and sanitizes it from the active context /
+	//     $JENTIC_SESSION_ID).
+	//   - traceparent is a fresh W3C trace context per execute so distributed
+	//     tracing correlates the broker span with this CLI call.
+	// A caller-provided header of the same name wins (already set above), so an
+	// orchestrator threading its own trace is never clobbered.
+	if r.SessionID != "" && req.Header.Get("X-Jentic-Session-Id") == "" {
+		req.Header.Set("X-Jentic-Session-Id", r.SessionID)
+	}
+	if req.Header.Get("traceparent") == "" {
+		if tp, ok := newTraceparent(); ok {
+			req.Header.Set("traceparent", tp)
+		}
+	}
+	// Idempotency (13 §4, F8-13). A caller-supplied key makes a retried POST/PUT
+	// de-duplicated by the broker AND flips the SDK transport's retry-safety for
+	// this request (it treats a key-carrying POST as replayable). Without it a
+	// plain POST is never retried, so transient 5xx/timeouts surface as failures.
+	if r.IdempotencyKey != "" && req.Header.Get("Idempotency-Key") == "" {
+		req.Header.Set("Idempotency-Key", r.IdempotencyKey)
+	}
+
+	return req, nil
+}
+
+// Do sends a built broker request through the SDK broker transport
+// (client.BrokerTransport) rather than a bare http.Client, so execute inherits
+// the same response policy (401 re-exchange, 429 Retry-After, bounded
+// 5xx/transport backoff — 13 §5) every generated broker call gets, while still
+// composing the broker catch-all URL itself to preserve its exact contract and
+// exit-2 denial handling. The 60s ceiling is carried on the base client the
+// policy decorates. The response body is read bounded (MaxBodyBytes) into the
+// returned ExecuteResult.
+func Do(req *http.Request) (*ExecuteResult, error) {
+	httpClient := sdkclient.BrokerTransport(sdkclient.Config{
+		HTTPClient: &http.Client{Timeout: 60 * time.Second},
+	})
+	// G704 (SSRF) is intentional, not a finding: dialing a caller-chosen broker
+	// target IS this function's contract. The URL is guarded upstream —
+	// BuildRequest enforces SEC-1 (no bearer over plaintext to a non-loopback
+	// host) and the CLI layer enforces the SEC-21 machine-mode broker pin and
+	// the remote-CP/loopback fail-closed guard before the request reaches here.
+	resp, err := httpClient.Do(req) //nolint:gosec // G704: see above — brokered execute exists to call the resolved target.
+	if err != nil {
+		// AGT-23: a failure is single-sourced on stderr as the coded envelope
+		// below. We deliberately do NOT also write an unversioned
+		// {error,status:0} to stdout — that double-signalled the same failure on
+		// two streams, and an agent parsing stdout would see a bogus "response".
+		coded := &ux.CodedError{
+			Code: ux.CodeTransportError,
+			Msg:  fmt.Sprintf("transport error: %v", err),
+		}
+		// UX-4: the classic local papercut is an https default resolving against a
+		// plain-http local broker ("server gave HTTP response to HTTPS client").
+		// Attach the exact recovery when the signature matches a loopback broker,
+		// so the operator isn't left with a bare, unactionable transport error.
+		if brokerTLSMismatch(err, req.URL.String()) {
+			coded.Actionable = "The broker resolved to https but is serving http. Set the environment's broker_url " +
+				"(`jentic env add <env> --broker-url http://127.0.0.1:8100 --force`), or override this call with " +
+				"`--broker-scheme http --broker-host 127.0.0.1:8100`."
+		}
+		return nil, coded
+	}
+	defer resp.Body.Close()
+
+	body, err := sdkclient.ReadAllBounded(resp.Body, sdkclient.MaxBodyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	return &ExecuteResult{
+		Status:      resp.StatusCode,
+		Headers:     resp.Header,
+		Body:        body,
+		ExecutionID: resp.Header.Get("Jentic-Execution-Id"),
+	}, nil
+}
+
+// Execute is the one-call UX-free core (ExecuteRequest → ExecuteResult):
+// BuildRequest + Do. The CLI drives the two phases itself so its --dry-run/
+// --export-plan hook can render the built request and stop; embedders with no
+// plan surface (the MCP handler) call this.
+func Execute(ctx context.Context, r ExecuteRequest) (*ExecuteResult, error) {
+	req, err := BuildRequest(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return Do(req)
+}
+
+// newTraceparent builds a fresh W3C Trace Context `traceparent` header value
+// (version-00): "00-<32 hex trace-id>-<16 hex span-id>-01" with the sampled flag
+// set. execute is the root of its own trace (it does not continue an inbound
+// one), so a new random trace/span id per call is correct. Returns ok=false only
+// if the crypto RNG fails, in which case the header is simply omitted.
+func newTraceparent() (string, bool) {
+	var traceID [16]byte
+	var spanID [8]byte
+	if _, err := rand.Read(traceID[:]); err != nil {
+		return "", false
+	}
+	if _, err := rand.Read(spanID[:]); err != nil {
+		return "", false
+	}
+	return fmt.Sprintf("00-%s-%s-01", hex.EncodeToString(traceID[:]), hex.EncodeToString(spanID[:])), true
+}
+
+// brokerTLSMismatch reports whether err is the "https client hit an http server"
+// signature against a loopback broker — the local default-scheme papercut UX-4
+// makes actionable. Restricted to loopback so we never suggest downgrading a
+// remote broker to plaintext.
+func brokerTLSMismatch(err error, brokerURL string) bool {
+	if err == nil || !strings.Contains(err.Error(), "server gave HTTP response to HTTPS client") {
+		return false
+	}
+	u, perr := url.Parse(brokerURL)
+	if perr != nil {
+		return false
+	}
+	return IsLoopbackHost(u.Hostname())
+}
+
+// IsLoopbackHost reports whether host is "localhost" or a loopback IP. It is
+// the single loopback classifier the execute path and the CLI's broker-target
+// guards share (the auth layer keeps its own private copy by design).
+func IsLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}

--- a/cli/internal/agentops/execute_test.go
+++ b/cli/internal/agentops/execute_test.go
@@ -1,0 +1,118 @@
+package agentops
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// The two tests below cover Do's dial-level transport branch — the one execute
+// branch no golden can pin (a real dial failure's error string embeds an
+// ephemeral port and OS-specific text, never byte-stable), so it is asserted
+// here by fields (PR #1179 review #1). Both use POST without an
+// Idempotency-Key so the broker transport's idempotent-retry backoff
+// (client/transport.go) gives the dial exactly one attempt instead of
+// sleeping through three.
+
+// TestDo_DialTLSMismatchAgainstLoopbackBroker pins the AGT-23/UX-4 half of the
+// branch: an https scheme dialed against a plain-HTTP loopback server
+// reproduces the exact local papercut signature ("server gave HTTP response to
+// HTTPS client"), which must map to a coded TRANSPORT_ERROR carrying the
+// loopback TLS-mismatch actionable — not a bare, unactionable error.
+func TestDo_DialTLSMismatchAgainstLoopbackBroker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	// srv serves plain HTTP on 127.0.0.1; dialing it with the https scheme
+	// (which passes SEC-1, so BuildRequest cannot short-circuit) forces the
+	// mismatch inside Do itself.
+	req, err := BuildRequest(context.Background(), ExecuteRequest{
+		Method:       http.MethodPost,
+		Path:         "/v1/pets",
+		BrokerScheme: "https",
+		BrokerHost:   srv.Listener.Addr().String(),
+		Token:        "tok_abc",
+	})
+	if err != nil {
+		t.Fatalf("BuildRequest: %v", err)
+	}
+
+	_, err = Do(req)
+	if err == nil {
+		t.Fatal("Do against an https→http mismatch must fail")
+	}
+	var coded *ux.CodedError
+	if !errors.As(err, &coded) {
+		t.Fatalf("Do returned %T (%v), want *ux.CodedError", err, err)
+	}
+	if coded.Code != ux.CodeTransportError {
+		t.Errorf("code = %q, want %q", coded.Code, ux.CodeTransportError)
+	}
+	if !strings.HasPrefix(coded.Msg, "transport error: ") {
+		t.Errorf("msg = %q, want the single-sourced \"transport error: …\" prefix (AGT-23)", coded.Msg)
+	}
+	// UX-4: the loopback mismatch must carry the exact recovery, not a bare
+	// transport error.
+	for _, want := range []string{
+		"resolved to https but is serving http",
+		"--broker-scheme http --broker-host 127.0.0.1:8100",
+		"jentic env add <env> --broker-url http://127.0.0.1:8100 --force",
+	} {
+		if !strings.Contains(coded.Actionable, want) {
+			t.Errorf("actionable %q missing %q (the UX-4 loopback TLS-mismatch recovery)", coded.Actionable, want)
+		}
+	}
+}
+
+// TestDo_DialClosedPortIsBareTransportError pins the other half of the branch:
+// a refused dial (closed loopback port) is a coded TRANSPORT_ERROR with NO
+// actionable — the TLS-mismatch recovery is reserved for its exact signature,
+// so we never suggest a scheme downgrade for an unrelated dial failure.
+func TestDo_DialClosedPortIsBareTransportError(t *testing.T) {
+	// Reserve a loopback port, then close the listener so the dial is refused.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	// Plain http to a loopback host passes SEC-1, so the failure happens at
+	// dial time inside Do.
+	req, err := BuildRequest(context.Background(), ExecuteRequest{
+		Method:       http.MethodPost,
+		Path:         "/v1/pets",
+		BrokerScheme: "http",
+		BrokerHost:   addr,
+		Token:        "tok_abc",
+	})
+	if err != nil {
+		t.Fatalf("BuildRequest: %v", err)
+	}
+
+	_, err = Do(req)
+	if err == nil {
+		t.Fatal("Do against a closed port must fail")
+	}
+	var coded *ux.CodedError
+	if !errors.As(err, &coded) {
+		t.Fatalf("Do returned %T (%v), want *ux.CodedError", err, err)
+	}
+	if coded.Code != ux.CodeTransportError {
+		t.Errorf("code = %q, want %q", coded.Code, ux.CodeTransportError)
+	}
+	if !strings.HasPrefix(coded.Msg, "transport error: ") {
+		t.Errorf("msg = %q, want the single-sourced \"transport error: …\" prefix (AGT-23)", coded.Msg)
+	}
+	if coded.Actionable != "" {
+		t.Errorf("actionable = %q, want empty — a plain refused dial is not the TLS-mismatch papercut", coded.Actionable)
+	}
+}

--- a/cli/internal/agentops/types.go
+++ b/cli/internal/agentops/types.go
@@ -1,0 +1,206 @@
+// Package agentops is the UX-free execute/inspect core shared by the `jentic`
+// command tree and future embedders (the local MCP server, phase 1 of the
+// local-MCP plan). It owns the resolve → build → send → classify lifecycle of a
+// brokered call, lifted out of the cobra layer.
+//
+// Dependency rules (phase-0 §0.2, deliberate and load-bearing):
+//   - agentops receives token strings and a RESOLVED broker target. Token
+//     acquisition (sessions, credential resolution) and broker-target
+//     precedence (flag reading, environment broker_url, SEC-21 pinning,
+//     fail-closed guards) stay caller-side.
+//   - Control-plane resolve/inspect calls go through the narrow Inspector
+//     seam, never the whole generated client surface.
+//   - No io.Writer output, no cobra, no exit-code mapping, no TTY detection,
+//     no stdin. Errors are *ux.CodedError values carrying the closed-enum
+//     machine contract; the exit taxonomy stays in ux/contract.go.
+package agentops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// Inspector is the narrow control-plane seam agentops needs: the raw inspect
+// call returning the FULL inspect document (JSON/Markdown/OpenAPI negotiated by
+// format), not just the {method,url} projection ResolveOperation reads from it.
+// The raw form is deliberate: the MCP inspect_operation tool needs the whole
+// body, and `jentic inspect` delegates through the same seam. The api layer's
+// generated-SDK wrapper satisfies it; token acquisition happens behind the
+// implementation, never here.
+type Inspector interface {
+	// Inspect resolves an operation (opaque id or METHOD:url) to its full
+	// structural document. format is one of "json", "markdown", or "openapi";
+	// revision optionally pins a revision ID. A non-2xx backend response
+	// surfaces as *HTTPError.
+	Inspect(ctx context.Context, target, revision, format string) ([]byte, error)
+}
+
+// Operation holds the resolved HTTP method and target for an operation. URL is
+// an absolute upstream URL (from inspect or a METHOD:URL target); Path is a
+// broker-relative path (from a METHOD:/path target). Exactly one of URL or
+// Path is set.
+type Operation struct {
+	Method string `json:"method"`
+	URL    string `json:"url"`
+	Path   string `json:"-"`
+}
+
+// KV is one parsed key=value pair (path parameter, query parameter, or
+// header). The caller owns the flag-syntax parsing — under MCP the parameters
+// arrive structured, so the key=value CLI surface never reaches this package.
+// A slice (not a map) preserves the caller's ordering semantics exactly: path
+// substitution applies pairs in order (a repeated key is a no-op after the
+// first replaced every placeholder), and repeated query keys accumulate.
+type KV struct {
+	Key   string
+	Value string
+}
+
+// ExecuteRequest is the UX-free input to BuildRequest/Execute: a resolved
+// operation, the request surface (params/headers/body), the RESOLVED broker
+// target, and the caller's credentials/correlation strings. No flag state, no
+// session objects.
+type ExecuteRequest struct {
+	// Method is the HTTP method of the resolved operation.
+	Method string
+	// URL is the absolute upstream URL to route through the broker. Exactly one
+	// of URL or Path is set (mirroring Operation).
+	URL string
+	// Path is a broker-relative path sent to the broker host verbatim.
+	Path string
+
+	// PathParams substitute {key} placeholders in the upstream target
+	// (percent-escaped, in order).
+	PathParams []KV
+	// QueryParams are appended to the upstream target before broker-wrapping.
+	QueryParams []KV
+	// Headers are extra request headers, applied after the automatic ones so a
+	// caller-supplied header always wins.
+	Headers []KV
+	// Body is the request body reader, or nil for a bodyless request (nil vs a
+	// reader — even an empty one — gates the automatic Content-Type, matching
+	// the historical behavior). The stdin fallback and --data/--data-file
+	// reading stay caller-side (under stdio MCP, stdin is the JSON-RPC wire).
+	Body io.Reader
+
+	// BrokerScheme/BrokerHost are the RESOLVED broker target — precedence
+	// (defaults < environment broker_url < flags) has already run caller-side.
+	BrokerScheme string
+	BrokerHost   string
+
+	// Token is the agent bearer forwarded to the broker (never to the upstream).
+	Token string
+	// SessionID, when set, is stamped as X-Jentic-Session-Id (already sanitized
+	// by the caller). Correlation is best-effort and never blocks a call.
+	SessionID string
+	// IdempotencyKey, when set, is stamped as Idempotency-Key so a retried
+	// POST/PUT is de-duplicated by the broker and treated as replayable by the
+	// SDK transport's retry policy.
+	IdempotencyKey string
+}
+
+// ExecuteResult is the UX-free outcome of a brokered call: the relayed status,
+// the full response headers, the bounded-read body, and the broker's execution
+// id. Rendering (envelope vs pretty vs raw) and exit-code mapping happen
+// caller-side; classification lives in classify.go.
+type ExecuteResult struct {
+	Status      int
+	Headers     http.Header
+	Body        []byte
+	ExecutionID string
+}
+
+// Envelope projects the result onto the shared success envelope
+// (ux.ExecuteEnvelope, schema version stamped): single-value headers, the body
+// parsed as JSON when it decodes (else the raw string).
+func (r *ExecuteResult) Envelope() ux.ExecuteEnvelope {
+	headers := make(map[string]string, len(r.Headers))
+	for k := range r.Headers {
+		headers[k] = r.Headers.Get(k)
+	}
+	var parsedBody any
+	if err := json.Unmarshal(r.Body, &parsedBody); err != nil {
+		parsedBody = string(r.Body)
+	}
+	return ux.NewExecuteEnvelope(r.Status, headers, parsedBody, r.ExecutionID)
+}
+
+// Denial is the classification of a broker-denied call (classify.go): the
+// denying HTTP status plus the recovery directive when the body carried one.
+type Denial struct {
+	Status int
+	// Directive is the parsed agent_directive, or nil when the denial carried
+	// none (the caller synthesizes a status-keyed recovery hint instead).
+	Directive *ux.Directive
+}
+
+// Err returns the typed denial every broker-denial exit shares (AGT-6):
+// BROKER_DENIED with the denying HTTP status in Details, so the agent envelope
+// and the exit code come from the same table. The recovery directive is
+// rendered by the caller before this is returned.
+func (d *Denial) Err() *ux.CodedError {
+	return &ux.CodedError{
+		Code:    ux.CodeBrokerDenied,
+		Msg:     "the broker denied this call before it reached the upstream API",
+		Details: map[string]any{"http_status": d.Status},
+	}
+}
+
+// HTTPError is a non-2xx control-plane response from the Inspector seam. It
+// mirrors the shape the hand-written httpx.HTTPError offered — StatusCode plus
+// the raw problem-details body — so error-mapping logic ports unchanged. The
+// api command tree aliases it (api.HTTPError) so its call sites are untouched.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("http %d: %s", e.StatusCode, e.Detail())
+}
+
+// Detail extracts an RFC 9457 problem-details message, preferring the most
+// specific key (matching the old httpx.HTTPError.Detail order exactly).
+func (e *HTTPError) Detail() string {
+	p := e.Fields()
+	for _, k := range []string{"detail", "title", "error_description", "error"} {
+		if v, ok := p[k].(string); ok && v != "" {
+			return v
+		}
+	}
+	return e.Body
+}
+
+// Fields decodes the problem-details body into a map so callers can read
+// extension members. Returns an empty map when the body is not a JSON object.
+func (e *HTTPError) Fields() map[string]any {
+	var p map[string]any
+	if json.Unmarshal([]byte(e.Body), &p) == nil {
+		return p
+	}
+	return map[string]any{}
+}
+
+// ParseKVs parses raw key=value strings (the CLI's --path/--query/--header
+// value syntax) into KV pairs. Both halves are kept VERBATIM — the header path
+// trims whitespace at application time (BuildRequest), path/query never did —
+// so the split is pure syntax. badKV builds the caller's typed error for a
+// malformed pair (the CLI keeps its coded MISSING_ARGUMENT with the flag name;
+// other callers supply their own), so input-shape errors stay caller-owned.
+func ParseKVs(raw []string, badKV func(value string) error) ([]KV, error) {
+	out := make([]KV, 0, len(raw))
+	for _, kv := range raw {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			return nil, badKV(kv)
+		}
+		out = append(out, KV{Key: k, Value: v})
+	}
+	return out, nil
+}

--- a/cli/internal/cli/api/errors.go
+++ b/cli/internal/cli/api/errors.go
@@ -1,12 +1,11 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/jentic/jentic-one/cli/client/auth"
+	"github.com/jentic/jentic-one/cli/internal/agentops"
 	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 )
@@ -88,40 +87,16 @@ type httpResponse interface {
 	GetBody() []byte
 }
 
-// HTTPError is a non-2xx control-plane response. It mirrors the shape the
-// hand-written httpx.HTTPError offered — StatusCode plus the raw problem-details
-// body — so existing error-mapping logic ports unchanged. (Named HTTPError, not
-// APIError, so it does not stutter as api.APIError — revive `exported`.)
-type HTTPError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *HTTPError) Error() string {
-	return fmt.Sprintf("http %d: %s", e.StatusCode, e.Detail())
-}
-
-// Detail extracts an RFC 9457 problem-details message, preferring the most
-// specific key (matching the old httpx.HTTPError.Detail order exactly).
-func (e *HTTPError) Detail() string {
-	p := e.Fields()
-	for _, k := range []string{"detail", "title", "error_description", "error"} {
-		if v, ok := p[k].(string); ok && v != "" {
-			return v
-		}
-	}
-	return e.Body
-}
-
-// Fields decodes the problem-details body into a map so callers can read
-// extension members. Returns an empty map when the body is not a JSON object.
-func (e *HTTPError) Fields() map[string]any {
-	var p map[string]any
-	if json.Unmarshal([]byte(e.Body), &p) == nil {
-		return p
-	}
-	return map[string]any{}
-}
+// HTTPError is a non-2xx control-plane response. The type moved to the UX-free
+// core with the Inspector seam (plan 0.2) — agentops.ResolveOperation maps a
+// 404 from the same error type this package's per-command mappers read — and is
+// aliased here so every existing call site (apiErrorFor constructions, the
+// errors.As targets in apisListErr/apiActionErr/catalogListErr/…) is untouched.
+// It mirrors the shape the hand-written httpx.HTTPError offered — StatusCode
+// plus the raw problem-details body (Detail()/Fields()) — so error-mapping
+// logic ported unchanged. (Named HTTPError, not APIError, so it does not
+// stutter as api.APIError — revive `exported`.)
+type HTTPError = agentops.HTTPError
 
 // apiErrorFor is the single check every migrated call site makes after a
 // `...WithResponse` call. `transportErr` is the error the SDK method returned

--- a/cli/internal/cli/api/execute.go
+++ b/cli/internal/cli/api/execute.go
@@ -2,46 +2,34 @@ package api
 
 import (
 	"bytes"
-	"crypto/rand"
-	"encoding/hex"
-	"encoding/json"
-	"errors"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/charmbracelet/x/term"
 	sdkclient "github.com/jentic/jentic-one/cli/client"
-	"github.com/jentic/jentic-one/cli/client/auth"
+	"github.com/jentic/jentic-one/cli/internal/agentops"
 	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 	"github.com/jentic/jentic-one/cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
-var errInspectMissingFields = errors.New("inspect response missing method or url")
-
 // apiEnvelopeSchemaVersion pins the machine-contract version of the ad-hoc JSON
-// envelopes this package emits that are NOT a ux wrapper (the execute success
-// map and the catalog import maps). Their bodies are arbitrary upstream/job data
-// so they can't reuse ux.List/Result, but they must still carry schema_version
-// like every sanctioned envelope (AGT-23). Mirrors ux.currentSchemaVersion; bump
-// in lockstep with the ux envelope contract.
+// envelopes this package emits that are NOT a ux wrapper (the catalog import
+// maps; the execute success envelope moved to the shared ux.ExecuteEnvelope,
+// which stamps the same version). Their bodies are arbitrary job data so they
+// can't reuse ux.List/Result, but they must still carry schema_version like
+// every sanctioned envelope (AGT-23). Mirrors ux.currentSchemaVersion; bump in
+// lockstep with the ux envelope contract.
 const apiEnvelopeSchemaVersion = "1"
 
-// operationInfo holds the resolved HTTP method and target for an operation.
-// URL is an absolute upstream URL (from inspect or a METHOD:URL target); Path
-// is a broker-relative path (from a METHOD:/path target). Exactly one of URL or
-// Path is set.
-type operationInfo struct {
-	Method string `json:"method"`
-	URL    string `json:"url"`
-	Path   string `json:"-"`
-}
+// operationInfo — the resolved {method, url|path} pair — moved to the UX-free
+// core as agentops.Operation (plan 0.2); resolveOperation below returns it.
 
 type executeOptions struct {
 	pathParams     []string
@@ -210,65 +198,24 @@ func (a *app) executeE(cmd *cobra.Command, opts *executeOptions, target string) 
 
 	// Resolve phase: determine method and path either from METHOD:/path syntax
 	// or by inspecting an operation_id.
-	opInfo, err := a.resolveOperation(cmd, opts, target)
+	opInfo, err := a.resolveOperation(cmd.Context(), target, opts.revision)
 	if err != nil {
 		return err
 	}
 
-	// Build phase: assemble the upstream URL (path params + query), then route
-	// it through the broker.
-	//
-	// All traffic goes through the Jentic broker so the agent authenticates to
-	// the broker with its own token (Authorization: Bearer) and the broker
-	// injects the stored upstream credential. We never send the agent token to
-	// the upstream API directly. The broker is addressed as a catch-all proxy:
-	// {brokerScheme}://{brokerHost}/{upstreamURL}  (mirrors the run-proxy rewrite
-	// in internal/proxy and the broker's /{upstream_url:path} route).
-	//
-	//   - opInfo.URL  (absolute upstream URL, from inspect / METHOD:url) is
-	//     prefixed with the broker host.
-	//   - opInfo.Path (broker-relative METHOD:/path) is sent to the broker host
-	//     verbatim — the caller supplied the broker path themselves.
-	var upstream string
-	brokerRelative := opInfo.URL == ""
-	if brokerRelative {
-		upstream = opInfo.Path
-	} else {
-		upstream = opInfo.URL
+	// Parse the key=value flag surfaces (ARCH-4 coded errors stay here — the
+	// flag syntax is a CLI concern; agentops receives structured pairs).
+	pathParams, err := agentops.ParseKVs(opts.pathParams, func(v string) error { return badFlagKV("--path", v) })
+	if err != nil {
+		return err
 	}
-	for _, kv := range opts.pathParams {
-		k, v, ok := strings.Cut(kv, "=")
-		if !ok {
-			return badFlagKV("--path", kv)
-		}
-		upstream = strings.ReplaceAll(upstream, "{"+k+"}", url.PathEscape(v))
+	queryParams, err := agentops.ParseKVs(opts.queryParams, func(v string) error { return badFlagKV("--query", v) })
+	if err != nil {
+		return err
 	}
 
-	// Append query params to the upstream URL (before broker-wrapping).
-	if len(opts.queryParams) > 0 {
-		qv := url.Values{}
-		for _, kv := range opts.queryParams {
-			k, v, ok := strings.Cut(kv, "=")
-			if !ok {
-				return badFlagKV("--query", kv)
-			}
-			qv.Add(k, v)
-		}
-		sep := "?"
-		if strings.Contains(upstream, "?") {
-			sep = "&"
-		}
-		upstream += sep + qv.Encode()
-	}
-
-	var brokerURL string
-	if brokerRelative {
-		brokerURL = opts.brokerScheme + "://" + opts.brokerHost + upstream
-	} else {
-		brokerURL = opts.brokerScheme + "://" + opts.brokerHost + "/" + upstream
-	}
-
-	// Resolve request body.
+	// Resolve request body (cobra-side by design: the stdin fallback must never
+	// move into agentops — under stdio MCP, stdin is the JSON-RPC wire).
 	var body io.Reader
 	switch {
 	case opts.data == "-" || (opts.data == "" && opts.dataFile == "" && !term.IsTerminal(os.Stdin.Fd())):
@@ -289,114 +236,51 @@ func (a *app) executeE(cmd *cobra.Command, opts *executeOptions, target string) 
 		body = strings.NewReader(opts.data)
 	}
 
-	// Build HTTP request.
-	req, err := http.NewRequestWithContext(cmd.Context(), opInfo.Method, brokerURL, body)
+	headers, err := agentops.ParseKVs(opts.headers, func(v string) error { return badFlagKV("--header", v) })
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
+		return err
 	}
 
-	// Forward the agent bearer token to the broker.
-	// SEC-1: never send the bearer over plaintext to a non-loopback broker.
-	if err := auth.RequireSecureURL(brokerURL); err != nil {
-		return &ux.CodedError{
-			Code:       ux.CodeTransportError,
-			Msg:        err.Error(),
-			Actionable: "Use an https broker URL, or a loopback (127.0.0.1/localhost) http broker for local installs.",
-		}
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	// Auto-set Content-Type for body requests.
-	hasContentType := false
-	for _, kv := range opts.headers {
-		k, _, ok := strings.Cut(kv, "=")
-		if ok && strings.EqualFold(strings.TrimSpace(k), "content-type") {
-			hasContentType = true
-			break
-		}
-	}
-	if body != nil && !hasContentType {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	// Merge custom headers.
-	for _, kv := range opts.headers {
-		k, v, ok := strings.Cut(kv, "=")
-		if !ok {
-			return badFlagKV("--header", kv)
-		}
-		req.Header.Set(strings.TrimSpace(k), strings.TrimSpace(v))
-	}
-
-	// Correlation (P5.2, F8-6). execute builds a bare request outside the SDK
-	// editor chain, so the SDK's session/trace editors never run on this path —
-	// we attach the same headers here so a broker-side trace can be joined back
-	// to this invocation:
-	//   - X-Jentic-Session-Id groups every call of one agent run/batch (the SDK
-	//     Config.SessionID, sourced from the active context / $JENTIC_SESSION_ID).
-	//   - traceparent is a fresh W3C trace context per execute so distributed
-	//     tracing correlates the broker span with this CLI call.
-	// A user-provided --header of the same name wins (already set above), so an
-	// orchestrator threading its own trace is never clobbered.
-	if sid := sessionIDFromContext(cmd); sid != "" && req.Header.Get("X-Jentic-Session-Id") == "" {
-		req.Header.Set("X-Jentic-Session-Id", sid)
-	}
-	if req.Header.Get("traceparent") == "" {
-		if tp, ok := newTraceparent(); ok {
-			req.Header.Set("traceparent", tp)
-		}
-	}
-	// Idempotency (13 §4, F8-13). A caller-supplied key makes a retried POST/PUT
-	// de-duplicated by the broker AND flips the SDK transport's retry-safety for
-	// this request (it treats a key-carrying POST as replayable). Without it a
-	// plain POST is never retried, so transient 5xx/timeouts surface as failures.
-	if opts.idempotencyKey != "" && req.Header.Get("Idempotency-Key") == "" {
-		req.Header.Set("Idempotency-Key", opts.idempotencyKey)
+	// Build phase (agentops.BuildRequest): path-param substitution, query
+	// append, the broker catch-all URL, SEC-1 secure-transport guard, bearer/
+	// correlation/idempotency headers. The two-phase drive (Build, then Do)
+	// exists so --dry-run/--export-plan below can render the built request and
+	// stop before firing.
+	req, err := agentops.BuildRequest(cmd.Context(), agentops.ExecuteRequest{
+		Method:         opInfo.Method,
+		URL:            opInfo.URL,
+		Path:           opInfo.Path,
+		PathParams:     pathParams,
+		QueryParams:    queryParams,
+		Headers:        headers,
+		Body:           body,
+		BrokerScheme:   opts.brokerScheme,
+		BrokerHost:     opts.brokerHost,
+		Token:          token,
+		SessionID:      sessionIDFromContext(cmd),
+		IdempotencyKey: opts.idempotencyKey,
+	})
+	if err != nil {
+		return err
 	}
 
 	// Dry-run / plan (impl/5.0 §5, F8-15). execute is a mutating (side-effecting)
 	// call, so it honors --dry-run/--export-plan: render the fully-resolved
 	// request that WOULD be sent — method, broker-wrapped URL, and the correlation
-	// headers we just attached — and STOP before firing. The operation name
+	// headers agentops just attached — and STOP before firing. The operation name
 	// mirrors the effect ("brokerExecute"); the plan-parity test keeps it honest.
 	if maybeEmitPlan(cmd, "brokerExecute", executePlanPayload(req)) {
 		return nil
 	}
 
-	// Send phase. Route through the SDK broker transport (client.BrokerTransport)
-	// rather than a bare http.Client so execute inherits the same response policy
-	// (401 re-exchange, 429 Retry-After, bounded 5xx/transport backoff — 13 §5)
-	// every generated broker call gets, while still composing the broker
-	// catch-all URL itself to preserve its exact contract and exit-2 denial
-	// handling (plan.md Phase 5 item 1). The 60s ceiling is carried on the base
-	// client the policy decorates.
-	httpClient := sdkclient.BrokerTransport(sdkclient.Config{
-		HTTPClient: &http.Client{Timeout: 60 * time.Second},
-	})
-	resp, err := httpClient.Do(req)
+	// Send phase (agentops.Do): the SDK broker transport with its response
+	// policy, and a bounded body read into the UX-free result.
+	result, err := agentops.Do(req)
 	if err != nil {
-		// AGT-23: a failure is single-sourced on stderr as the coded envelope
-		// below. We deliberately do NOT also write an unversioned
-		// {error,status:0} to stdout — that double-signalled the same failure on
-		// two streams, and an agent parsing stdout would see a bogus "response".
-		coded := &ux.CodedError{
-			Code: ux.CodeTransportError,
-			Msg:  fmt.Sprintf("transport error: %v", err),
-		}
-		// UX-4: the classic local papercut is an https default resolving against a
-		// plain-http local broker ("server gave HTTP response to HTTPS client").
-		// Attach the exact recovery when the signature matches a loopback broker,
-		// so the operator isn't left with a bare, unactionable transport error.
-		if brokerTLSMismatch(err, brokerURL) {
-			coded.Actionable = "The broker resolved to https but is serving http. Set the environment's broker_url " +
-				"(`jentic env add <env> --broker-url http://127.0.0.1:8100 --force`), or override this call with " +
-				"`--broker-scheme http --broker-host 127.0.0.1:8100`."
-		}
-		return coded
+		return err
 	}
-	defer resp.Body.Close()
 
-	return a.executeOutput(cmd, opts, resp)
+	return a.executeOutput(cmd, opts, result)
 }
 
 // badFlagKV builds the coded error for a malformed key=value flag (ARCH-4). A
@@ -451,84 +335,29 @@ func sessionIDFromContext(cmd *cobra.Command) string {
 	return sdkclient.SanitizeSessionID(os.Getenv("JENTIC_SESSION_ID"))
 }
 
-// newTraceparent builds a fresh W3C Trace Context `traceparent` header value
-// (version-00): "00-<32 hex trace-id>-<16 hex span-id>-01" with the sampled flag
-// set. execute is the root of its own trace (it does not continue an inbound
-// one), so a new random trace/span id per call is correct. Returns ok=false only
-// if the crypto RNG fails, in which case the header is simply omitted.
-func newTraceparent() (string, bool) {
-	var traceID [16]byte
-	var spanID [8]byte
-	if _, err := rand.Read(traceID[:]); err != nil {
-		return "", false
-	}
-	if _, err := rand.Read(spanID[:]); err != nil {
-		return "", false
-	}
-	return fmt.Sprintf("00-%s-%s-01", hex.EncodeToString(traceID[:]), hex.EncodeToString(spanID[:])), true
-}
-
-// parseMethodPath checks if target is in METHOD:/path format (a broker-relative
-// path, e.g. GET:/v1/pets). Returns the method and path if valid, or empty
-// strings if not in this format. A METHOD:URL absolute form (GET:https://…) is
-// deliberately NOT matched here — that is handled as an inspectable identifier.
+// parseMethodPath reports whether target is in METHOD:/path form (a broker-
+// relative path). Thin shim over the extracted core (agentops.ParseMethodPath)
+// so the CLI-side call sites and tests keep their name.
 func parseMethodPath(target string) (method, path string) {
-	idx := strings.IndexByte(target, ':')
-	if idx < 1 || idx >= len(target)-1 || target[idx+1] != '/' {
-		return "", ""
-	}
-	// Reject the scheme separator of an absolute URL (https://…): the char
-	// after ':' is '/', but it's followed by another '/'.
-	if idx+2 < len(target) && target[idx+2] == '/' {
-		return "", ""
-	}
-	m := strings.ToUpper(target[:idx])
-	switch m {
-	case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS":
-		return m, target[idx+1:]
-	default:
-		return "", ""
-	}
+	return agentops.ParseMethodPath(target)
 }
 
-func (a *app) resolveOperation(cmd *cobra.Command, opts *executeOptions, target string) (*operationInfo, error) {
+// resolveOperation resolves an execute target to its method and destination.
+// It is deliberately cobra-free (plan 0.2): METHOD:/path short-circuits with no
+// network call (and no session resolution — constructing the control client
+// first would fail invocations that never need it), everything else resolves
+// through the agentops core over the apiClient Inspector seam.
+func (a *app) resolveOperation(ctx context.Context, target, revision string) (*agentops.Operation, error) {
 	// METHOD:/path → broker-relative direct send (uses --broker-host/scheme).
 	if method, path := parseMethodPath(target); method != "" {
-		return &operationInfo{Method: method, Path: path}, nil
+		return &agentops.Operation{Method: method, Path: path}, nil
 	}
 
 	// METHOD URL / METHOD:URL (absolute) and opaque operation_id both resolve
 	// via inspect, which returns the absolute upstream URL to send to.
-	client, err := a.apisSession(cmd.Context())
+	client, err := a.apisSession(ctx)
 	if err != nil {
 		return nil, err
 	}
-	inspectBody, err := client.Inspect(cmd.Context(), target, opts.revision, "json")
-	if err != nil {
-		var he *HTTPError
-		if errors.As(err, &he) && he.StatusCode == http.StatusNotFound {
-			// AGT-23: single-source the failure on stderr (the coded envelope
-			// below). No unversioned {error,status:0} on stdout.
-			return nil, &ux.CodedError{
-				Code:       ux.CodeResolveFailed,
-				Msg:        fmt.Sprintf("operation %q not found", target),
-				Actionable: "jentic search \"<what you want to do>\"",
-			}
-		}
-		// A non-404 inspect failure (transport, 5xx, malformed) still exits 2,
-		// but surface the cause so the agent isn't left with a bare exit code.
-		return nil, &ux.CodedError{
-			Code: ux.CodeResolveFailed,
-			Msg:  fmt.Sprintf("resolve %q failed: %v", target, err),
-		}
-	}
-
-	var opInfo operationInfo
-	if err := json.Unmarshal(inspectBody, &opInfo); err != nil {
-		return nil, fmt.Errorf("decode inspect response: %w", err)
-	}
-	if opInfo.Method == "" || opInfo.URL == "" {
-		return nil, errInspectMissingFields
-	}
-	return &opInfo, nil
+	return agentops.ResolveOperation(ctx, client, target, revision)
 }

--- a/cli/internal/cli/api/execute.go
+++ b/cli/internal/cli/api/execute.go
@@ -169,9 +169,9 @@ func (a *app) executeE(cmd *cobra.Command, opts *executeOptions, target string) 
 	// install and never configured a broker. Silently dialing 127.0.0.1 would
 	// leak the agent bearer + injected upstream context at the caller's own
 	// loopback and fail with a confusing connection-refused. Refuse with a
-	// recovery directive instead. Keyed off loopback-ness (reusing the auth
-	// layer's classifier via isLoopbackHostname), so a genuinely-local workflow
-	// (loopback base_url, seeded loopback broker) never trips it.
+	// recovery directive instead. Keyed off loopback-ness (reusing the execute
+	// core's classifier via agentops.IsLoopbackHost), so a genuinely-local
+	// workflow (loopback base_url, seeded loopback broker) never trips it.
 	//
 	// M1 (review round-3 #3): only fire when the loopback broker is the built-in
 	// DEFAULT, not an EXPLICIT operator choice. An operator running

--- a/cli/internal/cli/api/execute_broker.go
+++ b/cli/internal/cli/api/execute_broker.go
@@ -2,38 +2,17 @@ package api
 
 import (
 	"net"
-	"net/http"
 	"net/url"
-	"strings"
 
-	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+	"github.com/jentic/jentic-one/cli/internal/agentops"
 )
 
-// brokerTLSMismatch reports whether err is the "https client hit an http server"
-// signature against a loopback broker — the local default-scheme papercut UX-4
-// makes actionable. Restricted to loopback so we never suggest downgrading a
-// remote broker to plaintext.
-func brokerTLSMismatch(err error, brokerURL string) bool {
-	if err == nil || !strings.Contains(err.Error(), "server gave HTTP response to HTTPS client") {
-		return false
-	}
-	u, perr := url.Parse(brokerURL)
-	if perr != nil {
-		return false
-	}
-	return isLoopbackHostname(u.Hostname())
-}
-
-// isLoopbackHostname reports whether host is "localhost" or a loopback IP.
-func isLoopbackHostname(host string) bool {
-	if host == "localhost" {
-		return true
-	}
-	if ip := net.ParseIP(host); ip != nil {
-		return ip.IsLoopback()
-	}
-	return false
-}
+// Denial classification (isBrokerDenial / the Jentic-Error-Origin
+// disambiguation) and the TLS-mismatch papercut detection moved to the UX-free
+// core: agentops.Classify / agentops.IsBrokerDenial (classify.go) and the
+// transport-error mapping inside agentops.Do. What remains here are the
+// broker-TARGET guards — they read flag/environment state, so they are
+// cobra-side by design (plan 0.2).
 
 // brokerIsLoopbackDefault reports whether hostPort (host or host:port) is a
 // loopback target — the built-in default the fail-closed guard must catch. An
@@ -48,7 +27,7 @@ func brokerIsLoopbackDefault(hostPort string) bool {
 	if h, _, err := net.SplitHostPort(hostPort); err == nil {
 		host = h
 	}
-	return isLoopbackHostname(host)
+	return agentops.IsLoopbackHost(host)
 }
 
 // baseURLIsRemote reports whether the control-plane base_url points at a
@@ -63,63 +42,5 @@ func baseURLIsRemote(base string) bool {
 	if err != nil || u.Hostname() == "" {
 		return false
 	}
-	return !isLoopbackHostname(u.Hostname())
-}
-
-// brokerDeniedErr is the typed denial every broker-denial exit shares (AGT-6):
-// BROKER_DENIED (exit 2) with the denying HTTP status in Details, so the agent
-// envelope and the exit code come from the same table. The response body /
-// directive recovery text is printed by the caller before this is returned.
-func brokerDeniedErr(resp *http.Response) *ux.CodedError {
-	return &ux.CodedError{
-		Code:    ux.CodeBrokerDenied,
-		Msg:     "the broker denied this call before it reached the upstream API",
-		Details: map[string]any{"http_status": resp.StatusCode},
-	}
-}
-
-// isBrokerDenial reports whether a response is one the broker itself emitted to
-// deny a call the agent can recover from: missing toolkit binding → 403,
-// ambiguous toolkit → 409, credential needs reconnect → 401, no credential →
-// 424. Each carries an agent_directive (see broker/web/errors.STATUS_BY_ERROR).
-//
-// Status alone is NOT sufficient: the broker is a transparent forward proxy, so
-// an *upstream* API can return these same 4xx codes on a call the broker
-// successfully proxied (the upstream auth failed, the resource is forbidden,
-// etc.). Treating those as broker denials would exit 2 and print a misleading
-// "recovery required" for a call that actually ran. The broker disambiguates
-// with the Jentic-Error-Origin response header (broker/core/headers): it stamps
-// "broker" on its own errors and "upstream" on mirrored pass-through 4xx/5xx
-// (broker/services/execution/pipeline.enrich_error_origin). So a denial-class
-// status is a broker denial only when the origin is not "upstream" (a missing
-// header is treated as broker, since the loopback broker always sets it on its
-// own errors and only a non-conformant proxy would omit it).
-func isBrokerDenial(resp *http.Response) bool {
-	if resp == nil {
-		return false
-	}
-	if errorOrigin(resp) == errorOriginUpstream {
-		return false
-	}
-	switch resp.StatusCode {
-	case http.StatusUnauthorized,
-		http.StatusForbidden,
-		http.StatusConflict,
-		http.StatusFailedDependency:
-		return true
-	default:
-		return false
-	}
-}
-
-// errorOriginUpstream is the Jentic-Error-Origin value the broker stamps on a
-// mirrored upstream response (broker ErrorOrigin.UPSTREAM). The matching header
-// name mirrors broker/core/headers.JenticHeader.ERROR_ORIGIN.
-const errorOriginUpstream = "upstream"
-
-func errorOrigin(resp *http.Response) string {
-	if resp == nil {
-		return ""
-	}
-	return strings.ToLower(strings.TrimSpace(resp.Header.Get("Jentic-Error-Origin")))
+	return !agentops.IsLoopbackHost(u.Hostname())
 }

--- a/cli/internal/cli/api/execute_directive.go
+++ b/cli/internal/cli/api/execute_directive.go
@@ -2,111 +2,26 @@ package api
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"strings"
 
-	"github.com/jentic/jentic-one/cli/internal/theme"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 )
+
+// The agent_directive type and its parsing moved to the UX-free core
+// (ux.Directive / agentops.ParseAgentDirective); the styled rendering moved
+// into ux (the sole terminal gatekeeper — plan 0.2: command code no longer
+// composes stderr text itself). These two thin methods keep the stream choice
+// (a.Err) here, where the app owns its writers.
 
 // printSynthesizedDenialRecovery prints a best-effort recovery hint for a broker
 // denial that carried no agent_directive, keyed off the HTTP status the broker
-// already returned (UX7). It mirrors printAgentDirective's shape (instruction +
-// `run:` command) so a directive-less denial reads the same as a directed one.
-// Unknown statuses fall back to the generic setup check.
+// already returned (UX7).
 func (a *app) printSynthesizedDenialRecovery(ctx context.Context, status int) {
-	st := theme.StylesFromContext(ctx)
-	fmt.Fprintln(a.Err, st.Warn.Render("Denied — recovery required:"))
-	switch status {
-	case http.StatusForbidden: // 403: have an identity, no access to this toolkit yet.
-		fmt.Fprintln(a.Err, "  This agent isn't bound to the toolkit you called. Check what you can run, then request access.")
-		fmt.Fprintln(a.Err, "  run: "+st.Accent.Render("jentic access whoami"))
-		fmt.Fprintln(a.Err, "  run: "+st.Accent.Render("jentic access request --toolkit <vendor/name> --wait"))
-	case http.StatusFailedDependency: // 424: no credential provisioned for the call.
-		fmt.Fprintln(a.Err, "  No credential is provisioned for this call. Provision one, then retry.")
-		fmt.Fprintln(a.Err, "  run: "+st.Accent.Render("jentic access request --toolkit <vendor/name> --provision --wait"))
-	case http.StatusUnauthorized: // 401: credential expired / needs reconnecting.
-		fmt.Fprintln(a.Err, "  Your credential needs reconnecting. Re-run access to refresh it.")
-		fmt.Fprintln(a.Err, "  run: "+st.Accent.Render("jentic access request --toolkit <vendor/name> --provision --wait"))
-	default:
-		fmt.Fprintln(a.Err, "  The broker denied this call. Check what you can run and your setup.")
-		fmt.Fprintln(a.Err, "  run: "+st.Accent.Render("jentic access whoami"))
-	}
-	// Point at the read-only self-check as the catch-all when the specific hint
-	// above doesn't unblock (UX9).
-	fmt.Fprintln(a.Err, "  stuck? "+st.Accent.Render("jentic doctor"))
-}
-
-// agentDirective mirrors the broker's problem+json agent_directive extension
-// member (broker/core/exceptions.py AgentDirective). The strategy vocabulary
-// below mirrors broker AgentStrategy; until the contract is a shared OpenAPI
-// schema, the Python test test_directive_factories_emit_known_strategies and
-// this list must be kept in lock-step (review P1-1).
-type agentDirective struct {
-	Strategy    string         `json:"strategy"`
-	Parameters  map[string]any `json:"parameters"`
-	Instruction string         `json:"human_readable_instruction"`
-}
-
-// Recovery strategies the broker may emit in an agent_directive (mirrors
-// broker AgentStrategy): wait, retry, modify_headers, prompt_human,
-// switch_toolkit, fatal. Only the ones this CLI branches on are named here.
-const (
-	directiveWait  = "wait"
-	directiveRetry = "retry"
-)
-
-// parseAgentDirective extracts an agent_directive from a denial response body.
-// It only treats recoverable broker-denial responses as directives so a normal
-// 4xx (including an upstream pass-through with an incidental
-// "agent_directive"-shaped body) can't trip the exit code.
-func parseAgentDirective(resp *http.Response, body []byte) (agentDirective, bool) {
-	if !isBrokerDenial(resp) {
-		return agentDirective{}, false
-	}
-	var envelope struct {
-		Directive *agentDirective `json:"agent_directive"`
-	}
-	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Directive == nil {
-		return agentDirective{}, false
-	}
-	return *envelope.Directive, true
+	ux.RenderSynthesizedDenialRecovery(ctx, a.Err, status)
 }
 
 // printAgentDirective renders a recovery directive to stderr, lifting the
 // suggested_command / provisioning_url out of parameters so the agent (or its
 // operator) sees the exact next action without parsing JSON.
-func (a *app) printAgentDirective(ctx context.Context, d agentDirective) {
-	st := theme.StylesFromContext(ctx)
-	fmt.Fprintln(a.Err, st.Warn.Render("Denied — recovery required:"))
-	if d.Instruction != "" {
-		fmt.Fprintln(a.Err, "  "+d.Instruction)
-	}
-	if cmd, ok := d.Parameters["suggested_command"].(string); ok && cmd != "" {
-		fmt.Fprintln(a.Err, "  run: "+st.Accent.Render(cmd))
-	}
-	if u, ok := d.Parameters["provisioning_url"].(string); ok && u != "" {
-		fmt.Fprintln(a.Err, "  open: "+st.Accent.Render(u))
-	}
-	if cands, ok := d.Parameters["candidates"].([]any); ok && len(cands) > 0 {
-		parts := make([]string, 0, len(cands))
-		for _, c := range cands {
-			if s, isStr := c.(string); isStr {
-				parts = append(parts, s)
-			}
-		}
-		if len(parts) > 0 {
-			fmt.Fprintln(a.Err, "  candidates: "+st.Accent.Render(strings.Join(parts, ", ")))
-		}
-	}
-	// A wait/retry directive carries a backoff hint the agent should honor before
-	// retrying; surface it so the recovery loop doesn't hot-spin.
-	if d.Strategy == directiveWait || d.Strategy == directiveRetry {
-		if secs, ok := d.Parameters["retry_after_seconds"]; ok {
-			fmt.Fprintf(a.Err, "  retry after: %v\n", secs)
-		}
-	}
-	// Catch-all self-check for when the directive's step doesn't unblock (UX9).
-	fmt.Fprintln(a.Err, "  stuck? "+st.Accent.Render("jentic doctor"))
+func (a *app) printAgentDirective(ctx context.Context, d ux.Directive) {
+	ux.RenderDirective(ctx, a.Err, d)
 }

--- a/cli/internal/cli/api/execute_print.go
+++ b/cli/internal/cli/api/execute_print.go
@@ -8,125 +8,94 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/jentic/jentic-one/cli/internal/agentops"
 	"github.com/jentic/jentic-one/cli/internal/cli/cmdcore"
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 	"github.com/jentic/jentic-one/cli/internal/theme"
 	"github.com/spf13/cobra"
-
-	sdkclient "github.com/jentic/jentic-one/cli/client"
 )
 
-func (a *app) executeOutput(cmd *cobra.Command, opts *executeOptions, resp *http.Response) error {
+// executeOutput renders an ExecuteResult and maps a broker denial to its exit.
+// Classification is the extracted core's job (agentops.Classify — the old
+// fused render-and-classify is unfused per plan 0.2); this method owns only
+// the UX side: which stream, which format, and the recovery rendering.
+func (a *app) executeOutput(cmd *cobra.Command, opts *executeOptions, res *agentops.ExecuteResult) error {
+	denial := agentops.Classify(res)
+
 	if opts.raw {
-		// Read the body bounded (review round-3 P0 / theme 2: the old comment
-		// claimed a broker-transport cap that does not exist — the response read
-		// was unbounded), then redact before streaming, so --raw matches the
-		// redaction guarantee of the JSON and `jentic api` paths (SEC-2). A secret
-		// in an upstream body must not leak just because the caller asked for raw
-		// output.
-		body, err := sdkclient.ReadAllBounded(resp.Body, sdkclient.MaxBodyBytes)
-		if err != nil {
-			return fmt.Errorf("read response: %w", err)
-		}
-		if _, err := a.Out.Write(ux.RedactBytes(body)); err != nil {
+		// Redact before streaming, so --raw matches the redaction guarantee of
+		// the JSON and `jentic api` paths (SEC-2). A secret in an upstream body
+		// must not leak just because the caller asked for raw output. (The read
+		// itself was already bounded in agentops.Do.)
+		if _, err := a.Out.Write(ux.RedactBytes(res.Body)); err != nil {
 			return err
 		}
-		if isBrokerDenial(resp) {
-			return brokerDeniedErr(resp)
+		if denial != nil {
+			return denial.Err()
 		}
 		return nil
 	}
 
-	respBody, err := sdkclient.ReadAllBounded(resp.Body, sdkclient.MaxBodyBytes)
-	if err != nil {
-		return fmt.Errorf("read response: %w", err)
-	}
-
 	if cmdcore.JSONOrPretty(cmd, opts.json) {
-		if err := a.executeJSONOutput(resp, respBody); err != nil {
+		// The success envelope is the shared ux type (AGT-23 schema_version
+		// stamped by NewExecuteEnvelope), written via the legacy WriteJSON
+		// path — its body is arbitrary upstream data, outside ux.Render's
+		// three-layer funnel, so WriteJSON's byte-level redaction backstop
+		// applies.
+		if err := cmdcore.WriteJSON(a.Out, res.Envelope()); err != nil {
 			return err
 		}
 	} else {
-		a.executePrettyOutput(cmd.Context(), resp, respBody)
+		a.executePrettyOutput(cmd.Context(), res)
 	}
 
 	// A broker denial (403/409/424/401) means the call did not run; exit 2 so a
 	// scripted agent can branch on the denial instead of mistaking the 4xx body
 	// for success. The exit code keys off the *status*, not the presence of an
-	// agent_directive: some denials (e.g. action_denied from a permission rule)
-	// carry no directive, and gating exit 2 on a parsed directive would let those
-	// silently exit 0 — the exact regression this surfacing is meant to remove.
-	// When a directive *is* present it enriches the message with recovery steps.
-	if isBrokerDenial(resp) {
-		if directive, ok := parseAgentDirective(resp, respBody); ok {
-			a.printAgentDirective(cmd.Context(), directive)
+	// agent_directive (see agentops.Classify). When a directive *is* present it
+	// enriches the message with recovery steps.
+	if denial != nil {
+		if denial.Directive != nil {
+			a.printAgentDirective(cmd.Context(), *denial.Directive)
 		} else {
 			// No agent_directive on the body (UX7): a first-timer who most needs the
 			// pointer would otherwise get only the generic "broker denied" line and
 			// a dead end. Synthesize a default next-step from the HTTP status the
 			// broker already returned so no denial is a dead end.
-			a.printSynthesizedDenialRecovery(cmd.Context(), resp.StatusCode)
+			a.printSynthesizedDenialRecovery(cmd.Context(), denial.Status)
 		}
-		return brokerDeniedErr(resp)
+		return denial.Err()
 	}
 	return nil
 }
 
-func (a *app) executeJSONOutput(resp *http.Response, body []byte) error {
-	headers := make(map[string]string)
-	for k := range resp.Header {
-		headers[k] = resp.Header.Get(k)
-	}
-
-	var parsedBody any
-	if err := json.Unmarshal(body, &parsedBody); err != nil {
-		parsedBody = string(body)
-	}
-
-	envelope := map[string]any{
-		// AGT-23: stamp the machine-contract schema_version like every sanctioned
-		// wrapper (ux.List/Page/Result/Export), so an agent can branch on the
-		// envelope shape. execute builds an ad-hoc map (not a ux type) because its
-		// body is the arbitrary upstream response, so the version is set here.
-		"schema_version": apiEnvelopeSchemaVersion,
-		"status":         resp.StatusCode,
-		"headers":        headers,
-		"body":           parsedBody,
-	}
-	if execID := resp.Header.Get("Jentic-Execution-Id"); execID != "" {
-		envelope["execution_id"] = execID
-	}
-
-	return cmdcore.WriteJSON(a.Out, envelope)
-}
-
-func (a *app) executePrettyOutput(ctx context.Context, resp *http.Response, body []byte) {
+func (a *app) executePrettyOutput(ctx context.Context, res *agentops.ExecuteResult) {
 	st := theme.StylesFromContext(ctx)
-	statusLine := fmt.Sprintf("HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	statusLine := fmt.Sprintf("HTTP %d %s", res.Status, http.StatusText(res.Status))
 	switch {
-	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+	case res.Status >= 200 && res.Status < 300:
 		fmt.Fprintln(a.Out, st.Success.Render(statusLine))
-	case resp.StatusCode >= 400:
+	case res.Status >= 400:
 		fmt.Fprintln(a.Out, st.Warn.Render(statusLine))
 	default:
 		fmt.Fprintln(a.Out, statusLine)
 	}
 
-	for k, vs := range resp.Header {
+	for k, vs := range res.Headers {
 		if strings.HasPrefix(k, "Jentic-") {
 			fmt.Fprintln(a.Out, st.Dim.Render(fmt.Sprintf("  %s: %s", k, strings.Join(vs, ", "))))
 		}
 	}
 
 	fmt.Fprintln(a.Out)
-	if len(body) > 0 {
+	if len(res.Body) > 0 {
 		// Redact the upstream body before display (SEC-2): the pretty path is
 		// human-facing but can still carry secrets echoed by an upstream API.
 		var pretty bytes.Buffer
-		if err := json.Indent(&pretty, body, "", "  "); err == nil {
+		if err := json.Indent(&pretty, res.Body, "", "  "); err == nil {
 			_, _ = a.Out.Write(ux.RedactBytes(pretty.Bytes()))
 		} else {
-			_, _ = a.Out.Write(ux.RedactBytes(body))
+			_, _ = a.Out.Write(ux.RedactBytes(res.Body))
 		}
 		fmt.Fprintln(a.Out)
 	}

--- a/cli/internal/cli/api/execute_test.go
+++ b/cli/internal/cli/api/execute_test.go
@@ -41,6 +41,53 @@ func TestBadFlagKV(t *testing.T) {
 	}
 }
 
+// TestExecuteMalformedHeaderWinsOverInsecureBroker freezes the doubly-invalid
+// precedence the agentops extraction changed (PR #1179 review #2): ParseKVs on
+// --header now runs BEFORE BuildRequest's SEC-1 secure-transport guard, so a
+// malformed --header combined with a SEC-1-violating broker target (plaintext
+// http to a non-loopback host) surfaces MISSING_ARGUMENT — previously SEC-1 ran
+// first and TRANSPORT_ERROR won. Both codes map to exit 1 (ux/contract.go), so
+// exit parity holds; error_code is part of the closed machine contract (13
+// §3a), so the new order is pinned here as a decision, not an accident.
+func TestExecuteMalformedHeaderWinsOverInsecureBroker(t *testing.T) {
+	app := testApp(t)
+	// Loopback control plane; never dialed — GET:/v1/pets short-circuits the
+	// resolve phase and the header parse fails before any request is built.
+	seedRegistered(t, app, "default", "http://127.0.0.1:1")
+
+	out := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	app.Out = out
+	app.Err = errBuf
+	root := newAPIRootCmd(app.App)
+	root.SetOut(out)
+	root.SetErr(errBuf)
+	root.SetArgs([]string{
+		"execute", "GET:/v1/pets",
+		"--header", "no-equals-sign",
+		// SEC-1 violation (plaintext http to a non-loopback broker) — would be
+		// TRANSPORT_ERROR if the request were ever built.
+		"--broker-scheme", "http",
+		"--broker-host", "203.0.113.9:8100",
+	})
+
+	err := root.Execute()
+	var coded *ux.CodedError
+	if !errors.As(err, &coded) {
+		t.Fatalf("doubly-invalid execute returned %T (%v), want *ux.CodedError", err, err)
+	}
+	if coded.Code != ux.CodeMissingArgument {
+		t.Errorf("code = %q, want %q (the malformed --header wins over the SEC-1 refusal)",
+			coded.Code, ux.CodeMissingArgument)
+	}
+	if coded.ExitCode() != 1 {
+		t.Errorf("exit = %d, want 1 (exit parity with the old TRANSPORT_ERROR precedence)", coded.ExitCode())
+	}
+	if !strings.Contains(coded.Msg, "--header") || !strings.Contains(coded.Msg, "no-equals-sign") {
+		t.Errorf("msg %q should name the flag and offending value", coded.Msg)
+	}
+}
+
 func TestExecuteCmdJSONEnvelope(t *testing.T) {
 	// One server plays both roles: control plane (/inspect) and broker (the
 	// catch-all that receives /{upstreamURL}). Inspect returns an upstream URL;

--- a/cli/internal/cli/ux/execute.go
+++ b/cli/internal/cli/ux/execute.go
@@ -1,0 +1,137 @@
+package ux
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/jentic/jentic-one/cli/internal/theme"
+)
+
+// ExecuteEnvelope is the versioned success envelope for `jentic execute` (and
+// any other surface — e.g. an MCP handler — that relays a brokered upstream
+// response): {schema_version, status, headers, body, execution_id?}, matching
+// the agent-commands contract. It replaces the ad-hoc inline map the execute
+// command used to build, so the CLI and future callers share one struct.
+//
+// FIELD ORDER IS LOAD-BEARING: encoding/json emits struct fields in declaration
+// order, and the golden-pinned envelope was historically marshaled from a map —
+// alphabetical key order. The fields are declared alphabetically by JSON key so
+// the emitted document stays byte-identical to the frozen contract.
+type ExecuteEnvelope struct {
+	// Body is the upstream response body: parsed JSON when it decodes, else the
+	// raw body as a string.
+	Body any `json:"body"`
+	// ExecutionID is the broker's Jentic-Execution-Id, when one was stamped.
+	ExecutionID string `json:"execution_id,omitempty"`
+	// Headers is the single-value projection of the upstream response headers.
+	Headers map[string]string `json:"headers"`
+	// SchemaVersion pins the machine-contract envelope shape (AGT-23). Use
+	// NewExecuteEnvelope so it is always stamped: this envelope is written via
+	// the legacy WriteJSON path (its body is arbitrary upstream data), which —
+	// unlike Render — does not stamp versions itself.
+	SchemaVersion string `json:"schema_version"`
+	// Status is the upstream HTTP status the broker relayed.
+	Status int `json:"status"`
+}
+
+// NewExecuteEnvelope builds an ExecuteEnvelope with the current machine-contract
+// schema version stamped.
+func NewExecuteEnvelope(status int, headers map[string]string, body any, executionID string) ExecuteEnvelope {
+	return ExecuteEnvelope{
+		Body:          body,
+		ExecutionID:   executionID,
+		Headers:       headers,
+		SchemaVersion: currentSchemaVersion,
+		Status:        status,
+	}
+}
+
+// Directive mirrors the broker's problem+json agent_directive extension member
+// (broker/core/exceptions.py AgentDirective). The strategy vocabulary below
+// mirrors broker AgentStrategy; until the contract is a shared OpenAPI schema,
+// the Python test test_directive_factories_emit_known_strategies and this list
+// must be kept in lock-step (review P1-1).
+type Directive struct {
+	Strategy    string         `json:"strategy"`
+	Parameters  map[string]any `json:"parameters"`
+	Instruction string         `json:"human_readable_instruction"`
+}
+
+// Recovery strategies the broker may emit in a Directive (mirrors broker
+// AgentStrategy): wait, retry, modify_headers, prompt_human, switch_toolkit,
+// fatal. Only the ones the rendering branches on are named here.
+const (
+	DirectiveWait  = "wait"
+	DirectiveRetry = "retry"
+)
+
+// RenderDirective renders a recovery directive to w (the caller's stderr),
+// lifting the suggested_command / provisioning_url out of parameters so the
+// agent (or its operator) sees the exact next action without parsing JSON.
+// It lives in ux — the terminal gatekeeper — so command code never composes
+// styled output itself; the palette is the one the root interceptor resolved
+// into ctx.
+func RenderDirective(ctx context.Context, w io.Writer, d Directive) {
+	st := theme.StylesFromContext(ctx)
+	fmt.Fprintln(w, st.Warn.Render("Denied — recovery required:"))
+	if d.Instruction != "" {
+		fmt.Fprintln(w, "  "+d.Instruction)
+	}
+	if cmd, ok := d.Parameters["suggested_command"].(string); ok && cmd != "" {
+		fmt.Fprintln(w, "  run: "+st.Accent.Render(cmd))
+	}
+	if u, ok := d.Parameters["provisioning_url"].(string); ok && u != "" {
+		fmt.Fprintln(w, "  open: "+st.Accent.Render(u))
+	}
+	if cands, ok := d.Parameters["candidates"].([]any); ok && len(cands) > 0 {
+		parts := make([]string, 0, len(cands))
+		for _, c := range cands {
+			if s, isStr := c.(string); isStr {
+				parts = append(parts, s)
+			}
+		}
+		if len(parts) > 0 {
+			fmt.Fprintln(w, "  candidates: "+st.Accent.Render(strings.Join(parts, ", ")))
+		}
+	}
+	// A wait/retry directive carries a backoff hint the agent should honor before
+	// retrying; surface it so the recovery loop doesn't hot-spin.
+	if d.Strategy == DirectiveWait || d.Strategy == DirectiveRetry {
+		if secs, ok := d.Parameters["retry_after_seconds"]; ok {
+			fmt.Fprintf(w, "  retry after: %v\n", secs)
+		}
+	}
+	// Catch-all self-check for when the directive's step doesn't unblock (UX9).
+	fmt.Fprintln(w, "  stuck? "+st.Accent.Render("jentic doctor"))
+}
+
+// RenderSynthesizedDenialRecovery writes a best-effort recovery hint for a
+// broker denial that carried no agent_directive, keyed off the HTTP status the
+// broker already returned (UX7). It mirrors RenderDirective's shape
+// (instruction + `run:` command) so a directive-less denial reads the same as a
+// directed one. Unknown statuses fall back to the generic setup check.
+func RenderSynthesizedDenialRecovery(ctx context.Context, w io.Writer, status int) {
+	st := theme.StylesFromContext(ctx)
+	fmt.Fprintln(w, st.Warn.Render("Denied — recovery required:"))
+	switch status {
+	case http.StatusForbidden: // 403: have an identity, no access to this toolkit yet
+		fmt.Fprintln(w, "  This agent isn't bound to the toolkit you called. Check what you can run, then request access.")
+		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access whoami"))
+		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access request --toolkit <vendor/name> --wait"))
+	case http.StatusFailedDependency: // 424: no credential provisioned for the call
+		fmt.Fprintln(w, "  No credential is provisioned for this call. Provision one, then retry.")
+		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access request --toolkit <vendor/name> --provision --wait"))
+	case http.StatusUnauthorized: // 401: credential expired / needs reconnecting
+		fmt.Fprintln(w, "  Your credential needs reconnecting. Re-run access to refresh it.")
+		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access request --toolkit <vendor/name> --provision --wait"))
+	default:
+		fmt.Fprintln(w, "  The broker denied this call. Check what you can run and your setup.")
+		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access whoami"))
+	}
+	// Point at the read-only self-check as the catch-all when the specific hint
+	// above doesn't unblock (UX9).
+	fmt.Fprintln(w, "  stuck? "+st.Accent.Render("jentic doctor"))
+}

--- a/cli/tests/arch/layering_test.go
+++ b/cli/tests/arch/layering_test.go
@@ -1,6 +1,7 @@
 package arch
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -139,5 +140,55 @@ func TestCommandTreesDoNotImportEachOther(t *testing.T) {
 	if seenAPI == 0 || seenCtl == 0 {
 		t.Fatalf("leaf-layering: expected both command trees present (api=%d, ctl=%d) — a rename moved one; "+
 			"this gate must not pass vacuously (ARCH-2)", seenAPI, seenCtl)
+	}
+}
+
+// agentopsForbiddenImports are the direct imports internal/agentops must never
+// grow (phase-0 §0.2 purity constraints): no cobra (command wiring), no os
+// (stdin/TTY/env/exit-code logic stays caller-side — under stdio MCP, stdin is
+// the JSON-RPC wire), no terminal detection. Prefix-matched so subpackages
+// (e.g. os/exec) are fenced too.
+var agentopsForbiddenImports = []string{
+	"github.com/spf13/cobra",
+	"github.com/charmbracelet/x/term",
+	"os",
+}
+
+// TestAgentopsStaysUXFree fences the extracted execute/inspect core
+// (internal/agentops): it must not import cobra, os, or the terminal detector
+// (agentopsForbiddenImports), and the ONLY internal/cli sibling it may use is
+// ux — the sanctioned CodedError/envelope/directive types (plan 0.2). This
+// turns the package doc's prose dependency rules into an enforced gate: an
+// agentops → cmdcore/api/ctl(cmd) import would re-fuse the UX-free core to a
+// command tree, and an os/term import would smuggle the stdin/TTY logic back
+// in. (agentops → ux → theme is deliberate and stays allowed.)
+func TestAgentopsStaysUXFree(t *testing.T) {
+	pkgs := loadCLI(t)
+
+	var seen int
+	for _, p := range pkgs {
+		if !underPrefixes(p.PkgPath, "internal/agentops") {
+			continue
+		}
+		seen++
+		for imp := range p.Imports {
+			for _, forbidden := range agentopsForbiddenImports {
+				if imp == forbidden || strings.HasPrefix(imp, forbidden+"/") {
+					t.Errorf("agentops fence: %s imports %q — the UX-free core must not depend on "+
+						"cobra/os/term (phase-0 §0.2); keep flag/stdin/TTY/exit logic caller-side",
+						rel(p.PkgPath), imp)
+				}
+			}
+			if underPrefixes(imp, "internal/cli") && !underPrefixes(imp, "internal/cli/ux") {
+				t.Errorf("agentops fence: %s imports %q — the only internal/cli package the core may "+
+					"use is ux (the CodedError/envelope contract types); anything more re-fuses the "+
+					"core to the command layer (phase-0 §0.2)",
+					rel(p.PkgPath), rel(imp))
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("agentops fence found no internal/agentops packages — the core moved; " +
+			"this gate must not pass vacuously (phase-0 §0.2)")
 	}
 }

--- a/cli/tests/golden/agentops_parity_test.go
+++ b/cli/tests/golden/agentops_parity_test.go
@@ -159,6 +159,108 @@ func TestAgentopsReproducesGoldens(t *testing.T) {
 		}
 	})
 
+	t.Run("execute_upstream_4xx_passthrough_json classification and envelope", func(t *testing.T) {
+		wantStdout := goldenSection(t, "execute_upstream_4xx_passthrough_json", "stdout")
+
+		// A denial-class status stamped origin UPSTREAM: the broker proxied the
+		// call and mirrored the upstream's own 403 — NOT a denial.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header()["Date"] = nil
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Jentic-Error-Origin", "upstream")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"upstream said no"}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		op, err := agentops.ResolveOperation(ctx, nil, "GET:/v1/pets", "")
+		if err != nil {
+			t.Fatalf("ResolveOperation: %v", err)
+		}
+		res, err := agentops.Execute(ctx, agentops.ExecuteRequest{
+			Method:       op.Method,
+			Path:         op.Path,
+			BrokerScheme: "http",
+			BrokerHost:   srv.Listener.Addr().String(),
+			Token:        "tok_abc",
+		})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+
+		// The disambiguation branch guarding the exit-0/exit-2 boundary: a 403
+		// with origin "upstream" must classify as NOT-a-denial (exit 0
+		// pass-through caller-side), never as a broker denial.
+		if d := agentops.Classify(res); d != nil {
+			t.Fatalf("Classify(403 + origin: upstream) = %+v, want nil (pass-through exits 0 caller-side)", d)
+		}
+
+		var got bytes.Buffer
+		if err := cmdcore.WriteJSON(&got, res.Envelope()); err != nil {
+			t.Fatalf("WriteJSON: %v", err)
+		}
+		if got.String() != wantStdout {
+			t.Errorf("pass-through envelope diverged from the golden.\n--- want ---\n%s\n--- got ---\n%s", wantStdout, got.String())
+		}
+	})
+
+	t.Run("execute_broker_denial_no_directive_json synthesized recovery", func(t *testing.T) {
+		wantStderr := goldenSection(t, "execute_broker_denial_no_directive_json", "stderr")
+
+		// A broker denial with NO agent_directive (e.g. credential gap): the
+		// caller synthesizes the status-keyed recovery via the moved renderer.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header()["Date"] = nil
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.Header().Set("Jentic-Error-Origin", "broker")
+			w.WriteHeader(http.StatusFailedDependency)
+			_, _ = w.Write([]byte(`{
+			"type": "credential_not_provisioned",
+			"title": "No credential provisioned",
+			"status": 424,
+			"error_origin": "broker"
+		}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		op, err := agentops.ResolveOperation(ctx, nil, "GET:/v1/pets", "")
+		if err != nil {
+			t.Fatalf("ResolveOperation: %v", err)
+		}
+		res, err := agentops.Execute(ctx, agentops.ExecuteRequest{
+			Method:       op.Method,
+			Path:         op.Path,
+			BrokerScheme: "http",
+			BrokerHost:   srv.Listener.Addr().String(),
+			Token:        "tok_abc",
+		})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+
+		denial := agentops.Classify(res)
+		if denial == nil || denial.Status != http.StatusFailedDependency || denial.Directive != nil {
+			t.Fatalf("Classify = %+v, want a 424 denial with no directive", denial)
+		}
+
+		// The stderr golden is (synthesized recovery rendered by ux) + (the
+		// coded error envelope the Audience layer emits from denial.Err()). The
+		// moved renderer must reproduce the recovery block byte-for-byte.
+		var recovery bytes.Buffer
+		ux.RenderSynthesizedDenialRecovery(ctx, &recovery, denial.Status)
+		if !strings.HasPrefix(wantStderr, recovery.String()) {
+			t.Errorf("ux.RenderSynthesizedDenialRecovery diverged from the golden recovery block.\n--- want prefix of ---\n%s\n--- got ---\n%s",
+				wantStderr, recovery.String())
+		}
+		coded := denial.Err()
+		rest := strings.TrimPrefix(wantStderr, recovery.String())
+		for _, frozen := range []string{`"error_code":"BROKER_DENIED"`, `"http_status":424`, jsonField(t, "error", coded.Msg)} {
+			if !strings.Contains(rest, frozen) {
+				t.Errorf("golden stderr envelope %q does not carry %s from denial.Err()", strings.TrimSpace(rest), frozen)
+			}
+		}
+	})
+
 	t.Run("execute_resolve_not_found_json coded error", func(t *testing.T) {
 		wantStderr := goldenSection(t, "execute_resolve_not_found_json", "stderr")
 

--- a/cli/tests/golden/agentops_parity_test.go
+++ b/cli/tests/golden/agentops_parity_test.go
@@ -1,0 +1,259 @@
+package golden
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jentic/jentic-one/cli/internal/agentops"
+	"github.com/jentic/jentic-one/cli/internal/cli/cmdcore"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// TestAgentopsReproducesGoldens is the extraction-parity half of the execute
+// contract (phase-0 §0.2): it drives the extracted UX-free core
+// (agentops.ResolveOperation → Execute → Classify → Envelope, plus the ux
+// directive renderer) DIRECTLY — no cobra, no command tree — against the same
+// mock broker responses TestGolden_ExecuteContract recorded, and proves the
+// core reproduces the frozen bytes. TestGolden_ExecuteContract keeps proving
+// the CLI wiring end-to-end; this test proves the seam extraction itself lost
+// nothing, and documents exactly which golden bytes each layer owns (envelope
+// + recovery text: agentops/ux; the coded stderr envelope + exit code: the
+// cobra/Audience layer).
+func TestAgentopsReproducesGoldens(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("execute_ok_json envelope", func(t *testing.T) {
+		want := goldenSection(t, "execute_ok_json", "stdout")
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/inspect" {
+				w.Header()["Date"] = nil
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"method":"GET","url":"https://upstream.example/v1/pets"}`))
+				return
+			}
+			w.Header()["Date"] = nil
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Jentic-Execution-Id", "exec-123")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":1,"name":"Fido"}]`))
+		}))
+		t.Cleanup(srv.Close)
+
+		op, err := agentops.ResolveOperation(ctx, rawInspector{srv.URL}, "listPets", "")
+		if err != nil {
+			t.Fatalf("ResolveOperation: %v", err)
+		}
+		res, err := agentops.Execute(ctx, agentops.ExecuteRequest{
+			Method:       op.Method,
+			URL:          op.URL,
+			BrokerScheme: "http",
+			BrokerHost:   srv.Listener.Addr().String(),
+			Token:        "tok_abc",
+		})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if d := agentops.Classify(res); d != nil {
+			t.Fatalf("Classify(2xx) = %+v, want nil (exit 0 stays caller-side)", d)
+		}
+
+		// Serialize through the same legacy path the CLI uses (WriteJSON:
+		// indent-2 + redaction backstop) so the comparison is byte-exact.
+		var got bytes.Buffer
+		if err := cmdcore.WriteJSON(&got, res.Envelope()); err != nil {
+			t.Fatalf("WriteJSON: %v", err)
+		}
+		if got.String() != want {
+			t.Errorf("agentops envelope diverged from the golden.\n--- want ---\n%s\n--- got ---\n%s", want, got.String())
+		}
+	})
+
+	t.Run("execute_broker_denial_directive_json classification and recovery", func(t *testing.T) {
+		wantStdout := goldenSection(t, "execute_broker_denial_directive_json", "stdout")
+		wantStderr := goldenSection(t, "execute_broker_denial_directive_json", "stderr")
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header()["Date"] = nil
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.Header().Set("Jentic-Error-Origin", "broker")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{
+			"type": "no_toolkit_binding",
+			"title": "No toolkit binding for this API",
+			"status": 403,
+			"error_origin": "broker",
+			"agent_directive": {
+				"strategy": "wait",
+				"parameters": {
+					"suggested_command": "jentic access request --toolkit acme/pets --wait",
+					"provisioning_url": "https://console.example/connect/acme",
+					"candidates": ["acme/pets", "acme/pets-admin"],
+					"retry_after_seconds": 30
+				},
+				"human_readable_instruction": "You are not bound to a toolkit for this API."
+			}
+		}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		// GET:/v1/pets is the broker-relative short-circuit: no Inspector call.
+		op, err := agentops.ResolveOperation(ctx, nil, "GET:/v1/pets", "")
+		if err != nil {
+			t.Fatalf("ResolveOperation: %v", err)
+		}
+		res, err := agentops.Execute(ctx, agentops.ExecuteRequest{
+			Method:       op.Method,
+			Path:         op.Path,
+			BrokerScheme: "http",
+			BrokerHost:   srv.Listener.Addr().String(),
+			Token:        "tok_abc",
+		})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+
+		var gotStdout bytes.Buffer
+		if err := cmdcore.WriteJSON(&gotStdout, res.Envelope()); err != nil {
+			t.Fatalf("WriteJSON: %v", err)
+		}
+		if gotStdout.String() != wantStdout {
+			t.Errorf("denial envelope diverged from the golden.\n--- want ---\n%s\n--- got ---\n%s", wantStdout, gotStdout.String())
+		}
+
+		denial := agentops.Classify(res)
+		if denial == nil || denial.Status != http.StatusForbidden || denial.Directive == nil {
+			t.Fatalf("Classify = %+v, want 403 denial with directive", denial)
+		}
+
+		// The stderr golden is (recovery text rendered by ux) + (the coded error
+		// envelope the Audience layer emits from denial.Err()). The renderer must
+		// reproduce the recovery block byte-for-byte; the trailing envelope line
+		// is the Audience's, so here we assert denial.Err() carries exactly the
+		// fields frozen in it.
+		var recovery bytes.Buffer
+		ux.RenderDirective(ctx, &recovery, *denial.Directive)
+		if !strings.HasPrefix(wantStderr, recovery.String()) {
+			t.Errorf("ux.RenderDirective diverged from the golden recovery block.\n--- want prefix of ---\n%s\n--- got ---\n%s",
+				wantStderr, recovery.String())
+		}
+		coded := denial.Err()
+		if coded.Code != ux.CodeBrokerDenied {
+			t.Errorf("denial.Err().Code = %q, want BROKER_DENIED", coded.Code)
+		}
+		rest := strings.TrimPrefix(wantStderr, recovery.String())
+		for _, frozen := range []string{`"error_code":"BROKER_DENIED"`, `"http_status":403`, jsonField(t, "error", coded.Msg)} {
+			if !strings.Contains(rest, frozen) {
+				t.Errorf("golden stderr envelope %q does not carry %s from denial.Err()", strings.TrimSpace(rest), frozen)
+			}
+		}
+	})
+
+	t.Run("execute_resolve_not_found_json coded error", func(t *testing.T) {
+		wantStderr := goldenSection(t, "execute_resolve_not_found_json", "stderr")
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header()["Date"] = nil
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"detail":"operation not found"}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := agentops.ResolveOperation(ctx, rawInspector{srv.URL}, "nonexistentOp", "")
+		var coded *ux.CodedError
+		if !errors.As(err, &coded) {
+			t.Fatalf("ResolveOperation 404 returned %T (%v), want *ux.CodedError", err, err)
+		}
+		if coded.Code != ux.CodeResolveFailed {
+			t.Errorf("code = %q, want RESOLVE_FAILED", coded.Code)
+		}
+		// The golden stderr envelope is the Audience's serialization of exactly
+		// this coded error — its frozen fields must all come from it.
+		for _, frozen := range []string{
+			`"error_code":"RESOLVE_FAILED"`,
+			jsonField(t, "error", coded.Msg),
+			jsonField(t, "actionable_step", coded.Actionable),
+		} {
+			if !strings.Contains(wantStderr, frozen) {
+				t.Errorf("golden stderr %q does not carry %s from the agentops coded error", strings.TrimSpace(wantStderr), frozen)
+			}
+		}
+	})
+}
+
+// jsonField renders `"key":<json(value)>` exactly as encoding/json would emit
+// it inside the Audience's error envelope (incl. its HTML-safe \u003c escapes),
+// so a Contains check compares like for like.
+func jsonField(t *testing.T, key string, value any) string {
+	t.Helper()
+	b, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", key, err)
+	}
+	return fmt.Sprintf("%q:%s", key, b)
+}
+
+// rawInspector is the minimal agentops.Inspector for parity tests: it fetches
+// the mock control plane's /inspect and mirrors the api layer's error mapping
+// (non-2xx → *agentops.HTTPError), which is all ResolveOperation depends on.
+type rawInspector struct{ baseURL string }
+
+func (i rawInspector) Inspect(ctx context.Context, _, _, _ string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, i.baseURL+"/inspect", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &agentops.HTTPError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(body))}
+	}
+	return body, nil
+}
+
+// goldenSection extracts one recorded stream from a golden file ("stdout" or
+// "stderr"), trailing content up to the next marker (or EOF) inclusive of its
+// final newline — the exact bytes formatResult wrote for that stream.
+func goldenSection(t *testing.T, name, section string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", "golden", "v2", name+".txt"))
+	if err != nil {
+		t.Fatalf("read golden %s: %v", name, err)
+	}
+	content := string(raw)
+	_, afterStdout, ok := strings.Cut(content, "--- stdout ---\n")
+	if !ok {
+		t.Fatalf("golden %s has no stdout marker", name)
+	}
+	stdout, stderr, ok := strings.Cut(afterStdout, "--- stderr ---\n")
+	if !ok {
+		t.Fatalf("golden %s has no stderr marker", name)
+	}
+	switch section {
+	case "stdout":
+		return stdout
+	case "stderr":
+		return stderr
+	default:
+		t.Fatalf("unknown golden section %q", section)
+		return ""
+	}
+}

--- a/cli/tests/golden/execute_contract_test.go
+++ b/cli/tests/golden/execute_contract_test.go
@@ -22,7 +22,9 @@ import (
 // refusal (plaintext http to a non-loopback broker) rather than a real dial
 // failure: a refused dial's error string embeds an ephemeral port and
 // OS-specific text, which can never be golden-stable. Dial-level transport
-// failures stay covered by the api unit tests, which assert fields, not bytes.
+// failures are covered by the internal/agentops unit tests
+// (TestDo_DialTLSMismatchAgainstLoopbackBroker and
+// TestDo_DialClosedPortIsBareTransportError), which assert fields, not bytes.
 func TestGolden_ExecuteContract(t *testing.T) {
 	// Handlers keyed by role. Each case runs one httptest server that plays
 	// both the control plane (/inspect) and the broker catch-all — the same

--- a/cli/tests/golden/execute_contract_test.go
+++ b/cli/tests/golden/execute_contract_test.go
@@ -1,0 +1,195 @@
+package golden
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestGolden_ExecuteContract freezes the observable execute contract — the
+// stdout envelope, the stderr error/recovery surface, and the exit code — for
+// the resolve × broker outcome matrix (phase-0 §0.2 of the local-MCP plan):
+//
+//	resolve ok   × broker 2xx                  → envelope, exit 0
+//	resolve ok   × upstream 4xx pass-through   → envelope, exit 0 (origin: upstream)
+//	resolve ok   × broker denial + directive   → envelope + recovery stderr, exit 2
+//	resolve ok   × broker denial, no directive → envelope + synthesized stderr, exit 2
+//	resolve ok   × transport failure           → coded TRANSPORT_ERROR, exit 1
+//	resolve fail (404 / backend error)         → coded RESOLVE_FAILED, exit 2
+//
+// These goldens are recorded BEFORE the agentops extraction so the refactor can
+// prove byte-identical behavior. The transport case uses the SEC-1 secure-URL
+// refusal (plaintext http to a non-loopback broker) rather than a real dial
+// failure: a refused dial's error string embeds an ephemeral port and
+// OS-specific text, which can never be golden-stable. Dial-level transport
+// failures stay covered by the api unit tests, which assert fields, not bytes.
+func TestGolden_ExecuteContract(t *testing.T) {
+	// Handlers keyed by role. Each case runs one httptest server that plays
+	// both the control plane (/inspect) and the broker catch-all — the same
+	// dual-role shape the api unit tests use. Every handler suppresses the
+	// auto Date header so the recorded envelope headers are byte-stable.
+	inspectOK := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header()["Date"] = nil
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"method":"GET","url":"https://upstream.example/v1/pets"}`))
+	}
+	inspectNotFound := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header()["Date"] = nil
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"operation not found"}`))
+	}
+	inspectBackendError := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header()["Date"] = nil
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"detail":"registry exploded"}`))
+	}
+
+	broker200 := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header()["Date"] = nil
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Jentic-Execution-Id", "exec-123")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":1,"name":"Fido"}]`))
+	}
+	// A denial-class status stamped origin UPSTREAM: the broker successfully
+	// proxied the call and mirrored the upstream's own 403 — NOT a denial.
+	brokerUpstream403 := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header()["Date"] = nil
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Jentic-Error-Origin", "upstream")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"upstream said no"}`))
+	}
+	// A broker denial carrying a rich agent_directive: every rendering branch
+	// (instruction, run:, open:, candidates, retry-after, stuck?) is frozen.
+	brokerDenial403Directive := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header()["Date"] = nil
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.Header().Set("Jentic-Error-Origin", "broker")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{
+			"type": "no_toolkit_binding",
+			"title": "No toolkit binding for this API",
+			"status": 403,
+			"error_origin": "broker",
+			"agent_directive": {
+				"strategy": "wait",
+				"parameters": {
+					"suggested_command": "jentic access request --toolkit acme/pets --wait",
+					"provisioning_url": "https://console.example/connect/acme",
+					"candidates": ["acme/pets", "acme/pets-admin"],
+					"retry_after_seconds": 30
+				},
+				"human_readable_instruction": "You are not bound to a toolkit for this API."
+			}
+		}`))
+	}
+	// A broker denial with NO agent_directive (e.g. action_denied): exit 2 with
+	// the synthesized status-keyed recovery, never a dead end.
+	brokerDenial424NoDirective := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header()["Date"] = nil
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.Header().Set("Jentic-Error-Origin", "broker")
+		w.WriteHeader(http.StatusFailedDependency)
+		_, _ = w.Write([]byte(`{
+			"type": "credential_not_provisioned",
+			"title": "No credential provisioned",
+			"status": 424,
+			"error_origin": "broker"
+		}`))
+	}
+
+	cases := []struct {
+		name    string
+		target  string
+		flags   []string // appended after the broker flags
+		inspect http.HandlerFunc
+		broker  http.HandlerFunc
+		// fixedBroker overrides the mock's address with a static broker target
+		// (the SEC-1 transport case must not depend on an ephemeral port).
+		fixedBroker []string
+	}{
+		{
+			name:    "execute_ok_json",
+			target:  "listPets", // opaque id → resolved via /inspect
+			inspect: inspectOK,
+			broker:  broker200,
+		},
+		{
+			name:    "execute_ok_raw",
+			target:  "listPets",
+			flags:   []string{"--raw"},
+			inspect: inspectOK,
+			broker:  broker200,
+		},
+		{
+			name:   "execute_upstream_4xx_passthrough_json",
+			target: "GET:/v1/pets", // broker-relative → no inspect round-trip
+			broker: brokerUpstream403,
+		},
+		{
+			name:   "execute_broker_denial_directive_json",
+			target: "GET:/v1/pets",
+			broker: brokerDenial403Directive,
+		},
+		{
+			name:   "execute_broker_denial_no_directive_json",
+			target: "GET:/v1/pets",
+			broker: brokerDenial424NoDirective,
+		},
+		{
+			name:   "execute_transport_insecure_broker",
+			target: "GET:/v1/pets",
+			// Plaintext http to a non-loopback broker → SEC-1 refusal before
+			// any dial (deterministic TRANSPORT_ERROR, exit 1).
+			fixedBroker: []string{"--broker-scheme", "http", "--broker-host", "203.0.113.9:8100"},
+		},
+		{
+			name:    "execute_resolve_not_found_json",
+			target:  "nonexistentOp",
+			inspect: inspectNotFound,
+		},
+		{
+			name:    "execute_resolve_backend_error_json",
+			target:  "listPets",
+			inspect: inspectBackendError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/inspect" {
+					if tc.inspect == nil {
+						t.Errorf("unexpected /inspect call in case %s", tc.name)
+						w.WriteHeader(http.StatusNotFound)
+						return
+					}
+					tc.inspect(w, r)
+					return
+				}
+				if tc.broker == nil {
+					t.Errorf("unexpected broker call in case %s", tc.name)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				tc.broker(w, r)
+			}))
+			t.Cleanup(srv.Close)
+
+			seedSession(t, srv.URL)
+			args := []string{"execute", tc.target}
+			if tc.fixedBroker != nil {
+				args = append(args, tc.fixedBroker...)
+			} else {
+				args = append(args, "--broker-scheme", "http", "--broker-host", srv.Listener.Addr().String())
+			}
+			args = append(args, tc.flags...)
+
+			got := runAPI(t, t.TempDir(), agentEnv, args...)
+			assertGolden(t, tc.name, got)
+		})
+	}
+}

--- a/cli/tests/golden/testdata/golden/v2/execute_broker_denial_directive_json.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_broker_denial_directive_json.txt
@@ -1,0 +1,39 @@
+exit: 2
+--- stdout ---
+{
+  "body": {
+    "agent_directive": {
+      "human_readable_instruction": "You are not bound to a toolkit for this API.",
+      "parameters": {
+        "candidates": [
+          "acme/pets",
+          "acme/pets-admin"
+        ],
+        "provisioning_url": "https://console.example/connect/acme",
+        "retry_after_seconds": 30,
+        "suggested_command": "jentic access request --toolkit acme/pets --wait"
+      },
+      "strategy": "wait"
+    },
+    "error_origin": "broker",
+    "status": 403,
+    "title": "No toolkit binding for this API",
+    "type": "no_toolkit_binding"
+  },
+  "headers": {
+    "Content-Length": "520",
+    "Content-Type": "application/problem+json",
+    "Jentic-Error-Origin": "broker"
+  },
+  "schema_version": "1",
+  "status": 403
+}
+--- stderr ---
+Denied — recovery required:
+  You are not bound to a toolkit for this API.
+  run: jentic access request --toolkit acme/pets --wait
+  open: https://console.example/connect/acme
+  candidates: acme/pets, acme/pets-admin
+  retry after: 30
+  stuck? jentic doctor
+{"details":{"http_status":403},"error":"the broker denied this call before it reached the upstream API","error_code":"BROKER_DENIED","schema_version":"1"}

--- a/cli/tests/golden/testdata/golden/v2/execute_broker_denial_no_directive_json.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_broker_denial_no_directive_json.txt
@@ -1,0 +1,23 @@
+exit: 2
+--- stdout ---
+{
+  "body": {
+    "error_origin": "broker",
+    "status": 424,
+    "title": "No credential provisioned",
+    "type": "credential_not_provisioned"
+  },
+  "headers": {
+    "Content-Length": "133",
+    "Content-Type": "application/problem+json",
+    "Jentic-Error-Origin": "broker"
+  },
+  "schema_version": "1",
+  "status": 424
+}
+--- stderr ---
+Denied — recovery required:
+  No credential is provisioned for this call. Provision one, then retry.
+  run: jentic access request --toolkit <vendor/name> --provision --wait
+  stuck? jentic doctor
+{"details":{"http_status":424},"error":"the broker denied this call before it reached the upstream API","error_code":"BROKER_DENIED","schema_version":"1"}

--- a/cli/tests/golden/testdata/golden/v2/execute_ok_json.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_ok_json.txt
@@ -1,0 +1,20 @@
+exit: 0
+--- stdout ---
+{
+  "body": [
+    {
+      "id": 1,
+      "name": "Fido"
+    }
+  ],
+  "execution_id": "exec-123",
+  "headers": {
+    "Content-Length": "24",
+    "Content-Type": "application/json",
+    "Jentic-Execution-Id": "exec-123"
+  },
+  "schema_version": "1",
+  "status": 200
+}
+--- stderr ---
+

--- a/cli/tests/golden/testdata/golden/v2/execute_ok_raw.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_ok_raw.txt
@@ -1,0 +1,5 @@
+exit: 0
+--- stdout ---
+[{"id":1,"name":"Fido"}]
+--- stderr ---
+

--- a/cli/tests/golden/testdata/golden/v2/execute_resolve_backend_error_json.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_resolve_backend_error_json.txt
@@ -1,0 +1,5 @@
+exit: 2
+--- stdout ---
+
+--- stderr ---
+{"error":"resolve \"listPets\" failed: http 500: registry exploded","error_code":"RESOLVE_FAILED","schema_version":"1"}

--- a/cli/tests/golden/testdata/golden/v2/execute_resolve_not_found_json.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_resolve_not_found_json.txt
@@ -1,0 +1,5 @@
+exit: 2
+--- stdout ---
+
+--- stderr ---
+{"actionable_step":"jentic search \"\u003cwhat you want to do\u003e\"","error":"operation \"nonexistentOp\" not found","error_code":"RESOLVE_FAILED","schema_version":"1"}

--- a/cli/tests/golden/testdata/golden/v2/execute_transport_insecure_broker.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_transport_insecure_broker.txt
@@ -1,0 +1,5 @@
+exit: 1
+--- stdout ---
+
+--- stderr ---
+{"actionable_step":"Use an https broker URL, or a loopback (127.0.0.1/localhost) http broker for local installs.","error":"refusing to use insecure endpoint \"http://203.0.113.9:8100/v1/pets\": https is required (http allowed only for localhost)","error_code":"TRANSPORT_ERROR","schema_version":"1"}

--- a/cli/tests/golden/testdata/golden/v2/execute_upstream_4xx_passthrough_json.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_upstream_4xx_passthrough_json.txt
@@ -1,0 +1,16 @@
+exit: 0
+--- stdout ---
+{
+  "body": {
+    "error": "upstream said no"
+  },
+  "headers": {
+    "Content-Length": "28",
+    "Content-Type": "application/json",
+    "Jentic-Error-Origin": "upstream"
+  },
+  "schema_version": "1",
+  "status": 403
+}
+--- stderr ---
+


### PR DESCRIPTION
## Summary

Extracts the UX-free execute core out of the cobra command tree into `cli/internal/agentops` (local-MCP theme, phase-0 item 0.2; plan: `jentic-one-plans/themes/local-mcp/phase-0.md`). **Pure refactor — no behavior change**; part of #1174, unblocks #1175.

## Changes

- `cli` — new **`cli/internal/agentops/`**, the reusable core a future MCP handler can call without cobra:
  - `types.go`: `ExecuteRequest` / `ExecuteResult` (+ `Envelope()`), `Denial`, `Operation`, `KV`, the narrow **`Inspector`** seam (`Inspect(ctx, target, revision, format) ([]byte, error)` — satisfied by the existing generated-SDK wrapper, shared by execute-resolve and `jentic inspect`), and `HTTPError` (moved from `api`, aliased there so every existing call site is untouched).
  - `execute.go`: `ParseMethodPath` / `ResolveOperation` (de-cobra'd — takes `ctx` + `Inspector`), `BuildRequest` (path-param substitution, query append, broker catch-all URL, SEC-1 secure-transport guard, bearer/correlation/idempotency headers), `Do` (SDK broker transport, bounded read), and one-call `Execute`.
  - `classify.go`: `IsBrokerDenial` / `ParseAgentDirective` lifted intact; `Classify` unfuses the old `executeOutput`'s classification from printing.
- `cli` — **`cli/internal/cli/ux/execute.go`**: the shared success envelope (`ux.ExecuteEnvelope`, replacing the inline map; fields declared alphabetically so the emitted bytes stay frozen) and the directive / synthesized-denial renderers (command code no longer composes stderr text; the app keeps only the stream choice).
- Dependency rules held: `agentops` receives token strings and a **resolved** broker target. Session acquisition, broker precedence + SEC-21 machine-mode pin + remote-CP fail-closed guard, the stdin fallback, `--data`/`--raw`, rendering, and exit-code mapping all stay cobra-side. No `io.Writer`, no cobra, no exit codes, no TTY, no stdin in `agentops`.
- **Out of scope**: no MCP SDK dependency (phase-1 PR 1-A), no behavior change of any kind — the goldens exist to prove that.

## Risk & rollback

- The diff **relocates** the bearer-token forwarding and the SEC-1 secure-transport guard (`api/execute.go` → `agentops/execute.go`) — behavior pinned byte-for-byte by the golden matrix recorded on the parent commit; the parity test drives the moved code directly.
- One deliberate corner-case precedence change: doubly-invalid input (malformed `--header` + SEC-1-violating broker target) now surfaces `MISSING_ARGUMENT` instead of `TRANSPORT_ERROR` (same exit 1); pinned by unit test.
- Rollback: revert the squash commit — no migrations, no config, no API shape changes.

## Test plan

- New goldens (recorded on the **parent** commit, before the extraction) freeze the execute contract matrix — envelope / stderr / exit code for resolve ok/fail × broker 2xx / upstream-4xx pass-through / denial(±directive) / transport-fail.
- `tests/golden/agentops_parity_test.go` drives the extracted functions directly (no cobra) against the frozen bytes.
- Unit tests cover `agentops.Do`'s dial-level transport branch (TLS-mismatch actionable + bare dial failure) and the doubly-invalid precedence; `tests/arch` fences `agentops` imports (no cobra/os/term/`internal/cli/*` except `ux`).
- `GOWORK=off make -C cli check` green (lint, vet, race incl. tests/arch and tests/golden, vendored specs).

Made with [Cursor](https://cursor.com)
