### PR TITLE
feat(cli): serve skills as MCP resources with hosted/bundled provenance

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -171,6 +171,33 @@ make help    # list all targets (test, lint, check, cov, ...)
 `make build-ctl` / `make build-api` build a single binary; `make check` runs
 lint + vet + race tests.
 
+### Debugging the MCP server (Inspector loop)
+
+`jentic mcp` serves the agent tool surface over **stdio MCP** — stdin/stdout
+are the JSON-RPC wire, so you can't poke it from a shell. The fast debug loop
+is the official Inspector, a local web UI that spawns the server exactly like
+a real client would:
+
+```bash
+make build-api
+npx @modelcontextprotocol/inspector ./jentic mcp
+```
+
+It opens a browser page where you can run `tools/list`, call tools with
+hand-written arguments, read the `skill://` resources, and watch the raw
+JSON-RPC frames. Handy checks while developing:
+
+- `tools/list` works with **no config at all** (the "always boots"
+  invariant), and `get_started` diagnoses the machine's setup state.
+- `resources/read` on `skill://jentic` reports `one.jentic/source: hosted`
+  when the configured backend answers, `bundled` offline / pre-auth.
+- Flag behavior: `--read-only` withholds exactly `execute`;
+  `--exclude-tools` drops what you name.
+
+Server logs never touch stdout (it's the wire) — tail them with
+`tail -f ~/.local/state/jentic/logs/mcp.log`, or point `--log-file`
+somewhere else (pass flags after `jentic mcp` in the Inspector command line).
+
 The examples below assume both binaries are on your `PATH`:
 
 ```bash

--- a/cli/internal/cli/api/mcp_golden_test.go
+++ b/cli/internal/cli/api/mcp_golden_test.go
@@ -1,0 +1,181 @@
+package api
+
+// mcp_golden_test.go pins the PR 1-D shared-goldens contract: the MCP execute
+// result is a strict superset of the CLI envelope (§3.7.4 — five envelope keys
+// plus the sibling `instance` stamp), so with `instance` stripped it must
+// reproduce the SAME frozen bytes the tests/golden suite pinned for the CLI
+// and the agentops core. The goldens are read in place from
+// cli/tests/golden/testdata — one frozen source of truth, never a re-pin: a
+// drift in either surface fails against the identical file. Only the cases
+// where the tool result IS the envelope are shareable (success, upstream-4xx
+// passthrough); denials deliberately diverge into the soft-error taxonomy
+// (1-C) and stay covered by mcp_execute_test.go field assertions.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jentic/jentic-one/cli/internal/cli/cmdcore"
+)
+
+// sharedGoldenStdout reads the stdout section of one frozen CLI golden from
+// the tests/golden suite's testdata — the exact envelope bytes the phase-0
+// contract recorded (regenerate there with `go test ./tests/golden -update`).
+func sharedGoldenStdout(t *testing.T, name string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "tests", "golden", "testdata", "golden", "v2", name+".txt"))
+	if err != nil {
+		t.Fatalf("read shared golden %s: %v", name, err)
+	}
+	_, afterStdout, ok := strings.Cut(string(raw), "--- stdout ---\n")
+	if !ok {
+		t.Fatalf("golden %s has no stdout marker", name)
+	}
+	stdout, _, ok := strings.Cut(afterStdout, "--- stderr ---\n")
+	if !ok {
+		t.Fatalf("golden %s has no stderr marker", name)
+	}
+	return stdout
+}
+
+// envelopeWithoutStamp re-serializes a decoded tool payload minus the sibling
+// `instance` key through the same WriteJSON path the CLI envelope golden was
+// recorded with (indent-2, sorted keys, redaction backstop), so the comparison
+// is byte-exact like for like.
+func envelopeWithoutStamp(t *testing.T, payload map[string]any) string {
+	t.Helper()
+	if _, ok := payload["instance"]; !ok {
+		t.Fatalf("tool payload carries no instance stamp to strip: %v", payload)
+	}
+	delete(payload, "instance")
+	var buf bytes.Buffer
+	if err := cmdcore.WriteJSON(&buf, payload); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	return buf.String()
+}
+
+func TestMCPExecute_EnvelopeMatchesSharedGoldens(t *testing.T) {
+	cases := []struct {
+		name   string // the shared golden case in tests/golden/testdata/golden/v2
+		target string
+		// inspect answers /inspect when the target is an opaque id; nil for
+		// broker-relative METHOD:path targets that skip resolution.
+		inspect http.HandlerFunc
+		broker  http.HandlerFunc
+	}{
+		{
+			// The same mock responses TestGolden_ExecuteContract recorded
+			// execute_ok_json from (Date suppressed for byte-stable headers).
+			name:   "execute_ok_json",
+			target: "listPets",
+			inspect: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header()["Date"] = nil
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"method":"GET","url":"https://upstream.example/v1/pets"}`))
+			},
+			broker: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header()["Date"] = nil
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Jentic-Execution-Id", "exec-123")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[{"id":1,"name":"Fido"}]`))
+			},
+		},
+		{
+			// An upstream 4xx relayed by the broker is a normal envelope on
+			// both surfaces (§3.7 row 1) — the passthrough golden is shared too.
+			name:   "execute_upstream_4xx_passthrough_json",
+			target: "GET:/v1/pets",
+			broker: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header()["Date"] = nil
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Jentic-Error-Origin", "upstream")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"error":"upstream said no"}`))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/inspect" {
+					if tc.inspect == nil {
+						t.Errorf("unexpected /inspect call for target %q", tc.target)
+						w.WriteHeader(http.StatusNotFound)
+						return
+					}
+					tc.inspect(w, r)
+					return
+				}
+				tc.broker(w, r)
+			}))
+			t.Cleanup(srv.Close)
+
+			s := stampedTestMCPServer(t)
+			res, err := s.handleExecute(activeCtxWithBroker(srv.URL, srv.URL),
+				callToolRequest("execute", `{"operation_id":"`+tc.target+`"}`))
+			if err != nil {
+				t.Fatalf("handleExecute: %v", err)
+			}
+			if res.IsError {
+				t.Fatalf("unexpected soft error: %v", res.Content)
+			}
+
+			payload := decodeToolJSON(t, res)
+			got := envelopeWithoutStamp(t, payload)
+			want := sharedGoldenStdout(t, tc.name)
+			if got != want {
+				t.Errorf("MCP envelope diverged from the shared CLI golden %s.\n"+
+					"The tool result must stay a strict superset of the CLI envelope (§3.7.4).\n--- want ---\n%s\n--- got ---\n%s",
+					tc.name, want, got)
+			}
+		})
+	}
+}
+
+// TestMCPExecute_PayloadIsEnvelopePlusStampOnly locks the superset shape
+// itself: exactly the golden envelope's keys plus `instance`, nothing else —
+// a new sibling key is a contract change that must consciously touch both the
+// CLI golden and this pin.
+func TestMCPExecute_PayloadIsEnvelopePlusStampOnly(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Jentic-Execution-Id", "exec-123")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(broker.Close)
+
+	s := stampedTestMCPServer(t)
+	res, err := s.handleExecute(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL),
+		callToolRequest("execute", `{"operation_id":"GET:/v1/pets"}`))
+	if err != nil {
+		t.Fatalf("handleExecute: %v", err)
+	}
+	payload := decodeToolJSON(t, res)
+
+	var goldenEnv map[string]any
+	if err := json.Unmarshal([]byte(sharedGoldenStdout(t, "execute_ok_json")), &goldenEnv); err != nil {
+		t.Fatalf("golden stdout is not JSON: %v", err)
+	}
+	want := map[string]bool{"instance": true}
+	for key := range goldenEnv {
+		want[key] = true
+	}
+	for key := range payload {
+		if !want[key] {
+			t.Errorf("payload carries %q — not an envelope key from the shared golden and not the instance stamp", key)
+		}
+	}
+	for key := range want {
+		if _, ok := payload[key]; !ok {
+			t.Errorf("payload is missing %q", key)
+		}
+	}
+}

--- a/cli/internal/cli/api/mcp_resources.go
+++ b/cli/internal/cli/api/mcp_resources.go
@@ -19,6 +19,7 @@ package api
 // registration is still pending approval).
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -27,6 +28,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -55,6 +57,13 @@ const (
 	skillMarkdownMIME = "text/markdown; charset=utf-8"
 	skillIndexMIME    = "application/json"
 )
+
+// hostedSkillFetchTimeout is the default sub-budget for one hosted document
+// probe, applied as a child deadline inside the call's mcpCallTimeout. The
+// hosted copy is a preference with a bundled fallback always in hand, so a
+// hung backend must cost seconds — not the whole 30s call budget — before the
+// read degrades to the embed.
+const hostedSkillFetchTimeout = 5 * time.Second
 
 // skillProvenanceNote is appended to every skill resource description so a
 // client (and its model) knows where the bytes come from and how to read the
@@ -92,7 +101,12 @@ func (s *mcpServer) registerResources() {
 		Name:  "index",
 		Title: "Jentic skill index",
 		Description: "Manifest of the served skill set: name, description, version, and the sha256 of each " +
-			"document's raw bytes, so a client can pick and verify skills without reading them all." +
+			"document's raw bytes, so a client can pick and verify skills without reading them all. " +
+			"Rows served from the backend locate each document with an absolute `url`; the offline " +
+			"bundled manifest carries the `uri` of the skill:// resource this server serves instead. " +
+			"A sha256 digest is only valid for verifying a document read when that read reports the " +
+			"same " + skillMetaSource + " as the index read (the two sources may carry different " +
+			"revisions of the same skill)." +
 			skillProvenanceNote,
 		MIMEType: skillIndexMIME,
 	}, s.handleSkillIndexResource)
@@ -127,10 +141,22 @@ func (s *mcpServer) handleSkillResource(ctx context.Context, req *mcp.ReadResour
 // hosted document may be newer or older than this binary), the bundled embed
 // otherwise (source bundled). A hosted failure is never an error — offline is
 // a supported state — but it is logged so version-skew debugging has a trail.
+//
+// A 200 body only counts as the hosted document when it is shape-valid: the
+// frontmatter must parse and its `name` must be the requested skill. Anything
+// else (a captive portal's HTML, a proxy error page, the wrong document) is
+// treated exactly like a non-200 — logged, then the bundled copy serves.
+// Without this gate, ParseDocMeta would happily label arbitrary bytes as a
+// hosted skill at fabricated version "1".
 func (s *mcpServer) skillDocFor(ctx context.Context, name string) (skillDoc, error) {
-	if raw, err := s.fetchHostedSkill(ctx, "/skills/"+name+".md"); err == nil {
-		return skillDoc{raw: raw, source: skillgen.SourceHosted, version: skillgen.ParseDocMeta(raw).Version}, nil
-	} else if !errors.Is(err, errNoBackend) {
+	hosted, err := s.fetchHostedSkill(ctx, "/skills/"+name+".md")
+	if err == nil {
+		if meta := skillgen.ParseDocMeta(hosted); meta.Name == name {
+			return skillDoc{raw: hosted, source: skillgen.SourceHosted, version: meta.Version}, nil
+		}
+		err = fmt.Errorf("hosted body is not skill %q (missing or mismatched frontmatter name)", name)
+	}
+	if !errors.Is(err, errNoBackend) {
 		s.logger.Info("skill resource: hosted fetch failed, serving bundled", "skill", name, "error", err)
 	}
 	raw, err := skillgen.RawBundled(name)
@@ -142,17 +168,30 @@ func (s *mcpServer) skillDocFor(ctx context.Context, name string) (skillDoc, err
 
 // handleSkillIndexResource reads skill://index: the backend's own manifest
 // verbatim when reachable (it describes exactly what `GET /skills/*` serves,
-// including per-row versions and sha256 digests), else a locally composed
-// manifest of the bundled set in the same row shape, with each row's url
-// replaced by the skill:// URI this server actually serves.
+// including per-row versions and sha256 digests — hosted rows locate each
+// document with a backend-stamped absolute `url`), else a locally composed
+// manifest of the bundled set in the same row shape with `uri` (the skill://
+// resource URI this server actually serves) in place of `url`. The verbatim
+// posture is deliberate: hosted bytes are never rewritten (the per-row sha256
+// covers the raw served bytes), so the `url`/`uri` key difference is the
+// documented tell for which source produced the manifest.
+//
+// A hosted 200 body only serves when it is shape-valid — well-formed JSON
+// whose top level is an array (the manifest's row list). Anything else is
+// treated exactly like a non-200: logged, then the bundled manifest serves.
 func (s *mcpServer) handleSkillIndexResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 	cctx, cancel := s.callContext(ctx)
 	defer cancel()
 
-	if raw, err := s.fetchHostedSkill(cctx, "/skills/index.json"); err == nil {
-		s.logger.Info("skill index read", "source", skillgen.SourceHosted)
-		return skillReadResult(req.Params.URI, skillIndexMIME, skillDoc{raw: raw, source: skillgen.SourceHosted}), nil
-	} else if !errors.Is(err, errNoBackend) {
+	hosted, err := s.fetchHostedSkill(cctx, "/skills/index.json")
+	if err == nil {
+		if validSkillIndex(hosted) {
+			s.logger.Info("skill index read", "source", skillgen.SourceHosted)
+			return skillReadResult(req.Params.URI, skillIndexMIME, skillDoc{raw: hosted, source: skillgen.SourceHosted}), nil
+		}
+		err = errors.New("hosted body is not a JSON-array manifest")
+	}
+	if !errors.Is(err, errNoBackend) {
 		s.logger.Info("skill index: hosted fetch failed, serving bundled manifest", "error", err)
 	}
 
@@ -164,10 +203,24 @@ func (s *mcpServer) handleSkillIndexResource(ctx context.Context, req *mcp.ReadR
 	return skillReadResult(req.Params.URI, skillIndexMIME, skillDoc{raw: raw, source: skillgen.SourceBundled}), nil
 }
 
+// validSkillIndex is the shape gate for a hosted index body: well-formed JSON
+// whose top level is an array. The row list is the only manifest shape either
+// side of the fetch has ever served, so anything else (an HTML error page, a
+// JSON error object) is a bad response, not a manifest.
+func validSkillIndex(raw []byte) bool {
+	if !json.Valid(raw) {
+		return false
+	}
+	trimmed := bytes.TrimLeft(raw, " \t\r\n")
+	return len(trimmed) > 0 && trimmed[0] == '['
+}
+
 // bundledSkillIndex composes the offline manifest from the embedded set: the
 // backend's row shape (name, description, version, sha256 of the raw served
 // bytes) with `uri` pointing at the skill:// resource instead of the
-// backend's base-stamped absolute URL (there is no backend to stamp).
+// backend's base-stamped absolute `url` (there is no backend to stamp). The
+// offline manifest always emits `uri`; `url` stays a hosted-only key because
+// hosted bytes are served verbatim (see handleSkillIndexResource).
 func bundledSkillIndex() ([]byte, error) {
 	names := skillgen.BundledNames()
 	rows := make([]map[string]string, 0, len(names))
@@ -223,6 +276,15 @@ var errNoBackend = errors.New("no backend configured")
 // document larger than that cannot be served whole into a model's context, so
 // an oversized response is treated as a bad response — the caller falls back
 // to the bundled copy — never truncated mid-document.
+//
+// The probe carries its own sub-budget (hostedFetchTimeout) inside the call's
+// mcpCallTimeout deadline: a hung backend must degrade the read to the
+// bundled copy in seconds, not stall resources/read for the full call budget.
+//
+// Redirects are NOT followed: the backend serves these documents directly, so
+// a 3xx is a bad response (fall back to bundled), never a license for the CLI
+// to fetch an arbitrary — possibly internal/link-local — location with the
+// session's attribution headers and label the bytes hosted.
 func (s *mcpServer) fetchHostedSkill(ctx context.Context, path string) ([]byte, error) {
 	st := clictx.ActiveContext(ctx)
 	if st == nil || st.BaseURL == "" {
@@ -232,6 +294,13 @@ func (s *mcpServer) fetchHostedSkill(ctx context.Context, path string) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
+	hc.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	budget := s.hostedFetchTimeout
+	if budget <= 0 {
+		budget = hostedSkillFetchTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(st.BaseURL, "/")+path, nil)
 	if err != nil {
 		return nil, err

--- a/cli/internal/cli/api/mcp_resources.go
+++ b/cli/internal/cli/api/mcp_resources.go
@@ -1,0 +1,248 @@
+package api
+
+// mcp_resources.go serves the shipped skill set as MCP resources (PR 1-D,
+// §3.8): skill://<name> for every bundled skill, plus skill://index (the set
+// manifest). Content is fetched from the connected backend when reachable —
+// `GET /skills/<name>.md` / `/skills/index.json` (#651), the session's source
+// of truth, so a brew-updated CLI against an older backend serves the
+// BACKEND's bytes — with the embedded bundled copy as the offline fallback.
+// Every read stamps provenance into the resource contents' _meta: source
+// (hosted|bundled — skillgen's Source model, never a parallel one) and the
+// document's content version. Reads work pre-auth (the §3.3 always-boots
+// invariant): with no configuration at all, the bundled copy is served with
+// source "bundled".
+//
+// The hosted routes are public and schema-hidden (no generated client method
+// exists), so the fetch is a raw GET through clictx.ControlHTTPClient — the
+// SEC-20 CA-pinned transport with the session's attribution hook composed
+// over it, and no auth editors (the documents must be fetchable while a
+// registration is still pending approval).
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	sdkclient "github.com/jentic/jentic-one/cli/client"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/skillgen"
+)
+
+// Resource URI scheme. skill://<name> serves one skill document;
+// skill://index serves the set manifest.
+const (
+	skillURIScheme = "skill://"
+	skillIndexURI  = skillURIScheme + "index"
+)
+
+// _meta keys carrying the §3.8 provenance on every read result. Namespaced
+// per the MCP general-fields guidance so they can never collide with another
+// party's metadata.
+const (
+	skillMetaSource  = "one.jentic/source"
+	skillMetaVersion = "one.jentic/version"
+)
+
+// MIME types mirror what the backend serves for the same documents.
+const (
+	skillMarkdownMIME = "text/markdown; charset=utf-8"
+	skillIndexMIME    = "application/json"
+)
+
+// skillProvenanceNote is appended to every skill resource description so a
+// client (and its model) knows where the bytes come from and how to read the
+// provenance stamp.
+const skillProvenanceNote = " Served from the connected Jentic One backend when reachable " +
+	"(the session's source of truth), falling back to the copy embedded in this binary offline; " +
+	"the read result's _meta carries " + skillMetaSource + " (hosted|bundled) and " + skillMetaVersion + "."
+
+// registerResources declares the skill:// resource surface: one resource per
+// bundled skill (the shipped set is the stable, pre-auth-listable surface —
+// BundledNames is its single source of truth) plus the index manifest. The
+// URIs stay valid whatever the backend serves; a hosted set that has drifted
+// from this binary shows up in the index read, not in resources/list.
+func (s *mcpServer) registerResources() {
+	for _, name := range skillgen.BundledNames() {
+		raw, err := skillgen.RawBundled(name)
+		if err != nil {
+			// The content is compiled in via go:embed; a read failure is a
+			// build-time programming error. Skip rather than panic so the
+			// session still boots.
+			s.logger.Error("skill resource skipped: bundled read failed", "skill", name, "error", err)
+			continue
+		}
+		meta := skillgen.ParseDocMeta(raw)
+		s.server.AddResource(&mcp.Resource{
+			URI:         skillURIScheme + name,
+			Name:        name,
+			Title:       "Jentic skill: " + name,
+			Description: meta.Description + skillProvenanceNote,
+			MIMEType:    skillMarkdownMIME,
+		}, s.handleSkillResource)
+	}
+	s.server.AddResource(&mcp.Resource{
+		URI:   skillIndexURI,
+		Name:  "index",
+		Title: "Jentic skill index",
+		Description: "Manifest of the served skill set: name, description, version, and the sha256 of each " +
+			"document's raw bytes, so a client can pick and verify skills without reading them all." +
+			skillProvenanceNote,
+		MIMEType: skillIndexMIME,
+	}, s.handleSkillIndexResource)
+}
+
+// skillDoc is one resolved skill document: the exact bytes to serve plus the
+// §3.8 provenance (where they came from, which content version they are).
+type skillDoc struct {
+	raw     []byte
+	source  skillgen.Source
+	version string
+}
+
+// handleSkillResource reads one skill://<name> document. Only registered URIs
+// reach here (the SDK answers unknown URIs with resource-not-found itself), so
+// name is always a bundled skill and the fallback can never miss.
+func (s *mcpServer) handleSkillResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	name := strings.TrimPrefix(req.Params.URI, skillURIScheme)
+	cctx, cancel := s.callContext(ctx)
+	defer cancel()
+
+	doc, err := s.skillDocFor(cctx, name)
+	if err != nil {
+		return nil, err
+	}
+	s.logger.Info("skill resource read", "skill", name, "source", doc.source, "version", doc.version)
+	return skillReadResult(req.Params.URI, skillMarkdownMIME, doc), nil
+}
+
+// skillDocFor resolves one skill's bytes hosted-first: the connected backend's
+// copy when it answers (source hosted, version from ITS frontmatter — the
+// hosted document may be newer or older than this binary), the bundled embed
+// otherwise (source bundled). A hosted failure is never an error — offline is
+// a supported state — but it is logged so version-skew debugging has a trail.
+func (s *mcpServer) skillDocFor(ctx context.Context, name string) (skillDoc, error) {
+	if raw, err := s.fetchHostedSkill(ctx, "/skills/"+name+".md"); err == nil {
+		return skillDoc{raw: raw, source: skillgen.SourceHosted, version: skillgen.ParseDocMeta(raw).Version}, nil
+	} else if !errors.Is(err, errNoBackend) {
+		s.logger.Info("skill resource: hosted fetch failed, serving bundled", "skill", name, "error", err)
+	}
+	raw, err := skillgen.RawBundled(name)
+	if err != nil {
+		return skillDoc{}, fmt.Errorf("bundled skill %q: %w", name, err)
+	}
+	return skillDoc{raw: raw, source: skillgen.SourceBundled, version: skillgen.ParseDocMeta(raw).Version}, nil
+}
+
+// handleSkillIndexResource reads skill://index: the backend's own manifest
+// verbatim when reachable (it describes exactly what `GET /skills/*` serves,
+// including per-row versions and sha256 digests), else a locally composed
+// manifest of the bundled set in the same row shape, with each row's url
+// replaced by the skill:// URI this server actually serves.
+func (s *mcpServer) handleSkillIndexResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	cctx, cancel := s.callContext(ctx)
+	defer cancel()
+
+	if raw, err := s.fetchHostedSkill(cctx, "/skills/index.json"); err == nil {
+		s.logger.Info("skill index read", "source", skillgen.SourceHosted)
+		return skillReadResult(req.Params.URI, skillIndexMIME, skillDoc{raw: raw, source: skillgen.SourceHosted}), nil
+	} else if !errors.Is(err, errNoBackend) {
+		s.logger.Info("skill index: hosted fetch failed, serving bundled manifest", "error", err)
+	}
+
+	raw, err := bundledSkillIndex()
+	if err != nil {
+		return nil, err
+	}
+	s.logger.Info("skill index read", "source", skillgen.SourceBundled)
+	return skillReadResult(req.Params.URI, skillIndexMIME, skillDoc{raw: raw, source: skillgen.SourceBundled}), nil
+}
+
+// bundledSkillIndex composes the offline manifest from the embedded set: the
+// backend's row shape (name, description, version, sha256 of the raw served
+// bytes) with `uri` pointing at the skill:// resource instead of the
+// backend's base-stamped absolute URL (there is no backend to stamp).
+func bundledSkillIndex() ([]byte, error) {
+	names := skillgen.BundledNames()
+	rows := make([]map[string]string, 0, len(names))
+	for _, name := range names {
+		raw, err := skillgen.RawBundled(name)
+		if err != nil {
+			return nil, fmt.Errorf("bundled skill %q: %w", name, err)
+		}
+		meta := skillgen.ParseDocMeta(raw)
+		sum := sha256.Sum256(raw)
+		rows = append(rows, map[string]string{
+			"name":        name,
+			"description": meta.Description,
+			"version":     meta.Version,
+			"sha256":      hex.EncodeToString(sum[:]),
+			"uri":         skillURIScheme + name,
+		})
+	}
+	return json.Marshal(rows)
+}
+
+// skillReadResult builds the one read-result shape both handlers return: the
+// document bytes VERBATIM with the provenance stamped into the contents'
+// _meta. Deliberately not routed through ux.RedactBytes: these are static,
+// public, version-stamped documents (never relayed API responses carrying
+// session data), the index manifest pins each document's sha256 over its raw
+// served bytes so any rewrite would break client-side verification — and the
+// pattern-based redactor mangles innocent prose ("bearer token" →
+// "bearer [REDACTED]"). version is omitted when the document has no single
+// version (the index manifest carries its versions per row).
+func skillReadResult(uri, mimeType string, doc skillDoc) *mcp.ReadResourceResult {
+	meta := mcp.Meta{skillMetaSource: string(doc.source)}
+	if doc.version != "" {
+		meta[skillMetaVersion] = doc.version
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      uri,
+			MIMEType: mimeType,
+			Text:     string(doc.raw),
+			Meta:     meta,
+		}},
+	}
+}
+
+// errNoBackend marks the deliberate pre-auth path: no active state or no
+// control-plane URL means there is no backend to prefer — serve the bundled
+// copy without logging a failure (nothing failed).
+var errNoBackend = errors.New("no backend configured")
+
+// fetchHostedSkill GETs one agent-discovery document from the connected
+// backend. The read is bounded by the session's result cap (§3.7 posture): a
+// document larger than that cannot be served whole into a model's context, so
+// an oversized response is treated as a bad response — the caller falls back
+// to the bundled copy — never truncated mid-document.
+func (s *mcpServer) fetchHostedSkill(ctx context.Context, path string) ([]byte, error) {
+	st := clictx.ActiveContext(ctx)
+	if st == nil || st.BaseURL == "" {
+		return nil, errNoBackend
+	}
+	hc, err := clictx.ControlHTTPClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(st.BaseURL, "/")+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("backend answered %d for %s", resp.StatusCode, path)
+	}
+	return sdkclient.ReadAllBounded(resp.Body, s.maxResultBytes)
+}

--- a/cli/internal/cli/api/mcp_resources_test.go
+++ b/cli/internal/cli/api/mcp_resources_test.go
@@ -1,0 +1,234 @@
+package api
+
+// mcp_resources_test.go exercises the PR 1-D skill:// resources: the hosted
+// fetch (backend as the session's source of truth), the offline fallback to
+// the bundled embed, the §3.8 provenance metadata (source + version), and the
+// §3.3 pre-auth serving invariant. The wire-level resources/list +
+// resources/read round trip lives in mcp_session_test.go.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/skillgen"
+)
+
+// readResourceRequest builds the raw request shape the SDK hands a
+// ResourceHandler.
+func readResourceRequest(uri string) *mcp.ReadResourceRequest {
+	return &mcp.ReadResourceRequest{Params: &mcp.ReadResourceParams{URI: uri}}
+}
+
+// singleContents asserts the result carries exactly one contents item and
+// returns it.
+func singleContents(t *testing.T, res *mcp.ReadResourceResult) *mcp.ResourceContents {
+	t.Helper()
+	if len(res.Contents) != 1 {
+		t.Fatalf("contents items = %d, want 1", len(res.Contents))
+	}
+	return res.Contents[0]
+}
+
+const hostedJentic = `---
+name: jentic
+description: hosted copy from the backend
+version: 7
+---
+
+# Using Jentic from the CLI (hosted revision)
+`
+
+func TestMCPSkillResource_HostedFetchWithProvenance(t *testing.T) {
+	var gotPath, gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotUA = r.URL.Path, r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		_, _ = w.Write([]byte(hostedJentic))
+	}))
+	defer srv.Close()
+
+	s := newTestMCPServer(t, nil)
+	// The session's attribution hook must ride the skill fetch like every
+	// other backend call.
+	ctx := clictx.WithTransportHook(activeCtx(srv.URL), s.transportHook())
+
+	res, err := s.handleSkillResource(ctx, readResourceRequest("skill://jentic"))
+	if err != nil {
+		t.Fatalf("handleSkillResource: %v", err)
+	}
+	if gotPath != "/skills/jentic.md" {
+		t.Errorf("backend path = %q, want the #651 route /skills/jentic.md", gotPath)
+	}
+	if !strings.HasPrefix(gotUA, "jentic-mcp/") {
+		t.Errorf("User-Agent = %q, want the attribution hook composed onto the skill fetch", gotUA)
+	}
+
+	c := singleContents(t, res)
+	if c.Text != hostedJentic {
+		t.Errorf("text = %q, want the hosted bytes verbatim", c.Text)
+	}
+	if c.MIMEType != skillMarkdownMIME {
+		t.Errorf("mimeType = %q, want %q", c.MIMEType, skillMarkdownMIME)
+	}
+	if c.Meta[skillMetaSource] != string(skillgen.SourceHosted) {
+		t.Errorf("meta source = %v, want hosted", c.Meta[skillMetaSource])
+	}
+	if c.Meta[skillMetaVersion] != "7" {
+		t.Errorf("meta version = %v, want the HOSTED document's version 7 (not the bundled one)", c.Meta[skillMetaVersion])
+	}
+}
+
+func TestMCPSkillResource_OfflineFallsBackToBundled(t *testing.T) {
+	// A configured but unreachable backend: bind a listener, note the
+	// address, close it — the dial fails fast.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+	deadURL := srv.URL
+	srv.Close()
+
+	s := newTestMCPServer(t, nil)
+	res, err := s.handleSkillResource(activeCtx(deadURL), readResourceRequest("skill://jentic"))
+	if err != nil {
+		t.Fatalf("offline must fall back, not fail: %v", err)
+	}
+	assertBundledJentic(t, res)
+}
+
+func TestMCPSkillResource_PreAuthNoConfigServesBundled(t *testing.T) {
+	// The §3.3 invariant: no ActiveState at all (the interceptor's degraded
+	// no-config resolution) still serves the skill — from the embed.
+	s := newTestMCPServer(t, nil)
+	res, err := s.handleSkillResource(context.Background(), readResourceRequest("skill://jentic"))
+	if err != nil {
+		t.Fatalf("pre-auth read must serve the bundled copy: %v", err)
+	}
+	assertBundledJentic(t, res)
+}
+
+func TestMCPSkillResource_BackendErrorFallsBackToBundled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	s := newTestMCPServer(t, nil)
+	res, err := s.handleSkillResource(activeCtx(srv.URL), readResourceRequest("skill://jentic"))
+	if err != nil {
+		t.Fatalf("a backend error must fall back, not fail: %v", err)
+	}
+	assertBundledJentic(t, res)
+}
+
+func TestMCPSkillResource_OversizedHostedFallsBackToBundled(t *testing.T) {
+	// A hosted document over the result cap is a bad response (§3.7 posture):
+	// never truncated mid-document, the bundled copy serves instead.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", 4096)))
+	}))
+	defer srv.Close()
+
+	s := newTestMCPServer(t, nil)
+	s.maxResultBytes = 1024
+	res, err := s.handleSkillResource(activeCtx(srv.URL), readResourceRequest("skill://jentic"))
+	if err != nil {
+		t.Fatalf("an oversized hosted body must fall back, not fail: %v", err)
+	}
+	assertBundledJentic(t, res)
+}
+
+// assertBundledJentic pins the bundled-fallback contract: the embedded bytes
+// verbatim, source bundled, the bundled document's own version.
+func assertBundledJentic(t *testing.T, res *mcp.ReadResourceResult) {
+	t.Helper()
+	want, err := skillgen.RawBundled("jentic")
+	if err != nil {
+		t.Fatalf("RawBundled: %v", err)
+	}
+	c := singleContents(t, res)
+	if c.Text != string(want) {
+		t.Errorf("text does not match the bundled bytes (len %d vs %d)", len(c.Text), len(want))
+	}
+	if c.Meta[skillMetaSource] != string(skillgen.SourceBundled) {
+		t.Errorf("meta source = %v, want bundled", c.Meta[skillMetaSource])
+	}
+	if c.Meta[skillMetaVersion] != skillgen.ParseDocMeta(want).Version {
+		t.Errorf("meta version = %v, want the bundled document's version", c.Meta[skillMetaVersion])
+	}
+}
+
+func TestMCPSkillIndex_HostedVerbatim(t *testing.T) {
+	hosted := `[{"name":"jentic","description":"d","version":"7","sha256":"abc","url":"https://cp.example.com/skills/jentic.md"}]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/skills/index.json" {
+			t.Errorf("path = %q, want /skills/index.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(hosted))
+	}))
+	defer srv.Close()
+
+	s := newTestMCPServer(t, nil)
+	res, err := s.handleSkillIndexResource(activeCtx(srv.URL), readResourceRequest(skillIndexURI))
+	if err != nil {
+		t.Fatalf("handleSkillIndexResource: %v", err)
+	}
+	c := singleContents(t, res)
+	if c.Text != hosted {
+		t.Errorf("text = %q, want the backend manifest verbatim", c.Text)
+	}
+	if c.MIMEType != skillIndexMIME {
+		t.Errorf("mimeType = %q, want %q", c.MIMEType, skillIndexMIME)
+	}
+	if c.Meta[skillMetaSource] != string(skillgen.SourceHosted) {
+		t.Errorf("meta source = %v, want hosted", c.Meta[skillMetaSource])
+	}
+}
+
+func TestMCPSkillIndex_BundledManifestPreAuth(t *testing.T) {
+	s := newTestMCPServer(t, nil)
+	res, err := s.handleSkillIndexResource(context.Background(), readResourceRequest(skillIndexURI))
+	if err != nil {
+		t.Fatalf("pre-auth index read must serve the bundled manifest: %v", err)
+	}
+	c := singleContents(t, res)
+	if c.Meta[skillMetaSource] != string(skillgen.SourceBundled) {
+		t.Errorf("meta source = %v, want bundled", c.Meta[skillMetaSource])
+	}
+
+	var rows []map[string]string
+	if err := json.Unmarshal([]byte(c.Text), &rows); err != nil {
+		t.Fatalf("bundled manifest is not JSON: %v\n%s", err, c.Text)
+	}
+	names := skillgen.BundledNames()
+	if len(rows) != len(names) {
+		t.Fatalf("manifest rows = %d, want the full bundled set (%d)", len(rows), len(names))
+	}
+	for i, row := range rows {
+		name := names[i]
+		if row["name"] != name {
+			t.Errorf("row %d name = %q, want %q (BundledNames order)", i, row["name"], name)
+		}
+		if row["uri"] != skillURIScheme+name {
+			t.Errorf("row %d uri = %q, want the skill:// resource URI", i, row["uri"])
+		}
+		raw, err := skillgen.RawBundled(name)
+		if err != nil {
+			t.Fatalf("RawBundled(%s): %v", name, err)
+		}
+		sum := sha256.Sum256(raw)
+		if row["sha256"] != hex.EncodeToString(sum[:]) {
+			t.Errorf("row %d sha256 = %q, want the digest of the raw served bytes", i, row["sha256"])
+		}
+		if row["version"] == "" || row["description"] == "" {
+			t.Errorf("row %d must carry version and description: %v", i, row)
+		}
+	}
+}

--- a/cli/internal/cli/api/mcp_resources_test.go
+++ b/cli/internal/cli/api/mcp_resources_test.go
@@ -11,13 +11,18 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
 	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
 	"github.com/jentic/jentic-one/cli/internal/skillgen"
 )
@@ -48,9 +53,9 @@ version: 7
 `
 
 func TestMCPSkillResource_HostedFetchWithProvenance(t *testing.T) {
-	var gotPath, gotUA string
+	var gotPath, gotUA, gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath, gotUA = r.URL.Path, r.Header.Get("User-Agent")
+		gotPath, gotUA, gotAuth = r.URL.Path, r.Header.Get("User-Agent"), r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 		_, _ = w.Write([]byte(hostedJentic))
 	}))
@@ -70,6 +75,12 @@ func TestMCPSkillResource_HostedFetchWithProvenance(t *testing.T) {
 	}
 	if !strings.HasPrefix(gotUA, "jentic-mcp/") {
 		t.Errorf("User-Agent = %q, want the attribution hook composed onto the skill fetch", gotUA)
+	}
+	// The routes are public and the raw client carries no auth editors: the
+	// session's bearer token (activeCtx injects one) must NOT leak onto the
+	// skill fetch.
+	if gotAuth != "" {
+		t.Errorf("Authorization = %q, want no auth header on the public skills route", gotAuth)
 	}
 
 	c := singleContents(t, res)
@@ -144,6 +155,142 @@ func TestMCPSkillResource_OversizedHostedFallsBackToBundled(t *testing.T) {
 	assertBundledJentic(t, res)
 }
 
+// TestMCPSkillResource_MalformedHostedFallsBackToBundled pins the MAJOR-1
+// shape gate: a 200 body under the cap is only served as hosted when its
+// frontmatter parses AND names the requested skill. A captive portal's HTML
+// or the wrong document must degrade to the bundled copy (source bundled),
+// never be labeled hosted at a fabricated version.
+func TestMCPSkillResource_MalformedHostedFallsBackToBundled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"html error page", "<html><body><h1>503 Service Unavailable</h1></body></html>"},
+		{"frontmatter names another skill", "---\nname: other\ndescription: not jentic\nversion: 9\n---\n\n# other\n"},
+		{"no frontmatter at all", "# Using Jentic from the CLI\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			s := newTestMCPServer(t, nil)
+			res, err := s.handleSkillResource(activeCtx(srv.URL), readResourceRequest("skill://jentic"))
+			if err != nil {
+				t.Fatalf("a malformed hosted body must fall back, not fail: %v", err)
+			}
+			assertBundledJentic(t, res)
+		})
+	}
+}
+
+// TestMCPSkillResource_RedirectNotFollowed pins the MAJOR-2 posture: the
+// skills fetch never follows a redirect. A 3xx from the backend is a bad
+// response (bundled fallback) — never a license to fetch an attacker-chosen
+// location with the session's attribution headers and label the bytes hosted.
+func TestMCPSkillResource_RedirectNotFollowed(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path == "/redirected" {
+			_, _ = w.Write([]byte(hostedJentic))
+			return
+		}
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	s := newTestMCPServer(t, nil)
+	res, err := s.handleSkillResource(activeCtx(srv.URL), readResourceRequest("skill://jentic"))
+	if err != nil {
+		t.Fatalf("a redirecting backend must fall back, not fail: %v", err)
+	}
+	assertBundledJentic(t, res)
+	if len(paths) != 1 || paths[0] != "/skills/jentic.md" {
+		t.Errorf("requested paths = %v, want only the skills route (the redirect target must never be fetched)", paths)
+	}
+}
+
+// TestMCPSkillResource_HostedHonorsCAPin pins the skills-leg transport
+// posture (modeled on TestMCPExecute_BrokerLegHonorsCAPinAndHook): the fetch
+// rides the SEC-20 CA-pinned client, so it succeeds against a backend whose
+// cert chains to the environment's ca_cert_path — and when the bundle is set
+// but broken, the read SILENTLY DEGRADES to the bundled copy. That is the
+// deliberate posture for this surface: unlike the execute broker leg (which
+// fails closed with an error), a resource read never errors on transport
+// trouble — offline is a supported state — so a broken pin costs hosted
+// freshness, never correctness (the embed serves, labeled bundled).
+func TestMCPSkillResource_HostedHonorsCAPin(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(hostedJentic))
+	}))
+	defer srv.Close()
+
+	// Write the test server's own CA cert as the environment's bundle.
+	pemPath := filepath.Join(t.TempDir(), "ca.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+	if err := os.WriteFile(pemPath, pemBytes, 0o600); err != nil {
+		t.Fatalf("write ca bundle: %v", err)
+	}
+
+	s := newTestMCPServer(t, nil)
+	state := &clictx.ActiveState{
+		ResolvedState: &sdkconfig.ResolvedState{
+			IdentityName:    "test-agent",
+			EnvironmentName: "test",
+			BaseURL:         srv.URL,
+			CACertPath:      pemPath,
+		},
+		Mode: clictx.ModeHuman,
+	}
+	ctx := clictx.WithActiveState(context.Background(), state)
+
+	res, err := s.handleSkillResource(ctx, readResourceRequest("skill://jentic"))
+	if err != nil {
+		t.Fatalf("CA-pinned hosted fetch must succeed against the pinned cert: %v", err)
+	}
+	c := singleContents(t, res)
+	if c.Meta[skillMetaSource] != string(skillgen.SourceHosted) {
+		t.Errorf("meta source = %v, want hosted (the pinned TLS fetch must have served)", c.Meta[skillMetaSource])
+	}
+	if c.Text != hostedJentic {
+		t.Errorf("text = %q, want the hosted bytes over the pinned transport", c.Text)
+	}
+
+	// A set-but-broken bundle silently degrades to bundled (see the test
+	// comment above for why this differs from the execute leg's fail-closed).
+	state.CACertPath = filepath.Join(t.TempDir(), "missing.pem")
+	res, err = s.handleSkillResource(ctx, readResourceRequest("skill://jentic"))
+	if err != nil {
+		t.Fatalf("a broken ca_cert_path must degrade to bundled, not fail: %v", err)
+	}
+	assertBundledJentic(t, res)
+}
+
+// TestMCPSkillResource_HungBackendFallsBackWithinProbeBudget pins the
+// MINOR-6 sub-budget: a backend that accepts the connection and then hangs
+// must cost the hosted probe's budget, not the full 30s call deadline, before
+// the bundled copy serves.
+func TestMCPSkillResource_HungBackendFallsBackWithinProbeBudget(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { <-release }))
+	defer srv.Close()
+	defer close(release) // unblock the handler before srv.Close waits on it
+
+	s := newTestMCPServer(t, nil)
+	s.hostedFetchTimeout = 100 * time.Millisecond
+	start := time.Now()
+	res, err := s.handleSkillResource(activeCtx(srv.URL), readResourceRequest("skill://jentic"))
+	if err != nil {
+		t.Fatalf("a hung backend must fall back, not fail: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("fallback took %v, want the probe sub-budget (~100ms), not the call deadline", elapsed)
+	}
+	assertBundledJentic(t, res)
+}
+
 // assertBundledJentic pins the bundled-fallback contract: the embedded bytes
 // verbatim, source bundled, the bundled document's own version.
 func assertBundledJentic(t *testing.T, res *mcp.ReadResourceResult) {
@@ -192,6 +339,42 @@ func TestMCPSkillIndex_HostedVerbatim(t *testing.T) {
 	}
 }
 
+// TestMCPSkillIndex_MalformedHostedFallsBackToBundled pins the MAJOR-1 shape
+// gate on the manifest: a hosted 200 body only serves when it is well-formed
+// JSON whose top level is an array. Anything else degrades to the locally
+// composed bundled manifest.
+func TestMCPSkillIndex_MalformedHostedFallsBackToBundled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"html error page", "<html><body>oops</body></html>"},
+		{"truncated json", `[{"name":"jentic"`},
+		{"json object not array", `{"skills":[]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			s := newTestMCPServer(t, nil)
+			res, err := s.handleSkillIndexResource(activeCtx(srv.URL), readResourceRequest(skillIndexURI))
+			if err != nil {
+				t.Fatalf("a malformed hosted manifest must fall back, not fail: %v", err)
+			}
+			c := singleContents(t, res)
+			if c.Meta[skillMetaSource] != string(skillgen.SourceBundled) {
+				t.Errorf("meta source = %v, want bundled", c.Meta[skillMetaSource])
+			}
+			var rows []map[string]string
+			if err := json.Unmarshal([]byte(c.Text), &rows); err != nil {
+				t.Fatalf("fallback must be the bundled manifest, got: %v\n%s", err, c.Text)
+			}
+		})
+	}
+}
+
 func TestMCPSkillIndex_BundledManifestPreAuth(t *testing.T) {
 	s := newTestMCPServer(t, nil)
 	res, err := s.handleSkillIndexResource(context.Background(), readResourceRequest(skillIndexURI))
@@ -218,6 +401,12 @@ func TestMCPSkillIndex_BundledManifestPreAuth(t *testing.T) {
 		}
 		if row["uri"] != skillURIScheme+name {
 			t.Errorf("row %d uri = %q, want the skill:// resource URI", i, row["uri"])
+		}
+		// `url` is a hosted-only key (the backend's base-stamped absolute
+		// location); the offline manifest has no backend to stamp, so it
+		// always carries `uri` and never `url`.
+		if _, hasURL := row["url"]; hasURL {
+			t.Errorf("row %d carries %q — the offline manifest must emit uri, never url", i, row["url"])
 		}
 		raw, err := skillgen.RawBundled(name)
 		if err != nil {

--- a/cli/internal/cli/api/mcp_server.go
+++ b/cli/internal/cli/api/mcp_server.go
@@ -52,6 +52,10 @@ type mcpServer struct {
 	// maxResultBytes is the §3.7 context-protection cap applied to relayed
 	// upstream bodies (the execute family) — see mcp_execute.go.
 	maxResultBytes int64
+	// hostedFetchTimeout overrides the hosted skill probe's sub-budget
+	// (mcp_resources.go); zero means the hostedSkillFetchTimeout default.
+	// It exists as a field only so tests can inject a short budget.
+	hostedFetchTimeout time.Duration
 
 	// sessionID is the per-process UUID fallback for X-Jentic-Session-Id. The
 	// RoundTripper stamps it ONLY when the header is absent, so an env-set

--- a/cli/internal/cli/api/mcp_server.go
+++ b/cli/internal/cli/api/mcp_server.go
@@ -1,11 +1,11 @@
 package api
 
 // mcp_server.go assembles the MCP server: tool registration (with the
-// --read-only / --exclude-tools filters), the shared result/soft-error shape
-// (every tool result is a JSON object with a top-level sibling `instance`
-// stamp — never a wrapper, never _meta, §3.7.4), and the attribution
-// RoundTripper (User-Agent + X-Jentic-Session-Id fallback, §3.6) that rides
-// the clictx transport hook.
+// --read-only / --exclude-tools filters), the skill:// resource registration
+// (mcp_resources.go), the shared result/soft-error shape (every tool result
+// is a JSON object with a top-level sibling `instance` stamp — never a
+// wrapper, never _meta, §3.7.4), and the attribution RoundTripper (User-Agent
+// + X-Jentic-Session-Id fallback, §3.6) that rides the clictx transport hook.
 
 import (
 	"context"
@@ -101,7 +101,9 @@ func newMCPServer(a *app, version string, opts *mcpOptions, logger *slog.Logger)
 				"Call whoami to see the agent identity, status, scopes, and toolkit bindings. " +
 				"Every tool result carries a top-level `instance` key identifying the Jentic " +
 				"One instance it came from; instance.backend is \"unreachable\" when the " +
-				"control plane could not be reached.",
+				"control plane could not be reached. The skill://jentic resource is the " +
+				"canonical guide to the whole flow (skill://index lists every skill document); " +
+				"read it when unsure how the pieces fit together.",
 			Logger: logger,
 			// Legacy clients (< 2026-07-28) still send initialize; capture
 			// their clientInfo for the User-Agent upgrade the same way a
@@ -112,6 +114,7 @@ func newMCPServer(a *app, version string, opts *mcpOptions, logger *slog.Logger)
 		},
 	)
 	s.registerTools()
+	s.registerResources()
 	return s
 }
 

--- a/cli/internal/cli/api/mcp_session_test.go
+++ b/cli/internal/cli/api/mcp_session_test.go
@@ -2,9 +2,9 @@ package api
 
 // mcp_session_test.go proves the §3.3 "always boots" contract in-process: an
 // SDK client connects to the assembled server over an in-memory transport on
-// a machine with NO configuration, lists the tools, and gets a usable
-// get_started diagnosis with a degraded instance stamp — no network, no XDG
-// state, no prompts.
+// a machine with NO configuration, lists the tools AND the skill resources,
+// and gets a usable get_started diagnosis with a degraded instance stamp — no
+// network, no XDG state, no prompts.
 
 import (
 	"context"
@@ -21,6 +21,7 @@ import (
 	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
 	"github.com/jentic/jentic-one/cli/internal/cli/cmdcore"
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+	"github.com/jentic/jentic-one/cli/internal/skillgen"
 )
 
 // connectTestClient wires an SDK client to s over in-memory pipes and returns
@@ -162,9 +163,10 @@ func TestMCPSession_ReadOnlyWithholdsExactlyExecute(t *testing.T) {
 }
 
 // TestMCPSession_FullRoundTrip drives the complete §3.2 flow — whoami →
-// search_apis → inspect_operation → execute — through a real client session
-// against httptest control and broker planes: state, alias tolerance, the
-// broker leg, and the stamped envelopes must survive the full JSON-RPC round
+// search_apis → inspect_operation → execute, plus a resources/read of the
+// hosted skill — through a real client session against httptest control and
+// broker planes: state, alias tolerance, the broker leg, the stamped
+// envelopes, and the resource provenance must survive the full JSON-RPC round
 // trip, not just direct handler calls.
 func TestMCPSession_FullRoundTrip(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -198,6 +200,9 @@ func TestMCPSession_FullRoundTrip(t *testing.T) {
 			_, _ = w.Write([]byte(`{"method":"GET","url":"https://acme.com/pets","parameters":[]}`))
 		case "/instance":
 			_, _ = w.Write([]byte(`{"backend":"local","host":"127.0.0.1:8000","instance_id":"digest-1"}`))
+		case "/skills/jentic.md":
+			w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+			_, _ = w.Write([]byte(hostedJentic))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -285,6 +290,26 @@ func TestMCPSession_FullRoundTrip(t *testing.T) {
 	if stamp, ok := payload["instance"].(map[string]any); !ok || stamp["backend"] != "local" {
 		t.Errorf("execute result stamp = %v, want the live identity", payload["instance"])
 	}
+
+	// 5. resources/read alongside the tool round trip: connected to a live
+	// backend, skill://jentic serves the HOSTED copy (session source of
+	// truth) with its provenance riding the wire _meta.
+	rr, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "skill://jentic"})
+	if err != nil {
+		t.Fatalf("resources/read: %v", err)
+	}
+	if len(rr.Contents) != 1 {
+		t.Fatalf("contents = %d, want 1", len(rr.Contents))
+	}
+	if rr.Contents[0].Text != hostedJentic {
+		t.Errorf("resource text = %q, want the backend's bytes verbatim", rr.Contents[0].Text)
+	}
+	if rr.Contents[0].Meta[skillMetaSource] != string(skillgen.SourceHosted) {
+		t.Errorf("meta source = %v, want hosted (the backend answered)", rr.Contents[0].Meta[skillMetaSource])
+	}
+	if rr.Contents[0].Meta[skillMetaVersion] != "7" {
+		t.Errorf("meta version = %v, want the hosted document's version", rr.Contents[0].Meta[skillMetaVersion])
+	}
 }
 
 // TestMCPSession_MissingQueryIsProtocolError proves the invalid-params
@@ -364,6 +389,74 @@ func TestMCPSession_ExcludeToolsFilters(t *testing.T) {
 	}
 	if len(tools.Tools) != 6 {
 		t.Errorf("tools = %d, want 6 after exclusion", len(tools.Tools))
+	}
+}
+
+// TestMCPSession_ResourcesWorkPreAuth extends the §3.3 always-boots contract
+// to the PR 1-D resource surface over the real wire: with NO configuration,
+// resources/list serves the full bundled set (+ the index) and resources/read
+// answers with the embedded copy stamped source=bundled — never an error.
+func TestMCPSession_ResourcesWorkPreAuth(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	s := newTestMCPServer(t, nil)
+	cs := connectTestClient(t, s)
+	ctx := context.Background()
+
+	list, err := cs.ListResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("resources/list must work with no config: %v", err)
+	}
+	uris := make(map[string]*mcp.Resource, len(list.Resources))
+	for _, r := range list.Resources {
+		uris[r.URI] = r
+	}
+	names := skillgen.BundledNames()
+	wantURIs := make([]string, 0, len(names)+1)
+	wantURIs = append(wantURIs, skillIndexURI)
+	for _, name := range names {
+		wantURIs = append(wantURIs, skillURIScheme+name)
+	}
+	for _, want := range wantURIs {
+		r, ok := uris[want]
+		if !ok {
+			t.Fatalf("resources/list is missing %q (got %d resources)", want, len(list.Resources))
+		}
+		if r.Description == "" || r.MIMEType == "" {
+			t.Errorf("resource %q must carry a description and MIME type", want)
+		}
+	}
+	if len(uris) != len(wantURIs) {
+		t.Errorf("resources = %d, want exactly the bundled set + index (%d)", len(uris), len(wantURIs))
+	}
+
+	res, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "skill://jentic"})
+	if err != nil {
+		t.Fatalf("resources/read must work pre-auth: %v", err)
+	}
+	if len(res.Contents) != 1 {
+		t.Fatalf("contents = %d, want 1", len(res.Contents))
+	}
+	c := res.Contents[0]
+	want, err := skillgen.RawBundled("jentic")
+	if err != nil {
+		t.Fatalf("RawBundled: %v", err)
+	}
+	if c.Text != string(want) {
+		t.Errorf("pre-auth read must serve the bundled bytes verbatim (len %d vs %d)", len(c.Text), len(want))
+	}
+	if c.Meta[skillMetaSource] != string(skillgen.SourceBundled) {
+		t.Errorf("meta source = %v, want bundled (survives the wire round trip)", c.Meta[skillMetaSource])
+	}
+	if c.Meta[skillMetaVersion] == nil {
+		t.Errorf("meta must carry the content version")
+	}
+
+	// An unregistered URI is a protocol-level resource-not-found, never a
+	// handler panic or a silent empty read.
+	if _, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "skill://no-such-skill"}); err == nil {
+		t.Errorf("reading an unregistered skill URI must fail")
 	}
 }
 

--- a/cli/internal/cli/clictx/client.go
+++ b/cli/internal/cli/clictx/client.go
@@ -98,16 +98,34 @@ func stateForClient(state *ActiveState) (*ActiveState, error) {
 }
 
 // BrokerHTTPClient builds the base *http.Client for the broker leg of an
-// execute from the active context: the SEC-20 CA-pinned transport when the
-// environment declares ca_cert_path (fail closed on a broken bundle, exactly
-// like the control-plane clients), the default transport otherwise, with the
-// context's TransportHook composed over it (wrap, never displace — the pinning
-// decision stays the inner RoundTripper). Local-MCP §3.7.2: `execute`'s broker
-// leg historically built its own un-pinned client; the MCP path routes through
+// execute from the active context. Local-MCP §3.7.2: `execute`'s broker leg
+// historically built its own un-pinned client; the MCP path routes through
 // this constructor so broker calls honor the same trust decision as every
 // other backend call. Callers pass the result to client.BrokerTransport, which
 // decorates the retry/backoff policy on the outside.
 func BrokerHTTPClient(ctx context.Context) (*http.Client, error) {
+	return hookedPlaneHTTPClient(ctx)
+}
+
+// ControlHTTPClient builds the base *http.Client for RAW control-plane
+// requests that have no generated route — the schema-hidden agent-discovery
+// documents (`GET /skills/<name>.md` / `/skills/index.json`, #651) the
+// `jentic mcp` skill:// resources fetch. Those routes are public (no auth
+// editors needed — they must be fetchable while a registration is still
+// pending), but the transport posture is identical to every other plane call:
+// the SEC-20 CA-pinned client when the environment declares ca_cert_path,
+// with the context's TransportHook composed over it.
+func ControlHTTPClient(ctx context.Context) (*http.Client, error) {
+	return hookedPlaneHTTPClient(ctx)
+}
+
+// hookedPlaneHTTPClient is the shared constructor behind the raw plane
+// clients: the SEC-20 CA-pinned transport when the environment declares
+// ca_cert_path (fail closed on a broken bundle, exactly like the generated
+// clients), the default transport otherwise, with the context's TransportHook
+// composed over it (wrap, never displace — the pinning decision stays the
+// inner RoundTripper).
+func hookedPlaneHTTPClient(ctx context.Context) (*http.Client, error) {
 	state, err := stateForClient(FromContext(ctx))
 	if err != nil {
 		return nil, err

--- a/cli/internal/skillgen/bundled.go
+++ b/cli/internal/skillgen/bundled.go
@@ -68,6 +68,47 @@ func contentFor(name string) (string, error) {
 	return string(data), nil
 }
 
+// RawBundled returns the exact embedded bytes of one bundled skill — the same
+// bytes the backend serves at `GET /skills/<name>.md` (#651, drift-pinned by
+// tests/arch/test_skill_drift.py). It exists for consumers that serve the
+// document VERBATIM (the `jentic mcp` skill:// resources) rather than
+// rendering it into an operator layout: no BaseURL interpolation, no managed
+// block, byte-identical to the backend's copy at the same commit.
+func RawBundled(name string) ([]byte, error) {
+	data, err := bundledContent.ReadFile(bundledDir + "/" + name + ".md")
+	if err != nil {
+		return nil, fmt.Errorf("read bundled skill %q: %w", name, err)
+	}
+	return data, nil
+}
+
+// DocMeta is the frontmatter identity of one raw skill document, read without
+// the full structural parse so it works on bundled and hosted bytes alike
+// (a hosted document from a newer backend may carry sections parseSkill does
+// not know).
+type DocMeta struct {
+	Name        string
+	Description string
+	Version     string
+}
+
+// ParseDocMeta reads the identity frontmatter off a raw skill document.
+// Missing keys degrade to zero values except Version, which defaults to "1"
+// like parseSkill — a document with no version stamp is still versioned
+// content, just at the original revision.
+func ParseDocMeta(raw []byte) DocMeta {
+	_, fm := splitFrontmatter(string(raw))
+	m := DocMeta{
+		Name:        fm["name"],
+		Description: fm["description"],
+		Version:     fm["version"],
+	}
+	if m.Version == "" {
+		m.Version = "1"
+	}
+	return m
+}
+
 // Bundled parses the named embedded skill into a Canonical, stamping the
 // resolved control-plane base URL and bundled provenance into it. A malformed
 // embed is a build-time programming error (the content is compiled into the

--- a/cli/internal/skillgen/skillgen.go
+++ b/cli/internal/skillgen/skillgen.go
@@ -1,8 +1,9 @@
 // Package skillgen renders one canonical "how to use Jentic via the CLI" skill
 // into each supported agent runtime's ("operator") native skill/instruction
 // layout. It is the engine behind `jentic skill init/list/remove`: the
-// canonical content (bundled now, hosted via #277 later) is shared, and a small
-// per-operator Adapter owns where the file lives and how it is formatted.
+// canonical content is shared (the bundled embed here; the backend serves the
+// same bytes at `GET /skills/<name>.md`, #651), and a small per-operator
+// Adapter owns where the file lives and how it is formatted.
 //
 // Writes are idempotent and edit-preserving: generated content lives inside a
 // clearly-marked managed block so re-runs replace only our block and never
@@ -40,8 +41,10 @@ const (
 )
 
 // Canonical is the source-agnostic skill content every adapter renders from.
-// It is populated from the bundled fallback today and from #277's hosted
-// `GET /skills/*` once that endpoint exists. Despite the name it now models two
+// It is populated from the bundled embed today; the hosted counterpart —
+// `GET /skills/*`, anticipated by #277 — shipped as #651
+// (shared/web/agent_discovery.py serves the same bytes), and Origin records
+// which source a given Canonical came from. Despite the name it now models two
 // kinds (see Kind): the structured "canonical" jentic skill (sections/steps)
 // and a "freeform" runbook whose Body is emitted verbatim.
 type Canonical struct {


### PR DESCRIPTION
## Summary

PR 1-D of the local-MCP phase 1 (#1175) — skills as MCP resources plus the shared-goldens test consolidation, completing the phase-1 lane-A spine.

- **`skill://` resources**: every bundled skill (`skill://jentic`, …) plus a `skill://index` manifest is registered on the `jentic mcp` server. Reads are **hosted-first** — the connected backend's `GET /skills/<name>.md` / `/skills/index.json` (#651) is the session's source of truth — with the **embedded bundled copy as offline fallback**, and they work **pre-auth** (§3.3 always boots: no config ⇒ bundled copy).
- **Provenance** rides each read's `_meta`: `one.jentic/source` (`hosted`|`bundled`, reusing `skillgen`'s `Source` model) and `one.jentic/version` (the document's frontmatter version). Skill bytes are served verbatim (the index pins each document's `sha256`; no redaction pass on static public docs); an oversized hosted response falls back to bundled rather than truncating mid-document.
- **Seams**: `skillgen.RawBundled`/`ParseDocMeta` (raw embed + frontmatter identity), `clictx.ControlHTTPClient` (shares the SEC-20 CA-pinned + hooked constructor with `BrokerHTTPClient`; no auth editors — the routes are public). Fixed the stale `skillgen.go` comment claiming the hosted `GET /skills/*` endpoint doesn't exist (it shipped as #651).
- **Tests**: resource unit tests (hosted fetch with provenance, offline/pre-auth/backend-error/oversize fallback); the in-process session test now covers `resources/list` + `resources/read` pre-auth and a hosted read inside the full round trip; **shared envelope goldens** pin the MCP execute result (sibling `instance` stamp stripped) byte-for-byte against the frozen CLI goldens in `tests/golden` — one source of truth, no re-pin — plus a superset-shape guard.
- **Docs**: the Inspector debug loop (`npx @modelcontextprotocol/inspector`) documented in `cli/README.md` (developer section).

`GOWORK=off make -C cli check` is green.

Stacked on #1186 (→ #1183 → #1181 → #1179), sibling of #1191; retarget after they merge. Part of #1175 — completes the phase-1 lane-A spine.

Made with [Cursor](https://cursor.com)