### PR TITLE
docs(web): advertise jentic mcp in llms.txt + same-host hardening recipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,9 @@ allow. See `docs/security/hardening.md` before using real credentials.
 
 - One governed upstream call per execution. Compose multi-step work yourself; the Broker does
   not orchestrate.
-- A self-hosted deployment exposes no MCP endpoint. Integrate through the `jentic` CLI, the
-  skill it generates, or plain HTTP against the deployment's own API.
+- A self-hosted deployment serves no HTTP MCP endpoint. Integrate through the `jentic` CLI, the
+  skill it generates, the CLI's local MCP stdio server (an `mcp` subcommand shipping in the
+  next `jentic` release), or plain HTTP against the deployment's own API.
 - A running instance serves `/llms.txt` and `/.well-known/llms.txt` with that deployment's base
   URL. Once an instance exists, prefer those over this file for anything at runtime.
 - Never print, log or echo a stored credential. The Broker does not return them.

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ Most tools in this category are hosted: the credentials live in the vendor's inf
 Jentic One runs on infrastructure you control. Credentials are encrypted at rest in your own
 database and are decrypted only inside the Broker, at execution time.
 
-Jentic One exposes no MCP endpoint. An MCP server running beside an agent gives that agent a
-credential-bearing surface to call, which is what the Broker exists to avoid. Agents integrate
-through the `jentic` CLI, a generated skill, or plain HTTP.
+Agents integrate through the `jentic` CLI, a generated skill, the local `jentic mcp` server
+(available in the `jentic` CLI from the next release — check `jentic mcp --help`), or plain
+HTTP. Every path terminates at the credential-injecting Broker: the MCP server runs beside the
+agent as a thin client and holds no upstream credentials — those never leave your Broker.
 
 ## Quickstart
 
@@ -204,7 +205,7 @@ Full reference: [`cli/README.md`](cli/README.md).
 | [Security hardening](docs/security/hardening.md) | Deployment-tier ladder and production checklist. Read before using real credentials. |
 | [Build & deploy](deploy/README.md) | Docker, Helm, Terraform, versioning, kind, observability |
 | [Self-hosted containers + external Postgres](deploy/README.md#self-hosted-containers--external-postgres) | Production-shaped deployment without Kubernetes |
-| [Cloud vs self-hosted](docs/cloud-vs-self-hosted.md) | How Jentic One differs from the Jentic cloud platform, why there is no MCP endpoint, and how to run both (or migrate) without silent cross-talk |
+| [Cloud vs self-hosted](docs/cloud-vs-self-hosted.md) | How Jentic One differs from the Jentic cloud platform, how MCP works against each, and how to run both (or migrate) without silent cross-talk |
 
 **Reference**
 

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -10,6 +10,13 @@ Jentic is an API broker: you discover operations across many APIs, then execute
 them through a single authenticated gateway without managing each API's
 credentials yourself. The `jentic` CLI is the agent-facing entrypoint.
 
+The same loop is also exposed over **MCP** by the local `jentic mcp` stdio
+server — available in the `jentic` CLI from the next release; check
+`jentic mcp --help`. If your session has `jentic` MCP tools, prefer them; use
+the CLI for `setup`/`access` recovery and anything not exposed over MCP. Both
+surfaces talk to the same instance — check `backend`/`host` in the identity
+stamp on MCP tool results if in doubt.
+
 ## When to Use
 
 - You need to call a third-party API (Stripe, GitHub, Slack, …) but don't have
@@ -506,17 +513,20 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   "catalog read" scopes; they're rejected.
 - **Verify which backend you're talking to before diagnosing "missing" APIs
   or credentials.** If your session also has Jentic **MCP tools**
-  (`search_apis`, `list_credentials`, `execute`, …), they may be bound to a
-  **different backend** than this CLI — typically the hosted cloud workspace
-  vs the local install — and nothing in their responses says which one
-  replied. The symptom is *silent wrong answers*, not errors: an API the user
-  just imported "doesn't exist", credentials "disappeared", or operation ids
-  from one surface don't resolve on the other. Before concluding anything is
-  missing or broken, check where each surface points — `jentic context view`
-  shows this CLI's active environment/`base_url`, and `jentic api GET /instance`
-  reports which backend serves it (see "confirm which backend you're on" in step 3);
-  ask your operator which backend the MCP server was configured against —
-  and stick to one surface for the whole task.
+  (`search_apis`, `list_credentials`, `execute`, …), check which backend they
+  answer from. Tools served by the local `jentic mcp` server stamp
+  `backend`/`host` on every result — compare that against this CLI's backend.
+  Tools without the stamp (e.g. the hosted Jentic cloud platform's MCP server)
+  may be bound to a **different backend** than this CLI — typically the hosted
+  cloud workspace vs the local install. The symptom of a mismatch is *silent
+  wrong answers*, not errors: an API the user just imported "doesn't exist",
+  credentials "disappeared", or operation ids from one surface don't resolve
+  on the other. Before concluding anything is missing or broken, check where
+  each surface points — `jentic context view` shows this CLI's active
+  environment/`base_url`, and `jentic api GET /instance` reports which backend
+  serves it (see "confirm which backend you're on" in step 3); for MCP tools,
+  read the identity stamp or ask your operator which backend the MCP server
+  was configured against — and stick to one surface for the whole task.
 - An `execute` failure is not always an access problem. A DNS or TLS error
   means the **broker target** is misconfigured (see step 5); connection
   refused on a **local** target usually means the instance is **stopped** —

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -98,8 +98,9 @@ is still production-shaped.
 > **Public Beta.** The same caveat as the repo front page applies: we don't
 > recommend production use yet. "Production-shaped" here means the topology
 > and secret handling are the real thing — not that the product is done.
-> Also note a self-hosted instance serves the HTTP APIs + UI; the hosted MCP
-> endpoint is a cloud-tier feature — see
+> Also note a self-hosted instance serves the HTTP APIs + UI; MCP access is
+> via the local `jentic mcp` stdio server (available in the `jentic` CLI from
+> the next release), not an HTTP endpoint on the instance — see
 > [`docs/cloud-vs-self-hosted.md`](../docs/cloud-vs-self-hosted.md).
 
 ### The one-image, two-surfaces model

--- a/docs/cloud-vs-self-hosted.md
+++ b/docs/cloud-vs-self-hosted.md
@@ -22,8 +22,8 @@ stdio server** — available in the `jentic` CLI from the next release; check
 spawns it as an ordinary stdio MCP entry; it authenticates with the agent's
 registered identity and exposes the same discover → execute loop the CLI
 drives (`search_apis`, `inspect_operation`, `execute`, …). Every tool result
-carries an identity stamp (`backend`, `host`, `instance_id`) so an agent can
-always tell which instance answered.
+carries an identity stamp (`backend`, `host`, `instance_id`, `fetched_at`)
+so an agent can always tell which instance answered.
 
 There is still **no hosted `/mcp` HTTP endpoint** on the deployment itself.
 Probing the control plane (`:8000/mcp`, `/v1/mcp`, `/api/mcp`, `/sse`) returns

--- a/docs/cloud-vs-self-hosted.md
+++ b/docs/cloud-vs-self-hosted.md
@@ -6,7 +6,7 @@ especially for an AI agent (or its operator) that has used both:
 |  | Jentic cloud platform | Jentic One (this repo) |
 | --- | --- | --- |
 | Where it runs | Hosted by Jentic — dashboard at `app.jentic.com`, API at `api.jentic.com` | Your infrastructure (laptop, VM, Kubernetes) |
-| How agents connect | Remote **MCP server** (`https://api.jentic.com/mcp`) configured in the agent runtime with a workspace API key | **`jentic` CLI + generated skill** (or the raw HTTP flow) — see below |
+| How agents connect | Remote **MCP server** (`https://api.jentic.com/mcp`) configured in the agent runtime with a workspace API key | **`jentic` CLI + generated skill**, the local **`jentic mcp`** stdio server (available in the `jentic` CLI from the next release), or the raw HTTP flow — see below |
 | Agent identity | Workspace API key | Per-agent Ed25519 keypair via dynamic client registration (`jentic register` / `jentic setup`) |
 | Dashboard | `app.jentic.com` | The bundled UI on your deployment (`/app`) |
 | Data | Jentic-hosted workspace | Stays on your infrastructure; stored secrets are decrypted only inside your Broker at execution time |
@@ -14,35 +14,55 @@ especially for an AI agent (or its operator) that has used both:
 They do not share state: an API imported or a credential stored in one is
 invisible to the other.
 
-## Self-hosted Jentic One exposes no MCP endpoint
+## MCP against a self-hosted install: the local `jentic mcp` server
 
-There is **no `/mcp` endpoint** on a Jentic One deployment. Probing the
-control plane (`:8000/mcp`, `/v1/mcp`, `/api/mcp`, `/sse`) returns 404. The
-broker (`:8100`) answers 401 to an unauthenticated `/mcp` probe — that is
-**not** a hidden MCP server behind auth; it is the broker's credential-injecting
-forward proxy rejecting the request, like it would any other unauthenticated
-path. Do not configure an MCP server entry pointing at your self-hosted host;
-it cannot work.
+MCP access to a Jentic One deployment runs through the **local `jentic mcp`
+stdio server** — available in the `jentic` CLI from the next release; check
+`jentic mcp --help`. Your agent runtime (Claude Desktop/Code, Cursor, …)
+spawns it as an ordinary stdio MCP entry; it authenticates with the agent's
+registered identity and exposes the same discover → execute loop the CLI
+drives (`search_apis`, `inspect_operation`, `execute`, …). Every tool result
+carries an identity stamp (`backend`, `host`, `instance_id`) so an agent can
+always tell which instance answered.
+
+There is still **no hosted `/mcp` HTTP endpoint** on the deployment itself.
+Probing the control plane (`:8000/mcp`, `/v1/mcp`, `/api/mcp`, `/sse`) returns
+404. The broker (`:8100`) answers 401 to an unauthenticated `/mcp` probe —
+that is **not** a hidden MCP server behind auth; it is the broker's
+credential-injecting forward proxy rejecting the request, like it would any
+other unauthenticated path. Do not configure a *URL-based* MCP entry pointing
+at your self-hosted host; MCP entries for a self-hosted install spawn
+`jentic mcp` as a command.
 
 The supported integration paths for agents are:
 
-1. **CLI + skill (recommended).** Your operator runs `jentic setup` — it
-   registers the agent identity, waits for human approval, and installs the
-   onboarding skill into detected agent runtimes (Claude Code, Cursor, Codex,
-   Hermes, or a generic `AGENTS.md`). The skill teaches the agent to drive
+1. **CLI + skill.** Your operator runs `jentic setup` — it registers the
+   agent identity, waits for human approval, and installs the onboarding
+   skill into detected agent runtimes (Claude Code, Cursor, Codex, Hermes, or
+   a generic `AGENTS.md`). The skill teaches the agent to drive
    `jentic search` → `jentic inspect` → `jentic execute`.
-2. **Raw HTTP.** For runtimes without the CLI, every deployment self-describes
+2. **MCP (`jentic mcp`).** For MCP-capable runtimes, add a stdio entry that
+   spawns `jentic mcp --context <name>`. Setup and registration remain
+   CLI-only (`jentic setup`), so onboarding is unchanged; once registered,
+   the execute loop is MCP-preferred. If a session has both surfaces, prefer
+   the MCP tools and use the CLI for `setup`/`access` recovery and anything
+   not exposed over MCP — both talk to the same instance (check
+   `backend`/`host` in the identity stamp).
+3. **Raw HTTP.** For runtimes without the CLI, every deployment self-describes
    at `GET /llms.txt`: dynamic client registration, token exchange, discovery,
-   access requests, and brokered execution — no MCP required.
+   access requests, and brokered execution.
+
+If the agent runtime spawning `jentic mcp` shares a host with the instance,
+read [Hardening same-host MCP setups](security/mcp-same-host-hardening.md).
 
 ## Running both side by side (coexistence)
 
 If you used the cloud platform first and later installed Jentic One, you end
 up with a **dual setup**: the agent runtime's MCP tools (`search_apis`,
-`list_credentials`, `execute`, …) still point at the cloud workspace, while
-the `jentic` CLI points at the local install. Nothing in any tool response
-says which backend replied, so the failure mode is *silent wrong answers*,
-not errors:
+`list_credentials`, `execute`, …) may still point at the cloud workspace,
+while the `jentic` CLI (and a local `jentic mcp` entry) point at the local
+install. Cloud MCP responses don't say which backend replied, so the failure
+mode is *silent wrong answers*, not errors:
 
 - an API you just imported locally "doesn't exist" (the MCP search answered
   from the cloud workspace),
@@ -57,16 +77,19 @@ half the tools are talking to a different product.
 
 - **MCP server** — inspect the MCP entry in the agent runtime's config (e.g.
   Claude Desktop's `claude_desktop_config.json`, Cursor's MCP settings): a
-  URL on `api.jentic.com` is the cloud platform. A self-hosted install is
-  never behind an MCP entry.
+  URL on `api.jentic.com` is the cloud platform; an entry that spawns
+  `jentic mcp` is the local server, bound to whatever backend its context's
+  environment points at. `jentic mcp` tool results also stamp
+  `backend`/`host` on every response, so the answering instance is visible
+  in-session.
 - **CLI** — `jentic env list` prints each environment's `base_url` (and
   `broker_url`); `jentic context view` shows the active one. Local installs
   point at your own host (e.g. `http://127.0.0.1:8000`).
 
 **Rule of thumb:** pick one surface per task and stay on it. If you work
-against the self-hosted install, use the `jentic` CLI for everything, and
-consider removing (or disabling) the stale cloud MCP entry so an agent can't
-answer from the wrong backend.
+against the self-hosted install, use the `jentic` CLI and its `jentic mcp`
+tools for everything, and consider removing (or disabling) the stale cloud
+MCP entry so an agent can't answer from the wrong backend.
 
 ## Migrating from the cloud MCP to a self-hosted install
 
@@ -76,5 +99,6 @@ answer from the wrong backend.
 3. Re-enter credentials in your deployment's dashboard — secrets cannot be
    exported from the cloud platform (nor from Jentic One; that's the point).
 4. Register your agents against the local install (`jentic setup`).
-5. Remove the cloud MCP server entry from your agent runtime's config to
-   avoid the split-brain scenario above.
+5. Replace the cloud MCP server entry in your agent runtime's config with a
+   `jentic mcp` entry (or remove it entirely) to avoid the split-brain
+   scenario above.

--- a/docs/context-and-config.md
+++ b/docs/context-and-config.md
@@ -175,11 +175,15 @@ at the wrong backend.
 
 ### Repointing an MCP server (or any client) at a local install
 
-The per-response backend field is added by the external Jentic MCP server; the
-`jentic-one` side of the contract is the `/instance` endpoint above. To move an
-MCP server (or the CLI) from a remote backend to a local install, update *that
-client's* backend base URL to your local `canonical_base_url` (e.g.
-`http://127.0.0.1:8000`) and re-check with `GET /instance`. `jentic-one` never
-silently resolves to a remote backend on its own — a client only reaches a
-remote backend because it is configured to.
+The per-response `backend` field is stamped by the MCP server — the local
+`jentic mcp` server (available in the `jentic` CLI from the next release)
+reads it from the `/instance` endpoint above, which is the `jentic-one` side
+of the contract. To move an MCP server (or the CLI) from a remote backend to
+a local install, update *that client's* backend base URL to your local
+`canonical_base_url` (e.g. `http://127.0.0.1:8000`) and re-check with
+`GET /instance`. For `jentic mcp` the backend comes from the context's
+environment (`base_url`/`broker_url`), so repoint the environment (or switch
+the context the MCP entry pins with `--context`). `jentic-one` never silently
+resolves to a remote backend on its own — a client only reaches a remote
+backend because it is configured to.
 

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -155,6 +155,11 @@ the key/DB by construction, so agent sandboxing becomes about limiting what a
 compromised agent can *do* (egress control, least-privilege tokens) rather than
 protecting the key at rest.
 
+If an agent runtime spawns the local `jentic mcp` server on the same host as
+the instance, see [Hardening same-host MCP setups](mcp-same-host-hardening.md)
+for MCP-entry-shaped recipes (isolated instance, sudo-shim with a per-agent
+service user, container entry).
+
 ## Agent access credentials
 
 How the agent authenticates to Jentic One depends on where Jentic One is

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -155,8 +155,10 @@ the key/DB by construction, so agent sandboxing becomes about limiting what a
 compromised agent can *do* (egress control, least-privilege tokens) rather than
 protecting the key at rest.
 
-If an agent runtime spawns the local `jentic mcp` server on the same host as
-the instance, see [Hardening same-host MCP setups](mcp-same-host-hardening.md)
+If an agent runtime spawns the local `jentic mcp` server (available in the
+`jentic` CLI from the next release — check `jentic mcp --help`) on the same
+host as the instance, see
+[Hardening same-host MCP setups](mcp-same-host-hardening.md)
 for MCP-entry-shaped recipes (isolated instance, sudo-shim with a per-agent
 service user, container entry).
 

--- a/docs/security/mcp-same-host-hardening.md
+++ b/docs/security/mcp-same-host-hardening.md
@@ -1,0 +1,143 @@
+# Hardening same-host MCP setups
+
+The local `jentic mcp` stdio server (available in the `jentic` CLI from the
+next release — check `jentic mcp --help`) is spawned by the agent runtime
+itself: a GUI runtime (Claude Desktop, Cursor, …) starts the process as the
+**desktop user**, and there is no seam to interpose a different Unix user the
+way `jentic run` does for agents the CLI launches. When the Jentic One
+instance runs on the **same host**, that default has two consequences:
+
+- The MCP server process — and the context's key/token files it reads — run
+  and live under the desktop user's uid.
+- If the instance also runs as that same OS user, a shell-capable agent can
+  read the instance's config, database, and encryption key directly off disk,
+  bypassing the broker. (This is not MCP-specific — any same-user local agent
+  can do it today — but MCP makes same-host setups more common.)
+
+Two things to keep straight before choosing a recipe:
+
+- **The API-level credential boundary holds in every mode.** Upstream
+  credentials are injected by the broker server-side and are never returned
+  to the agent — no recipe below changes that, and no recipe is needed for
+  it. What the recipes close is the **OS-level** exposure of the agent's
+  signing key and the instance's files in same-host setups.
+- **Plain stdio remains the supported default.** The recipes are additive
+  hardening for stricter environments. Every rung keeps the same MCP entry
+  shape: a command to spawn.
+
+Pick the lowest rung that matches the sensitivity of the credentials your
+instance holds (the general tier ladder is in [hardening.md](hardening.md)).
+
+## Recipe 1 — isolate the instance
+
+Close the instance-file half entirely by making sure the instance's files are
+not readable by the desktop user:
+
+- **Containerized instance**: `jenticctl install`'s Docker deployment already
+  keeps the database and key material inside container volumes not shared
+  with the desktop user's home.
+- **Different OS user**: run the instance under a dedicated non-root user (or
+  rootless container) so its key/DB are not readable by the agent's uid —
+  tier T2 in the [hardening guide](hardening.md#deployment-tiers).
+- **Remote instance**: point the MCP entry's context at an instance on
+  another host/VM/private network (tier T3) — the agent cannot touch the
+  key store by construction.
+
+With any of these, the desktop side still holds the *agent's own* signing
+key; recipes 2 and 3 move that behind a boundary too.
+
+## Recipe 2 — sudo-shim entry with a per-agent service user
+
+Run the MCP server (and its key/token files) under a dedicated service user,
+and let the agent runtime spawn it through an argv-pinned `sudo` line. `sudo`
+inherits stdin/stdout, so the JSON-RPC pipe survives the user switch; the
+desktop side is left holding only a disposable spawn line, while the process
+and the context's key/token files live under the service user, unreadable by
+the desktop user. macOS/Linux only; this is a manual recipe today — a later
+release automates it as an optional `jentic setup` isolation step.
+
+1. **Create one service user per agent identity/runtime** (`_jentic-claude`,
+   `_jentic-cursor`, …) — *not* a shared catch-all user, which would
+   co-locate every runtime's keys and recreate the shared-key failure mode
+   that one-agent-per-runtime exists to kill. One runtime ↔ one agent ↔ one
+   context ↔ one uid ↔ one sudoers line; revoking a runtime = disable the
+   agent + delete the user. Service-account hygiene: system-uid range, `_`
+   prefix (the macOS convention), no login shell, state under the service
+   user's own `0700` home. Never use setuid wrappers.
+2. **Register the agent under the service user** (your operator runs
+   `sudo -u _jentic-claude jentic register --url <install URL> …` and
+   approves it), so the context and key files are created in the service
+   user's own config dir.
+3. **Install an argv-pinned NOPASSWD sudoers line** (via `visudo -f
+   /etc/sudoers.d/jentic-claude`):
+
+   ```
+   yourdesktopuser ALL=(_jentic-claude) NOPASSWD: /usr/local/bin/jentic mcp --context claude
+   ```
+
+   One source user → one target user → the exact `jentic mcp --context
+   <name>` argv. `sudo` matches the full argv, so the entry cannot be
+   replayed with a different context or subcommand.
+4. **Point the MCP entry at the shim** (`-n` because GUI spawns cannot answer
+   prompts):
+
+   ```json
+   {
+     "command": "sudo",
+     "args": ["-n", "-u", "_jentic-claude",
+              "/usr/local/bin/jentic", "mcp", "--context", "claude"]
+   }
+   ```
+
+**Env boundary (by design):** `sudo`'s default `env_reset` means environment
+variables do **not** cross into the service user. The MCP entry's `env`
+block, `$JENTIC_CONTEXT`, and the file-less overrides
+(`JENTIC_BASE_URL`/`JENTIC_BEARER_TOKEN`) are all incompatible with the
+sudo-shim entry — the context comes from the pinned argv and the config from
+the service user's own files. An orchestrator-set `$JENTIC_SESSION_ID` does
+not cross either, so under the shim the server's own per-process session UUID
+is always the session key. **Never add `env_keep` for `JENTIC_*`** — an
+env-writable desktop user could otherwise re-point the isolated server at
+another instance or token and defeat the boundary.
+
+Residual risk: any process running as the desktop user can invoke the shim —
+impersonation *within* the audited channel, bounded by the entry's pinned
+context and the agent's server-side scopes. Key exfiltration is blocked: the
+desktop-user side never holds long-lived key material.
+
+## Recipe 3 — container entry
+
+Where Docker Desktop is available (including Windows), spawn the MCP server
+in a container instead — the MCP ecosystem's mainstream isolation pattern.
+The keys live in a named volume no desktop-user process mounts:
+
+```json
+{
+  "command": "docker",
+  "args": ["run", "-i", "--rm",
+           "--read-only", "--cap-drop=ALL",
+           "--security-opt", "no-new-privileges",
+           "--user", "10001:10001",
+           "-v", "jentic-mcp-claude:/home/jentic/.config/jentic",
+           "<your-jentic-cli-image>", "jentic", "mcp", "--context", "claude"]
+}
+```
+
+Narrow the container's egress to the instance's address (e.g. a dedicated
+Docker network or host firewall rules). An instance listening on the host's
+loopback needs `host.docker.internal` plumbing
+(`--add-host=host.docker.internal:host-gateway` on Linux) and a context whose
+environment points at `http://host.docker.internal:8000`. Register the agent
+once inside the container (state persists in the named volume).
+
+Prefer this rung where Docker Desktop exists; the sudo-shim serves
+docker-less machines.
+
+## Choosing a rung
+
+| Setup | Recommendation |
+|---|---|
+| Instance on another host / VPC | Recipe 1 (remote) already covers the instance files; add 2 or 3 if the agent's own key must move off the desktop uid |
+| Same host, Docker available | Recipe 1 (containerized instance) + Recipe 3 |
+| Same host, no Docker (macOS/Linux) | Recipe 1 (different OS user) + Recipe 2 |
+| Trying it out, low-value credentials | Plain stdio entry — the supported default |

--- a/docs/security/mcp-same-host-hardening.md
+++ b/docs/security/mcp-same-host-hardening.md
@@ -44,7 +44,8 @@ not readable by the desktop user:
   key store by construction.
 
 With any of these, the desktop side still holds the *agent's own* signing
-key; recipes 2 and 3 move that behind a boundary too.
+key; recipes 2 and 3 move that behind a boundary too (of differing strength
+— see each recipe's residual risk).
 
 ## Recipe 2 — sudo-shim entry with a per-agent service user
 
@@ -65,10 +66,23 @@ release automates it as an optional `jentic setup` isolation step.
    prefix (the macOS convention), no login shell, state under the service
    user's own `0700` home. Never use setuid wrappers.
 2. **Register the agent under the service user** (your operator runs
-   `sudo -u _jentic-claude jentic register --url <install URL> …` and
-   approves it), so the context and key files are created in the service
-   user's own config dir.
-3. **Install an argv-pinned NOPASSWD sudoers line** (via `visudo -f
+   `sudo -u _jentic-claude jentic register --url <install URL> --env local
+   --name claude` and approves it), so the context and key files are
+   created in the service user's own config dir. Pass `--env`/`--name`
+   explicitly so the derived context name is predictable; a remote install
+   also needs `--broker-url`.
+3. **Rename the derived context** (run as the service user). Registration
+   derives the context name as `<env>-<name>` (here `local-claude`; env
+   defaults to the first DNS label of the install URL and name to the
+   hostname) — it never creates a context named `claude` on its own.
+   Rename it so the sudoers pin and MCP entry below can use the short
+   name:
+
+   ```
+   sudo -u _jentic-claude jentic context rename local-claude claude
+   ```
+
+4. **Install an argv-pinned NOPASSWD sudoers line** (via `visudo -f
    /etc/sudoers.d/jentic-claude`):
 
    ```
@@ -78,7 +92,7 @@ release automates it as an optional `jentic setup` isolation step.
    One source user → one target user → the exact `jentic mcp --context
    <name>` argv. `sudo` matches the full argv, so the entry cannot be
    replayed with a different context or subcommand.
-4. **Point the MCP entry at the shim** (`-n` because GUI spawns cannot answer
+5. **Point the MCP entry at the shim** (`-n` because GUI spawns cannot answer
    prompts):
 
    ```json
@@ -109,35 +123,107 @@ desktop-user side never holds long-lived key material.
 
 Where Docker Desktop is available (including Windows), spawn the MCP server
 in a container instead — the MCP ecosystem's mainstream isolation pattern.
-The keys live in a named volume no desktop-user process mounts:
+The keys live in a named volume rather than in the desktop user's home, so
+ordinary file reads by desktop-user processes cannot reach them (but see the
+residual risk below — Docker daemon access can).
 
-```json
-{
-  "command": "docker",
-  "args": ["run", "-i", "--rm",
-           "--read-only", "--cap-drop=ALL",
-           "--security-opt", "no-new-privileges",
-           "--user", "10001:10001",
-           "-v", "jentic-mcp-claude:/home/jentic/.config/jentic",
-           "<your-jentic-cli-image>", "jentic", "mcp", "--context", "claude"]
-}
+**Bring your own image.** No official CLI image is published today — build
+one from the released `jentic` binary. The steps below assume an image that
+provides: the `jentic` binary on `PATH`; a non-root user (uid 10001 here)
+with a writable `HOME` (`/home/jentic`); and the config directory
+`$HOME/.config/jentic` pre-created and **owned by that user**, so the named
+volume initializes with the right ownership on first mount (Docker seeds an
+empty named volume from the image's content at the mount path). A minimal
+example:
+
+```dockerfile
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --uid 10001 --create-home jentic \
+ && mkdir -p /home/jentic/.config/jentic \
+ && chown -R jentic:jentic /home/jentic
+# The released jentic CLI binary for the image's OS/arch.
+COPY jentic /usr/local/bin/jentic
+USER 10001:10001
+ENV HOME=/home/jentic
 ```
 
-Narrow the container's egress to the instance's address (e.g. a dedicated
-Docker network or host firewall rules). An instance listening on the host's
-loopback needs `host.docker.internal` plumbing
-(`--add-host=host.docker.internal:host-gateway` on Linux) and a context whose
-environment points at `http://host.docker.internal:8000`. Register the agent
-once inside the container (state persists in the named volume).
+1. **Register the agent once inside the container** (state persists in the
+   named volume; your operator approves the registration). An instance
+   listening on the host's loopback is reached as `host.docker.internal`
+   (add `--add-host=host.docker.internal:host-gateway` on Linux) — which is
+   **not** loopback from the container's point of view, so `register` does
+   not auto-seed the broker URL. Pass `--broker-url` explicitly or
+   `execute` fail-closes:
 
-Prefer this rung where Docker Desktop exists; the sudo-shim serves
-docker-less machines.
+   ```
+   docker run -i --rm \
+     --add-host=host.docker.internal:host-gateway \
+     -v jentic-mcp-claude:/home/jentic/.config/jentic \
+     your-jentic-cli-image \
+     jentic register --url http://host.docker.internal:8000 \
+       --broker-url http://host.docker.internal:8100 \
+       --env local --name claude
+   ```
+
+2. **Rename the derived context.** Registration derives the context name as
+   `<env>-<name>` (here `local-claude`; env defaults to the first DNS label
+   of the install URL and name to the hostname — pass `--env`/`--name` as
+   above so it is predictable). It never creates a context named `claude`
+   on its own, so rename it to match the pin in the entry below:
+
+   ```
+   docker run --rm -v jentic-mcp-claude:/home/jentic/.config/jentic \
+     your-jentic-cli-image jentic context rename local-claude claude
+   ```
+
+3. **Point the MCP entry at the container.** `--read-only` makes the rootfs
+   unwritable, and `jentic mcp` opens its log sink (default: under the XDG
+   state dir, on that read-only rootfs) *before* serving — so pass
+   `--log-file` on a writable mount. A tmpfs is the simplest; use a second
+   named volume instead if the log should survive the session:
+
+   ```json
+   {
+     "command": "docker",
+     "args": ["run", "-i", "--rm",
+              "--read-only", "--cap-drop=ALL",
+              "--security-opt", "no-new-privileges",
+              "--user", "10001:10001",
+              "--add-host=host.docker.internal:host-gateway",
+              "--tmpfs", "/tmp",
+              "-v", "jentic-mcp-claude:/home/jentic/.config/jentic",
+              "your-jentic-cli-image",
+              "jentic", "mcp", "--context", "claude",
+              "--log-file", "/tmp/mcp.log"]
+   }
+   ```
+
+Narrow the container's egress to the instance's address (e.g. a dedicated
+Docker network or host firewall rules). The context's environment points at
+`http://host.docker.internal:8000` (broker `:8100`), as seeded by the
+registration step.
+
+Residual risk: this rung's boundary is only as strong as access to the
+Docker daemon — which the desktop user necessarily holds, since the MCP
+entry itself runs `docker`. Any desktop-user process that can reach the
+daemon can mount the named volume (`docker run -v jentic-mcp-claude:/x …`)
+and read the key files, so unlike Recipe 2 the ladder invariant — the
+desktop-user side never holds long-lived key material — does **not** hold
+here against daemon-capable processes. What the rung buys is convenience,
+containment of the *server* (read-only rootfs, dropped capabilities,
+narrowed egress), and protection against casual file reads — not key
+exfiltration by a shell-capable agent. Recipe 3 is the convenient rung
+where Docker Desktop exists (and the only one on Windows); on isolation
+strength, Recipe 2's uid boundary is the stronger of the two, and the
+sudo-shim also serves docker-less machines.
 
 ## Choosing a rung
 
 | Setup | Recommendation |
 |---|---|
 | Instance on another host / VPC | Recipe 1 (remote) already covers the instance files; add 2 or 3 if the agent's own key must move off the desktop uid |
-| Same host, Docker available | Recipe 1 (containerized instance) + Recipe 3 |
+| Same host, Docker available | Recipe 1 (containerized instance) + Recipe 3 for convenience — but Recipe 3's key boundary yields to Docker-daemon access (see its residual risk); pick Recipe 2 where key exfiltration is the concern |
 | Same host, no Docker (macOS/Linux) | Recipe 1 (different OS user) + Recipe 2 |
 | Trying it out, low-value credentials | Plain stdio entry — the supported default |

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@ What an agent can do once an instance is running:
 
 What it does not do. Jentic One bounds what a mistaken or compromised agent can reach. It does not make an agent correct or reliable, and it does not remove the judgment call about which operations an agent should be allowed to touch at all.
 
-A self-hosted deployment exposes no MCP endpoint. Agents integrate through the `jentic` CLI and the skill it generates, or over plain HTTP against the deployment's own API. Both paths are documented below.
+Agents integrate through the `jentic` CLI and the skill it generates, over MCP via the CLI's local stdio server (an `mcp` subcommand shipping in the next `jentic` release), or over plain HTTP against the deployment's own API. The deployment itself serves no HTTP MCP endpoint; MCP runs through the local server. All paths are documented below.
 
 Jentic One runs on one machine and the agent runs on another. Install on both with the same bootstrap:
 

--- a/skills/jentic/SKILL.md
+++ b/skills/jentic/SKILL.md
@@ -10,6 +10,13 @@ Jentic is an API broker: you discover operations across many APIs, then execute
 them through a single authenticated gateway without managing each API's
 credentials yourself. The `jentic` CLI is the agent-facing entrypoint.
 
+The same loop is also exposed over **MCP** by the local `jentic mcp` stdio
+server — available in the `jentic` CLI from the next release; check
+`jentic mcp --help`. If your session has `jentic` MCP tools, prefer them; use
+the CLI for `setup`/`access` recovery and anything not exposed over MCP. Both
+surfaces talk to the same instance — check `backend`/`host` in the identity
+stamp on MCP tool results if in doubt.
+
 ## When to Use
 
 - You need to call a third-party API (Stripe, GitHub, Slack, …) but don't have
@@ -506,17 +513,20 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   "catalog read" scopes; they're rejected.
 - **Verify which backend you're talking to before diagnosing "missing" APIs
   or credentials.** If your session also has Jentic **MCP tools**
-  (`search_apis`, `list_credentials`, `execute`, …), they may be bound to a
-  **different backend** than this CLI — typically the hosted cloud workspace
-  vs the local install — and nothing in their responses says which one
-  replied. The symptom is *silent wrong answers*, not errors: an API the user
-  just imported "doesn't exist", credentials "disappeared", or operation ids
-  from one surface don't resolve on the other. Before concluding anything is
-  missing or broken, check where each surface points — `jentic context view`
-  shows this CLI's active environment/`base_url`, and `jentic api GET /instance`
-  reports which backend serves it (see "confirm which backend you're on" in step 3);
-  ask your operator which backend the MCP server was configured against —
-  and stick to one surface for the whole task.
+  (`search_apis`, `list_credentials`, `execute`, …), check which backend they
+  answer from. Tools served by the local `jentic mcp` server stamp
+  `backend`/`host` on every result — compare that against this CLI's backend.
+  Tools without the stamp (e.g. the hosted Jentic cloud platform's MCP server)
+  may be bound to a **different backend** than this CLI — typically the hosted
+  cloud workspace vs the local install. The symptom of a mismatch is *silent
+  wrong answers*, not errors: an API the user just imported "doesn't exist",
+  credentials "disappeared", or operation ids from one surface don't resolve
+  on the other. Before concluding anything is missing or broken, check where
+  each surface points — `jentic context view` shows this CLI's active
+  environment/`base_url`, and `jentic api GET /instance` reports which backend
+  serves it (see "confirm which backend you're on" in step 3); for MCP tools,
+  read the identity stamp or ask your operator which backend the MCP server
+  was configured against — and stick to one surface for the whole task.
 - An `execute` failure is not always an access problem. A DNS or TLS error
   means the **broker target** is misconfigured (see step 5); connection
   refused on a **local** target usually means the instance is **stopped** —

--- a/src/jentic_one/shared/web/agent_discovery.py
+++ b/src/jentic_one/shared/web/agent_discovery.py
@@ -196,12 +196,18 @@ Agents: read the onboarding skill at {base}{SKILL_PATH} first. It is the
 canonical guide to the identity → discover → request access → execute loop —
 the same canonical guide the `jentic` CLI renders into agent runtimes.
 
-This deployment exposes **no MCP endpoint** — that transport belongs to the
-separately hosted Jentic cloud platform. Probing `/mcp` returns 404 on the
-control plane; a 401 from the broker is its auth-gated forward proxy, not a
-hidden MCP server. Integrate via the `jentic` CLI + skill or the raw HTTP
-sequence below; if your session also carries Jentic MCP tools, they answer
-from a different backend than this deployment.
+This deployment is reachable over **MCP** via the local `jentic mcp` stdio
+server — available in the `jentic` CLI from the next release; check
+`jentic mcp --help`. It exposes the same discover → execute loop as the CLI
+tools against this deployment. MCP access runs through that local server, not
+an HTTP endpoint here: probing `/mcp` still returns 404 on the control plane,
+and a 401 from the broker is its auth-gated forward proxy, not a hidden MCP
+server.
+
+If your session has `jentic` MCP tools, prefer them; use the `jentic` CLI for
+`setup`/`access` recovery and anything not exposed over MCP. Both surfaces
+talk to the same instance — check `backend`/`host` in the identity stamp on
+MCP tool results (or `GET {base}/instance`) if in doubt.
 
 ## Quickstart (agent onboarding)
 

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -10,6 +10,13 @@ Jentic is an API broker: you discover operations across many APIs, then execute
 them through a single authenticated gateway without managing each API's
 credentials yourself. The `jentic` CLI is the agent-facing entrypoint.
 
+The same loop is also exposed over **MCP** by the local `jentic mcp` stdio
+server — available in the `jentic` CLI from the next release; check
+`jentic mcp --help`. If your session has `jentic` MCP tools, prefer them; use
+the CLI for `setup`/`access` recovery and anything not exposed over MCP. Both
+surfaces talk to the same instance — check `backend`/`host` in the identity
+stamp on MCP tool results if in doubt.
+
 ## When to Use
 
 - You need to call a third-party API (Stripe, GitHub, Slack, …) but don't have
@@ -506,17 +513,20 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   "catalog read" scopes; they're rejected.
 - **Verify which backend you're talking to before diagnosing "missing" APIs
   or credentials.** If your session also has Jentic **MCP tools**
-  (`search_apis`, `list_credentials`, `execute`, …), they may be bound to a
-  **different backend** than this CLI — typically the hosted cloud workspace
-  vs the local install — and nothing in their responses says which one
-  replied. The symptom is *silent wrong answers*, not errors: an API the user
-  just imported "doesn't exist", credentials "disappeared", or operation ids
-  from one surface don't resolve on the other. Before concluding anything is
-  missing or broken, check where each surface points — `jentic context view`
-  shows this CLI's active environment/`base_url`, and `jentic api GET /instance`
-  reports which backend serves it (see "confirm which backend you're on" in step 3);
-  ask your operator which backend the MCP server was configured against —
-  and stick to one surface for the whole task.
+  (`search_apis`, `list_credentials`, `execute`, …), check which backend they
+  answer from. Tools served by the local `jentic mcp` server stamp
+  `backend`/`host` on every result — compare that against this CLI's backend.
+  Tools without the stamp (e.g. the hosted Jentic cloud platform's MCP server)
+  may be bound to a **different backend** than this CLI — typically the hosted
+  cloud workspace vs the local install. The symptom of a mismatch is *silent
+  wrong answers*, not errors: an API the user just imported "doesn't exist",
+  credentials "disappeared", or operation ids from one surface don't resolve
+  on the other. Before concluding anything is missing or broken, check where
+  each surface points — `jentic context view` shows this CLI's active
+  environment/`base_url`, and `jentic api GET /instance` reports which backend
+  serves it (see "confirm which backend you're on" in step 3); for MCP tools,
+  read the identity stamp or ask your operator which backend the MCP server
+  was configured against — and stick to one surface for the whole task.
 - An `execute` failure is not always an access problem. A DNS or TLS error
   means the **broker target** is misconfigured (see step 5); connection
   refused on a **local** target usually means the instance is **stopped** —

--- a/tests/unit/shared/web/test_agent_discovery.py
+++ b/tests/unit/shared/web/test_agent_discovery.py
@@ -274,10 +274,11 @@ def test_llms_txt_advertises_mcp_server(client: TestClient) -> None:
     assert "jentic mcp --help" in body
     # The §3.5 routing paragraph: MCP preferred, CLI for recovery, same instance.
     assert "prefer them" in body
+    assert "`setup`/`access` recovery" in body
     assert "same instance" in body
     assert "`backend`/`host`" in body
     # The /mcp probe still 404s — the advertisement must not imply an HTTP endpoint.
-    assert "404" in body
+    assert "probing `/mcp` still returns 404" in body
 
 
 def test_render_llms_txt_stamps_base_everywhere() -> None:

--- a/tests/unit/shared/web/test_agent_discovery.py
+++ b/tests/unit/shared/web/test_agent_discovery.py
@@ -258,15 +258,26 @@ def test_llms_txt_quickstart_matches_backend_contract(client: TestClient) -> Non
     assert "300 seconds in the future" in body
 
 
-def test_llms_txt_disclaims_mcp_endpoint(client: TestClient) -> None:
-    """llms.txt tells agents there is no MCP endpoint on this deployment (#753).
+def test_llms_txt_advertises_mcp_server(client: TestClient) -> None:
+    """llms.txt advertises the local `jentic mcp` server and the routing rule (#1176).
 
-    Agents arriving from the Jentic cloud platform probe ``/mcp`` and then
-    misdiagnose the 404; the document must state the integration path is the
-    CLI + skill (or raw HTTP), not MCP.
+    The document must advertise MCP as the preferred surface for MCP-capable
+    runtimes (with the CLI for bootstrap/recovery), state that both surfaces
+    reach the same instance (verifiable via ``backend``/``host`` in the
+    identity stamp), and still preempt the ``/mcp``-probe misdiagnosis (#753):
+    MCP runs through the local stdio server, not an HTTP endpoint on the
+    deployment.
     """
     body = client.get(LLMS_TXT_PATH).text
-    assert "no MCP endpoint" in body
+    assert "no MCP endpoint" not in body
+    assert "`jentic mcp`" in body
+    assert "jentic mcp --help" in body
+    # The §3.5 routing paragraph: MCP preferred, CLI for recovery, same instance.
+    assert "prefer them" in body
+    assert "same instance" in body
+    assert "`backend`/`host`" in body
+    # The /mcp probe still 404s — the advertisement must not imply an HTTP endpoint.
+    assert "404" in body
 
 
 def test_render_llms_txt_stamps_base_everywhere() -> None:


### PR DESCRIPTION
## Summary

Product sign-off for local MCP is recorded (YES, 2026-08-28, #1174), so the "no MCP endpoint" stance in the served and static docs is now stale. This flips every disclaimer into an advertisement of the local `jentic mcp` stdio server plus the decided routing rule (MCP preferred for MCP-capable runtimes; CLI for bootstrap/recovery; both reach the same instance — check `backend`/`host` in the identity stamp), and ships the same-host hardening ladder as operator recipes usable with phase-1 code as-is. Lane B of the local-MCP theme (plan: `jentic-one-plans/themes/local-mcp/phase-1.md`).

> **Merge gate: do not merge until jentic-one PR 1-A (the `jentic mcp` skeleton, branch `feat/mcp-command-skeleton`) is at least in review.** Gate satisfied: 1-A shipped as #1181 (in review, adversarially reviewed with fixes landed) — the docs no longer advertise a command no build has.

## Changes

- `shared/web/agent_discovery.py` (`render_llms_txt`): the "no MCP endpoint" disclaimer becomes the MCP advertisement + routing paragraph. Keeps the #753 probe guidance (`/mcp` still 404s — MCP runs through the local server, not an HTTP endpoint).
- `tests/unit/shared/web/test_agent_discovery.py`: `test_llms_txt_disclaims_mcp_endpoint` renamed to `test_llms_txt_advertises_mcp_server`, now a positive assertion (advertisement + routing + probe guidance present, stale text absent).
- Skill (`skills/jentic/SKILL.md` source, both mirrors regenerated via `make skills` — byte-identical, `test_skill_drift.py` green): routing paragraph added; the "verify which backend" pitfall now explains the `backend`/`host` identity stamp on `jentic mcp` tool results.
- Docs sweep — every stale "no MCP" claim removed: `README.md` ("Why self-hosted" + docs table), `docs/cloud-vs-self-hosted.md` (section rewritten as "MCP against a self-hosted install", coexistence + migration updated for the identity stamp), `deploy/README.md`, `docs/context-and-config.md` (repointing section covers `jentic mcp` context targeting). Two stragglers beyond the plan's list also flipped: repo-root `llms.txt` and `AGENTS.md`.
- **New page `docs/security/mcp-same-host-hardening.md`**: the hardening ladder as operator recipes — (1) isolated instance (docker deploy / different OS user / remote instance); (2) sudo-shim entry with a per-agent service user (`_jentic-claude` etc.) and an argv-pinned NOPASSWD `sudoers.d` line, incl. the sudo `env_reset` boundary (entry `env` blocks, `$JENTIC_CONTEXT`, orchestrator-set `$JENTIC_SESSION_ID` do not cross; never `env_keep JENTIC_*`); (3) `docker run -i --rm` container entry. States plainly that the API-level credential boundary (broker-side injection) holds in every mode, the recipes close OS-level key/instance-file exposure for same-host setups, and plain stdio stays the supported default. Cross-linked from `docs/security/hardening.md` and `docs/cloud-vs-self-hosted.md`.
- Interim wording throughout (`jentic mcp` unreleased): "available in the `jentic` CLI from the next release — check `jentic mcp --help`". A one-line follow-up PR removes the caveat at release (tracked in #1176). The repo-root `llms.txt`/`AGENTS.md` phrase it without a backticked `jentic mcp` invocation because `tests/arch/test_agent_docs_refs.py` pins those two files' CLI mentions to the shipped command tree.
- Out of scope: any Go/CLI code (lane A), automation of the sudo-shim (`jentic setup`, phase 2), the HTTP daemon rung (phase 3).

## Risk & rollback

- Low risk: docs, one rendered-template string, and a renamed test — no behaviour, auth, or API-shape change. Revert the squash commit to roll back.

## Test plan

- `uv run pytest tests/unit/shared/web/ tests/arch/ --no-cov` — 336 passed (incl. the renamed llms.txt test and the skill-drift + agent-docs-refs arch guards)
- `make lint` — ruff check, ruff format, mypy all clean

Closes #1176

Made with [Cursor](https://cursor.com)
