### PR TITLE
feat(cli): add search_apis + inspect_operation MCP discovery tools

### DIFF
--- a/cli/internal/cli/api/mcp.go
+++ b/cli/internal/cli/api/mcp.go
@@ -104,11 +104,11 @@ func (a *app) mcpE(cmd *cobra.Command, opts *mcpOptions) error {
 	case isClientDisconnect(err):
 		// The MCP client closed (or killed) the stdio pipe — the normal end of
 		// a stdio session, even when it arrives mid-flight. Not an error.
-		logger.Info("mcp client disconnected", "cause", err.Error())
+		logger.Info("mcp client disconnected", "cause", redactedErr(err))
 		err = nil
 	}
 	if err != nil {
-		logger.Error("mcp server exited", "error", err)
+		logger.Error("mcp server exited", "error", redactedErr(err))
 		return reportCoded(aud, err)
 	}
 	return nil

--- a/cli/internal/cli/api/mcp_discovery.go
+++ b/cli/internal/cli/api/mcp_discovery.go
@@ -38,7 +38,11 @@ var searchAPIsParams = []paramSpec{
 	{name: "query", kind: paramString},
 	{name: "apis", aliases: []string{"api"}, kind: paramStringList},
 	{name: "limit", kind: paramInt},
-	{name: "cursor", kind: paramString},
+	// next_cursor is aliased because it's the single most predictable drift:
+	// a model copying the response key straight back as the argument name.
+	// Without the fold the key would be silently dropped and the tool would
+	// re-serve page 1 forever.
+	{name: "cursor", aliases: []string{"next_cursor"}, kind: paramString},
 }
 
 func (s *mcpServer) handleSearchAPIs(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -57,7 +61,7 @@ func (s *mcpServer) handleSearchAPIs(ctx context.Context, req *mcp.CallToolReque
 
 	client, err := s.app.controlClient(cctx)
 	if err != nil {
-		s.logger.Warn("search_apis failed", "error", err)
+		s.logger.Warn("search_apis failed", "error", redactedErr(err))
 		return s.softError(cctx, err), nil
 	}
 
@@ -66,6 +70,13 @@ func (s *mcpServer) handleSearchAPIs(ctx context.Context, req *mcp.CallToolReque
 		body.Apis = &apis
 	}
 	if limit, ok := args["limit"].(int); ok && limit != 0 {
+		// The docstring promises 1-100 (the server's own bound); enforce it
+		// here so an out-of-range value is an invalid-params protocol error
+		// the model can correct, not a soft INTERNAL_ERROR round-tripped from
+		// the server's 422 (which mis-hints retryability).
+		if limit < 1 || limit > 100 {
+			return nil, invalidParams(fmt.Errorf("limit must be between 1 and 100, got %d", limit))
+		}
 		body.Limit = &limit
 	}
 	if cursor, ok := args["cursor"].(string); ok && cursor != "" {
@@ -80,7 +91,7 @@ func (s *mcpServer) handleSearchAPIs(ctx context.Context, req *mcp.CallToolReque
 		if errors.As(err, &he) && he.StatusCode == http.StatusNotImplemented {
 			err = &ux.CodedError{Code: ux.CodeInternalError, Msg: errSearchUnsupported.Error()}
 		}
-		s.logger.Warn("search_apis failed", "error", err)
+		s.logger.Warn("search_apis failed", "error", redactedErr(err))
 		return s.softError(cctx, err), nil
 	}
 	if resp.JSON200 == nil {
@@ -97,11 +108,20 @@ func (s *mcpServer) handleSearchAPIs(ctx context.Context, req *mcp.CallToolReque
 	for _, h := range resp.JSON200.Data {
 		hits = append(hits, toSearchHit(h))
 	}
+	// Pagination mirrors ux.NewList's invariant: has_more is DERIVED from
+	// cursor presence and an empty next_cursor is omitted, so the
+	// inconsistent pair {has_more:true, next_cursor:""} — which the CLI list
+	// envelope cannot represent, and which would trap a docstring-following
+	// model in a page-1 loop (the handler drops an empty cursor argument) —
+	// is unrepresentable here too, whatever the server sends.
+	nextCursor := deref(resp.JSON200.NextCursor)
 	payload := map[string]any{
 		"schema_version": mcpSchemaVersion,
 		"data":           hits,
-		"has_more":       resp.JSON200.HasMore,
-		"next_cursor":    deref(resp.JSON200.NextCursor),
+		"has_more":       nextCursor != "",
+	}
+	if nextCursor != "" {
+		payload["next_cursor"] = nextCursor
 	}
 	return s.result(cctx, payload), nil
 }
@@ -132,7 +152,7 @@ func (s *mcpServer) handleInspectOperation(ctx context.Context, req *mcp.CallToo
 
 	ins, err := s.inspector(cctx)
 	if err != nil {
-		s.logger.Warn("inspect_operation failed", "error", err)
+		s.logger.Warn("inspect_operation failed", "error", redactedErr(err))
 		return s.softError(cctx, err), nil
 	}
 	body, err := ins.Inspect(cctx, target, revision, "json")
@@ -149,7 +169,7 @@ func (s *mcpServer) handleInspectOperation(ctx context.Context, req *mcp.CallToo
 					"then inspect the operation_id (or the METHOD:url) from one of its hits.",
 			}, "search_apis"), nil
 		}
-		s.logger.Warn("inspect_operation failed", "error", err)
+		s.logger.Warn("inspect_operation failed", "error", redactedErr(err))
 		return s.softError(cctx, err), nil
 	}
 

--- a/cli/internal/cli/api/mcp_discovery.go
+++ b/cli/internal/cli/api/mcp_discovery.go
@@ -1,0 +1,174 @@
+package api
+
+// mcp_discovery.go holds the PR 1-B discovery tools. search_apis is the CLI's
+// `jentic search` as a tool: the same SearchOperationsWithResponse call and
+// the same envelope, passed through one page at a time (the model paginates
+// with next_cursor; auto-following --all style would flood its context).
+// inspect_operation is `jentic inspect` over the agentops Inspector seam with
+// the format fixed to json — the raw full inspect document, redacted through
+// the same funnel as CLI output. Both fold their arguments through the shared
+// normalizer (mcp_params.go) before touching the wire.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+	"github.com/jentic/jentic-one/cli/internal/agentops"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// invalidParams maps a malformed-arguments failure to the JSON-RPC
+// invalid-params error, per the §3.7 error-mapping table: a request the
+// server cannot even interpret is a protocol error, not a soft error result
+// (those are reserved for diagnosable states the model should act on).
+func invalidParams(err error) error {
+	return &jsonrpc.Error{Code: jsonrpc.CodeInvalidParams, Message: err.Error()}
+}
+
+// searchAPIsParams mirrors the `jentic search` surface: the query plus the
+// pagination/filter knobs the CLI already has (--api/--limit/--cursor).
+var searchAPIsParams = []paramSpec{
+	{name: "query", kind: paramString},
+	{name: "apis", aliases: []string{"api"}, kind: paramStringList},
+	{name: "limit", kind: paramInt},
+	{name: "cursor", kind: paramString},
+}
+
+func (s *mcpServer) handleSearchAPIs(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	s.noteClient(req.ClientInfo())
+	cctx, cancel := s.callContext(ctx)
+	defer cancel()
+
+	args, err := normalizeToolArgs(req.Params.Arguments, searchAPIsParams)
+	if err != nil {
+		return nil, invalidParams(err)
+	}
+	query, _ := args["query"].(string)
+	if query == "" {
+		return nil, invalidParams(errors.New(`search_apis requires a non-empty "query" string, e.g. {"query": "create github issue"}`))
+	}
+
+	client, err := s.app.controlClient(cctx)
+	if err != nil {
+		s.logger.Warn("search_apis failed", "error", err)
+		return s.softError(cctx, err), nil
+	}
+
+	body := control.SearchRequest{Query: query}
+	if apis, ok := args["apis"].([]string); ok && len(apis) > 0 {
+		body.Apis = &apis
+	}
+	if limit, ok := args["limit"].(int); ok && limit != 0 {
+		body.Limit = &limit
+	}
+	if cursor, ok := args["cursor"].(string); ok && cursor != "" {
+		body.Cursor = &cursor
+	}
+
+	resp, searchErr := client.SearchOperationsWithResponse(cctx, body)
+	if err := apiErrorFor(resp, searchErr); err != nil {
+		// The same 501 mapping searchE makes: search disabled on this
+		// deployment is a deployment fact, not a malformed call.
+		var he *HTTPError
+		if errors.As(err, &he) && he.StatusCode == http.StatusNotImplemented {
+			err = &ux.CodedError{Code: ux.CodeInternalError, Msg: errSearchUnsupported.Error()}
+		}
+		s.logger.Warn("search_apis failed", "error", err)
+		return s.softError(cctx, err), nil
+	}
+	if resp.JSON200 == nil {
+		return s.softError(cctx, &ux.CodedError{
+			Code: ux.CodeInternalError,
+			Msg:  fmt.Sprintf("unexpected backend response (status %d)", resp.StatusCode()),
+		}), nil
+	}
+
+	// Envelope passthrough: the exact hit projection `jentic search --json`
+	// emits, under the same {data, has_more, next_cursor} keys, one page per
+	// call. Non-nil so an empty result serializes as [] (never null).
+	hits := make([]searchHit, 0, len(resp.JSON200.Data))
+	for _, h := range resp.JSON200.Data {
+		hits = append(hits, toSearchHit(h))
+	}
+	payload := map[string]any{
+		"schema_version": mcpSchemaVersion,
+		"data":           hits,
+		"has_more":       resp.JSON200.HasMore,
+		"next_cursor":    deref(resp.JSON200.NextCursor),
+	}
+	return s.result(cctx, payload), nil
+}
+
+// inspectOperationParams: the shared operation-identity aliases plus the CLI's
+// --revision pin. Format is NOT a parameter — the tool fixes json (markdown/
+// openapi are human/CLI shapes).
+var inspectOperationParams = []paramSpec{
+	operationIDSpec,
+	{name: "revision", kind: paramString},
+}
+
+func (s *mcpServer) handleInspectOperation(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	s.noteClient(req.ClientInfo())
+	cctx, cancel := s.callContext(ctx)
+	defer cancel()
+
+	args, err := normalizeToolArgs(req.Params.Arguments, inspectOperationParams)
+	if err != nil {
+		return nil, invalidParams(err)
+	}
+	target, _ := args["operation_id"].(string)
+	if target == "" {
+		return nil, invalidParams(errors.New(`inspect_operation requires "operation_id" (aliases: "id", "uuid"): ` +
+			`a registry operation id from a search_apis hit, or a METHOD:url pair like "GET:https://api.example.com/v1/things"`))
+	}
+	revision, _ := args["revision"].(string)
+
+	ins, err := s.inspector(cctx)
+	if err != nil {
+		s.logger.Warn("inspect_operation failed", "error", err)
+		return s.softError(cctx, err), nil
+	}
+	body, err := ins.Inspect(cctx, target, revision, "json")
+	if err != nil {
+		var he *HTTPError
+		if errors.As(err, &he) && he.StatusCode == http.StatusNotFound {
+			// The same 404 → RESOLVE_FAILED mapping inspectE and the execute
+			// resolve path make — with the recovery pointed at the search
+			// tool, not get_started (the identity is fine; the id is not).
+			return s.softErrorNext(cctx, &ux.CodedError{
+				Code: ux.CodeResolveFailed,
+				Msg:  fmt.Sprintf("operation %q not found", target),
+				Actionable: "Call search_apis with a natural-language description of what you want to do, " +
+					"then inspect the operation_id (or the METHOD:url) from one of its hits.",
+			}, "search_apis"), nil
+		}
+		s.logger.Warn("inspect_operation failed", "error", err)
+		return s.softError(cctx, err), nil
+	}
+
+	// Envelope: the raw full inspect document itself, with schema_version and
+	// the instance stamp joined as top-level siblings (the whoami pattern —
+	// a strict superset of what `jentic inspect --format json` prints).
+	// s.result routes the marshaled payload through ux.RedactBytes, the same
+	// redaction guarantee inspectE applies to the body before writing it.
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return s.softError(cctx, &ux.CodedError{Code: ux.CodeInternalError, Msg: "decode inspect response: " + err.Error()}), nil
+	}
+	payload["schema_version"] = mcpSchemaVersion
+	return s.result(cctx, payload), nil
+}
+
+// inspector resolves the agentops Inspector seam for one call: the api layer's
+// generated-SDK wrapper (apiClient) over the active context's control client —
+// the same implementation `jentic inspect` and the execute resolve path use.
+func (s *mcpServer) inspector(ctx context.Context) (agentops.Inspector, error) {
+	return s.app.apisSession(ctx)
+}

--- a/cli/internal/cli/api/mcp_discovery_test.go
+++ b/cli/internal/cli/api/mcp_discovery_test.go
@@ -1,0 +1,299 @@
+package api
+
+// mcp_discovery_test.go exercises the PR 1-B tool handlers against an httptest
+// control plane: envelope passthrough with the sibling instance stamp, alias/
+// coercion tolerance on the wire, the 404 → RESOLVE_FAILED soft error with its
+// search_apis recovery pointer, and the redaction funnel on inspect bodies.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// stampedTestMCPServer is newTestMCPServer with a HEALTHY instance-stamp seam,
+// for tests asserting the fresh stamp on success envelopes.
+func stampedTestMCPServer(t *testing.T) *mcpServer {
+	t.Helper()
+	s := newTestMCPServer(t, nil)
+	instanceID := "digest-test"
+	s.instances.fetch = func(context.Context) (*control.InstanceIdentityResponse, error) {
+		return &control.InstanceIdentityResponse{Backend: "local", Host: "127.0.0.1:8000", InstanceId: &instanceID}, nil
+	}
+	return s
+}
+
+// callToolRequest builds the raw request shape the SDK hands a ToolHandler.
+func callToolRequest(name, arguments string) *mcp.CallToolRequest {
+	params := &mcp.CallToolParamsRaw{Name: name}
+	if arguments != "" {
+		params.Arguments = json.RawMessage(arguments)
+	}
+	return &mcp.CallToolRequest{Params: params}
+}
+
+func TestMCPSearchAPIs_EnvelopePassthroughWithStamp(t *testing.T) {
+	var gotBody control.SearchRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [{"type":"operation","api":{"vendor":"acme","name":"pets","version":"v1","host":"acme.com"},"operation_id":"op1","method":"GET","url":"/pets","name":"List Pets","relevance_score":0.9,"_links":{"inspect":"/inspect?id=GET%20/pets"}}],
+			"has_more": true,
+			"next_cursor": "page2"
+		}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleSearchAPIs(activeCtx(srv.URL), callToolRequest("search_apis", `{"query":"pets","limit":5,"cursor":"c0"}`))
+	if err != nil {
+		t.Fatalf("handleSearchAPIs: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+	if gotBody.Query != "pets" || gotBody.Limit == nil || *gotBody.Limit != 5 || gotBody.Cursor == nil || *gotBody.Cursor != "c0" {
+		t.Errorf("wire body = %+v, want query/limit/cursor mirrored", gotBody)
+	}
+
+	payload := decodeToolJSON(t, res)
+	if payload["schema_version"] != mcpSchemaVersion {
+		t.Errorf("schema_version = %v, want %q", payload["schema_version"], mcpSchemaVersion)
+	}
+	data, ok := payload["data"].([]any)
+	if !ok || len(data) != 1 {
+		t.Fatalf("data = %v, want one hit", payload["data"])
+	}
+	hit := data[0].(map[string]any)
+	if hit["operation_id"] != "op1" || hit["relevance_score"] != 0.9 {
+		t.Errorf("hit = %v, want the searchE projection (operation_id, relevance_score)", hit)
+	}
+	if payload["has_more"] != true || payload["next_cursor"] != "page2" {
+		t.Errorf("pagination = has_more %v next_cursor %v, want passthrough true/page2", payload["has_more"], payload["next_cursor"])
+	}
+	stamp, ok := payload["instance"].(map[string]any)
+	if !ok {
+		t.Fatalf("result has no top-level instance stamp: %v", payload)
+	}
+	if stamp["backend"] != "local" || stamp["instance_id"] != "digest-test" {
+		t.Errorf("instance stamp = %v, want the fresh identity", stamp)
+	}
+}
+
+func TestMCPSearchAPIs_EmptyResultsEmitEmptyArray(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"has_more":false,"next_cursor":null}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleSearchAPIs(activeCtx(srv.URL), callToolRequest("search_apis", `{"query":"nothing"}`))
+	if err != nil {
+		t.Fatalf("handleSearchAPIs: %v", err)
+	}
+	text := res.Content[0].(*mcp.TextContent).Text
+	if strings.Contains(text, `"data":null`) {
+		t.Fatalf("data serialized as null, want []: %s", text)
+	}
+	payload := decodeToolJSON(t, res)
+	if data, ok := payload["data"].([]any); !ok || len(data) != 0 {
+		t.Errorf("data = %v, want an empty array", payload["data"])
+	}
+}
+
+func TestMCPSearchAPIs_AliasAndStringCoercionReachTheWire(t *testing.T) {
+	var gotBody control.SearchRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"has_more":false,"next_cursor":null}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	// `api` (singular alias) as a bare string, `limit` as a numeric string —
+	// both must be normalized before the SDK call.
+	res, err := s.handleSearchAPIs(activeCtx(srv.URL), callToolRequest("search_apis", `{"query":"q","api":"acme/pets/v1","limit":"3"}`))
+	if err != nil {
+		t.Fatalf("handleSearchAPIs: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+	if gotBody.Apis == nil || len(*gotBody.Apis) != 1 || (*gotBody.Apis)[0] != "acme/pets/v1" {
+		t.Errorf("apis on the wire = %v, want the coerced one-element list", gotBody.Apis)
+	}
+	if gotBody.Limit == nil || *gotBody.Limit != 3 {
+		t.Errorf("limit on the wire = %v, want the parsed 3", gotBody.Limit)
+	}
+}
+
+func TestMCPSearchAPIs_MissingQueryIsInvalidParams(t *testing.T) {
+	s := stampedTestMCPServer(t)
+	res, err := s.handleSearchAPIs(activeCtx("http://127.0.0.1:0"), callToolRequest("search_apis", `{}`))
+	if res != nil {
+		t.Fatalf("want a protocol error, got a result: %v", res)
+	}
+	var wireErr *jsonrpc.Error
+	if !errors.As(err, &wireErr) || wireErr.Code != jsonrpc.CodeInvalidParams {
+		t.Fatalf("err = %v, want a JSON-RPC invalid-params error", err)
+	}
+	if !strings.Contains(wireErr.Message, "query") {
+		t.Errorf("message %q must name the missing parameter", wireErr.Message)
+	}
+}
+
+func TestMCPSearchAPIs_NoContextIsSoftResolveFailed(t *testing.T) {
+	s := newTestMCPServer(t, nil)
+	// No active state in the context: the canonical no-context RESOLVE_FAILED,
+	// pointed at get_started (the default mapping).
+	res, err := s.handleSearchAPIs(context.Background(), callToolRequest("search_apis", `{"query":"pets"}`))
+	if err != nil {
+		t.Fatalf("a diagnosable state must be a soft error, not a protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeResolveFailed {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeResolveFailed)
+	}
+	if payload["next_tool"] != "get_started" {
+		t.Errorf("next_tool = %v, want get_started", payload["next_tool"])
+	}
+	if stamp, ok := payload["instance"].(map[string]any); !ok || stamp["backend"] != backendUnreachable {
+		t.Errorf("soft errors carry the (degraded) instance stamp too, got %v", payload["instance"])
+	}
+}
+
+func TestMCPInspectOperation_PassesBodyThroughWithStamp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/inspect" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if got := r.URL.Query().Get("operation_id"); got != "op_abc" {
+			t.Errorf("operation_id on the wire = %q, want op_abc", got)
+		}
+		if got := r.URL.Query().Get("revision_id"); got != "rev1" {
+			t.Errorf("revision_id on the wire = %q, want rev1", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("Accept = %q, want application/json (format is fixed to json)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"method":"GET","url":"https://api.acme.com/v1/pets","parameters":[{"name":"limit","in":"query"}]}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	// `id` alias for operation_id must fold before the wire call.
+	res, err := s.handleInspectOperation(activeCtx(srv.URL), callToolRequest("inspect_operation", `{"id":"op_abc","revision":"rev1"}`))
+	if err != nil {
+		t.Fatalf("handleInspectOperation: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["method"] != "GET" || payload["url"] != "https://api.acme.com/v1/pets" {
+		t.Errorf("payload = %v, want the raw inspect document passed through", payload)
+	}
+	if payload["schema_version"] != mcpSchemaVersion {
+		t.Errorf("schema_version = %v, want %q stamped as a sibling", payload["schema_version"], mcpSchemaVersion)
+	}
+	if stamp, ok := payload["instance"].(map[string]any); !ok || stamp["backend"] != "local" {
+		t.Errorf("instance stamp = %v, want the fresh identity", payload["instance"])
+	}
+}
+
+func TestMCPInspectOperation_404IsSoftResolveFailedPointingAtSearch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"operation not found"}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleInspectOperation(activeCtx(srv.URL), callToolRequest("inspect_operation", `{"operation_id":"op_missing"}`))
+	if err != nil {
+		t.Fatalf("a resolve failure must be a soft error, not a protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeResolveFailed {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeResolveFailed)
+	}
+	if msg, _ := payload["error"].(string); !strings.Contains(msg, "op_missing") {
+		t.Errorf("error %q must name the unresolved target", msg)
+	}
+	// The identity resolved fine — the recovery is rediscovery, not setup.
+	if payload["next_tool"] != "search_apis" {
+		t.Errorf("next_tool = %v, want search_apis", payload["next_tool"])
+	}
+	if step, _ := payload["actionable_step"].(string); !strings.Contains(step, "search_apis") {
+		t.Errorf("actionable_step %q must route through search_apis", step)
+	}
+}
+
+func TestMCPInspectOperation_MissingTargetIsInvalidParams(t *testing.T) {
+	s := stampedTestMCPServer(t)
+	res, err := s.handleInspectOperation(activeCtx("http://127.0.0.1:0"), callToolRequest("inspect_operation", `{}`))
+	if res != nil {
+		t.Fatalf("want a protocol error, got a result: %v", res)
+	}
+	var wireErr *jsonrpc.Error
+	if !errors.As(err, &wireErr) || wireErr.Code != jsonrpc.CodeInvalidParams {
+		t.Fatalf("err = %v, want a JSON-RPC invalid-params error", err)
+	}
+	for _, spelling := range []string{"operation_id", "id", "uuid"} {
+		if !strings.Contains(wireErr.Message, spelling) {
+			t.Errorf("message %q must name the accepted spelling %q", wireErr.Message, spelling)
+		}
+	}
+}
+
+func TestMCPInspectOperation_RedactsSecretsInBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// An inspect document can embed example secrets/auth blocks — the
+		// SEC guarantee inspectE carries (round-3 P0) must hold here too.
+		_, _ = w.Write([]byte(`{"method":"GET","url":"https://api.acme.com/v1/pets","examples":{"api_key":"sk-verysecret"}}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleInspectOperation(activeCtx(srv.URL), callToolRequest("inspect_operation", `{"operation_id":"op_abc"}`))
+	if err != nil {
+		t.Fatalf("handleInspectOperation: %v", err)
+	}
+	text := res.Content[0].(*mcp.TextContent).Text
+	if strings.Contains(text, "sk-verysecret") {
+		t.Fatalf("secret leaked through the tool result: %s", text)
+	}
+	if !strings.Contains(text, "[REDACTED]") {
+		t.Errorf("want the redaction marker in the result, got: %s", text)
+	}
+}

--- a/cli/internal/cli/api/mcp_discovery_test.go
+++ b/cli/internal/cli/api/mcp_discovery_test.go
@@ -6,10 +6,13 @@ package api
 // search_apis recovery pointer, and the redaction funnel on inspect bodies.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -144,6 +147,118 @@ func TestMCPSearchAPIs_AliasAndStringCoercionReachTheWire(t *testing.T) {
 	}
 	if gotBody.Limit == nil || *gotBody.Limit != 3 {
 		t.Errorf("limit on the wire = %v, want the parsed 3", gotBody.Limit)
+	}
+}
+
+func TestMCPSearchAPIs_LimitOutOfRangeIsInvalidParams(t *testing.T) {
+	s := stampedTestMCPServer(t)
+	for _, limit := range []int{-5, 500} {
+		res, err := s.handleSearchAPIs(activeCtx("http://127.0.0.1:0"),
+			callToolRequest("search_apis", fmt.Sprintf(`{"query":"pets","limit":%d}`, limit)))
+		if res != nil {
+			t.Fatalf("limit=%d: want a protocol error, got a result: %v", limit, res)
+		}
+		var wireErr *jsonrpc.Error
+		if !errors.As(err, &wireErr) || wireErr.Code != jsonrpc.CodeInvalidParams {
+			t.Fatalf("limit=%d: err = %v, want a JSON-RPC invalid-params error", limit, err)
+		}
+		// The message must name the bound so the model can correct the call.
+		if !strings.Contains(wireErr.Message, "between 1 and 100") {
+			t.Errorf("limit=%d: message %q must name the 1-100 bound", limit, wireErr.Message)
+		}
+	}
+}
+
+// TestMCPSearchAPIs_InconsistentPaginationForcedConsistent pins the ux.NewList
+// derivation rule on the MCP envelope: a server responding has_more:true with
+// an empty cursor must NOT reach the model as that inconsistent pair (the
+// handler drops an empty cursor argument, so a docstring-following model would
+// loop on page 1 forever). has_more is derived from cursor presence and an
+// empty next_cursor is omitted, matching the CLI list envelope shape.
+func TestMCPSearchAPIs_InconsistentPaginationForcedConsistent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"has_more":true,"next_cursor":""}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleSearchAPIs(activeCtx(srv.URL), callToolRequest("search_apis", `{"query":"pets"}`))
+	if err != nil {
+		t.Fatalf("handleSearchAPIs: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["has_more"] != false {
+		t.Errorf("has_more = %v, want false derived from the empty cursor", payload["has_more"])
+	}
+	if cursor, present := payload["next_cursor"]; present {
+		t.Errorf("next_cursor = %v, want the empty cursor omitted (CLI envelope shape)", cursor)
+	}
+}
+
+// TestMCPSearchAPIs_501IsSoftSearchUnsupported pins the 501 mapping on the MCP
+// path itself: search disabled on this deployment is a deployment fact the
+// model should read as a soft error, with searchE's exact message.
+func TestMCPSearchAPIs_501IsSoftSearchUnsupported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotImplemented)
+		_, _ = w.Write([]byte(`{"detail":"search not implemented"}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleSearchAPIs(activeCtx(srv.URL), callToolRequest("search_apis", `{"query":"pets"}`))
+	if err != nil {
+		t.Fatalf("a deployment fact must be a soft error, not a protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeInternalError {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeInternalError)
+	}
+	if msg, _ := payload["error"].(string); msg != errSearchUnsupported.Error() {
+		t.Errorf("error = %q, want %q", msg, errSearchUnsupported.Error())
+	}
+}
+
+// TestMCPSearchAPIs_FailureLogIsRedacted pins the redactedErr funnel on the
+// MCP log surface: HTTPError.Error() embeds the raw upstream body, so a
+// secret in a failure response must not reach the log file verbatim.
+func TestMCPSearchAPIs_FailureLogIsRedacted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		// A non-JSON body: Detail() falls back to the raw body, so Error()
+		// carries the embedded secret pair verbatim.
+		_, _ = w.Write([]byte(`upstream failure: {"api_key":"sk-logleak"}`))
+	}))
+	defer srv.Close()
+
+	var logBuf bytes.Buffer
+	s := stampedTestMCPServer(t)
+	s.logger = slog.New(slog.NewJSONHandler(&logBuf, nil))
+
+	res, err := s.handleSearchAPIs(activeCtx(srv.URL), callToolRequest("search_apis", `{"query":"pets"}`))
+	if err != nil {
+		t.Fatalf("handleSearchAPIs: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	logged := logBuf.String()
+	if logged == "" {
+		t.Fatalf("failure must be logged")
+	}
+	if strings.Contains(logged, "sk-logleak") {
+		t.Fatalf("secret leaked into the MCP log: %s", logged)
+	}
+	if !strings.Contains(logged, "[REDACTED]") {
+		t.Errorf("want the redaction marker in the log, got: %s", logged)
 	}
 }
 
@@ -292,6 +407,32 @@ func TestMCPInspectOperation_RedactsSecretsInBody(t *testing.T) {
 	text := res.Content[0].(*mcp.TextContent).Text
 	if strings.Contains(text, "sk-verysecret") {
 		t.Fatalf("secret leaked through the tool result: %s", text)
+	}
+	if !strings.Contains(text, "[REDACTED]") {
+		t.Errorf("want the redaction marker in the result, got: %s", text)
+	}
+}
+
+// TestMCPInspectOperation_RedactsNonStringSecretValues pins the STRUCTURED
+// redaction pass through the MCP marshal path: a secret carried as a
+// non-string value (here an object) is exactly the shape the byte-level reKV
+// backstop cannot catch (round-3 P0), so this distinguishes "full funnel
+// wired" from "byte backstop only".
+func TestMCPInspectOperation_RedactsNonStringSecretValues(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"method":"GET","url":"https://api.acme.com/v1/pets","auth":{"client_secret":{"value":"sk-nested-object-secret"}}}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleInspectOperation(activeCtx(srv.URL), callToolRequest("inspect_operation", `{"operation_id":"op_abc"}`))
+	if err != nil {
+		t.Fatalf("handleInspectOperation: %v", err)
+	}
+	text := res.Content[0].(*mcp.TextContent).Text
+	if strings.Contains(text, "sk-nested-object-secret") {
+		t.Fatalf("non-string secret value leaked through the tool result: %s", text)
 	}
 	if !strings.Contains(text, "[REDACTED]") {
 		t.Errorf("want the redaction marker in the result, got: %s", text)

--- a/cli/internal/cli/api/mcp_params.go
+++ b/cli/internal/cli/api/mcp_params.go
@@ -75,6 +75,12 @@ func normalizeToolArgs(raw json.RawMessage, specs []paramSpec) (map[string]any, 
 			if err != nil {
 				return nil, fmt.Errorf("parameter %q: %w", name, err)
 			}
+			if coerced == nil {
+				// The value decoded to JSON null (a stringified "null" for an
+				// object parameter): same absence semantics as the literal
+				// null handled above — absent, never present-but-nil.
+				continue
+			}
 			if !found {
 				got, gotName, found = coerced, name, true
 				continue
@@ -109,7 +115,13 @@ func coerceParam(v any, kind paramKind) (any, error) {
 	case paramInt:
 		return coerceInt(v)
 	case paramObject:
-		return coerceObject(v)
+		m, err := coerceObject(v)
+		if err != nil || m == nil {
+			// An untyped nil (not a typed nil map) signals "decoded to JSON
+			// null" so normalizeToolArgs can treat it as absent.
+			return nil, err
+		}
+		return m, nil
 	default:
 		return nil, fmt.Errorf("unknown parameter kind %d", kind)
 	}
@@ -189,6 +201,9 @@ func coerceObject(v any) (map[string]any, error) {
 		if err := json.Unmarshal([]byte(t), &m); err != nil {
 			return nil, fmt.Errorf("expected a JSON object (a stringified object is accepted): %w", err)
 		}
+		// A stringified "null" unmarshals to a nil map with no error; return
+		// it as-is — coerceParam maps it to the absent sentinel so it never
+		// surfaces as a present-but-nil parameter.
 		return m, nil
 	default:
 		return nil, fmt.Errorf("expected a JSON object, got %T", v)

--- a/cli/internal/cli/api/mcp_params.go
+++ b/cli/internal/cli/api/mcp_params.go
@@ -1,0 +1,206 @@
+package api
+
+// mcp_params.go is the shared tool-argument normalizer (master §3.2 "param
+// alias tolerance"). Models drift on parameter names and shapes — `id` for
+// `operation_id`, a bare string where a list is declared, a stringified JSON
+// object for structured inputs — and a hard schema rejection would burn a tool
+// round-trip on trivia the server can resolve unambiguously. Every tool
+// handler funnels its raw arguments through normalizeToolArgs with a declared
+// spec table, so the tolerance rules exist exactly once. Genuinely malformed
+// input (not an object, unresolvable types, conflicting aliases) errors out —
+// the handler maps that to a JSON-RPC invalid-params error, per the §3.7
+// error-mapping table.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// paramKind is the canonical value shape a tool parameter normalizes to.
+type paramKind int
+
+const (
+	paramString paramKind = iota
+	paramStringList
+	paramInt
+	paramObject
+)
+
+// paramSpec declares one tool parameter: its canonical name (the key handlers
+// read), the aliases folded onto it, and the shape values are coerced to.
+type paramSpec struct {
+	name    string
+	aliases []string
+	kind    paramKind
+}
+
+// The alias tables pinned by master §3.2. operationIDSpec serves the discovery
+// tools; inputsSpec is declared alongside it (the normalizer lands complete in
+// this PR) for 1-C's execute tools to reuse.
+var (
+	operationIDSpec = paramSpec{name: "operation_id", aliases: []string{"uuid", "id"}, kind: paramString}
+	inputsSpec      = paramSpec{name: "inputs", aliases: []string{"params", "parameters"}, kind: paramObject}
+)
+
+// normalizeToolArgs decodes a tool call's raw arguments and folds them onto
+// the spec table's canonical names: aliases are renamed, values are coerced to
+// the declared kind (see coerceParam), and keys no spec claims are dropped —
+// a stray key must not fail the call (the same permissive posture as the 1-A
+// input schemas). A parameter supplied under several names with conflicting
+// values errors — silently picking one would execute something the model did
+// not ask for. nil/empty arguments normalize to an empty map.
+func normalizeToolArgs(raw json.RawMessage, specs []paramSpec) (map[string]any, error) {
+	out := make(map[string]any, len(specs))
+	if len(raw) == 0 {
+		return out, nil
+	}
+	var args map[string]any
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, fmt.Errorf("arguments must be a JSON object: %w", err)
+	}
+	for _, spec := range specs {
+		var (
+			got     any
+			gotName string
+			found   bool
+		)
+		for _, name := range append([]string{spec.name}, spec.aliases...) {
+			v, ok := args[name]
+			if !ok || v == nil {
+				continue
+			}
+			coerced, err := coerceParam(v, spec.kind)
+			if err != nil {
+				return nil, fmt.Errorf("parameter %q: %w", name, err)
+			}
+			if !found {
+				got, gotName, found = coerced, name, true
+				continue
+			}
+			// The same parameter under a second name: identical values are
+			// harmless repetition, different values are ambiguous.
+			if !equalParam(got, coerced) {
+				return nil, fmt.Errorf("parameters %q and %q are aliases of %q but carry different values", gotName, name, spec.name)
+			}
+		}
+		if found {
+			out[spec.name] = got
+		}
+	}
+	return out, nil
+}
+
+// coerceParam converts a decoded JSON value to the declared kind, tolerating
+// the shapes models actually send:
+//   - string:      a one-element list unwraps; an integral number formats.
+//   - string list: a bare string splits on commas (mirroring the CLI's
+//     repeatable StringSlice flags); list elements coerce like strings.
+//   - int:         a numeric string parses; a JSON number must be integral.
+//   - object:      a JSON-object string decodes (models routinely stringify
+//     structured arguments).
+func coerceParam(v any, kind paramKind) (any, error) {
+	switch kind {
+	case paramString:
+		return coerceString(v)
+	case paramStringList:
+		return coerceStringList(v)
+	case paramInt:
+		return coerceInt(v)
+	case paramObject:
+		return coerceObject(v)
+	default:
+		return nil, fmt.Errorf("unknown parameter kind %d", kind)
+	}
+}
+
+func coerceString(v any) (string, error) {
+	switch t := v.(type) {
+	case string:
+		return t, nil
+	case float64:
+		if t == float64(int64(t)) {
+			return strconv.FormatInt(int64(t), 10), nil
+		}
+		return strconv.FormatFloat(t, 'g', -1, 64), nil
+	case []any:
+		if len(t) == 1 {
+			return coerceString(t[0])
+		}
+		return "", fmt.Errorf("expected a string, got a list of %d values", len(t))
+	default:
+		return "", fmt.Errorf("expected a string, got %T", v)
+	}
+}
+
+func coerceStringList(v any) ([]string, error) {
+	switch t := v.(type) {
+	case string:
+		// Mirror pflag's StringSlice: comma-separated, whitespace-trimmed,
+		// empties dropped.
+		parts := strings.Split(t, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if p = strings.TrimSpace(p); p != "" {
+				out = append(out, p)
+			}
+		}
+		return out, nil
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			s, err := coerceString(e)
+			if err != nil {
+				return nil, fmt.Errorf("list element: %w", err)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("expected a list of strings, got %T", v)
+	}
+}
+
+func coerceInt(v any) (int, error) {
+	switch t := v.(type) {
+	case float64:
+		if t != float64(int64(t)) {
+			return 0, fmt.Errorf("expected an integer, got %v", t)
+		}
+		return int(t), nil
+	case string:
+		n, err := strconv.Atoi(strings.TrimSpace(t))
+		if err != nil {
+			return 0, fmt.Errorf("expected an integer, got %q", t)
+		}
+		return n, nil
+	default:
+		return 0, fmt.Errorf("expected an integer, got %T", v)
+	}
+}
+
+func coerceObject(v any) (map[string]any, error) {
+	switch t := v.(type) {
+	case map[string]any:
+		return t, nil
+	case string:
+		var m map[string]any
+		if err := json.Unmarshal([]byte(t), &m); err != nil {
+			return nil, fmt.Errorf("expected a JSON object (a stringified object is accepted): %w", err)
+		}
+		return m, nil
+	default:
+		return nil, fmt.Errorf("expected a JSON object, got %T", v)
+	}
+}
+
+// equalParam compares two coerced values for the conflicting-alias check.
+// Coerced shapes are strings, ints, []string, and JSON maps — all comparable
+// through their JSON encoding, which spares a reflect.DeepEqual on interface
+// soup.
+func equalParam(a, b any) bool {
+	ja, errA := json.Marshal(a)
+	jb, errB := json.Marshal(b)
+	return errA == nil && errB == nil && string(ja) == string(jb)
+}

--- a/cli/internal/cli/api/mcp_params_test.go
+++ b/cli/internal/cli/api/mcp_params_test.go
@@ -1,0 +1,187 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// --- normalizeToolArgs: alias folding + coercion (master §3.2 tolerance) -----
+
+func TestNormalizeToolArgs_Table(t *testing.T) {
+	searchSpecs := searchAPIsParams
+	inspectSpecs := inspectOperationParams
+	inputsSpecs := []paramSpec{operationIDSpec, inputsSpec}
+
+	cases := []struct {
+		name    string
+		raw     string
+		specs   []paramSpec
+		want    map[string]any
+		wantErr string // substring of the expected error, "" for success
+	}{
+		{
+			name:  "nil arguments normalize to an empty map",
+			raw:   "",
+			specs: inspectSpecs,
+			want:  map[string]any{},
+		},
+		{
+			name:  "canonical keys pass through",
+			raw:   `{"query":"list pets","apis":["acme/pets/v1"],"limit":5,"cursor":"c1"}`,
+			specs: searchSpecs,
+			want:  map[string]any{"query": "list pets", "apis": []string{"acme/pets/v1"}, "limit": 5, "cursor": "c1"},
+		},
+		{
+			name:  "id aliases operation_id",
+			raw:   `{"id":"op_abc"}`,
+			specs: inspectSpecs,
+			want:  map[string]any{"operation_id": "op_abc"},
+		},
+		{
+			name:  "uuid aliases operation_id",
+			raw:   `{"uuid":"op_abc"}`,
+			specs: inspectSpecs,
+			want:  map[string]any{"operation_id": "op_abc"},
+		},
+		{
+			name:  "params aliases inputs",
+			raw:   `{"params":{"petId":"42"}}`,
+			specs: inputsSpecs,
+			want:  map[string]any{"inputs": map[string]any{"petId": "42"}},
+		},
+		{
+			name:  "parameters aliases inputs",
+			raw:   `{"parameters":{"petId":"42"}}`,
+			specs: inputsSpecs,
+			want:  map[string]any{"inputs": map[string]any{"petId": "42"}},
+		},
+		{
+			name:  "stringified object decodes for inputs",
+			raw:   `{"inputs":"{\"petId\":\"42\"}"}`,
+			specs: inputsSpecs,
+			want:  map[string]any{"inputs": map[string]any{"petId": "42"}},
+		},
+		{
+			name:  "bare string coerces to a one-element list",
+			raw:   `{"query":"q","apis":"acme/pets/v1"}`,
+			specs: searchSpecs,
+			want:  map[string]any{"query": "q", "apis": []string{"acme/pets/v1"}},
+		},
+		{
+			name:  "comma-separated string splits like the CLI flag",
+			raw:   `{"query":"q","apis":"acme/pets/v1, acme/toys/v2"}`,
+			specs: searchSpecs,
+			want:  map[string]any{"query": "q", "apis": []string{"acme/pets/v1", "acme/toys/v2"}},
+		},
+		{
+			name:  "api singular aliases apis",
+			raw:   `{"query":"q","api":"acme/pets/v1"}`,
+			specs: searchSpecs,
+			want:  map[string]any{"query": "q", "apis": []string{"acme/pets/v1"}},
+		},
+		{
+			name:  "one-element list unwraps to a string",
+			raw:   `{"operation_id":["op_abc"]}`,
+			specs: inspectSpecs,
+			want:  map[string]any{"operation_id": "op_abc"},
+		},
+		{
+			name:  "numeric string parses as int",
+			raw:   `{"query":"q","limit":"25"}`,
+			specs: searchSpecs,
+			want:  map[string]any{"query": "q", "limit": 25},
+		},
+		{
+			name:  "matching duplicate alias values are tolerated",
+			raw:   `{"id":"op_abc","operation_id":"op_abc"}`,
+			specs: inspectSpecs,
+			want:  map[string]any{"operation_id": "op_abc"},
+		},
+		{
+			name:  "unknown keys are dropped, not fatal",
+			raw:   `{"query":"q","verbosity":"high"}`,
+			specs: searchSpecs,
+			want:  map[string]any{"query": "q"},
+		},
+		{
+			name:  "null values are treated as absent",
+			raw:   `{"query":"q","cursor":null}`,
+			specs: searchSpecs,
+			want:  map[string]any{"query": "q"},
+		},
+		{
+			name:    "conflicting alias values error",
+			raw:     `{"id":"op_abc","operation_id":"op_xyz"}`,
+			specs:   inspectSpecs,
+			wantErr: "aliases",
+		},
+		{
+			name:    "non-object arguments error",
+			raw:     `["op_abc"]`,
+			specs:   inspectSpecs,
+			wantErr: "JSON object",
+		},
+		{
+			name:    "fractional limit errors",
+			raw:     `{"query":"q","limit":2.5}`,
+			specs:   searchSpecs,
+			wantErr: "integer",
+		},
+		{
+			name:    "multi-element list where a string is expected errors",
+			raw:     `{"operation_id":["op_a","op_b"]}`,
+			specs:   inspectSpecs,
+			wantErr: "list of 2 values",
+		},
+		{
+			name:    "non-string list element errors",
+			raw:     `{"query":"q","apis":[{"vendor":"acme"}]}`,
+			specs:   searchSpecs,
+			wantErr: "list element",
+		},
+		{
+			name:    "non-object inputs errors",
+			raw:     `{"inputs":42}`,
+			specs:   inputsSpecs,
+			wantErr: "JSON object",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var raw json.RawMessage
+			if tc.raw != "" {
+				raw = json.RawMessage(tc.raw)
+			}
+			got, err := normalizeToolArgs(raw, tc.specs)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got %v", tc.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q missing %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeToolArgs: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("normalized = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeToolArgs_NumberCoercesToString pins the number→string tolerance
+// separately (a model sending a bare numeric id must not lose the call).
+func TestNormalizeToolArgs_NumberCoercesToString(t *testing.T) {
+	got, err := normalizeToolArgs(json.RawMessage(`{"id":42}`), inspectOperationParams)
+	if err != nil {
+		t.Fatalf("normalizeToolArgs: %v", err)
+	}
+	if got["operation_id"] != "42" {
+		t.Errorf("operation_id = %v, want \"42\"", got["operation_id"])
+	}
+}

--- a/cli/internal/cli/api/mcp_params_test.go
+++ b/cli/internal/cli/api/mcp_params_test.go
@@ -82,6 +82,14 @@ func TestNormalizeToolArgs_Table(t *testing.T) {
 			want:  map[string]any{"query": "q", "apis": []string{"acme/pets/v1"}},
 		},
 		{
+			// The response key copied straight back as the argument name —
+			// the pagination drift the alias exists to absorb.
+			name:  "next_cursor aliases cursor",
+			raw:   `{"query":"q","next_cursor":"page2"}`,
+			specs: searchSpecs,
+			want:  map[string]any{"query": "q", "cursor": "page2"},
+		},
+		{
 			name:  "one-element list unwraps to a string",
 			raw:   `{"operation_id":["op_abc"]}`,
 			specs: inspectSpecs,
@@ -110,6 +118,15 @@ func TestNormalizeToolArgs_Table(t *testing.T) {
 			raw:   `{"query":"q","cursor":null}`,
 			specs: searchSpecs,
 			want:  map[string]any{"query": "q"},
+		},
+		{
+			// json.Unmarshal decodes "null" to a nil map without error; that
+			// must mean absent (matching the literal-null rule above), never
+			// a present-but-nil object.
+			name:  "stringified null object is treated as absent",
+			raw:   `{"operation_id":"op_abc","inputs":"null"}`,
+			specs: inputsSpecs,
+			want:  map[string]any{"operation_id": "op_abc"},
 		},
 		{
 			name:    "conflicting alias values error",

--- a/cli/internal/cli/api/mcp_server.go
+++ b/cli/internal/cli/api/mcp_server.go
@@ -150,9 +150,12 @@ var searchAPIsSchema = map[string]any{
 }
 
 // inspectOperationSchema declares no required list: operation_id may arrive
-// under its aliases (id, uuid), which a required constraint would reject
-// before the normalizer could fold them. The handler enforces presence with
-// a JSON-RPC invalid-params error naming all accepted spellings.
+// under its aliases (id, uuid), and a client-side schema validator would
+// reject those spellings before the call ever reached the normalizer. (The
+// server itself never validates — raw AddTool leaves that to the handler, as
+// noted above — so any `required` here, including search_apis' required
+// query, is advisory for clients; presence is enforced in the handler with
+// a JSON-RPC invalid-params error naming all accepted spellings.)
 var inspectOperationSchema = map[string]any{
 	"type": "object",
 	"properties": map[string]any{
@@ -314,6 +317,15 @@ func (s *mcpServer) result(ctx context.Context, payload map[string]any) *mcp.Cal
 // mcpSchemaVersion pins the machine-contract shape of the MCP tool payloads,
 // mirroring the CLI envelopes' schema_version (13 §2/§6).
 const mcpSchemaVersion = "1"
+
+// redactedErr funnels an error's message through the ux redaction backstop
+// before it is written to the MCP log file. The log is an output surface like
+// stderr — and HTTPError.Error() embeds the raw upstream response body — so
+// every failure-logging site must apply the same guarantee ReportError's
+// stderr path does, not write err verbatim.
+func redactedErr(err error) string {
+	return string(ux.RedactBytes([]byte(err.Error())))
+}
 
 // softError converts a failure into an isError tool result carrying the SAME
 // coded taxonomy as the CLI's agent envelope ({schema_version, error_code,

--- a/cli/internal/cli/api/mcp_server.go
+++ b/cli/internal/cli/api/mcp_server.go
@@ -119,9 +119,60 @@ type mcpToolSpec struct {
 // must not lose the diagnosis get_started exists to deliver.
 var noArgsSchema = map[string]any{"type": "object", "properties": map[string]any{}}
 
-// toolSpecs declares the PR 1-A surface: exactly get_started and whoami
-// (discovery and execute tools land in 1-B/1-C). Docstrings encode the flow
-// (get_started first, whoami before requesting/executing) per §3.2.
+// The discovery tools' input schemas. Like noArgsSchema they stay permissive —
+// no additionalProperties:false, no alias properties — because the SDK's raw
+// AddTool leaves validation to the handler, where the shared normalizer
+// (mcp_params.go) resolves aliases and coerces shapes the schema alone would
+// have rejected. The declared types are the canonical shapes a well-behaved
+// model should send.
+var searchAPIsSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"query": map[string]any{
+			"type":        "string",
+			"description": "Natural-language description of the operation you need, e.g. \"create github issue\".",
+		},
+		"apis": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "Restrict to these APIs, as vendor/name/version slugs from earlier hits (a single string is also accepted).",
+		},
+		"limit": map[string]any{
+			"type":        "integer",
+			"description": "Max results per page (1-100, server default 10).",
+		},
+		"cursor": map[string]any{
+			"type":        "string",
+			"description": "next_cursor from the previous page, to fetch the next one.",
+		},
+	},
+	"required": []string{"query"},
+}
+
+// inspectOperationSchema declares no required list: operation_id may arrive
+// under its aliases (id, uuid), which a required constraint would reject
+// before the normalizer could fold them. The handler enforces presence with
+// a JSON-RPC invalid-params error naming all accepted spellings.
+var inspectOperationSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"operation_id": map[string]any{
+			"type": "string",
+			"description": "The operation to inspect (required; \"id\" and \"uuid\" are accepted aliases): a registry " +
+				"operation id from a search_apis hit, or a METHOD:url pair like \"GET:https://api.example.com/v1/things\".",
+		},
+		"revision": map[string]any{
+			"type":        "string",
+			"description": "Pin a specific revision ID for reproducibility (defaults to the current revision).",
+		},
+	},
+}
+
+// toolSpecs declares the served tool surface: the 1-A pre-auth pair
+// (get_started, whoami) plus the 1-B discovery pair (search_apis,
+// inspect_operation); the execute tools land in 1-C. Docstrings encode the
+// flow (get_started first, whoami before discovery, search → inspect →
+// execute) per §3.2, with concrete argument examples a model can copy.
 func (s *mcpServer) toolSpecs() []mcpToolSpec {
 	readOnly := &mcp.ToolAnnotations{ReadOnlyHint: true}
 	return []mcpToolSpec{
@@ -150,11 +201,52 @@ func (s *mcpServer) toolSpecs() []mcpToolSpec {
 				Description: "Show the calling agent's identity as the Jentic control plane sees it: " +
 					"id, status, scopes, and toolkit bindings with the APIs each one serves. " +
 					"Call after get_started reports ready, and before requesting access or " +
-					"executing operations. On an auth error, call get_started for the fix.",
+					"executing operations — never execute an operation just to probe whether " +
+					"you have access. On an auth error, call get_started for the fix.",
 				InputSchema: noArgsSchema,
 				Annotations: readOnly,
 			},
 			handler:  s.handleWhoami,
+			readOnly: true,
+		},
+		{
+			tool: &mcp.Tool{
+				Name:  "search_apis",
+				Title: "Search API operations",
+				Description: "Search the connected Jentic One registry for API operations by " +
+					"natural-language query. This is the first step of the discovery flow " +
+					"(whoami → search_apis → inspect_operation → execute): call it whenever " +
+					"you need an operation you don't already have the id of. " +
+					`Example: {"query": "create github issue", "limit": 5}. Returns one page ` +
+					"as {data, has_more, next_cursor}; each hit carries the operation_id to " +
+					"pass to inspect_operation. When has_more is true, pass next_cursor back " +
+					"as cursor for the next page. Optionally restrict to specific APIs with " +
+					`apis (vendor/name/version slugs from earlier hits), e.g. ` +
+					`{"query": "list pets", "apis": ["acme/pets/v1"]}. An empty data array ` +
+					"means nothing matching is imported into this instance's registry yet.",
+				InputSchema: searchAPIsSchema,
+				Annotations: readOnly,
+			},
+			handler:  s.handleSearchAPIs,
+			readOnly: true,
+		},
+		{
+			tool: &mcp.Tool{
+				Name:  "inspect_operation",
+				Title: "Inspect an operation's contract",
+				Description: "Fetch one operation's full contract before executing it: HTTP method, " +
+					"URL, parameters, request/response schemas, and security requirements. " +
+					"This is the read-contract step of the flow (whoami → search_apis → " +
+					"inspect_operation → execute) — always inspect before you execute. " +
+					`Example: {"operation_id": "op_abc123"} with an id from a search_apis ` +
+					`hit, or a METHOD:url pair like {"operation_id": ` +
+					`"GET:https://rest.coincap.io/v3/markets"}. Optionally pin a revision ` +
+					"for reproducibility. If the operation is not found, call search_apis " +
+					"to rediscover the right id.",
+				InputSchema: inspectOperationSchema,
+				Annotations: readOnly,
+			},
+			handler:  s.handleInspectOperation,
 			readOnly: true,
 		},
 	}
@@ -231,6 +323,15 @@ const mcpSchemaVersion = "1"
 // reach the model as data it can act on. Auth/config failures append the
 // get_started pointer so the model's next step is always discoverable.
 func (s *mcpServer) softError(ctx context.Context, err error) *mcp.CallToolResult {
+	return s.softErrorNext(ctx, err, "")
+}
+
+// softErrorNext is softError with an explicit next_tool override for handlers
+// that know a better recovery than the code-keyed default — e.g. an inspect
+// 404 is RESOLVE_FAILED, but the fix is search_apis (find the right id), not
+// get_started (the identity already resolved). An empty nextTool keeps the
+// default mapping.
+func (s *mcpServer) softErrorNext(ctx context.Context, err error, nextTool string) *mcp.CallToolResult {
 	coded := mcpCoded(err)
 	payload := map[string]any{
 		"schema_version": mcpSchemaVersion,
@@ -243,9 +344,14 @@ func (s *mcpServer) softError(ctx context.Context, err error) *mcp.CallToolResul
 	if len(coded.Details) > 0 {
 		payload["details"] = coded.Details
 	}
-	switch coded.Code {
-	case ux.CodeNotAuthenticated, ux.CodePendingApproval, ux.CodeResolveFailed:
-		payload["next_tool"] = "get_started"
+	if nextTool == "" {
+		switch coded.Code {
+		case ux.CodeNotAuthenticated, ux.CodePendingApproval, ux.CodeResolveFailed:
+			nextTool = "get_started"
+		}
+	}
+	if nextTool != "" {
+		payload["next_tool"] = nextTool
 	}
 	switch coded.Code {
 	case ux.CodeNotAuthenticated, ux.CodePendingApproval:

--- a/cli/internal/cli/api/mcp_session_test.go
+++ b/cli/internal/cli/api/mcp_session_test.go
@@ -210,6 +210,31 @@ func TestMCPSession_DiscoveryRoundTrip(t *testing.T) {
 	}
 }
 
+// TestMCPSession_MissingQueryIsProtocolError proves the invalid-params
+// contract over a real client session, not just a direct handler call: the
+// *jsonrpc.Error a handler returns must reach the CLIENT as a protocol error
+// (the SDK's error propagation), never be flattened into a tool result.
+func TestMCPSession_MissingQueryIsProtocolError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	s := newTestMCPServer(t, nil)
+	cs := connectTestClient(t, s)
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "search_apis",
+		Arguments: map[string]any{},
+	})
+	if err == nil {
+		t.Fatalf("want a protocol error at the client, got a result: %v", res)
+	}
+	// The invalid-params message must survive the round trip so the model can
+	// correct the call.
+	if !strings.Contains(err.Error(), "query") {
+		t.Errorf("client-side error %q must name the missing parameter", err.Error())
+	}
+}
+
 func TestMCPSession_GetStartedDiagnosesNoConfig(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())

--- a/cli/internal/cli/api/mcp_session_test.go
+++ b/cli/internal/cli/api/mcp_session_test.go
@@ -27,20 +27,29 @@ import (
 // the live client session.
 func connectTestClient(t *testing.T, s *mcpServer) *mcp.ClientSession {
 	t.Helper()
-	return connectTestClientCtx(context.Background(), t, s)
+	return connectTestClientWithContext(context.Background(), t, s)
 }
 
 // connectTestClientCtx is connectTestClient with a caller-supplied SERVER
-// session context: the values on ctx (ActiveState, transport hook) are what
-// `jentic mcp` injects before srv.run — the tests pin that they survive the
-// SDK's jsonrpc2 plumbing into the tool-handler contexts.
+// session context — kept as an alias of connectTestClientWithContext so both
+// naming generations of the session tests share one implementation.
 func connectTestClientCtx(ctx context.Context, t *testing.T, s *mcpServer) *mcp.ClientSession {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	return connectTestClientWithContext(ctx, t, s)
+}
+
+// connectTestClientWithContext is connectTestClient with a caller-supplied
+// server-side context — the in-process stand-in for mcpE's run(ctx): values on
+// it (the interceptor's ActiveState, the transport hook) must reach the tool
+// handlers; the tests pin that they survive the SDK's jsonrpc2 plumbing into
+// the tool-handler contexts.
+func connectTestClientWithContext(serverCtx context.Context, t *testing.T, s *mcpServer) *mcp.ClientSession {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 
 	clientT, serverT := mcp.NewInMemoryTransports()
-	ss, err := s.server.Connect(ctx, serverT, nil)
+	ss, err := s.server.Connect(serverCtx, serverT, nil)
 	if err != nil {
 		t.Fatalf("server connect: %v", err)
 	}
@@ -91,7 +100,7 @@ func TestMCPSession_ToolsListWorksWithNoConfig(t *testing.T) {
 	for _, tool := range tools.Tools {
 		names[tool.Name] = tool
 	}
-	for _, want := range []string{"get_started", "whoami"} {
+	for _, want := range []string{"get_started", "whoami", "search_apis", "inspect_operation"} {
 		tool, ok := names[want]
 		if !ok {
 			t.Fatalf("tools/list = %v, missing %q", keys(names), want)
@@ -100,8 +109,104 @@ func TestMCPSession_ToolsListWorksWithNoConfig(t *testing.T) {
 			t.Errorf("tool %q must carry readOnlyHint", want)
 		}
 	}
-	if len(names) != 2 {
-		t.Errorf("PR 1-A registers exactly get_started and whoami, got %v", keys(names))
+	if len(names) != 4 {
+		t.Errorf("PR 1-B serves exactly get_started, whoami, search_apis, and inspect_operation, got %v", keys(names))
+	}
+}
+
+// TestMCPSession_ReadOnlyServesDiscoveryTools pins the --read-only contract on
+// the 1-B surface: every discovery tool is annotated read-only, so the flag
+// must not withhold any of them (it starts biting with 1-C's execute).
+func TestMCPSession_ReadOnlyServesDiscoveryTools(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	s := newTestMCPServer(t, &mcpOptions{readOnly: true})
+	cs := connectTestClient(t, s)
+
+	tools, err := cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	if len(tools.Tools) != 4 {
+		names := make([]string, 0, len(tools.Tools))
+		for _, tool := range tools.Tools {
+			names = append(names, tool.Name)
+		}
+		t.Errorf("--read-only must serve all 4 read-only tools, got %v", names)
+	}
+}
+
+// TestMCPSession_DiscoveryRoundTrip drives search_apis → inspect_operation
+// through a real client session against an httptest control plane: the state
+// and pagination/alias tolerance must survive the full JSON-RPC round trip,
+// not just a direct handler call.
+func TestMCPSession_DiscoveryRoundTrip(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/search":
+			_, _ = w.Write([]byte(`{
+				"data": [{"type":"operation","api":{"vendor":"acme","name":"pets","version":"v1","host":"acme.com"},"operation_id":"op1","method":"GET","url":"/pets","name":"List Pets","relevance_score":0.9,"_links":{"inspect":"/inspect?id=GET%20/pets"}}],
+				"has_more": false,
+				"next_cursor": ""
+			}`))
+		case "/inspect":
+			_, _ = w.Write([]byte(`{"method":"GET","url":"https://acme.com/pets","parameters":[]}`))
+		case "/instance":
+			_, _ = w.Write([]byte(`{"backend":"local","host":"127.0.0.1:8000","instance_id":"digest-1"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	s := newTestMCPServer(t, nil)
+	s.instances.fetch = fetchInstance // the real GET /instance path, against the httptest plane
+	cs := connectTestClientWithContext(activeCtx(srv.URL), t, s)
+	ctx := context.Background()
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search_apis",
+		Arguments: map[string]any{"query": "list pets"},
+	})
+	if err != nil {
+		t.Fatalf("search_apis: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("search_apis soft-errored: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	hits, ok := payload["data"].([]any)
+	if !ok || len(hits) != 1 {
+		t.Fatalf("data = %v, want one hit", payload["data"])
+	}
+	opID, _ := hits[0].(map[string]any)["operation_id"].(string)
+	if opID == "" {
+		t.Fatalf("hit carries no operation_id: %v", hits[0])
+	}
+	if stamp, ok := payload["instance"].(map[string]any); !ok || stamp["backend"] != "local" {
+		t.Errorf("instance stamp = %v, want the live identity", payload["instance"])
+	}
+
+	// Feed the hit's operation_id back — under the `id` alias, as a drifting
+	// model would.
+	res, err = cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "inspect_operation",
+		Arguments: map[string]any{"id": opID},
+	})
+	if err != nil {
+		t.Fatalf("inspect_operation: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("inspect_operation soft-errored: %v", res.Content)
+	}
+	payload = decodeToolJSON(t, res)
+	if payload["method"] != "GET" || payload["url"] != "https://acme.com/pets" {
+		t.Errorf("inspect payload = %v, want the raw contract passed through", payload)
 	}
 }
 
@@ -155,8 +260,8 @@ func TestMCPSession_ExcludeToolsFilters(t *testing.T) {
 			t.Errorf("--exclude-tools=whoami must withhold the tool")
 		}
 	}
-	if len(tools.Tools) != 1 {
-		t.Errorf("tools = %d, want 1 after exclusion", len(tools.Tools))
+	if len(tools.Tools) != 3 {
+		t.Errorf("tools = %d, want 3 after exclusion", len(tools.Tools))
 	}
 }
 

--- a/cli/internal/cli/api/mcp_tools.go
+++ b/cli/internal/cli/api/mcp_tools.go
@@ -248,7 +248,7 @@ func (s *mcpServer) handleWhoami(ctx context.Context, req *mcp.CallToolRequest) 
 
 	me, err := s.app.getMe(cctx)
 	if err != nil {
-		s.logger.Warn("whoami failed", "error", err)
+		s.logger.Warn("whoami failed", "error", redactedErr(err))
 		return s.softError(cctx, err), nil
 	}
 	// Envelope passthrough: the same GET /me agent object `jentic access


### PR DESCRIPTION
## Summary

Adds the two discovery tools to the `jentic mcp` stdio server (local-MCP phase 1, PR 1-B — plan: `jentic-one-plans/themes/local-mcp/phase-1.md`): `search_apis` and `inspect_operation`, completing the read half of the whoami → search → inspect → execute flow. Both pass their envelopes through unchanged from the CLI surface, carry the sibling `instance` stamp on every result, and tolerate the parameter drift models actually produce via one shared normalizer.

Stacked on #1181 (which stacks on #1179); retarget after they merge. Part of #1175.

## Changes

- `cli`: `search_apis` tool → the generated SDK's `SearchOperationsWithResponse` (the same call `searchE` makes), with the CLI's `{schema_version, data, has_more, next_cursor}` list envelope passed through one page per call (the model paginates with `next_cursor`; no `--all`-style auto-follow, which would flood its context). Inputs mirror the CLI surface: `query` + `apis`/`limit`/`cursor`. The 501 "search not enabled" mapping is kept.
- `cli`: `inspect_operation` tool → the `agentops` Inspector seam (raw full inspect document, format fixed to `json`), body redacted through the same `ux.RedactBytes` funnel as `inspectE`. A 404 maps to the shared `RESOLVE_FAILED` soft error — pointed at `next_tool: search_apis` (the identity resolved; the id didn't), while the code-keyed default for auth/config failures stays `get_started`.
- `cli`: shared param normalizer (`mcp_params.go`): `uuid`/`id` → `operation_id`, `params`/`parameters` → `inputs` (declared now per the plan; consumed by 1-C's execute tools), string↔list coercion (comma-split like the CLI's repeatable flags, one-element unwrap), numeric-string ints, stringified-object decode. Conflicting alias values and genuinely malformed arguments return JSON-RPC invalid-params, per the §3.7 error-mapping table.
- `cli`: both tools carry `readOnlyHint: true`, respect the 1-A `--read-only`/`--exclude-tools` filters, and their docstrings encode the flow per master §3.2 (whoami-first "don't execute to probe access", search → inspect → execute) with concrete argument examples.
- Out of scope (1-C): `execute`/`execute_read`, `get_execution_result`, response-size cap, broker-leg CA-pinning routing.

## Risk & rollback

- Low risk: additive tool registrations behind the unreleased `jentic mcp` command; no command-tree, envelope, or auth-surface changes. Revert the squash commit to roll back.

## Test plan

- `GOWORK=off make -C cli check` green (lint + race tests + arch + golden).
- New table-driven normalizer unit tests (aliases, coercions, conflicts, malformed input).
- Handler tests against an httptest control plane: envelope passthrough incl. fresh `instance` stamp, alias/coercion reaching the wire, empty `data` serializing as `[]`, 404 → soft `RESOLVE_FAILED` + `next_tool: search_apis`, no-context → soft `RESOLVE_FAILED` + `next_tool: get_started`, missing args → JSON-RPC invalid-params, secret redaction in inspect bodies.
- 1-A's in-process MCP session test extended: tools/list serves exactly the 4 read-only tools, `--read-only`/`--exclude-tools` filtering, and a full search → inspect round trip over a real client session (including the `id` alias on the wire).

Made with [Cursor](https://cursor.com)