### PR TITLE
feat(cli): add execute + get_execution_result MCP tools with broker hardening

### DIFF
--- a/cli/client/auth/middleware.go
+++ b/cli/client/auth/middleware.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // Credentials is the minimal, UX-free input the auth middleware needs. The
@@ -87,16 +89,40 @@ func BearerToken(creds Credentials) (string, error) {
 	tokens, err := ReadTokens(creds.IdentityRef())
 	needsExchange := err != nil || tokens == nil || time.Now().After(tokens.ExpiresAt)
 	if needsExchange {
-		newTokens, xerr := performOAuthExchange(creds)
+		// Singleflight (local-MCP §3.7.1): N concurrent callers hitting one
+		// expiry instant share ONE mint instead of racing N parallel
+		// exchanges. Mint-fresh is already concurrency-safe (V2 has no
+		// refresh tokens; SaveTokens is documented last-writer-wins), so this
+		// is purely an efficiency guard for long-lived concurrent embedders
+		// (the `jentic mcp` server) — every waiter gets the winner's
+		// independently valid token.
+		v, xerr, _ := mintGroup.Do(mintKey(creds), func() (any, error) {
+			newTokens, xerr := performOAuthExchange(creds)
+			if xerr != nil {
+				return nil, fmt.Errorf("failed to authenticate: %w", xerr)
+			}
+			if serr := SaveTokens(creds.IdentityRef(), newTokens); serr != nil {
+				return nil, serr
+			}
+			return newTokens, nil
+		})
 		if xerr != nil {
-			return "", fmt.Errorf("failed to authenticate: %w", xerr)
+			return "", xerr
 		}
-		if serr := SaveTokens(creds.IdentityRef(), newTokens); serr != nil {
-			return "", serr
-		}
-		tokens = newTokens
+		tokens = v.(*TokenSet)
 	}
 	return tokens.AccessToken, nil
+}
+
+// mintGroup dedupes concurrent token exchanges per (base URL, identity,
+// environment). Package-level: BearerToken is stateless per call, so the
+// dedup scope must be the process.
+var mintGroup singleflight.Group
+
+// mintKey scopes the singleflight to one logical credential: the same
+// identity pair against a different base URL must never share a mint.
+func mintKey(creds Credentials) string {
+	return creds.BaseURL + "\x00" + creds.IdentityName + "\x00" + creds.EnvironmentName
 }
 
 // RefreshBearerToken drops any cached token and forces a fresh assertion

--- a/cli/client/auth/middleware.go
+++ b/cli/client/auth/middleware.go
@@ -96,6 +96,13 @@ func BearerToken(creds Credentials) (string, error) {
 		// is purely an efficiency guard for long-lived concurrent embedders
 		// (the `jentic mcp` server) — every waiter gets the winner's
 		// independently valid token.
+		//
+		// Waiters are uncancellable today: BearerToken takes no context, so a
+		// caller whose own deadline fires still blocks here until the
+		// winner's exchange finishes (bounded by the exchange client's own
+		// timeout — oauth.go). A future ctx-aware BearerToken should switch
+		// to mintGroup.DoChan and select on ctx.Done() so a cancelled caller
+		// stops waiting without cancelling the shared flight.
 		v, xerr, _ := mintGroup.Do(mintKey(creds), func() (any, error) {
 			newTokens, xerr := performOAuthExchange(creds)
 			if xerr != nil {

--- a/cli/client/auth/middleware_test.go
+++ b/cli/client/auth/middleware_test.go
@@ -1,8 +1,12 @@
 package auth
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -73,4 +77,103 @@ func TestBearerToken_SingleflightsConcurrentMints(t *testing.T) {
 	if got := exchanges.Load(); got != 1 {
 		t.Errorf("token exchanges = %d, want 1 (singleflight must dedupe concurrent mints)", got)
 	}
+}
+
+// TestBearerToken_SingleflightIsolatesIdentities pins the OTHER half of the
+// singleflight contract: the key scopes the flight to ONE logical credential
+// (base URL, identity, environment), so two identities minting concurrently
+// must run two separate exchanges and each receive its OWN token — sharing a
+// flight across identities is the exact failure the key exists to prevent.
+func TestBearerToken_SingleflightIsolatesIdentities(t *testing.T) {
+	withConfigDir(t)
+	for i, id := range []string{"a1", "a2"} {
+		ref := IdentityRef{Identity: id, Environment: "e1"}
+		if _, err := GetOrGenerateKey(ref); err != nil {
+			t.Fatalf("generate key for %s: %v", id, err)
+		}
+		clientID := fmt.Sprintf("client_%d", i+1)
+		if err := config.MutateConfig(func(c *config.Config) error {
+			c.Identities[id] = config.Identity{
+				Type: "agent",
+				Environments: map[string]config.EnvRegState{
+					"e1": {ClientID: clientID, Status: "approved"},
+				},
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("persist registration for %s: %v", id, err)
+		}
+	}
+
+	var exchanges atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		exchanges.Add(1)
+		// Hold the flight open long enough that a wrongly-shared key would
+		// fold the second identity's mint into the first one's flight.
+		time.Sleep(250 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		// Key the minted token to the asserted client so a cross-identity
+		// token leak is visible in the assertion below.
+		_, _ = fmt.Fprintf(w, `{"access_token":"tok_%s","expires_in":3600}`, assertionIssuer(t, r))
+	}))
+	defer srv.Close()
+
+	var wg sync.WaitGroup
+	tokens := make([]string, 2)
+	errs := make([]error, 2)
+	start := make(chan struct{})
+	for i, id := range []string{"a1", "a2"} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			tokens[i], errs[i] = BearerToken(Credentials{BaseURL: srv.URL, IdentityName: id, EnvironmentName: "e1"})
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i, want := range []string{"tok_client_1", "tok_client_2"} {
+		if errs[i] != nil {
+			t.Fatalf("identity %d: %v", i, errs[i])
+		}
+		if tokens[i] != want {
+			t.Errorf("identity %d got %q, want its own minted token %q", i, tokens[i], want)
+		}
+	}
+	if got := exchanges.Load(); got != 2 {
+		t.Errorf("token exchanges = %d, want 2 (two identities must never share a flight)", got)
+	}
+}
+
+// assertionIssuer extracts the `iss` claim (the registered client id) from the
+// JWT-bearer assertion in an exchange request, without verifying the
+// signature — the test only needs to know WHICH identity is minting.
+func assertionIssuer(t *testing.T, r *http.Request) string {
+	t.Helper()
+	var body struct {
+		Assertion string `json:"assertion"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Errorf("decode exchange body: %v", err)
+		return ""
+	}
+	parts := strings.Split(body.Assertion, ".")
+	if len(parts) != 3 {
+		t.Errorf("assertion is not a JWT: %q", body.Assertion)
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Errorf("decode assertion payload: %v", err)
+		return ""
+	}
+	var claims struct {
+		Iss string `json:"iss"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Errorf("unmarshal assertion claims: %v", err)
+		return ""
+	}
+	return claims.Iss
 }

--- a/cli/client/auth/middleware_test.go
+++ b/cli/client/auth/middleware_test.go
@@ -1,0 +1,76 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jentic/jentic-one/cli/client/config"
+)
+
+// TestBearerToken_SingleflightsConcurrentMints pins the local-MCP §3.7.1
+// efficiency guard: N concurrent BearerToken callers hitting one expiry
+// instant share ONE token exchange (mint-fresh was already concurrency-safe —
+// last-writer-wins on independently valid tokens — so this asserts the dedup,
+// not correctness). The token endpoint stalls long enough that every waiter
+// joins the first caller's flight before it completes.
+func TestBearerToken_SingleflightsConcurrentMints(t *testing.T) {
+	withConfigDir(t)
+	ref := IdentityRef{Identity: "a1", Environment: "e1"}
+	if _, err := GetOrGenerateKey(ref); err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	if err := config.MutateConfig(func(c *config.Config) error {
+		c.Identities["a1"] = config.Identity{
+			Type: "agent",
+			Environments: map[string]config.EnvRegState{
+				"e1": {ClientID: "client_1", Status: "approved"},
+			},
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("persist registration: %v", err)
+	}
+
+	var exchanges atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges.Add(1)
+		// Hold the flight open so every concurrent caller joins it.
+		time.Sleep(250 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok_minted","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	creds := Credentials{BaseURL: srv.URL, IdentityName: "a1", EnvironmentName: "e1"}
+	const callers = 8
+	tokens := make([]string, callers)
+	errs := make([]error, callers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			tokens[i], errs[i] = BearerToken(creds)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i := range callers {
+		if errs[i] != nil {
+			t.Fatalf("caller %d: %v", i, errs[i])
+		}
+		if tokens[i] != "tok_minted" {
+			t.Errorf("caller %d got %q, want the shared minted token", i, tokens[i])
+		}
+	}
+	if got := exchanges.Load(); got != 1 {
+		t.Errorf("token exchanges = %d, want 1 (singleflight must dedupe concurrent mints)", got)
+	}
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/pb33f/libopenapi v0.38.7
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/tools v0.49.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -57,7 +58,6 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 )

--- a/cli/internal/agentops/classify.go
+++ b/cli/internal/agentops/classify.go
@@ -47,16 +47,30 @@ func IsBrokerDenial(r *ExecuteResult) bool {
 // 4xx (including an upstream pass-through with an incidental
 // "agent_directive"-shaped body) can't trip the caller's exit code.
 func ParseAgentDirective(r *ExecuteResult) (ux.Directive, bool) {
+	directive, _, ok := parseAgentDirectiveRaw(r)
+	return directive, ok
+}
+
+// parseAgentDirectiveRaw extracts both the typed projection (what the CLI's
+// renderer branches on) and the verbatim agent_directive JSON sub-object (what
+// the MCP payload relays — unknown future broker fields must survive the
+// round-trip, which a struct projection would silently drop).
+func parseAgentDirectiveRaw(r *ExecuteResult) (ux.Directive, json.RawMessage, bool) {
 	if !IsBrokerDenial(r) {
-		return ux.Directive{}, false
+		return ux.Directive{}, nil, false
 	}
 	var envelope struct {
-		Directive *ux.Directive `json:"agent_directive"`
+		Directive json.RawMessage `json:"agent_directive"`
 	}
-	if err := json.Unmarshal(r.Body, &envelope); err != nil || envelope.Directive == nil {
-		return ux.Directive{}, false
+	if err := json.Unmarshal(r.Body, &envelope); err != nil ||
+		len(envelope.Directive) == 0 || string(envelope.Directive) == "null" {
+		return ux.Directive{}, nil, false
 	}
-	return *envelope.Directive, true
+	var directive ux.Directive
+	if json.Unmarshal(envelope.Directive, &directive) != nil {
+		return ux.Directive{}, nil, false
+	}
+	return directive, envelope.Directive, true
 }
 
 // Classify is the unfused classification step (response → denial-or-not) the
@@ -72,8 +86,9 @@ func Classify(r *ExecuteResult) *Denial {
 		return nil
 	}
 	d := &Denial{Status: r.Status}
-	if directive, ok := ParseAgentDirective(r); ok {
+	if directive, raw, ok := parseAgentDirectiveRaw(r); ok {
 		d.Directive = &directive
+		d.DirectiveRaw = raw
 	}
 	return d
 }

--- a/cli/internal/agentops/execute.go
+++ b/cli/internal/agentops/execute.go
@@ -3,6 +3,8 @@ package agentops
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -11,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"syscall"
 	"time"
 
 	sdkclient "github.com/jentic/jentic-one/cli/client"
@@ -83,6 +86,11 @@ func ResolveOperation(ctx context.Context, ins Inspector, target, revision strin
 	if op.Method == "" || op.URL == "" {
 		return nil, ErrInspectMissingFields
 	}
+	// Normalize once at resolve time: registry documents may carry a
+	// lower/mixed-case method ("get"), and every downstream consumer — the
+	// execute_read GET/HEAD gate, BuildRequest, logging — assumes the
+	// canonical uppercase form.
+	op.Method = strings.ToUpper(op.Method)
 	return &op, nil
 }
 
@@ -240,8 +248,9 @@ func DoWith(hc *http.Client, req *http.Request) (*ExecuteResult, error) {
 		// {error,status:0} to stdout — that double-signalled the same failure on
 		// two streams, and an agent parsing stdout would see a bogus "response".
 		coded := &ux.CodedError{
-			Code: ux.CodeTransportError,
-			Msg:  fmt.Sprintf("transport error: %v", err),
+			Code:  ux.CodeTransportError,
+			Msg:   fmt.Sprintf("transport error: %v", err),
+			Cause: err,
 		}
 		// UX-4: the classic local papercut is an https default resolving against a
 		// plain-http local broker ("server gave HTTP response to HTTPS client").
@@ -295,6 +304,46 @@ func newTraceparent() (string, bool) {
 		return "", false
 	}
 	return fmt.Sprintf("00-%s-%s-01", hex.EncodeToString(traceID[:]), hex.EncodeToString(spanID[:])), true
+}
+
+// TransportFailurePreSend reports whether a transport failure provably
+// happened BEFORE the request could reach the server: dial failures
+// (connection refused, unreachable host, DNS) and TLS handshake/verification
+// failures. For these a retry cannot double-execute — the upstream never saw
+// the request. Everything else (deadline exceeded, connection reset, EOF
+// mid-response) is ambiguous: the request MAY have been delivered, so callers
+// must not advertise a blind retry for unkeyed mutating calls. The
+// classification is a whitelist on purpose — the fail-safe answer is false.
+func TransportFailurePreSend(err error) bool {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Op == "dial" {
+		return true
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	// TLS handshake/verification failures: the connection never carried the
+	// request. CertificateVerificationError wraps the x509 chain errors, and
+	// RecordHeaderError is the "server gave HTTP response to HTTPS client"
+	// signature.
+	var certErr *tls.CertificateVerificationError
+	if errors.As(err, &certErr) {
+		return true
+	}
+	var recErr tls.RecordHeaderError
+	if errors.As(err, &recErr) {
+		return true
+	}
+	var unknownAuthority x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthority) {
+		return true
+	}
+	var hostname x509.HostnameError
+	return errors.As(err, &hostname)
 }
 
 // brokerTLSMismatch reports whether err is the "https client hit an http server"

--- a/cli/internal/agentops/execute.go
+++ b/cli/internal/agentops/execute.go
@@ -207,9 +207,27 @@ func BuildRequest(ctx context.Context, r ExecuteRequest) (*http.Request, error) 
 // policy decorates. The response body is read bounded (MaxBodyBytes) into the
 // returned ExecuteResult.
 func Do(req *http.Request) (*ExecuteResult, error) {
-	httpClient := sdkclient.BrokerTransport(sdkclient.Config{
-		HTTPClient: &http.Client{Timeout: 60 * time.Second},
-	})
+	return DoWith(nil, req)
+}
+
+// DoWith is Do with a caller-supplied base *http.Client for the broker leg —
+// the §3.7.2 CA-pinning seam: a long-lived embedder (the MCP server) resolves
+// the SEC-20 CA-pinned client (plus its attribution TransportHook) through
+// clictx and passes it here, so the broker leg honors the environment's
+// ca_cert_path exactly like every control-plane call. The SDK broker response
+// policy still decorates the OUTSIDE (client.BrokerTransport wraps hc's
+// transport), so hooked headers ride every retry attempt. A nil hc keeps the
+// historical default client. A missing timeout gets the 60s execute ceiling.
+func DoWith(hc *http.Client, req *http.Request) (*ExecuteResult, error) {
+	if hc == nil {
+		hc = &http.Client{}
+	}
+	// Copy before adjusting: the caller may reuse its client elsewhere.
+	base := *hc
+	if base.Timeout == 0 {
+		base.Timeout = 60 * time.Second
+	}
+	httpClient := sdkclient.BrokerTransport(sdkclient.Config{HTTPClient: &base})
 	// G704 (SSRF) is intentional, not a finding: dialing a caller-chosen broker
 	// target IS this function's contract. The URL is guarded upstream —
 	// BuildRequest enforces SEC-1 (no bearer over plaintext to a non-loopback

--- a/cli/internal/agentops/execute_test.go
+++ b/cli/internal/agentops/execute_test.go
@@ -1,12 +1,22 @@
 package agentops
 
+// execute_test.go pins the transport-failure behaviors no golden can pin:
+// the dial-level branch of Do (a real dial failure's error string embeds an
+// ephemeral port and OS-specific text, never byte-stable) and the pre-send
+// classification the MCP execute surface keys its retryable hint off — only
+// provably PRE-SEND failures (the upstream cannot have received the request)
+// may invite a blind retry of an unkeyed mutating call.
+
 import (
 	"context"
+	"crypto/tls"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
@@ -114,5 +124,72 @@ func TestDo_DialClosedPortIsBareTransportError(t *testing.T) {
 	}
 	if coded.Actionable != "" {
 		t.Errorf("actionable = %q, want empty — a plain refused dial is not the TLS-mismatch papercut", coded.Actionable)
+	}
+}
+
+func TestTransportFailurePreSend(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "dial failure is pre-send",
+			err:  &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED},
+			want: true,
+		},
+		{
+			name: "connection refused is pre-send",
+			err:  syscall.ECONNREFUSED,
+			want: true,
+		},
+		{
+			name: "DNS failure is pre-send",
+			err:  &net.DNSError{Err: "no such host", Name: "broker.invalid"},
+			want: true,
+		},
+		{
+			name: "TLS record header mismatch is pre-send",
+			err:  tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"},
+			want: true,
+		},
+		{
+			name: "TLS certificate verification failure is pre-send",
+			err:  &tls.CertificateVerificationError{Err: errors.New("x509: certificate signed by unknown authority")},
+			want: true,
+		},
+		{
+			name: "deadline exceeded is NOT provably pre-send",
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			name: "mid-flight EOF is NOT provably pre-send",
+			err:  io.EOF,
+			want: false,
+		},
+		{
+			name: "connection reset is NOT provably pre-send",
+			err:  &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET},
+			want: false,
+		},
+		{
+			name: "nil is not a failure at all",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TransportFailurePreSend(tc.err); got != tc.want {
+				t.Errorf("TransportFailurePreSend(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+			// The classification must survive DoWith's CodedError wrapping
+			// (the Cause chain is how the MCP handler reaches it).
+			wrapped := &ux.CodedError{Code: ux.CodeTransportError, Msg: "transport error", Cause: tc.err}
+			if got := TransportFailurePreSend(wrapped); got != tc.want {
+				t.Errorf("TransportFailurePreSend(CodedError{Cause: %v}) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }

--- a/cli/internal/agentops/types.go
+++ b/cli/internal/agentops/types.go
@@ -138,6 +138,11 @@ type Denial struct {
 	// Directive is the parsed agent_directive, or nil when the denial carried
 	// none (the caller synthesizes a status-keyed recovery hint instead).
 	Directive *ux.Directive
+	// DirectiveRaw is the verbatim agent_directive JSON sub-object the denial
+	// carried (nil when Directive is nil). Relaying surfaces (the MCP payload)
+	// use it so unknown future broker fields survive intact; the CLI's styled
+	// renderer keeps reading the typed Directive projection.
+	DirectiveRaw json.RawMessage
 }
 
 // Err returns the typed denial every broker-denial exit shares (AGT-6):

--- a/cli/internal/cli/api/mcp.go
+++ b/cli/internal/cli/api/mcp.go
@@ -31,9 +31,10 @@ import (
 // targeting flag: context selection is the root --context flag, and broker
 // targeting comes from the context's environment (broker_url, never derived).
 type mcpOptions struct {
-	readOnly     bool
-	excludeTools []string
-	logFile      string
+	readOnly       bool
+	excludeTools   []string
+	logFile        string
+	maxResultBytes int64
 }
 
 func newMCPCmd(app *app) *cobra.Command {
@@ -67,6 +68,8 @@ func newMCPCmd(app *app) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.readOnly, "read-only", false, "serve only tools annotated read-only")
 	cmd.Flags().StringSliceVar(&opts.excludeTools, "exclude-tools", nil, "tool names to withhold from the client (repeatable or comma-separated)")
 	cmd.Flags().StringVar(&opts.logFile, "log-file", "", "server log file (default: <XDG state dir>/jentic/logs/mcp.log)")
+	cmd.Flags().Int64Var(&opts.maxResultBytes, "max-result-bytes", defaultMaxResultBytes,
+		"hard cap on a relayed response body in a tool result; larger bodies are truncated with {truncated, total_bytes, execution_id}")
 	return cmd
 }
 

--- a/cli/internal/cli/api/mcp_execute.go
+++ b/cli/internal/cli/api/mcp_execute.go
@@ -19,7 +19,10 @@ package api
 //     the only broker source (SEC-21 pinning is structural).
 //   - Relayed bodies are capped at maxResultBytes (§3.7 context protection —
 //     the transport's 64 MiB bound is not context protection) with the
-//     truncation envelope {truncated: true, total_bytes, execution_id}.
+//     truncation envelope {truncated: true, total_bytes, execution_id}, and
+//     relayed response headers ride under their own aggregate budget
+//     (headerBytesBudget) with a headers_truncated marker — headers must not
+//     smuggle around the body cap.
 
 import (
 	"bytes"
@@ -127,7 +130,10 @@ func (s *mcpServer) executeTool(ctx context.Context, req *mcp.CallToolRequest, r
 		toolName = "execute_read"
 	}
 	s.noteClient(req.ClientInfo())
-	cctx, cancel := s.callContext(ctx)
+	// The execute family gets the wider deadline: the broker leg relays
+	// arbitrary upstream latency, and the 30s control-plane deadline would
+	// silently cap the 60s execute ceiling (agentops.DoWith's client timeout).
+	cctx, cancel := s.executeCallContext(ctx)
 	defer cancel()
 
 	args, err := normalizeToolArgs(req.Params.Arguments, executeParams)
@@ -211,7 +217,13 @@ func (s *mcpServer) executeTool(ctx context.Context, req *mcp.CallToolRequest, r
 	}
 	res, err := agentops.DoWith(hc, breq)
 	if err != nil {
-		return s.executeTransportError(cctx, err), nil
+		// Retrying is provably safe when the call cannot double-execute: a
+		// GET/HEAD, or a mutating call the broker de-duplicates on its
+		// Idempotency-Key. Anything else defers to the pre-send/mid-flight
+		// classification inside executeTransportError.
+		retrySafe := execReq.IdempotencyKey != "" ||
+			op.Method == http.MethodGet || op.Method == http.MethodHead
+		return s.executeTransportError(cctx, err, retrySafe), nil
 	}
 	s.logger.Info(toolName, "target", target, "method", op.Method, "status", res.Status, "execution_id", res.ExecutionID)
 
@@ -318,34 +330,78 @@ func (s *mcpServer) executeResolveError(ctx context.Context, target string, err 
 	}, "search_apis")
 }
 
-// executeTransportError maps a broker transport failure per the §3.7 table:
-// retryable (the broker may be coming back), with the get_started pointer —
-// on a local install a dead broker usually means the instance is down, which
-// get_started diagnoses with the exact operator instruction. The instance
-// stamp on the result degrades naturally when the control plane is down too.
-func (s *mcpServer) executeTransportError(ctx context.Context, err error) *mcp.CallToolResult {
-	s.logger.Warn("execute transport failed", "error", err)
-	var extra map[string]any
-	nextTool := ""
-	if asCoded(err).Code == ux.CodeTransportError {
-		extra = map[string]any{"retryable": true}
-		nextTool = "get_started"
+// executeTransportError maps a transport failure per the §3.7 table: a soft
+// TRANSPORT_ERROR with the get_started pointer — on a local install a dead
+// broker usually means the instance is down, which get_started diagnoses with
+// the exact operator instruction. The instance stamp on the result degrades
+// naturally when the control plane is down too.
+//
+// The retryable hint is earned, not blanket: `retryable: true` only when the
+// caller proved the retry safe (GET/HEAD, or an Idempotency-Key the broker
+// de-duplicates on) or the failure is provably pre-send (dial/TLS/connection
+// refused — the upstream never saw the request). A mid-flight failure on an
+// unkeyed mutating call (deadline exceeded, connection reset) may have
+// ALREADY been delivered: hinting a retry there instructs the model to
+// double-execute, so it gets `retryable: false` plus recovery guidance
+// (verify first, idempotency_key, get_execution_result for held jobs).
+// get_execution_result shares this helper for its own transport failures
+// (finding: they previously surfaced as INTERNAL_ERROR with no hints).
+func (s *mcpServer) executeTransportError(ctx context.Context, err error, retrySafe bool) *mcp.CallToolResult {
+	s.logger.Warn("transport failure", "error", err, "retry_safe", retrySafe)
+	coded := asCoded(err)
+	if coded.Code != ux.CodeTransportError {
+		return s.softError(ctx, err)
 	}
-	return s.softErrorExtra(ctx, err, nextTool, extra)
+	retryable := retrySafe || agentops.TransportFailurePreSend(coded)
+	if !retryable {
+		coded = &ux.CodedError{
+			Code: coded.Code,
+			Msg:  coded.Msg + " — the failure happened mid-flight, so the request may already have reached the upstream",
+			Actionable: "Do not re-send this call blindly: it may have executed. Verify the effect with a read " +
+				"(execute_read) first, or re-send with an idempotency_key so the broker de-duplicates the retry. " +
+				"If the execute returned a held (202) job, poll it with get_execution_result — never re-send.",
+			Details: coded.Details,
+			Cause:   coded.Cause,
+		}
+	}
+	return s.softErrorExtra(ctx, coded, "get_started", map[string]any{"retryable": retryable})
+}
+
+// classifyTransportErr maps a generated-client transport failure (the request
+// never completed: no *HTTPError, no meaningful taxonomy code) onto the §3.7
+// transport row, so callers degrade like execute does — TRANSPORT_ERROR with
+// the retryable hint and the get_started pointer — instead of INTERNAL_ERROR
+// ("stop, CLI bug" semantics) with no recovery. Completed calls (*HTTPError)
+// and already-classifiable failures (auth, pending, no-config) pass through
+// untouched.
+func classifyTransportErr(err error) error {
+	var he *HTTPError
+	if err == nil || errors.As(err, &he) {
+		return err
+	}
+	if coded := asCoded(err); coded.Code != ux.CodeInternalError {
+		return err
+	}
+	return &ux.CodedError{
+		Code:  ux.CodeTransportError,
+		Msg:   fmt.Sprintf("transport error: %v", err),
+		Cause: err,
+	}
 }
 
 // executeDenialError maps a broker denial per the §3.7 table: a soft
-// BROKER_DENIED with the agent_directive passed through VERBATIM (the broker's
-// recovery instructions must reach the model intact), retryable: false —
-// re-sending the same call cannot succeed until access changes. next_tool is
-// whoami (deliberate): the §3.2 flow guidance is "check your bindings, never
-// execute to probe access", and no access-request tool exists on this surface
-// yet (it queues behind this PR).
+// BROKER_DENIED with the agent_directive relayed as the RAW JSON sub-object
+// the broker sent (the broker's recovery instructions must reach the model
+// intact — a struct projection would silently drop unknown future fields),
+// retryable: false — re-sending the same call cannot succeed until access
+// changes. next_tool is whoami (deliberate): the §3.2 flow guidance is "check
+// your bindings, never execute to probe access", and no access-request tool
+// exists on this surface yet (it queues behind this PR).
 func (s *mcpServer) executeDenialError(ctx context.Context, denial *agentops.Denial) *mcp.CallToolResult {
 	coded := denial.Err()
 	extra := map[string]any{"retryable": false}
 	if denial.Directive != nil {
-		extra["agent_directive"] = denial.Directive
+		extra["agent_directive"] = denial.DirectiveRaw
 		coded.Actionable = denial.Directive.Instruction
 	}
 	if coded.Actionable == "" {
@@ -377,17 +433,27 @@ func synthesizedDenialHint(status int) string {
 // executeResultPayload projects an ExecuteResult onto the tool payload: the
 // exact CLI envelope keys ({schema_version, status, headers, body,
 // execution_id} — shared goldens compare this sub-object with the sibling
-// `instance` stamp stripped), with the §3.7 size cap applied to the body. A
-// capped body is replaced by its leading maxResultBytes bytes as a string plus
-// the truncation envelope {truncated: true, total_bytes, execution_id} so the
-// model can fetch or act deliberately instead of flooding its context.
+// `instance` stamp stripped), with the §3.7 size cap applied to the body AND
+// an aggregate budget applied to the headers (Go's HTTP/1 transport accepts
+// up to 10 MiB of response headers — without their own budget they would ride
+// straight around the body cap). A capped body is replaced by its leading
+// maxResultBytes bytes — sanitized to valid UTF-8, which also strips invalid
+// sequences a binary body carries anywhere — as a string plus the truncation
+// envelope {truncated: true, total_bytes, execution_id} so the model can
+// fetch or act deliberately instead of flooding its context. Normal-sized
+// responses are relayed byte-identically to the CLI envelope.
 func (s *mcpServer) executeResultPayload(res *agentops.ExecuteResult) map[string]any {
 	env := res.Envelope()
+	headers, headersTruncated := capHeaders(env.Headers, s.headerBytesBudget())
 	payload := map[string]any{
 		"schema_version": env.SchemaVersion,
 		"status":         env.Status,
-		"headers":        env.Headers,
+		"headers":        headers,
 		"body":           env.Body,
+	}
+	if headersTruncated {
+		payload["headers_truncated"] = true
+		s.logger.Info("execute response headers truncated", "cap", s.headerBytesBudget())
 	}
 	if env.ExecutionID != "" {
 		payload["execution_id"] = env.ExecutionID
@@ -399,6 +465,57 @@ func (s *mcpServer) executeResultPayload(res *agentops.ExecuteResult) map[string
 		s.logger.Info("execute result truncated", "total_bytes", len(res.Body), "cap", s.maxResultBytes)
 	}
 	return payload
+}
+
+// headerBytesBudget is the slice of the §3.7 cap reserved for relayed
+// response headers: 8 KiB — generous for any sane API's headers — clamped to
+// the whole result cap when the operator shrank --max-result-bytes below it.
+func (s *mcpServer) headerBytesBudget() int64 {
+	const headerBudget int64 = 8 << 10
+	if s.maxResultBytes < headerBudget {
+		return s.maxResultBytes
+	}
+	return headerBudget
+}
+
+// capHeaders bounds the aggregate serialized size of the relayed response
+// headers to budget bytes. Headers are admitted whole in sorted key order; a
+// header that would overflow the remaining budget is dropped whole (a
+// half-relayed value is worse than an absent one) while smaller later headers
+// still fit — one hostile fat header must not evict Content-Type. When
+// everything fits (every normal response), the input map is returned
+// UNTOUCHED so the shared CLI-envelope bytes cannot change.
+func capHeaders(headers map[string]string, budget int64) (map[string]string, bool) {
+	var total int64
+	for k, v := range headers {
+		total += headerCost(k, v)
+	}
+	if total <= budget {
+		return headers, false
+	}
+	keys := make([]string, 0, len(headers))
+	for k := range headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	capped := make(map[string]string, len(keys))
+	var used int64
+	for _, k := range keys {
+		cost := headerCost(k, headers[k])
+		if used+cost > budget {
+			continue
+		}
+		used += cost
+		capped[k] = headers[k]
+	}
+	return capped, true
+}
+
+// headerCost estimates one header's serialized JSON size (pre-escaping —
+// close enough for a budget that sits far below the body cap).
+func headerCost(k, v string) int64 {
+	const perEntryOverhead = 6 // two quote pairs, colon, comma
+	return int64(len(k) + len(v) + perEntryOverhead)
 }
 
 // handleGetExecutionResult polls one job through the LIVE control-plane
@@ -442,7 +559,11 @@ func (s *mcpServer) handleGetExecutionResult(ctx context.Context, req *mcp.CallT
 			}, "get_execution_result"), nil
 		}
 		s.logger.Warn("get_execution_result failed", "job_id", jobID, "error", err)
-		return s.softError(cctx, err), nil
+		// §3.7 transport row: a transport failure on the RECOVERY path ("the
+		// control plane is briefly down, poll again") must come back as a
+		// retryable TRANSPORT_ERROR with the get_started pointer, never as
+		// INTERNAL_ERROR. The poll is a GET — re-polling is always safe.
+		return s.executeTransportError(cctx, classifyTransportErr(err), true), nil
 	}
 	if resp.JSON200 == nil {
 		return s.softError(cctx, &ux.CodedError{
@@ -471,9 +592,10 @@ func (s *mcpServer) handleGetExecutionResult(ctx context.Context, req *mcp.CallT
 }
 
 // attachJobResult adds the completed job's result document to the payload
-// (GET /jobs/{id}/result), size-capped like every relayed body. A result
-// fetch failure degrades to a `result_error` note rather than failing the
-// poll — the status the model asked for is already in hand.
+// (GET /jobs/{id}/result), size-capped like every relayed body (a capped
+// result is its leading maxResultBytes bytes, sanitized to valid UTF-8). A
+// result fetch failure degrades to a `result_error` note rather than failing
+// the poll — the status the model asked for is already in hand.
 func (s *mcpServer) attachJobResult(ctx context.Context, client jobResultClient, jobID string, payload map[string]any) {
 	resp, err := client.GetJobResultWithResponse(ctx, jobID)
 	if err := apiErrorFor(resp, err); err != nil {
@@ -528,7 +650,9 @@ func executeInputSchema(withBody bool) map[string]any {
 	if withBody {
 		props["body"] = map[string]any{
 			"description": "The request body as a JSON value (object, array, or string; \"data\" is an accepted alias). " +
-				"Omit it for bodyless calls — the body is ALWAYS this argument, never read from anywhere else.",
+				"Omit it for bodyless calls — the body is ALWAYS this argument, never read from anywhere else. " +
+				"A string whose content parses as JSON is deliberately treated as a stringified body and sent " +
+				"as that JSON value, not as a quoted string.",
 		}
 		props["idempotency_key"] = map[string]any{
 			"type": "string",

--- a/cli/internal/cli/api/mcp_execute.go
+++ b/cli/internal/cli/api/mcp_execute.go
@@ -1,0 +1,618 @@
+package api
+
+// mcp_execute.go holds the PR 1-C execute surface: the `execute` tool (any
+// method, destructiveHint), its `execute_read` GET/HEAD-only variant
+// (readOnlyHint), and the `get_execution_result` poll tool for held (202)
+// executes (§3.4). The handlers drive the agentops core (resolve → build →
+// send → classify) exactly like `jentic execute`, with three deliberate
+// differences:
+//
+//   - The body is ALWAYS an explicit tool argument (or absent). There is no
+//     stdin fallback on this path — under stdio MCP, stdin is the JSON-RPC
+//     wire — and the handlers are structurally unable to reach executeE's
+//     stdin sniffing: they never consult os.Stdin, and the agentops core they
+//     call has no stdin access by design (§3.7).
+//   - The broker leg rides the SEC-20 CA-pinned client from clictx
+//     (clictx.BrokerHTTPClient) with the session's attribution hook composed
+//     over it — wrap, never displace (§3.7.2). The CLI's flag-driven broker
+//     override surface does not exist here: the environment's broker_url is
+//     the only broker source (SEC-21 pinning is structural).
+//   - Relayed bodies are capped at maxResultBytes (§3.7 context protection —
+//     the transport's 64 MiB bound is not context protection) with the
+//     truncation envelope {truncated: true, total_bytes, execution_id}.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	sdkclient "github.com/jentic/jentic-one/cli/client"
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+	"github.com/jentic/jentic-one/cli/internal/agentops"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+	"github.com/jentic/jentic-one/cli/internal/config"
+)
+
+// defaultMaxResultBytes is the §3.7 context-protection cap on a relayed
+// response body in a tool result (overridable with --max-result-bytes). MCP
+// has no chunking — a tool result lands in the model's context whole — so
+// this is deliberately far below the 64 MiB transport bound
+// (client.MaxBodyBytes): 128 KiB is roughly a 30k-token page, large enough
+// for any sane API page and small enough that one oversized upstream response
+// cannot evict the session's working context.
+const defaultMaxResultBytes int64 = 128 << 10
+
+// executeParams is the execute tools' argument surface: the shared
+// operation-identity aliases, the §3.2 inputs alias table (inputs/params/
+// parameters), an explicit headers object, the raw JSON body, and the CLI's
+// --revision/--idempotency-key knobs. There are deliberately NO broker-target
+// parameters: the broker is pinned to the environment's broker_url.
+var executeParams = []paramSpec{
+	operationIDSpec,
+	inputsSpec,
+	{name: "headers", kind: paramObject},
+	{name: "body", aliases: []string{"data"}, kind: paramJSON},
+	{name: "revision", kind: paramString},
+	{name: "idempotency_key", kind: paramString},
+}
+
+// jobIDSpec is get_execution_result's single parameter. `execution_id` is NOT
+// an alias: the broker's Jentic-Execution-Id names the execution record, not
+// the job — folding them would silently poll the wrong resource.
+var jobIDSpec = paramSpec{name: "job_id", aliases: []string{"id", "job"}, kind: paramString}
+
+// getExecutionResultParams declares the poll tool's argument table.
+var getExecutionResultParams = []paramSpec{jobIDSpec}
+
+// resolveMCPBrokerTarget resolves the broker scheme/host for the MCP execute
+// path. Precedence is a strict subset of executeE's: the environment's
+// broker_url wins, else the built-in loopback default — there are no flag
+// overrides on this surface, so the SEC-21 machine-mode pin holds
+// structurally. The two executeE fail-closed guards port unchanged:
+//   - a SET but malformed broker_url errors rather than silently dialing the
+//     loopback default (M2);
+//   - a remote control plane with NO broker configured refuses rather than
+//     leaking the bearer at the caller's own loopback (remote-cli-usage F1).
+func resolveMCPBrokerTarget(st *clictx.ActiveState) (scheme, host string, err error) {
+	if st.BrokerURL != "" {
+		u, perr := url.Parse(st.BrokerURL)
+		if perr != nil || u.Host == "" || u.Scheme == "" {
+			return "", "", &ux.CodedError{
+				Code: ux.CodeResolveFailed,
+				Msg: fmt.Sprintf("environment %q has a malformed broker_url (%q): it must be an absolute URL with a scheme and host",
+					st.EnvironmentName, st.BrokerURL),
+				Actionable: fmt.Sprintf("Ask your operator to fix it with `jentic env add %s --broker-url https://<broker-host>:<port> --force`.",
+					st.EnvironmentName),
+			}
+		}
+		return u.Scheme, u.Host, nil
+	}
+	if baseURLIsRemote(st.BaseURL) {
+		return "", "", &ux.CodedError{
+			Code: ux.CodeResolveFailed,
+			Msg: fmt.Sprintf("environment %q has a remote control plane (%s) but no broker is configured; "+
+				"execute would target the local default %s://%s",
+				st.EnvironmentName, st.BaseURL, config.DefaultBrokerScheme, config.DefaultBrokerHost),
+			Actionable: fmt.Sprintf("Ask your operator to set the environment's broker_url "+
+				"(`jentic env add %s --url %s --broker-url https://<broker-host>:<port> --force`) — it is never derived from the control plane.",
+				st.EnvironmentName, st.BaseURL),
+		}
+	}
+	return config.DefaultBrokerScheme, config.DefaultBrokerHost, nil
+}
+
+func (s *mcpServer) handleExecute(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return s.executeTool(ctx, req, false)
+}
+
+func (s *mcpServer) handleExecuteRead(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return s.executeTool(ctx, req, true)
+}
+
+// executeTool is the shared execute/execute_read handler. readOnlyVariant
+// enforces the GET/HEAD-only contract of execute_read AFTER resolution (the
+// method is a property of the resolved operation, not of the arguments).
+func (s *mcpServer) executeTool(ctx context.Context, req *mcp.CallToolRequest, readOnlyVariant bool) (*mcp.CallToolResult, error) {
+	toolName := "execute"
+	if readOnlyVariant {
+		toolName = "execute_read"
+	}
+	s.noteClient(req.ClientInfo())
+	cctx, cancel := s.callContext(ctx)
+	defer cancel()
+
+	args, err := normalizeToolArgs(req.Params.Arguments, executeParams)
+	if err != nil {
+		return nil, invalidParams(err)
+	}
+	target, _ := args["operation_id"].(string)
+	if target == "" {
+		return nil, invalidParams(errors.New(toolName + ` requires "operation_id" (aliases: "id", "uuid"): ` +
+			`a registry operation id from a search_apis hit, or a METHOD:url pair like "GET:https://api.example.com/v1/things"`))
+	}
+	body, _ := args["body"].(json.RawMessage)
+	if readOnlyVariant && len(body) > 0 {
+		return nil, invalidParams(errors.New("execute_read never sends a request body; use the execute tool for body-carrying calls"))
+	}
+	revision, _ := args["revision"].(string)
+
+	st := clictx.ActiveContext(cctx)
+	if st == nil {
+		return s.softError(cctx, noContextErr()), nil
+	}
+	// Auth failures (not registered / pending / revoked) map to their coded
+	// soft errors with the default get_started pointer (§3.7 table).
+	_, token, err := s.app.contextSession(st)
+	if err != nil {
+		s.logger.Warn(toolName+" auth failed", "error", err)
+		return s.softError(cctx, err), nil
+	}
+	brokerScheme, brokerHost, err := resolveMCPBrokerTarget(st)
+	if err != nil {
+		// A broker-target gap is a setup problem: default pointer (get_started).
+		return s.softError(cctx, err), nil
+	}
+
+	op, err := s.app.resolveOperation(cctx, target, revision)
+	if err != nil {
+		return s.executeResolveError(cctx, target, err), nil
+	}
+	if readOnlyVariant && op.Method != http.MethodGet && op.Method != http.MethodHead {
+		return nil, invalidParams(fmt.Errorf(
+			"operation %q resolves to %s — execute_read only performs GET/HEAD; call the execute tool instead", target, op.Method))
+	}
+
+	pathParams, queryParams := splitInputs(args, op)
+	headers, err := headerKVs(args)
+	if err != nil {
+		return nil, invalidParams(err)
+	}
+	var bodyReader *bytes.Reader
+	execReq := agentops.ExecuteRequest{
+		Method:         op.Method,
+		URL:            op.URL,
+		Path:           op.Path,
+		PathParams:     pathParams,
+		QueryParams:    queryParams,
+		Headers:        headers,
+		BrokerScheme:   brokerScheme,
+		BrokerHost:     brokerHost,
+		Token:          token,
+		SessionID:      sdkclient.SanitizeSessionID(st.SessionID),
+		IdempotencyKey: stringArg(args, "idempotency_key"),
+	}
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+		execReq.Body = bodyReader
+	}
+
+	breq, err := agentops.BuildRequest(cctx, execReq)
+	if err != nil {
+		// SEC-1 (bearer over plaintext to a non-loopback broker) is the only
+		// coded failure here — a setup problem, default pointer.
+		return s.softError(cctx, err), nil
+	}
+
+	// §3.7.2: the broker leg rides clictx's SEC-20 CA-pinned client with the
+	// session's attribution hook composed over it; a broken ca_cert_path
+	// fails closed, exactly like every control-plane call.
+	hc, err := clictx.BrokerHTTPClient(cctx)
+	if err != nil {
+		return s.softError(cctx, err), nil
+	}
+	res, err := agentops.DoWith(hc, breq)
+	if err != nil {
+		return s.executeTransportError(cctx, err), nil
+	}
+	s.logger.Info(toolName, "target", target, "method", op.Method, "status", res.Status, "execution_id", res.ExecutionID)
+
+	// §3.7 table row 2: a broker denial is a soft error carrying the verbatim
+	// agent_directive, non-retryable until access changes.
+	if denial := agentops.Classify(res); denial != nil {
+		return s.executeDenialError(cctx, denial), nil
+	}
+
+	// Everything the broker relayed — 2xx, upstream 4xx/5xx, and the ask-tier
+	// 202-held envelope — is a normal result (§3.7 table row 1; §3.4: the held
+	// envelope passes through with its directive intact, the model polls with
+	// get_execution_result and never re-sends).
+	return s.result(cctx, s.executeResultPayload(res)), nil
+}
+
+// splitInputs folds the normalized `inputs` object onto agentops' path/query
+// split: a key matching a {placeholder} in the resolved target is a path
+// parameter, everything else is a query parameter. Keys are applied in sorted
+// order so the built URL is deterministic. Non-string scalars format like the
+// normalizer's string coercion; structured values marshal compact.
+func splitInputs(args map[string]any, op *agentops.Operation) (pathParams, queryParams []agentops.KV) {
+	inputs, _ := args["inputs"].(map[string]any)
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	target := op.URL
+	if target == "" {
+		target = op.Path
+	}
+	keys := make([]string, 0, len(inputs))
+	for k := range inputs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		kv := agentops.KV{Key: k, Value: inputValueString(inputs[k])}
+		if strings.Contains(target, "{"+k+"}") {
+			pathParams = append(pathParams, kv)
+		} else {
+			queryParams = append(queryParams, kv)
+		}
+	}
+	return pathParams, queryParams
+}
+
+// inputValueString renders one inputs/headers value as the wire string:
+// strings verbatim, scalars via their JSON form, structured values compact.
+func inputValueString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(raw)
+}
+
+// headerKVs converts the normalized `headers` object to KV pairs. A structured
+// header value is malformed input (headers are strings on the wire).
+func headerKVs(args map[string]any) ([]agentops.KV, error) {
+	obj, _ := args["headers"].(map[string]any)
+	if len(obj) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]agentops.KV, 0, len(keys))
+	for _, k := range keys {
+		s, err := coerceString(obj[k])
+		if err != nil {
+			return nil, fmt.Errorf("header %q: %w", k, err)
+		}
+		out = append(out, agentops.KV{Key: k, Value: s})
+	}
+	return out, nil
+}
+
+func stringArg(args map[string]any, name string) string {
+	s, _ := args[name].(string)
+	return s
+}
+
+// executeResolveError maps a resolve failure per the §3.7 table: an unknown
+// operation is RESOLVE_FAILED with "re-search" guidance pointed at search_apis
+// (deliberate — the identity already resolved; the id is wrong, so get_started
+// would be a dead end). Non-resolve codes (an auth failure surfacing inside
+// the inspect call) keep their own default pointers.
+func (s *mcpServer) executeResolveError(ctx context.Context, target string, err error) *mcp.CallToolResult {
+	s.logger.Warn("execute resolve failed", "target", target, "error", err)
+	coded := asCoded(err)
+	if coded.Code != ux.CodeResolveFailed {
+		return s.softError(ctx, err)
+	}
+	return s.softErrorNext(ctx, &ux.CodedError{
+		Code: ux.CodeResolveFailed,
+		Msg:  coded.Msg,
+		Actionable: "Call search_apis with a natural-language description of what you want to do, then " +
+			"inspect_operation on a hit to confirm the contract before executing it.",
+	}, "search_apis")
+}
+
+// executeTransportError maps a broker transport failure per the §3.7 table:
+// retryable (the broker may be coming back), with the get_started pointer —
+// on a local install a dead broker usually means the instance is down, which
+// get_started diagnoses with the exact operator instruction. The instance
+// stamp on the result degrades naturally when the control plane is down too.
+func (s *mcpServer) executeTransportError(ctx context.Context, err error) *mcp.CallToolResult {
+	s.logger.Warn("execute transport failed", "error", err)
+	var extra map[string]any
+	nextTool := ""
+	if asCoded(err).Code == ux.CodeTransportError {
+		extra = map[string]any{"retryable": true}
+		nextTool = "get_started"
+	}
+	return s.softErrorExtra(ctx, err, nextTool, extra)
+}
+
+// executeDenialError maps a broker denial per the §3.7 table: a soft
+// BROKER_DENIED with the agent_directive passed through VERBATIM (the broker's
+// recovery instructions must reach the model intact), retryable: false —
+// re-sending the same call cannot succeed until access changes. next_tool is
+// whoami (deliberate): the §3.2 flow guidance is "check your bindings, never
+// execute to probe access", and no access-request tool exists on this surface
+// yet (it queues behind this PR).
+func (s *mcpServer) executeDenialError(ctx context.Context, denial *agentops.Denial) *mcp.CallToolResult {
+	coded := denial.Err()
+	extra := map[string]any{"retryable": false}
+	if denial.Directive != nil {
+		extra["agent_directive"] = denial.Directive
+		coded.Actionable = denial.Directive.Instruction
+	}
+	if coded.Actionable == "" {
+		// UX7's synthesized recovery, tool-flavored: no denial is a dead end.
+		coded.Actionable = synthesizedDenialHint(denial.Status)
+	}
+	return s.softErrorExtra(ctx, coded, "whoami", extra)
+}
+
+// synthesizedDenialHint is the MCP counterpart of the CLI's status-keyed
+// denial recovery (ux.RenderSynthesizedDenialRecovery): same semantics,
+// phrased for a model that can call tools but must relay operator commands.
+func synthesizedDenialHint(status int) string {
+	switch status {
+	case http.StatusForbidden:
+		return "This agent isn't bound to a toolkit serving this API. Call whoami to see your bindings, " +
+			"then ask your operator to grant access (`jentic access request --toolkit <vendor/name> --wait`)."
+	case http.StatusFailedDependency:
+		return "No credential is provisioned for this call. Ask your operator to provision one " +
+			"(`jentic access request --toolkit <vendor/name> --provision --wait`), then retry."
+	case http.StatusUnauthorized:
+		return "The stored upstream credential needs reconnecting. Ask your operator to re-provision it " +
+			"(`jentic access request --toolkit <vendor/name> --provision --wait`), then retry."
+	default:
+		return "The broker denied this call before it reached the upstream API. Call whoami to check what you can run."
+	}
+}
+
+// executeResultPayload projects an ExecuteResult onto the tool payload: the
+// exact CLI envelope keys ({schema_version, status, headers, body,
+// execution_id} — shared goldens compare this sub-object with the sibling
+// `instance` stamp stripped), with the §3.7 size cap applied to the body. A
+// capped body is replaced by its leading maxResultBytes bytes as a string plus
+// the truncation envelope {truncated: true, total_bytes, execution_id} so the
+// model can fetch or act deliberately instead of flooding its context.
+func (s *mcpServer) executeResultPayload(res *agentops.ExecuteResult) map[string]any {
+	env := res.Envelope()
+	payload := map[string]any{
+		"schema_version": env.SchemaVersion,
+		"status":         env.Status,
+		"headers":        env.Headers,
+		"body":           env.Body,
+	}
+	if env.ExecutionID != "" {
+		payload["execution_id"] = env.ExecutionID
+	}
+	if int64(len(res.Body)) > s.maxResultBytes {
+		payload["body"] = strings.ToValidUTF8(string(res.Body[:s.maxResultBytes]), "")
+		payload["truncated"] = true
+		payload["total_bytes"] = len(res.Body)
+		s.logger.Info("execute result truncated", "total_bytes", len(res.Body), "cap", s.maxResultBytes)
+	}
+	return payload
+}
+
+// handleGetExecutionResult polls one job through the LIVE control-plane
+// routes: GET /jobs/{id} for the status, plus GET /jobs/{id}/result once the
+// job completed (agent tokens hold jobs:read by default — §3.4/§3.2). This is
+// the recovery path for a held (202) execute: poll until terminal, never
+// re-send the execute.
+func (s *mcpServer) handleGetExecutionResult(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	s.noteClient(req.ClientInfo())
+	cctx, cancel := s.callContext(ctx)
+	defer cancel()
+
+	args, err := normalizeToolArgs(req.Params.Arguments, getExecutionResultParams)
+	if err != nil {
+		return nil, invalidParams(err)
+	}
+	jobID, _ := args["job_id"].(string)
+	if jobID == "" {
+		return nil, invalidParams(errors.New(`get_execution_result requires "job_id" (aliases: "id", "job"): ` +
+			`the job id from a held (202) execute response`))
+	}
+
+	client, err := s.app.controlClient(cctx)
+	if err != nil {
+		s.logger.Warn("get_execution_result failed", "error", err)
+		return s.softError(cctx, err), nil
+	}
+	resp, jobErr := client.GetJobWithResponse(cctx, jobID)
+	if err := apiErrorFor(resp, jobErr); err != nil {
+		var he *HTTPError
+		if errors.As(err, &he) && he.StatusCode == http.StatusNotFound {
+			// The identity resolved fine — the job id is wrong, so the
+			// get_started default would be a dead end. The recovery is
+			// re-reading the held execute envelope and calling this tool
+			// again (self-pointer, deliberate).
+			return s.softErrorNext(cctx, &ux.CodedError{
+				Code: ux.CodeResolveFailed,
+				Msg:  fmt.Sprintf("job %q not found", jobID),
+				Actionable: "Re-check the job id — it is carried by the held (202) execute response — and call " +
+					"get_execution_result again with the exact value.",
+			}, "get_execution_result"), nil
+		}
+		s.logger.Warn("get_execution_result failed", "job_id", jobID, "error", err)
+		return s.softError(cctx, err), nil
+	}
+	if resp.JSON200 == nil {
+		return s.softError(cctx, &ux.CodedError{
+			Code: ux.CodeInternalError,
+			Msg:  fmt.Sprintf("unexpected backend response (status %d)", resp.StatusCode()),
+		}), nil
+	}
+
+	job := resp.JSON200
+	payload := map[string]any{
+		"schema_version": mcpSchemaVersion,
+		"job_id":         job.JobId,
+		"kind":           job.Kind,
+		"status":         job.Status,
+	}
+	if job.Error != nil && *job.Error != "" {
+		payload["error"] = *job.Error
+	}
+	if job.ExecutionId != nil && *job.ExecutionId != "" {
+		payload["execution_id"] = *job.ExecutionId
+	}
+	if job.Status == catJobCompleted {
+		s.attachJobResult(cctx, client, jobID, payload)
+	}
+	return s.result(cctx, payload), nil
+}
+
+// attachJobResult adds the completed job's result document to the payload
+// (GET /jobs/{id}/result), size-capped like every relayed body. A result
+// fetch failure degrades to a `result_error` note rather than failing the
+// poll — the status the model asked for is already in hand.
+func (s *mcpServer) attachJobResult(ctx context.Context, client jobResultClient, jobID string, payload map[string]any) {
+	resp, err := client.GetJobResultWithResponse(ctx, jobID)
+	if err := apiErrorFor(resp, err); err != nil {
+		s.logger.Warn("get_execution_result: result fetch failed", "job_id", jobID, "error", err)
+		payload["result_error"] = fmt.Sprintf("the job completed but its result could not be fetched: %v", err)
+		return
+	}
+	if int64(len(resp.Body)) > s.maxResultBytes {
+		payload["result"] = strings.ToValidUTF8(string(resp.Body[:s.maxResultBytes]), "")
+		payload["truncated"] = true
+		payload["total_bytes"] = len(resp.Body)
+		return
+	}
+	var result any
+	if len(resp.Body) > 0 && json.Unmarshal(resp.Body, &result) == nil {
+		payload["result"] = result
+	} else if len(resp.Body) > 0 {
+		payload["result"] = string(resp.Body)
+	}
+}
+
+// jobResultClient is the one generated-client method attachJobResult needs —
+// a seam so tests can drive the result fetch without the whole SDK surface.
+type jobResultClient interface {
+	GetJobResultWithResponse(ctx context.Context, jobID string, reqEditors ...control.RequestEditorFn) (*control.GetJobResultHTTPResp, error)
+}
+
+// The execute tools' input schema. Permissive like every 1-A/1-B schema (no
+// additionalProperties:false, no alias properties — the normalizer resolves
+// them handler-side); the declared shapes are the canonical spellings.
+func executeInputSchema(withBody bool) map[string]any {
+	props := map[string]any{
+		"operation_id": map[string]any{
+			"type": "string",
+			"description": "The operation to execute (required; \"id\" and \"uuid\" are accepted aliases): a registry " +
+				"operation id from a search_apis hit, or a METHOD:url pair like \"GET:https://api.example.com/v1/things\".",
+		},
+		"inputs": map[string]any{
+			"type": "object",
+			"description": "Operation parameters as one flat object (\"params\"/\"parameters\" are accepted aliases): " +
+				"keys matching a {placeholder} in the operation's path fill it; every other key is sent as a query parameter.",
+		},
+		"headers": map[string]any{
+			"type":        "object",
+			"description": "Extra request headers as a string-valued object.",
+		},
+		"revision": map[string]any{
+			"type":        "string",
+			"description": "Pin a specific revision ID for reproducibility (defaults to the current revision).",
+		},
+	}
+	if withBody {
+		props["body"] = map[string]any{
+			"description": "The request body as a JSON value (object, array, or string; \"data\" is an accepted alias). " +
+				"Omit it for bodyless calls — the body is ALWAYS this argument, never read from anywhere else.",
+		}
+		props["idempotency_key"] = map[string]any{
+			"type": "string",
+			"description": "Optional Idempotency-Key so a retried POST/PUT is de-duplicated by the broker instead of " +
+				"running twice.",
+		}
+	}
+	return map[string]any{"type": "object", "properties": props}
+}
+
+var getExecutionResultSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"job_id": map[string]any{
+			"type": "string",
+			"description": "The job to poll (required; \"id\" and \"job\" are accepted aliases), from a held (202) " +
+				"execute response.",
+		},
+	},
+}
+
+// executeToolSpecs declares the PR 1-C tool surface. Annotations per master
+// §3.2: execute is the ONLY tool carrying destructiveHint (openWorldHint on
+// both execute variants — they reach arbitrary upstream APIs); execute_read
+// and get_execution_result are read-only. --read-only therefore withholds
+// exactly `execute`.
+func (s *mcpServer) executeToolSpecs() []mcpToolSpec {
+	openWorld := true
+	destructive := true
+	return []mcpToolSpec{
+		{
+			tool: &mcp.Tool{
+				Name:  "execute",
+				Title: "Execute an API operation",
+				Description: "Execute an operation through the Jentic broker: the broker authenticates this agent " +
+					"and injects the stored upstream credential server-side — credentials never pass through " +
+					"this session. This is the final step of the flow (whoami → search_apis → " +
+					"inspect_operation → execute): always inspect the contract first, and never execute just " +
+					"to probe whether you have access (call whoami). " +
+					`Example: {"operation_id": "op_abc123", "inputs": {"petId": "42", "limit": 10}, ` +
+					`"body": {"name": "Bob"}}. ` +
+					"Returns {status, headers, body, execution_id}: any HTTP status, including upstream " +
+					"4xx/5xx, is the upstream's answer — a denial by the broker itself comes back as an " +
+					"error result with recovery directions instead. A 202 response with a directive means " +
+					"the call is HELD for human approval: poll it with get_execution_result using the job id " +
+					"it carries — never re-send the execute. Large bodies are truncated " +
+					"({truncated: true, total_bytes}); narrow the call (query parameters, pagination) to see " +
+					"the rest. Prefer execute_read for pure reads — it is approved more readily.",
+				InputSchema: executeInputSchema(true),
+				Annotations: &mcp.ToolAnnotations{DestructiveHint: &destructive, OpenWorldHint: &openWorld},
+			},
+			handler:  s.handleExecute,
+			readOnly: false,
+		},
+		{
+			tool: &mcp.Tool{
+				Name:  "execute_read",
+				Title: "Execute a read-only API operation",
+				Description: "Execute a GET or HEAD operation through the Jentic broker — the read-only variant of " +
+					"execute (same envelope, same flow, no request body). Use it for every pure read: clients " +
+					"approve read-only tools more readily. If the operation resolves to any other HTTP " +
+					"method, the call is rejected — use execute. " +
+					`Example: {"operation_id": "GET:https://rest.coincap.io/v3/markets", "inputs": {"limit": 5}}.`,
+				InputSchema: executeInputSchema(false),
+				Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+			},
+			handler:  s.handleExecuteRead,
+			readOnly: true,
+		},
+		{
+			tool: &mcp.Tool{
+				Name:  "get_execution_result",
+				Title: "Poll a held or asynchronous execution",
+				Description: "Poll a job by id: returns {job_id, kind, status, ...} and, once status is " +
+					"\"completed\", the result document. Use it when execute returns a 202 HELD response " +
+					"(human approval required): poll with the job id it carries until the status is terminal " +
+					"(completed, failed, cancelled, dead_letter) — NEVER re-send the execute while a job is " +
+					"pending; approval happens out-of-band and re-sending duplicates the call. " +
+					`Example: {"job_id": "job_abc123"}. While pending/running, wait briefly and poll again.`,
+				InputSchema: getExecutionResultSchema,
+				Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+			},
+			handler:  s.handleGetExecutionResult,
+			readOnly: true,
+		},
+	}
+}

--- a/cli/internal/cli/api/mcp_execute_test.go
+++ b/cli/internal/cli/api/mcp_execute_test.go
@@ -1,0 +1,698 @@
+package api
+
+// mcp_execute_test.go exercises the PR 1-C execute surface: envelope + stamp,
+// the §3.7 error-mapping table (denial with directive passthrough, transport
+// retryability, resolve → search_apis), the 202-held passthrough, the
+// response-size cap, the stdin structural-safety guarantee, the GET/HEAD-only
+// contract of execute_read, and the live-route get_execution_result poll.
+
+import (
+	"context"
+	"encoding/pem"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+
+	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// activeCtxWithBroker is activeCtx with the environment's broker_url set —
+// the only broker source on the MCP surface.
+func activeCtxWithBroker(baseURL, brokerURL string) context.Context {
+	return clictx.WithActiveState(context.Background(), &clictx.ActiveState{
+		ResolvedState: &sdkconfig.ResolvedState{
+			IdentityName:        "test-agent",
+			EnvironmentName:     "test",
+			BaseURL:             baseURL,
+			BrokerURL:           brokerURL,
+			InjectedBearerToken: "tok_abc",
+		},
+		Mode: clictx.ModeHuman,
+	})
+}
+
+func TestMCPExecute_SuccessEnvelopeWithStamp(t *testing.T) {
+	var got *http.Request
+	var gotBody []byte
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Clone(context.Background())
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Jentic-Execution-Id", "exec_1")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":7,"name":"Bob"}`))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets/{petId}/toys","inputs":{"petId":"42","verbose":true},"body":{"name":"Bob"},"headers":{"X-Extra":"1"}}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+
+	// The wire request: path param substituted, the leftover input as query,
+	// the explicit body, the custom header, and the agent bearer.
+	if got.URL.Path != "/v1/pets/42/toys" {
+		t.Errorf("broker path = %q, want the {petId} placeholder filled", got.URL.Path)
+	}
+	if got.URL.Query().Get("verbose") != "true" {
+		t.Errorf("query = %q, want the non-placeholder input as a query param", got.URL.RawQuery)
+	}
+	if string(gotBody) != `{"name":"Bob"}` {
+		t.Errorf("body on the wire = %q, want the explicit body argument", gotBody)
+	}
+	if got.Header.Get("X-Extra") != "1" || got.Header.Get("Authorization") != "Bearer tok_abc" {
+		t.Errorf("headers on the wire = %v, want the custom header and the bearer", got.Header)
+	}
+
+	// The result: the exact CLI envelope keys as a strict superset with the
+	// sibling instance stamp (§3.7.4).
+	payload := decodeToolJSON(t, res)
+	for _, key := range []string{"schema_version", "status", "headers", "body", "execution_id", "instance"} {
+		if _, ok := payload[key]; !ok {
+			t.Errorf("payload missing %q: %v", key, payload)
+		}
+	}
+	if payload["schema_version"] != mcpSchemaVersion || payload["status"] != float64(http.StatusCreated) || payload["execution_id"] != "exec_1" {
+		t.Errorf("envelope = %v, want schema_version/status/execution_id mirrored", payload)
+	}
+	if body, ok := payload["body"].(map[string]any); !ok || body["name"] != "Bob" {
+		t.Errorf("body = %v, want the upstream JSON parsed", payload["body"])
+	}
+	if _, ok := payload["truncated"]; ok {
+		t.Errorf("small body must not carry the truncation envelope")
+	}
+	if stamp, ok := payload["instance"].(map[string]any); !ok || stamp["backend"] != "local" {
+		t.Errorf("instance stamp = %v, want the fresh identity", payload["instance"])
+	}
+}
+
+func TestMCPExecute_DenialPassesDirectiveThrough(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.Header().Set("Jentic-Error-Origin", "broker")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"no toolkit binding","agent_directive":{"strategy":"prompt_human","parameters":{"suggested_command":"jentic access request --toolkit acme/pets --wait"},"human_readable_instruction":"Ask your operator to bind this agent to acme/pets."}}`))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("a broker denial must be a soft error, not a protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result for a broker denial")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeBrokerDenied {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeBrokerDenied)
+	}
+	if payload["retryable"] != false {
+		t.Errorf("retryable = %v, want false (non-retryable until access changes)", payload["retryable"])
+	}
+	if payload["next_tool"] != "whoami" {
+		t.Errorf("next_tool = %v, want whoami", payload["next_tool"])
+	}
+	details, _ := payload["details"].(map[string]any)
+	if details["http_status"] != float64(http.StatusForbidden) {
+		t.Errorf("details = %v, want the denying http_status", payload["details"])
+	}
+	// The directive passes through VERBATIM.
+	directive, ok := payload["agent_directive"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload has no agent_directive: %v", payload)
+	}
+	if directive["strategy"] != "prompt_human" {
+		t.Errorf("directive.strategy = %v, want prompt_human", directive["strategy"])
+	}
+	params, _ := directive["parameters"].(map[string]any)
+	if params["suggested_command"] != "jentic access request --toolkit acme/pets --wait" {
+		t.Errorf("directive.parameters = %v, want the suggested_command verbatim", directive["parameters"])
+	}
+	if step, _ := payload["actionable_step"].(string); !strings.Contains(step, "acme/pets") {
+		t.Errorf("actionable_step %q must relay the directive instruction", step)
+	}
+}
+
+func TestMCPExecute_DenialWithoutDirectiveSynthesizesHint(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Jentic-Error-Origin", "broker")
+		w.WriteHeader(http.StatusFailedDependency)
+		_, _ = w.Write([]byte(`{"detail":"no credential"}`))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeBrokerDenied {
+		t.Fatalf("error_code = %v, want BROKER_DENIED", payload["error_code"])
+	}
+	if _, ok := payload["agent_directive"]; ok {
+		t.Errorf("no directive was sent; none must be fabricated")
+	}
+	if step, _ := payload["actionable_step"].(string); !strings.Contains(step, "credential") {
+		t.Errorf("actionable_step %q must synthesize the 424 recovery (UX7)", step)
+	}
+}
+
+func TestMCPExecute_UpstreamErrorIsNormalResult(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// The broker relaying an upstream 403 stamps origin=upstream: NOT a
+		// denial — the call ran and this is the upstream's answer (§3.7 row 1).
+		w.Header().Set("Jentic-Error-Origin", "upstream")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"upstream says no"}`))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("an upstream 4xx is a normal result, got soft error: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["status"] != float64(http.StatusForbidden) {
+		t.Errorf("status = %v, want the upstream 403 relayed", payload["status"])
+	}
+}
+
+func TestMCPExecute_HeldEnvelopePassesThrough(t *testing.T) {
+	// The ask-tier 202-held broker behavior has not shipped; this mocks its
+	// envelope (§3.4) and pins the passthrough: NOT an error, directive and
+	// job pointer intact, so the model can poll with get_execution_result.
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Jentic-Execution-Id", "exec_held")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"job_id":"job_9","status":"held","agent_directive":{"strategy":"wait","parameters":{"job_id":"job_9","retry_after_seconds":30},"human_readable_instruction":"This call is held for human approval; poll the job for the outcome."}}`))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("a held (202) envelope is a normal result, got soft error: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["status"] != float64(http.StatusAccepted) || payload["execution_id"] != "exec_held" {
+		t.Fatalf("envelope = %v, want the 202 + execution id relayed", payload)
+	}
+	body, _ := payload["body"].(map[string]any)
+	if body["job_id"] != "job_9" {
+		t.Errorf("body = %v, want the job pointer intact", payload["body"])
+	}
+	directive, _ := body["agent_directive"].(map[string]any)
+	if directive["strategy"] != "wait" {
+		t.Errorf("held directive = %v, want the wait strategy passed through", body["agent_directive"])
+	}
+}
+
+func TestMCPExecute_TransportFailureIsRetryableSoftError(t *testing.T) {
+	// A broker that is down: bind a listener, note the address, close it.
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	brokerURL := broker.URL
+	broker.Close()
+
+	s := stampedTestMCPServer(t)
+	// POST without an idempotency key: never retried by the SDK policy, so
+	// the failure surfaces immediately.
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", brokerURL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("a transport failure must be a soft error, not a protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeTransportError {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeTransportError)
+	}
+	if payload["retryable"] != true {
+		t.Errorf("retryable = %v, want true (the broker may come back)", payload["retryable"])
+	}
+	if payload["next_tool"] != "get_started" {
+		t.Errorf("next_tool = %v, want get_started (diagnoses a down instance)", payload["next_tool"])
+	}
+}
+
+func TestMCPExecute_ResolveFailurePointsAtSearch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"operation not found"}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker(srv.URL, "http://127.0.0.1:1"),
+		callToolRequest("execute", `{"operation_id":"op_missing"}`))
+	if err != nil {
+		t.Fatalf("a resolve failure must be a soft error, not a protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeResolveFailed {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeResolveFailed)
+	}
+	if payload["next_tool"] != "search_apis" {
+		t.Errorf("next_tool = %v, want search_apis (the id is wrong, not the setup)", payload["next_tool"])
+	}
+	if step, _ := payload["actionable_step"].(string); !strings.Contains(step, "search_apis") {
+		t.Errorf("actionable_step %q must route through search_apis", step)
+	}
+}
+
+func TestMCPExecute_NoContextIsSoftResolveFailed(t *testing.T) {
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(context.Background(), callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("a diagnosable state must be a soft error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeResolveFailed || payload["next_tool"] != "get_started" {
+		t.Errorf("payload = %v, want the canonical no-context RESOLVE_FAILED → get_started", payload)
+	}
+}
+
+func TestMCPExecute_MissingTargetIsInvalidParams(t *testing.T) {
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", "http://127.0.0.1:1"),
+		callToolRequest("execute", `{}`))
+	if res != nil {
+		t.Fatalf("want a protocol error, got a result: %v", res)
+	}
+	var wireErr *jsonrpc.Error
+	if !errors.As(err, &wireErr) || wireErr.Code != jsonrpc.CodeInvalidParams {
+		t.Fatalf("err = %v, want a JSON-RPC invalid-params error", err)
+	}
+}
+
+func TestMCPExecute_TruncatesOversizedBody(t *testing.T) {
+	big := strings.Repeat("x", 4096)
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Jentic-Execution-Id", "exec_big")
+		_, _ = w.Write([]byte(`{"blob":"` + big + `"}`))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	s.maxResultBytes = 1024
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("truncation is not an error: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["truncated"] != true {
+		t.Fatalf("truncated = %v, want true", payload["truncated"])
+	}
+	if payload["total_bytes"] != float64(len(big)+11) {
+		t.Errorf("total_bytes = %v, want the full body size %d", payload["total_bytes"], len(big)+11)
+	}
+	if payload["execution_id"] != "exec_big" {
+		t.Errorf("execution_id = %v, must survive truncation (it is the retrieval pointer)", payload["execution_id"])
+	}
+	body, _ := payload["body"].(string)
+	if int64(len(body)) > s.maxResultBytes {
+		t.Errorf("body length = %d, want <= the %d cap", len(body), s.maxResultBytes)
+	}
+	if !strings.HasPrefix(body, `{"blob":"xxx`) {
+		t.Errorf("body must be the leading prefix of the raw bytes, got %q...", body[:16])
+	}
+}
+
+// TestMCPExecute_NeverReadsStdin pins the §3.7 structural guarantee: under
+// stdio MCP, stdin is the JSON-RPC wire — a tool call with no body argument
+// must send NO body and must not consume a single byte from stdin, even when
+// stdin is a non-TTY pipe with data pending (the exact condition that trips
+// executeE's stdin fallback).
+func TestMCPExecute_NeverReadsStdin(t *testing.T) {
+	sentinel := `{"protocol":"frames that must survive"}`
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString(sentinel); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = w.Close()
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig; _ = r.Close() })
+
+	var gotBody []byte
+	var hadBody bool
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotBody, _ = io.ReadAll(req.Body)
+		hadBody = len(gotBody) > 0
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	// No "body" argument at all — the case executeE would resolve from stdin.
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+	if hadBody {
+		t.Errorf("broker received a body (%q); a bodyless tool call must send none", gotBody)
+	}
+	// Every stdin byte must still be there: nothing on the MCP path read it.
+	leftover, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdin pipe: %v", err)
+	}
+	if string(leftover) != sentinel {
+		t.Fatalf("stdin was consumed: %d of %d bytes remain — the MCP path must never touch the JSON-RPC wire",
+			len(leftover), len(sentinel))
+	}
+}
+
+func TestMCPExecuteRead_RejectsNonGetOperations(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"method":"POST","url":"https://acme.com/pets"}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecuteRead(activeCtxWithBroker(srv.URL, "http://127.0.0.1:1"),
+		callToolRequest("execute_read", `{"operation_id":"op_post"}`))
+	if res != nil {
+		t.Fatalf("want a protocol error, got a result: %v", res)
+	}
+	var wireErr *jsonrpc.Error
+	if !errors.As(err, &wireErr) || wireErr.Code != jsonrpc.CodeInvalidParams {
+		t.Fatalf("err = %v, want a JSON-RPC invalid-params error", err)
+	}
+	if !strings.Contains(wireErr.Message, "execute") {
+		t.Errorf("message %q must point at the execute tool", wireErr.Message)
+	}
+}
+
+func TestMCPExecuteRead_RejectsBodyArgument(t *testing.T) {
+	s := stampedTestMCPServer(t)
+	_, err := s.handleExecuteRead(activeCtxWithBroker("http://127.0.0.1:8000", "http://127.0.0.1:1"),
+		callToolRequest("execute_read", `{"operation_id":"GET:/v1/pets","body":{"x":1}}`))
+	var wireErr *jsonrpc.Error
+	if !errors.As(err, &wireErr) || wireErr.Code != jsonrpc.CodeInvalidParams {
+		t.Fatalf("err = %v, want a JSON-RPC invalid-params error", err)
+	}
+}
+
+func TestMCPExecuteRead_GetRoundTrip(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecuteRead(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute_read", `{"operation_id":"GET:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecuteRead: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["status"] != float64(http.StatusOK) {
+		t.Errorf("status = %v, want 200", payload["status"])
+	}
+}
+
+// TestMCPExecute_BrokerLegHonorsCAPinAndHook pins §3.7.2: the broker leg is
+// built by clictx (CA-pinned to the environment's ca_cert_path, fail-closed)
+// with the session's attribution hook composed over it — the User-Agent
+// reaches the BROKER, not just the control plane.
+func TestMCPExecute_BrokerLegHonorsCAPinAndHook(t *testing.T) {
+	var gotUA string
+	broker := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer broker.Close()
+
+	// Write the test server's own CA cert as the environment's bundle.
+	pemPath := filepath.Join(t.TempDir(), "ca.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: broker.Certificate().Raw})
+	if err := os.WriteFile(pemPath, pemBytes, 0o600); err != nil {
+		t.Fatalf("write ca bundle: %v", err)
+	}
+
+	s := stampedTestMCPServer(t)
+	state := &clictx.ActiveState{
+		ResolvedState: &sdkconfig.ResolvedState{
+			IdentityName:        "test-agent",
+			EnvironmentName:     "test",
+			BaseURL:             "https://cp.example.com",
+			BrokerURL:           broker.URL,
+			CACertPath:          pemPath,
+			InjectedBearerToken: "tok_abc",
+		},
+		Mode: clictx.ModeHuman,
+	}
+	ctx := clictx.WithTransportHook(clictx.WithActiveState(context.Background(), state), s.transportHook())
+
+	res, err := s.handleExecute(ctx, callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("CA-pinned broker call must succeed against the pinned cert: %v", res.Content)
+	}
+	if !strings.HasPrefix(gotUA, "jentic-mcp/") {
+		t.Errorf("broker User-Agent = %q, want the attribution hook composed onto the broker leg", gotUA)
+	}
+
+	// SEC-20 fail-closed: a set-but-broken bundle is an error, never a silent
+	// fallback to system roots.
+	state.CACertPath = filepath.Join(t.TempDir(), "missing.pem")
+	res, err = s.handleExecute(ctx, callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("a broken ca_cert_path must fail closed")
+	}
+	payload := decodeToolJSON(t, res)
+	if msg, _ := payload["error"].(string); !strings.Contains(msg, "ca_cert_path") {
+		t.Errorf("error %q must name the broken ca_cert_path", msg)
+	}
+}
+
+// TestMCPGetExecutionResult_LiveRoutesRoundTrip drives the poll tool against
+// httptest versions of the LIVE routes it wires (§3.4): GET /jobs/{id} and
+// GET /jobs/{id}/result.
+func TestMCPGetExecutionResult_LiveRoutesRoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/jobs/job_9":
+			_, _ = w.Write([]byte(`{"job_id":"job_9","kind":"execution","status":"completed","execution_id":"exec_9","created_at":"2026-08-28T12:00:00Z","_links":{"self":"/jobs/job_9"}}`))
+		case "/jobs/job_9/result":
+			_, _ = w.Write([]byte(`{"status":201,"body":{"id":7}}`))
+		default:
+			t.Errorf("unexpected control-plane call %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	// `id` alias for job_id must fold before the wire call.
+	res, err := s.handleGetExecutionResult(activeCtx(srv.URL), callToolRequest("get_execution_result", `{"id":"job_9"}`))
+	if err != nil {
+		t.Fatalf("handleGetExecutionResult: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["job_id"] != "job_9" || payload["status"] != "completed" || payload["execution_id"] != "exec_9" {
+		t.Errorf("payload = %v, want the job projection", payload)
+	}
+	result, ok := payload["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("completed job must include its result document: %v", payload)
+	}
+	if result["status"] != float64(201) {
+		t.Errorf("result = %v, want the /result body passed through", result)
+	}
+	if stamp, ok := payload["instance"].(map[string]any); !ok || stamp["backend"] != "local" {
+		t.Errorf("instance stamp = %v, want the fresh identity", payload["instance"])
+	}
+}
+
+func TestMCPGetExecutionResult_PendingJobHasNoResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/result") {
+			t.Errorf("a pending job's result must not be fetched")
+		}
+		_, _ = w.Write([]byte(`{"job_id":"job_9","kind":"execution","status":"pending","created_at":"2026-08-28T12:00:00Z","_links":{"self":"/jobs/job_9"}}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleGetExecutionResult(activeCtx(srv.URL), callToolRequest("get_execution_result", `{"job_id":"job_9"}`))
+	if err != nil {
+		t.Fatalf("handleGetExecutionResult: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("a pending job is a normal result the model polls again: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["status"] != "pending" {
+		t.Errorf("status = %v, want pending", payload["status"])
+	}
+	if _, ok := payload["result"]; ok {
+		t.Errorf("pending job must carry no result key")
+	}
+}
+
+func TestMCPGetExecutionResult_UnknownJobIsSoftResolveFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"job not found"}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleGetExecutionResult(activeCtx(srv.URL), callToolRequest("get_execution_result", `{"job_id":"job_gone"}`))
+	if err != nil {
+		t.Fatalf("an unknown job must be a soft error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeResolveFailed {
+		t.Errorf("error_code = %v, want RESOLVE_FAILED", payload["error_code"])
+	}
+	// The identity is fine — the pointer is this tool with the corrected id,
+	// never get_started.
+	if payload["next_tool"] != "get_execution_result" {
+		t.Errorf("next_tool = %v, want get_execution_result", payload["next_tool"])
+	}
+}
+
+func TestMCPGetExecutionResult_MissingJobIDIsInvalidParams(t *testing.T) {
+	s := stampedTestMCPServer(t)
+	_, err := s.handleGetExecutionResult(activeCtx("http://127.0.0.1:1"), callToolRequest("get_execution_result", `{}`))
+	var wireErr *jsonrpc.Error
+	if !errors.As(err, &wireErr) || wireErr.Code != jsonrpc.CodeInvalidParams {
+		t.Fatalf("err = %v, want a JSON-RPC invalid-params error", err)
+	}
+}
+
+func TestMCPGetExecutionResult_TruncatesOversizedResult(t *testing.T) {
+	big := strings.Repeat("y", 4096)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/result") {
+			_, _ = w.Write([]byte(`{"blob":"` + big + `"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"job_id":"job_9","kind":"execution","status":"completed","created_at":"2026-08-28T12:00:00Z","_links":{"self":"/jobs/job_9"}}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	s.maxResultBytes = 512
+	res, err := s.handleGetExecutionResult(activeCtx(srv.URL), callToolRequest("get_execution_result", `{"job_id":"job_9"}`))
+	if err != nil {
+		t.Fatalf("handleGetExecutionResult: %v", err)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["truncated"] != true {
+		t.Errorf("truncated = %v, want true", payload["truncated"])
+	}
+	if result, _ := payload["result"].(string); int64(len(result)) > s.maxResultBytes {
+		t.Errorf("result length = %d, want <= the %d cap", len(result), s.maxResultBytes)
+	}
+}
+
+func TestResolveMCPBrokerTarget(t *testing.T) {
+	state := func(baseURL, brokerURL string) *clictx.ActiveState {
+		return &clictx.ActiveState{ResolvedState: &sdkconfig.ResolvedState{
+			EnvironmentName: "test", BaseURL: baseURL, BrokerURL: brokerURL,
+		}}
+	}
+
+	t.Run("environment broker_url wins", func(t *testing.T) {
+		scheme, host, err := resolveMCPBrokerTarget(state("https://cp.example.com", "https://broker.example.com:8100"))
+		if err != nil || scheme != "https" || host != "broker.example.com:8100" {
+			t.Fatalf("got %s://%s, %v", scheme, host, err)
+		}
+	})
+	t.Run("local default without broker_url", func(t *testing.T) {
+		scheme, host, err := resolveMCPBrokerTarget(state("http://127.0.0.1:8000", ""))
+		if err != nil || scheme != "https" || host != "127.0.0.1:8100" {
+			t.Fatalf("got %s://%s, %v", scheme, host, err)
+		}
+	})
+	t.Run("malformed broker_url fails closed", func(t *testing.T) {
+		_, _, err := resolveMCPBrokerTarget(state("http://127.0.0.1:8000", "not a url"))
+		if asCoded(err).Code != ux.CodeResolveFailed {
+			t.Fatalf("err = %v, want coded RESOLVE_FAILED", err)
+		}
+	})
+	t.Run("remote control plane without broker_url fails closed", func(t *testing.T) {
+		_, _, err := resolveMCPBrokerTarget(state("https://cp.example.com", ""))
+		if asCoded(err).Code != ux.CodeResolveFailed {
+			t.Fatalf("err = %v, want coded RESOLVE_FAILED (never dial the loopback default with a remote CP)", err)
+		}
+		if !strings.Contains(err.Error(), "broker") {
+			t.Errorf("error %q must name the missing broker", err.Error())
+		}
+	})
+}

--- a/cli/internal/cli/api/mcp_execute_test.go
+++ b/cli/internal/cli/api/mcp_execute_test.go
@@ -7,7 +7,9 @@ package api
 // contract of execute_read, and the live-route get_execution_result poll.
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"io"
@@ -17,6 +19,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 
@@ -149,6 +153,41 @@ func TestMCPExecute_DenialPassesDirectiveThrough(t *testing.T) {
 	}
 }
 
+// TestMCPExecute_DenialRelaysUnknownDirectiveFields pins the VERBATIM half of
+// the directive passthrough: the payload carries the RAW agent_directive JSON
+// sub-object, so a field this CLI build has never heard of still reaches the
+// model (a struct projection would silently drop it).
+func TestMCPExecute_DenialRelaysUnknownDirectiveFields(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.Header().Set("Jentic-Error-Origin", "broker")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"no toolkit binding","agent_directive":{"strategy":"prompt_human",` +
+			`"future_field":"must-survive","parameters":{"nested_unknown":{"keep":"me"}},` +
+			`"human_readable_instruction":"Ask your operator."}}`))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	payload := decodeToolJSON(t, res)
+	directive, ok := payload["agent_directive"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload has no agent_directive: %v", payload)
+	}
+	if directive["future_field"] != "must-survive" {
+		t.Errorf("directive = %v, want the unknown top-level field relayed verbatim", directive)
+	}
+	params, _ := directive["parameters"].(map[string]any)
+	if nested, _ := params["nested_unknown"].(map[string]any); nested["keep"] != "me" {
+		t.Errorf("directive.parameters = %v, want the nested unknown value intact", params)
+	}
+}
+
 func TestMCPExecute_DenialWithoutDirectiveSynthesizesHint(t *testing.T) {
 	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Jentic-Error-Origin", "broker")
@@ -245,7 +284,9 @@ func TestMCPExecute_TransportFailureIsRetryableSoftError(t *testing.T) {
 
 	s := stampedTestMCPServer(t)
 	// POST without an idempotency key: never retried by the SDK policy, so
-	// the failure surfaces immediately.
+	// the failure surfaces immediately. Connection refused is a PRE-SEND
+	// failure — the upstream provably never saw the request — so even an
+	// unkeyed POST earns retryable: true.
 	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", brokerURL),
 		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
 	if err != nil {
@@ -259,10 +300,128 @@ func TestMCPExecute_TransportFailureIsRetryableSoftError(t *testing.T) {
 		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeTransportError)
 	}
 	if payload["retryable"] != true {
-		t.Errorf("retryable = %v, want true (the broker may come back)", payload["retryable"])
+		t.Errorf("retryable = %v, want true (pre-send failure: the request never left)", payload["retryable"])
 	}
 	if payload["next_tool"] != "get_started" {
 		t.Errorf("next_tool = %v, want get_started (diagnoses a down instance)", payload["next_tool"])
+	}
+}
+
+// midflightBroker accepts the request in full and then kills the connection
+// without writing a response — a transport failure that is NOT provably
+// pre-send: the upstream may have received (and executed) the call.
+func midflightBroker(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		conn, _, err := http.NewResponseController(w).Hijack()
+		if err != nil {
+			t.Errorf("hijack: %v", err)
+			return
+		}
+		_ = conn.Close()
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestMCPExecute_MidflightFailureUnkeyedPostIsNotRetryable pins the
+// double-execution guard: a mid-flight failure on a POST with no
+// Idempotency-Key may have ALREADY executed upstream, so the soft error must
+// NOT carry retryable: true — it must say the request may have been
+// delivered and route recovery through idempotency keys /
+// get_execution_result instead of a blind re-send.
+func TestMCPExecute_MidflightFailureUnkeyedPostIsNotRetryable(t *testing.T) {
+	broker := midflightBroker(t)
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets","body":{"name":"Bob"}}`))
+	if err != nil {
+		t.Fatalf("a transport failure must be a soft error, not a protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeTransportError {
+		t.Fatalf("error_code = %v, want %q", payload["error_code"], ux.CodeTransportError)
+	}
+	if payload["retryable"] != false {
+		t.Errorf("retryable = %v, want false (mid-flight unkeyed POST: a retry may double-execute)", payload["retryable"])
+	}
+	if msg, _ := payload["error"].(string); !strings.Contains(msg, "may already have reached the upstream") {
+		t.Errorf("error %q must say the request may have been delivered", msg)
+	}
+	step, _ := payload["actionable_step"].(string)
+	for _, want := range []string{"idempotency_key", "get_execution_result"} {
+		if !strings.Contains(step, want) {
+			t.Errorf("actionable_step %q must point at %s", step, want)
+		}
+	}
+}
+
+// TestMCPExecute_MidflightFailureWithIdempotencyKeyIsRetryable: the same
+// mid-flight failure IS safely retryable when the call carries an
+// Idempotency-Key — the broker de-duplicates the re-send.
+func TestMCPExecute_MidflightFailureWithIdempotencyKeyIsRetryable(t *testing.T) {
+	broker := midflightBroker(t)
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets","body":{"name":"Bob"},"idempotency_key":"key-1"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeTransportError || payload["retryable"] != true {
+		t.Errorf("payload = {error_code: %v, retryable: %v}, want a retryable TRANSPORT_ERROR (keyed POST is de-duplicated)",
+			payload["error_code"], payload["retryable"])
+	}
+}
+
+// TestMCPExecuteRead_MidflightFailureIsRetryable: a GET cannot mutate, so a
+// mid-flight failure on the read variant keeps the retryable hint.
+func TestMCPExecuteRead_MidflightFailureIsRetryable(t *testing.T) {
+	broker := midflightBroker(t)
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecuteRead(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute_read", `{"operation_id":"GET:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecuteRead: %v", err)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeTransportError || payload["retryable"] != true {
+		t.Errorf("payload = {error_code: %v, retryable: %v}, want a retryable TRANSPORT_ERROR (GET is idempotent)",
+			payload["error_code"], payload["retryable"])
+	}
+}
+
+// TestMCPCallContexts_DeadlineSplit pins the deadline split: the execute
+// family's per-call deadline must sit ABOVE the 60s broker-leg ceiling the
+// CLI's execute carries (agentops.DoWith's default client timeout) — the 30s
+// control-plane deadline would make the advertised ceiling unreachable —
+// while control-plane-only tools keep the tight 30s bound.
+func TestMCPCallContexts_DeadlineSplit(t *testing.T) {
+	s := newTestMCPServer(t, nil)
+	now := time.Now()
+
+	cctx, cancel := s.callContext(context.Background())
+	defer cancel()
+	ectx, ecancel := s.executeCallContext(context.Background())
+	defer ecancel()
+
+	controlDeadline, ok := cctx.Deadline()
+	if !ok {
+		t.Fatalf("callContext must carry a deadline")
+	}
+	executeDeadline, ok := ectx.Deadline()
+	if !ok {
+		t.Fatalf("executeCallContext must carry a deadline")
+	}
+	if got := executeDeadline.Sub(now); got < 60*time.Second {
+		t.Errorf("execute deadline = %v, want >= the 60s CLI execute ceiling", got.Round(time.Second))
+	}
+	if got := controlDeadline.Sub(now); got > 31*time.Second {
+		t.Errorf("control-plane deadline = %v, want the tight 30s bound", got.Round(time.Second))
 	}
 }
 
@@ -360,6 +519,122 @@ func TestMCPExecute_TruncatesOversizedBody(t *testing.T) {
 	}
 }
 
+// TestMCPExecute_TruncationDropsRuneSplitAtCap pins the UTF-8 boundary: when
+// the cap lands mid-rune, the split rune's leading byte is dropped rather
+// than relayed as garbage (a tool result must stay valid UTF-8).
+func TestMCPExecute_TruncationDropsRuneSplitAtCap(t *testing.T) {
+	// 1023 ASCII bytes, then two-byte runes: byte 1024 (the cap) falls in the
+	// middle of the first "é".
+	payloadBody := strings.Repeat("a", 1023) + strings.Repeat("é", 64)
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(payloadBody))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	s.maxResultBytes = 1024
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["truncated"] != true {
+		t.Fatalf("truncated = %v, want true", payload["truncated"])
+	}
+	body, _ := payload["body"].(string)
+	if !utf8.ValidString(body) {
+		t.Errorf("truncated body must be valid UTF-8")
+	}
+	if body != strings.Repeat("a", 1023) {
+		t.Errorf("body = %q..., want the 1023 leading bytes with the split rune dropped", body[:16])
+	}
+}
+
+// TestMCPExecute_TruncationSanitizesBinaryBody pins the docstring's "leading
+// bytes, sanitized to valid UTF-8": a binary body's invalid sequences are
+// stripped EVERYWHERE, not only at the cap boundary, so the relayed string is
+// always valid UTF-8 (and therefore not byte-identical to the raw prefix).
+func TestMCPExecute_TruncationSanitizesBinaryBody(t *testing.T) {
+	chunk := append([]byte("data"), 0xFF, 0xFE, 0x00)
+	raw := bytes.Repeat(chunk, 300) // 2100 bytes, invalid UTF-8 throughout
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(raw)
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	s.maxResultBytes = 1024
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["truncated"] != true || payload["total_bytes"] != float64(len(raw)) {
+		t.Fatalf("payload = {truncated: %v, total_bytes: %v}, want the truncation envelope for %d bytes",
+			payload["truncated"], payload["total_bytes"], len(raw))
+	}
+	body, _ := payload["body"].(string)
+	if !utf8.ValidString(body) {
+		t.Errorf("binary body must be sanitized to valid UTF-8")
+	}
+	if !strings.HasPrefix(body, "data") || strings.ContainsRune(body, 0xFFFD) {
+		t.Errorf("body %q..., want the readable bytes kept and invalid sequences dropped (not replaced)", body[:8])
+	}
+}
+
+// TestMCPExecute_CapsOversizedResponseHeaders pins the header half of the
+// §3.7 context-protection cap: response headers ride under their own
+// aggregate budget, so a hostile/buggy upstream cannot push megabytes into
+// the model's context THROUGH headers while the body cap holds. Small
+// headers survive a fat sibling; the marker names the truncation.
+func TestMCPExecute_CapsOversizedResponseHeaders(t *testing.T) {
+	fat := strings.Repeat("h", 64<<10) // 64 KiB in ONE header, body tiny
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Bloat", fat)
+		w.Header().Set("Jentic-Execution-Id", "exec_fat")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer broker.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"POST:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("header truncation is not an error: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["headers_truncated"] != true {
+		t.Fatalf("headers_truncated = %v, want true", payload["headers_truncated"])
+	}
+	headers, _ := payload["headers"].(map[string]any)
+	if _, ok := headers["X-Bloat"]; ok {
+		t.Errorf("the over-budget header must be dropped")
+	}
+	if headers["Content-Type"] != "application/json" {
+		t.Errorf("headers = %v, want the small headers to survive the fat sibling", headers)
+	}
+	serialized, _ := json.Marshal(headers)
+	if int64(len(serialized)) > s.headerBytesBudget()+256 {
+		t.Errorf("serialized headers = %d bytes, want them under the %d budget", len(serialized), s.headerBytesBudget())
+	}
+	// The BODY cap is untouched: the small body is relayed whole.
+	if _, ok := payload["truncated"]; ok {
+		t.Errorf("a small body must not carry the body-truncation envelope")
+	}
+	if body, ok := payload["body"].(map[string]any); !ok || body["ok"] != true {
+		t.Errorf("body = %v, want the upstream JSON intact", payload["body"])
+	}
+	if payload["execution_id"] != "exec_fat" {
+		t.Errorf("execution_id = %v, must survive header truncation", payload["execution_id"])
+	}
+}
+
 // TestMCPExecute_NeverReadsStdin pins the §3.7 structural guarantee: under
 // stdio MCP, stdin is the JSON-RPC wire — a tool call with no body argument
 // must send NO body and must not consume a single byte from stdin, even when
@@ -431,6 +706,37 @@ func TestMCPExecuteRead_RejectsNonGetOperations(t *testing.T) {
 	}
 	if !strings.Contains(wireErr.Message, "execute") {
 		t.Errorf("message %q must point at the execute tool", wireErr.Message)
+	}
+}
+
+// TestMCPExecuteRead_AcceptsLowercaseRegistryMethod pins the resolve-time
+// method normalization: a registry inspect document carrying "get" (allowed —
+// the document is data, not our canon) must pass the GET/HEAD gate and go on
+// the wire as canonical GET, not be rejected with "resolves to get".
+func TestMCPExecuteRead_AcceptsLowercaseRegistryMethod(t *testing.T) {
+	var gotMethod string
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer broker.Close()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"method":"get","url":"https://acme.com/pets"}`))
+	}))
+	defer srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecuteRead(activeCtxWithBroker(srv.URL, broker.URL),
+		callToolRequest("execute_read", `{"operation_id":"op_lower"}`))
+	if err != nil {
+		t.Fatalf("a lowercase registry method must not fail the GET/HEAD gate: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method on the wire = %q, want the canonical GET", gotMethod)
 	}
 }
 
@@ -622,6 +928,41 @@ func TestMCPGetExecutionResult_UnknownJobIsSoftResolveFailed(t *testing.T) {
 	// never get_started.
 	if payload["next_tool"] != "get_execution_result" {
 		t.Errorf("next_tool = %v, want get_execution_result", payload["next_tool"])
+	}
+}
+
+// TestMCPGetExecutionResult_TransportFailureIsRetryable pins the §3.7
+// transport row on the POLL tool: its most likely transient failure is
+// "control plane briefly down, poll again", so a transport failure must come
+// back as a retryable TRANSPORT_ERROR with the get_started pointer — not as
+// INTERNAL_ERROR ("stop, CLI bug") with no hints. The poll is a GET, so
+// re-polling is always safe.
+func TestMCPGetExecutionResult_TransportFailureIsRetryable(t *testing.T) {
+	// A control plane that is down: bind a listener, note the address, close it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	baseURL := srv.URL
+	srv.Close()
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleGetExecutionResult(activeCtx(baseURL), callToolRequest("get_execution_result", `{"job_id":"job_9"}`))
+	if err != nil {
+		t.Fatalf("a transport failure must be a soft error, not a protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeTransportError {
+		t.Errorf("error_code = %v, want %q (never INTERNAL_ERROR for a down control plane)",
+			payload["error_code"], ux.CodeTransportError)
+	}
+	if payload["retryable"] != true {
+		t.Errorf("retryable = %v, want true (polling again is the recovery)", payload["retryable"])
+	}
+	if payload["next_tool"] != "get_started" {
+		t.Errorf("next_tool = %v, want get_started (diagnoses a down instance)", payload["next_tool"])
 	}
 }
 

--- a/cli/internal/cli/api/mcp_params.go
+++ b/cli/internal/cli/api/mcp_params.go
@@ -26,6 +26,11 @@ const (
 	paramStringList
 	paramInt
 	paramObject
+	// paramJSON passes any JSON value through as raw bytes (json.RawMessage) —
+	// the execute tool's request body, which may legitimately be an object,
+	// array, string, number, or bool. A string that itself parses as JSON is
+	// kept verbatim as the body text (models routinely stringify bodies).
+	paramJSON
 )
 
 // paramSpec declares one tool parameter: its canonical name (the key handlers
@@ -122,6 +127,8 @@ func coerceParam(v any, kind paramKind) (any, error) {
 			return nil, err
 		}
 		return m, nil
+	case paramJSON:
+		return coerceJSON(v)
 	default:
 		return nil, fmt.Errorf("unknown parameter kind %d", kind)
 	}
@@ -208,6 +215,21 @@ func coerceObject(v any) (map[string]any, error) {
 	default:
 		return nil, fmt.Errorf("expected a JSON object, got %T", v)
 	}
+}
+
+// coerceJSON re-encodes any decoded JSON value as raw bytes. A string whose
+// content parses as JSON is treated as the stringified form and its content
+// kept verbatim; any other string is encoded as a JSON string (the value the
+// model sent IS the value).
+func coerceJSON(v any) (json.RawMessage, error) {
+	if s, ok := v.(string); ok && json.Valid([]byte(s)) {
+		return json.RawMessage(s), nil
+	}
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("value does not encode as JSON: %w", err)
+	}
+	return raw, nil
 }
 
 // equalParam compares two coerced values for the conflicting-alias check.

--- a/cli/internal/cli/api/mcp_params_test.go
+++ b/cli/internal/cli/api/mcp_params_test.go
@@ -202,3 +202,92 @@ func TestNormalizeToolArgs_NumberCoercesToString(t *testing.T) {
 		t.Errorf("operation_id = %v, want \"42\"", got["operation_id"])
 	}
 }
+
+// --- coerceJSON: the execute body's paramJSON semantics ----------------------
+
+// TestCoerceJSON_Table pins the DELIBERATE reinterpretation rule for the
+// execute tools' body: a string whose content parses as JSON is treated as
+// the stringified form and its content kept verbatim (models routinely
+// stringify bodies), so a literal string body that happens to parse as JSON
+// — "123", "true", "[1,2]" — CANNOT be sent as a quoted JSON string. That
+// trade-off is intentional and stated in the body schema description; this
+// table is the contract.
+func TestCoerceJSON_Table(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string // the JSON value the model sent for "body"
+		want string // the exact bytes that go on the wire
+	}{
+		{
+			name: "object passes through",
+			raw:  `{"name":"Bob"}`,
+			want: `{"name":"Bob"}`,
+		},
+		{
+			name: "array passes through",
+			raw:  `[1,2,3]`,
+			want: `[1,2,3]`,
+		},
+		{
+			name: "stringified object unwraps to its content verbatim",
+			raw:  `"{\"name\":\"Bob\"}"`,
+			want: `{"name":"Bob"}`,
+		},
+		{
+			name: "plain string stays a JSON string",
+			raw:  `"just some text"`,
+			want: `"just some text"`,
+		},
+		{
+			name: "string that parses as a scalar is reinterpreted as the scalar",
+			raw:  `"123"`,
+			want: `123`,
+		},
+		{
+			name: "string that parses as a bool is reinterpreted as the bool",
+			raw:  `"true"`,
+			want: `true`,
+		},
+		{
+			name: "string that parses as an array is reinterpreted as the array",
+			raw:  `"[1,2]"`,
+			want: `[1,2]`,
+		},
+		{
+			name: "bare number encodes as JSON",
+			raw:  `42`,
+			want: `42`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v any
+			if err := json.Unmarshal(json.RawMessage(tc.raw), &v); err != nil {
+				t.Fatalf("test input is not JSON: %v", err)
+			}
+			got, err := coerceJSON(v)
+			if err != nil {
+				t.Fatalf("coerceJSON: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("coerceJSON(%s) = %s, want %s", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCoerceJSON_ThroughNormalizer proves the same semantics hold end-to-end
+// through the execute tools' spec table (the "data" alias included).
+func TestCoerceJSON_ThroughNormalizer(t *testing.T) {
+	got, err := normalizeToolArgs(json.RawMessage(`{"operation_id":"op1","data":"{\"a\":1}"}`), executeParams)
+	if err != nil {
+		t.Fatalf("normalizeToolArgs: %v", err)
+	}
+	body, ok := got["body"].(json.RawMessage)
+	if !ok {
+		t.Fatalf("body = %T, want json.RawMessage", got["body"])
+	}
+	if string(body) != `{"a":1}` {
+		t.Errorf("body = %s, want the stringified object's content verbatim", body)
+	}
+}

--- a/cli/internal/cli/api/mcp_server.go
+++ b/cli/internal/cli/api/mcp_server.go
@@ -31,6 +31,15 @@ import (
 // the CALL, not wedge the session.
 const mcpCallTimeout = 30 * time.Second
 
+// mcpExecuteCallTimeout bounds one execute/execute_read call. It is
+// deliberately ABOVE the 60s broker-leg ceiling the CLI's execute carries
+// (agentops.DoWith's default client timeout), so the per-call context never
+// undercuts it: an upstream that answers in 45s succeeds over MCP exactly
+// like it does over the CLI, and the effective ceiling on both surfaces is
+// the same 60s client timeout. The headroom covers the pre-send control-plane
+// work (resolve/inspect) that shares this context.
+const mcpExecuteCallTimeout = 90 * time.Second
+
 // mcpServer is one `jentic mcp` process: a single stdio session plus the
 // process-scoped attribution state (session UUID, last-seen clientInfo) and
 // the TTL instance-stamp cache.
@@ -295,8 +304,17 @@ func (s *mcpServer) noteClient(ci *mcp.Implementation) {
 
 // callContext derives the per-call context every handler uses: the session
 // context's values (ActiveState, transport hook) with this call's deadline.
+// Control-plane-only tools get the 30s mcpCallTimeout.
 func (s *mcpServer) callContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, mcpCallTimeout)
+}
+
+// executeCallContext is callContext for the execute family: the broker leg
+// relays arbitrary upstream latency, so it gets the wider
+// mcpExecuteCallTimeout instead of the control-plane deadline (which would
+// silently cap the advertised 60s execute ceiling at 30s).
+func (s *mcpServer) executeCallContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, mcpExecuteCallTimeout)
 }
 
 // result builds the one tool-result shape every tool returns: the payload

--- a/cli/internal/cli/api/mcp_server.go
+++ b/cli/internal/cli/api/mcp_server.go
@@ -40,6 +40,9 @@ type mcpServer struct {
 	logger   *slog.Logger
 	readOnly bool
 	excluded map[string]bool
+	// maxResultBytes is the §3.7 context-protection cap applied to relayed
+	// upstream bodies (the execute family) — see mcp_execute.go.
+	maxResultBytes int64
 
 	// sessionID is the per-process UUID fallback for X-Jentic-Session-Id. The
 	// RoundTripper stamps it ONLY when the header is absent, so an env-set
@@ -68,13 +71,17 @@ func newMCPServer(a *app, version string, opts *mcpOptions, logger *slog.Logger)
 		}
 	}
 	s := &mcpServer{
-		app:       a,
-		version:   version,
-		logger:    logger,
-		readOnly:  opts.readOnly,
-		excluded:  excluded,
-		sessionID: uuid.NewString(),
-		instances: newInstanceCache(),
+		app:            a,
+		version:        version,
+		logger:         logger,
+		readOnly:       opts.readOnly,
+		excluded:       excluded,
+		maxResultBytes: opts.maxResultBytes,
+		sessionID:      uuid.NewString(),
+		instances:      newInstanceCache(),
+	}
+	if s.maxResultBytes <= 0 {
+		s.maxResultBytes = defaultMaxResultBytes
 	}
 	s.server = mcp.NewServer(
 		&mcp.Implementation{Name: "jentic-mcp", Title: "Jentic One", Version: version},
@@ -172,13 +179,16 @@ var inspectOperationSchema = map[string]any{
 }
 
 // toolSpecs declares the served tool surface: the 1-A pre-auth pair
-// (get_started, whoami) plus the 1-B discovery pair (search_apis,
-// inspect_operation); the execute tools land in 1-C. Docstrings encode the
-// flow (get_started first, whoami before discovery, search → inspect →
-// execute) per §3.2, with concrete argument examples a model can copy.
+// (get_started, whoami), the 1-B discovery pair (search_apis,
+// inspect_operation), and the 1-C execute surface (execute, execute_read,
+// get_execution_result — mcp_execute.go). Docstrings encode the flow
+// (get_started first, whoami before discovery, search → inspect → execute)
+// per §3.2, with concrete argument examples a model can copy.
 func (s *mcpServer) toolSpecs() []mcpToolSpec {
 	readOnly := &mcp.ToolAnnotations{ReadOnlyHint: true}
-	return []mcpToolSpec{
+	execSpecs := s.executeToolSpecs()
+	specs := make([]mcpToolSpec, 0, 4+len(execSpecs))
+	specs = append(specs, []mcpToolSpec{
 		{
 			tool: &mcp.Tool{
 				Name:  "get_started",
@@ -252,13 +262,13 @@ func (s *mcpServer) toolSpecs() []mcpToolSpec {
 			handler:  s.handleInspectOperation,
 			readOnly: true,
 		},
-	}
+	}...)
+	return append(specs, execSpecs...)
 }
 
 // registerTools applies the serving filters. --exclude-tools drops by name;
-// --read-only drops everything not annotated read-only. Both PR 1-A tools are
-// read-only, so the flag only bites from 1-C on — but the filter is wired now
-// so the flag's contract holds from the first release that has it.
+// --read-only drops everything not annotated read-only — from 1-C on that is
+// exactly the `execute` tool (execute_read and get_execution_result stay).
 func (s *mcpServer) registerTools() {
 	for _, spec := range s.toolSpecs() {
 		if s.excluded[spec.tool.Name] {
@@ -344,6 +354,14 @@ func (s *mcpServer) softError(ctx context.Context, err error) *mcp.CallToolResul
 // get_started (the identity already resolved). An empty nextTool keeps the
 // default mapping.
 func (s *mcpServer) softErrorNext(ctx context.Context, err error, nextTool string) *mcp.CallToolResult {
+	return s.softErrorExtra(ctx, err, nextTool, nil)
+}
+
+// softErrorExtra is softErrorNext plus caller-supplied payload keys — the
+// §3.7 error-mapping table's per-class enrichments (a broker denial's verbatim
+// agent_directive passthrough, the retryable hint on transport failures).
+// Extra keys never displace the coded contract keys.
+func (s *mcpServer) softErrorExtra(ctx context.Context, err error, nextTool string, extra map[string]any) *mcp.CallToolResult {
 	coded := mcpCoded(err)
 	payload := map[string]any{
 		"schema_version": mcpSchemaVersion,
@@ -373,6 +391,11 @@ func (s *mcpServer) softErrorNext(ctx context.Context, err error, nextTool strin
 		// stamp joining THIS result to re-validate instead of serving the
 		// cached "fresh" identity next to an auth error.
 		s.instances.invalidate()
+	}
+	for k, v := range extra {
+		if _, taken := payload[k]; !taken {
+			payload[k] = v
+		}
 	}
 	res := s.result(ctx, payload)
 	res.IsError = true

--- a/cli/internal/cli/api/mcp_session_test.go
+++ b/cli/internal/cli/api/mcp_session_test.go
@@ -100,7 +100,7 @@ func TestMCPSession_ToolsListWorksWithNoConfig(t *testing.T) {
 	for _, tool := range tools.Tools {
 		names[tool.Name] = tool
 	}
-	for _, want := range []string{"get_started", "whoami", "search_apis", "inspect_operation"} {
+	for _, want := range []string{"get_started", "whoami", "search_apis", "inspect_operation", "execute_read", "get_execution_result"} {
 		tool, ok := names[want]
 		if !ok {
 			t.Fatalf("tools/list = %v, missing %q", keys(names), want)
@@ -109,15 +109,36 @@ func TestMCPSession_ToolsListWorksWithNoConfig(t *testing.T) {
 			t.Errorf("tool %q must carry readOnlyHint", want)
 		}
 	}
-	if len(names) != 4 {
-		t.Errorf("PR 1-B serves exactly get_started, whoami, search_apis, and inspect_operation, got %v", keys(names))
+	// execute is the ONLY tool carrying destructiveHint (§3.2 annotations),
+	// and it must not be read-only.
+	execTool, ok := names["execute"]
+	if !ok {
+		t.Fatalf("tools/list = %v, missing execute", keys(names))
+	}
+	if execTool.Annotations == nil || execTool.Annotations.ReadOnlyHint {
+		t.Errorf("execute must not carry readOnlyHint")
+	}
+	if execTool.Annotations == nil || execTool.Annotations.DestructiveHint == nil || !*execTool.Annotations.DestructiveHint {
+		t.Errorf("execute must carry destructiveHint")
+	}
+	for name, tool := range names {
+		if name == "execute" {
+			continue
+		}
+		if tool.Annotations != nil && tool.Annotations.DestructiveHint != nil && *tool.Annotations.DestructiveHint {
+			t.Errorf("tool %q must not carry destructiveHint (execute alone does)", name)
+		}
+	}
+	if len(names) != 7 {
+		t.Errorf("PR 1-C serves exactly the 7 phase-1 tools, got %v", keys(names))
 	}
 }
 
-// TestMCPSession_ReadOnlyServesDiscoveryTools pins the --read-only contract on
-// the 1-B surface: every discovery tool is annotated read-only, so the flag
-// must not withhold any of them (it starts biting with 1-C's execute).
-func TestMCPSession_ReadOnlyServesDiscoveryTools(t *testing.T) {
+// TestMCPSession_ReadOnlyWithholdsExactlyExecute pins the --read-only contract
+// on the 1-C surface: every tool except `execute` is annotated read-only, so
+// the flag withholds exactly that one (execute_read and get_execution_result
+// stay servable).
+func TestMCPSession_ReadOnlyWithholdsExactlyExecute(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
@@ -128,26 +149,45 @@ func TestMCPSession_ReadOnlyServesDiscoveryTools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tools/list: %v", err)
 	}
-	if len(tools.Tools) != 4 {
-		names := make([]string, 0, len(tools.Tools))
-		for _, tool := range tools.Tools {
-			names = append(names, tool.Name)
+	names := make([]string, 0, len(tools.Tools))
+	for _, tool := range tools.Tools {
+		names = append(names, tool.Name)
+		if tool.Name == "execute" {
+			t.Errorf("--read-only must withhold the execute tool")
 		}
-		t.Errorf("--read-only must serve all 4 read-only tools, got %v", names)
+	}
+	if len(tools.Tools) != 6 {
+		t.Errorf("--read-only must serve the 6 read-only tools, got %v", names)
 	}
 }
 
-// TestMCPSession_DiscoveryRoundTrip drives search_apis → inspect_operation
-// through a real client session against an httptest control plane: the state
-// and pagination/alias tolerance must survive the full JSON-RPC round trip,
-// not just a direct handler call.
-func TestMCPSession_DiscoveryRoundTrip(t *testing.T) {
+// TestMCPSession_FullRoundTrip drives the complete §3.2 flow — whoami →
+// search_apis → inspect_operation → execute — through a real client session
+// against httptest control and broker planes: state, alias tolerance, the
+// broker leg, and the stamped envelopes must survive the full JSON-RPC round
+// trip, not just direct handler calls.
+func TestMCPSession_FullRoundTrip(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "acme.com/pets") {
+			t.Errorf("broker got %s %s, want the resolved upstream GET", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tok_abc" {
+			t.Errorf("broker Authorization = %q, want the agent bearer", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Jentic-Execution-Id", "exec_42")
+		_, _ = w.Write([]byte(`{"pets":[{"id":1}]}`))
+	}))
+	defer broker.Close()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
+		case "/me":
+			_, _ = w.Write([]byte(`{"type":"agent","id":"agent_1","name":"pets-agent","scopes":["execute"],"status":"active","token_scopes":["execute"],"toolkit_bindings":[]}`))
 		case "/search":
 			_, _ = w.Write([]byte(`{
 				"data": [{"type":"operation","api":{"vendor":"acme","name":"pets","version":"v1","host":"acme.com"},"operation_id":"op1","method":"GET","url":"/pets","name":"List Pets","relevance_score":0.9,"_links":{"inspect":"/inspect?id=GET%20/pets"}}],
@@ -166,10 +206,24 @@ func TestMCPSession_DiscoveryRoundTrip(t *testing.T) {
 
 	s := newTestMCPServer(t, nil)
 	s.instances.fetch = fetchInstance // the real GET /instance path, against the httptest plane
-	cs := connectTestClientWithContext(activeCtx(srv.URL), t, s)
+	cs := connectTestClientWithContext(activeCtxWithBroker(srv.URL, broker.URL), t, s)
 	ctx := context.Background()
 
-	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+	// 1. whoami — identity before discovery.
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "whoami"})
+	if err != nil {
+		t.Fatalf("whoami: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("whoami soft-errored: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["id"] != "agent_1" || payload["status"] != "active" {
+		t.Fatalf("whoami payload = %v, want the agent identity", payload)
+	}
+
+	// 2. search_apis.
+	res, err = cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "search_apis",
 		Arguments: map[string]any{"query": "list pets"},
 	})
@@ -179,7 +233,7 @@ func TestMCPSession_DiscoveryRoundTrip(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("search_apis soft-errored: %v", res.Content)
 	}
-	payload := decodeToolJSON(t, res)
+	payload = decodeToolJSON(t, res)
 	hits, ok := payload["data"].([]any)
 	if !ok || len(hits) != 1 {
 		t.Fatalf("data = %v, want one hit", payload["data"])
@@ -192,8 +246,8 @@ func TestMCPSession_DiscoveryRoundTrip(t *testing.T) {
 		t.Errorf("instance stamp = %v, want the live identity", payload["instance"])
 	}
 
-	// Feed the hit's operation_id back — under the `id` alias, as a drifting
-	// model would.
+	// 3. inspect_operation — the hit's id under the `id` alias, as a drifting
+	// model would send it.
 	res, err = cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "inspect_operation",
 		Arguments: map[string]any{"id": opID},
@@ -207,6 +261,29 @@ func TestMCPSession_DiscoveryRoundTrip(t *testing.T) {
 	payload = decodeToolJSON(t, res)
 	if payload["method"] != "GET" || payload["url"] != "https://acme.com/pets" {
 		t.Errorf("inspect payload = %v, want the raw contract passed through", payload)
+	}
+
+	// 4. execute — the inspected operation, through the broker leg.
+	res, err = cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "execute",
+		Arguments: map[string]any{"operation_id": opID},
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("execute soft-errored: %v", res.Content)
+	}
+	payload = decodeToolJSON(t, res)
+	if payload["status"] != float64(200) || payload["execution_id"] != "exec_42" {
+		t.Fatalf("execute envelope = %v, want status 200 + execution_id", payload)
+	}
+	body, _ := payload["body"].(map[string]any)
+	if _, ok := body["pets"]; !ok {
+		t.Errorf("execute body = %v, want the upstream JSON parsed", payload["body"])
+	}
+	if stamp, ok := payload["instance"].(map[string]any); !ok || stamp["backend"] != "local" {
+		t.Errorf("execute result stamp = %v, want the live identity", payload["instance"])
 	}
 }
 
@@ -285,8 +362,8 @@ func TestMCPSession_ExcludeToolsFilters(t *testing.T) {
 			t.Errorf("--exclude-tools=whoami must withhold the tool")
 		}
 	}
-	if len(tools.Tools) != 3 {
-		t.Errorf("tools = %d, want 3 after exclusion", len(tools.Tools))
+	if len(tools.Tools) != 6 {
+		t.Errorf("tools = %d, want 6 after exclusion", len(tools.Tools))
 	}
 }
 

--- a/cli/internal/cli/clictx/client.go
+++ b/cli/internal/cli/clictx/client.go
@@ -97,6 +97,38 @@ func stateForClient(state *ActiveState) (*ActiveState, error) {
 	return state, nil
 }
 
+// BrokerHTTPClient builds the base *http.Client for the broker leg of an
+// execute from the active context: the SEC-20 CA-pinned transport when the
+// environment declares ca_cert_path (fail closed on a broken bundle, exactly
+// like the control-plane clients), the default transport otherwise, with the
+// context's TransportHook composed over it (wrap, never displace — the pinning
+// decision stays the inner RoundTripper). Local-MCP §3.7.2: `execute`'s broker
+// leg historically built its own un-pinned client; the MCP path routes through
+// this constructor so broker calls honor the same trust decision as every
+// other backend call. Callers pass the result to client.BrokerTransport, which
+// decorates the retry/backoff policy on the outside.
+func BrokerHTTPClient(ctx context.Context) (*http.Client, error) {
+	state, err := stateForClient(FromContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	hc, err := caCertHTTPClient(state.CACertPath)
+	if err != nil {
+		return nil, err
+	}
+	if hc == nil {
+		hc = &http.Client{}
+	}
+	if hook := transportHookFrom(ctx); hook != nil {
+		base := hc.Transport
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		hc.Transport = hook(base)
+	}
+	return hc, nil
+}
+
 // GetControlClient is the single constructor every Control Plane command uses. It
 // pulls the ActiveState the root interceptor injected and delegates to the SDK, so
 // token state, API-key credentials, and the file-less override are all handled

--- a/cli/internal/cli/ux/envelope.go
+++ b/cli/internal/cli/ux/envelope.go
@@ -134,6 +134,10 @@ type CodedError struct {
 	Msg        string         // human/LLM-readable prose (redacted on output)
 	Actionable string         // machine-runnable recovery step, when one exists
 	Details    map[string]any // e.g. {"agent_directive": ..., "http_status": 403}
+	// Cause optionally preserves the underlying error for errors.Is/As
+	// classification (e.g. distinguishing a pre-send dial failure from a
+	// mid-flight timeout). It is never rendered: Msg carries the prose.
+	Cause error
 
 	// reported records that an Audience.ReportError already rendered this error
 	// (envelope on stderr in agent mode, styled line in human mode), so the
@@ -143,6 +147,10 @@ type CodedError struct {
 }
 
 func (e *CodedError) Error() string { return e.Msg }
+
+// Unwrap exposes the preserved cause (when any) to errors.Is/errors.As, so
+// callers can classify the underlying failure without parsing Msg.
+func (e *CodedError) Unwrap() error { return e.Cause }
 
 // MarkReported flags the error as already rendered by an Audience. Called by
 // every ReportError implementation; command code never needs it.

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -2792,6 +2792,12 @@
               "usage": "server log file (default: \u003cXDG state dir\u003e/jentic/logs/mcp.log)"
             },
             {
+              "name": "max-result-bytes",
+              "type": "int64",
+              "default": "131072",
+              "usage": "hard cap on a relayed response body in a tool result; larger bodies are truncated with {truncated, total_bytes, execution_id}"
+            },
+            {
               "name": "mode",
               "type": "string",
               "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"


### PR DESCRIPTION
Stacked on #1183 (→ #1181 → #1179); retarget after they merge. Part of #1175.

## What

PR 1-C of the local-MCP theme: the execute surface for `jentic mcp`.

- **`execute`** (+ **`execute_read`**, GET/HEAD-only) via the `agentops` core: CLI envelope `{schema_version, status, headers, body, execution_id}` + sibling `instance` stamp. `execute` is the only tool carrying `destructiveHint`; `execute_read` rejects non-GET/HEAD operations post-resolve and never takes a body.
- **`get_execution_result(job_id)`** wired to the live `GET /jobs/{id}` + `/jobs/{id}/result` routes — the poll path for held (202) executes. The 202-held envelope passes through as a normal result with its `agent_directive` intact ("poll, never re-send" is encoded in both docstrings); the broker's ask-tier behavior is mocked in tests only.
- **Stdin structural safety**: tool handlers pass an explicit body (or none) into `agentops`; the MCP path cannot reach `executeE`'s stdin fallback. A test swaps `os.Stdin` for a data-laden pipe and proves not a byte is consumed.

## Hardening decisions (for reviewers)

- **CA pinning (§3.7.2)**: new `clictx.BrokerHTTPClient` builds the broker-leg client — SEC-20 CA-pinned when the environment sets `ca_cert_path` (fail closed), with the session `TransportHook` (UA + session header) composed over it, wrap-never-displace. `agentops.DoWith(hc, req)` is the seam; the SDK broker retry policy still decorates the outside, so hooked headers ride every retry. Broker target resolution is a strict subset of `executeE`'s (environment `broker_url` or loopback default — no flag overrides), keeping the SEC-21 pin structural; the malformed-broker_url and remote-CP-without-broker fail-closed guards port unchanged.
- **Response-size cap**: default **128 KiB** (`--max-result-bytes`), applied to relayed execute bodies and job result documents. Far below the 64 MiB transport bound — MCP has no chunking, so this is context protection. Truncation envelope: `{truncated: true, total_bytes, execution_id}` with the leading bytes kept, so the model can act deliberately.
- **Singleflight (§3.7.1)**: `auth.BearerToken`'s mint path dedupes per `(base URL, identity, environment)` via `golang.org/x/sync/singleflight` — N concurrent tool calls at one expiry instant share one exchange. Efficiency only; mint-fresh stays last-writer-wins correct.
- **Error mapping (§3.7 table)** — `next_tool` pointers chosen per failure class:
  - broker denial → soft `BROKER_DENIED`, verbatim `agent_directive` passthrough, `retryable: false`, `next_tool: whoami` (check bindings, never execute to probe); directive-less denials get the UX7-synthesized status-keyed hint.
  - transport → soft `TRANSPORT_ERROR`, `retryable: true`, `next_tool: get_started` (diagnoses a down instance).
  - resolve → soft `RESOLVE_FAILED`, `next_tool: search_apis` (the id is wrong, not the setup); unknown `job_id` points back at `get_execution_result` itself.
  - auth → coded soft errors with the default `get_started` pointer.
  - malformed args → JSON-RPC invalid-params.
  - upstream 4xx/5xx and 202-held → normal results (the upstream's answer is data, not an error).
- Both execute tools respect `--exclude-tools`; `--read-only` withholds exactly `execute` (everything else is `readOnlyHint`).

## Tests

Success envelope + stamp; denial with directive passthrough + synthesized-hint variant; 202-held passthrough (mocked); live-route `get_execution_result` round trip (+ pending, 404, truncation); size-cap truncation; stdin structural safety; CA-pin + hook on the broker leg (TLS httptest, fail-closed check); broker-target guards; read-only/exclude filtering; invalid-params rows; singleflight concurrency (with `-race`); in-process MCP session test extended to the full whoami → search → inspect → execute round trip. `GOWORK=off make -C cli check` green.

Not in scope (deliberate): `include_paths` output filtering (phase 4); ask-tier live end-to-end (7b, cross-plan).

Made with [Cursor](https://cursor.com)