### PR TITLE
feat(ui): per-agent MCP config card + sessions list + origin filter

### DIFF
--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -141,6 +141,17 @@ export const handlers = [
 	http.get('/system/version', () =>
 		HttpResponse.json({ current: '0.26.0', latest: null, update_available: false }),
 	),
+	// Backend self-identity (GET /instance, unauthenticated) — the per-agent
+	// MCP config card shows which instance a pasted snippet registers against
+	// (local-MCP 2-E2). Canonical base URL configured, local install.
+	http.get('/instance', () =>
+		HttpResponse.json({
+			backend: 'local',
+			canonical_base_url: 'https://jentic.example.test',
+			host: 'jentic.example.test',
+			instance_id: 'inst_digest_1',
+		}),
+	),
 	// Feature modules append their handlers here, e.g.:
 	//   import { discoverHandlers } from '@/modules/discover/mocks/handlers';
 	//   ...discoverHandlers,

--- a/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
@@ -688,6 +688,102 @@ describe('AgentDetailPage', () => {
 		expect(screen.getByText('Connect via MCP')).toBeInTheDocument();
 	});
 
+	it('survives a set-but-unparseable canonical_base_url (scheme-less) without crashing', async () => {
+		const user = userEvent.setup();
+		// The backend allows an unparseable canonical_base_url with host: ""
+		// (instance_identity.py) — a scheme-less value must degrade to the raw
+		// string, not throw in render and take out the page via the boundary.
+		worker.use(
+			http.get('/instance', () =>
+				HttpResponse.json({
+					backend: 'local',
+					canonical_base_url: 'jentic.example.com',
+					host: '',
+					instance_id: null,
+				}),
+			),
+		);
+		renderDetail('agnt_active_1');
+		await screen.findByRole('heading', { name: 'support-agent' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+		expect(await screen.findByText('Connect via MCP')).toBeInTheDocument();
+
+		// The register snippet carries the configured (raw) address…
+		expect(
+			await screen.findByText('jentic register --url jentic.example.com'),
+		).toBeInTheDocument();
+		// …and the Instance meta item falls back to the raw string as the host.
+		expect(screen.getAllByText('jentic.example.com').length).toBeGreaterThan(0);
+		// The page survived — no error boundary.
+		expect(screen.getByRole('heading', { name: 'support-agent' })).toBeInTheDocument();
+	});
+
+	it('shows an error state — not a false empty state — when the sessions read fails (500)', async () => {
+		const user = userEvent.setup();
+		worker.use(createErrorHandler('get', '/events', { status: 500 }));
+		renderDetail('agnt_active_1');
+		await screen.findByRole('heading', { name: 'support-agent' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+
+		// A real failure surfaces as an error, never as "No MCP sessions
+		// recorded" (which would tell the operator the transport is unused).
+		expect(await screen.findByText('Failed to load MCP sessions.')).toBeInTheDocument();
+		expect(screen.getByRole('alert')).toBeInTheDocument();
+		expect(screen.queryByText(/No MCP sessions recorded/)).not.toBeInTheDocument();
+		expect(
+			screen.queryByText('MCP session history requires event-read permissions.'),
+		).not.toBeInTheDocument();
+		// The config card is independent and still renders.
+		expect(screen.getByText('Connect via MCP')).toBeInTheDocument();
+	});
+
+	it('falls back to the browser origin when GET /instance fails (500)', async () => {
+		const user = userEvent.setup();
+		worker.use(createErrorHandler('get', '/instance', { status: 500 }));
+		renderDetail('agnt_active_1');
+		await screen.findByRole('heading', { name: 'support-agent' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+		expect(await screen.findByText('Connect via MCP')).toBeInTheDocument();
+
+		// The identity read failing is not fatal: the operator is looking at a
+		// working address of this instance, so the browser origin stands in.
+		expect(
+			await screen.findByText(`jentic register --url "${window.location.origin}"`),
+		).toBeInTheDocument();
+	});
+
+	it('includes the --broker-url hint in the register snippet on a remote install', async () => {
+		const user = userEvent.setup();
+		worker.use(
+			http.get('/instance', () =>
+				HttpResponse.json({
+					backend: 'remote',
+					canonical_base_url: 'https://jentic.example.test',
+					host: 'jentic.example.test',
+					instance_id: 'inst_digest_1',
+				}),
+			),
+		);
+		renderDetail('agnt_active_1');
+		await screen.findByRole('heading', { name: 'support-agent' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+		await screen.findByText('Connect via MCP');
+
+		// On a remote install the broker is never derived from the control-plane
+		// URL; without --broker-url `jentic execute` fail-closes (register.go),
+		// so the snippet must carry the flag.
+		expect(
+			await screen.findByText(
+				'jentic register --url "https://jentic.example.test" --broker-url <broker-url>',
+			),
+		).toBeInTheDocument();
+		expect(screen.getByText(/fail-closes/)).toBeInTheDocument();
+	});
+
 	// --- #607: agent-side bind / unbind toolkit ---------------------------
 
 	it('binds a toolkit picked from the picker and updates the bound list', async () => {

--- a/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
@@ -14,6 +14,7 @@ import {
 import { setToken } from '@/shared/api';
 import { Toaster } from '@/shared/ui';
 import { resetAgentsStore } from '@/modules/agents/mocks/handlers';
+import { SHOW_HTTP_VARIANT } from '@/modules/agents/components/detail/McpPanel';
 import AgentDetailPage from '@/modules/agents/pages/AgentDetailPage';
 
 function renderDetail(agentId: string) {
@@ -561,6 +562,130 @@ describe('AgentDetailPage', () => {
 		const { container } = renderDetail('agnt_active_1');
 		await screen.findByRole('heading', { name: 'support-agent' });
 		await checkA11y(container);
+	});
+
+	// --- local-MCP 2-E2 (#1188): MCP tab — config card + sessions ----------
+
+	it('shows the per-agent MCP config card with the pinned --context snippet', async () => {
+		const user = userEvent.setup();
+		renderDetail('agnt_active_1');
+		await screen.findByRole('heading', { name: 'support-agent' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+		expect(await screen.findByText('Connect via MCP')).toBeInTheDocument();
+
+		// The snippet is the CONTEXT variant, pinned per §3.10's
+		// one-agent-per-runtime model — never a bare `jentic mcp`.
+		expect(screen.getByText('jentic mcp --context support-agent')).toBeInTheDocument();
+		// JSON client-config variant carries the same pinned args.
+		expect(screen.getByText(/"mcp", "--context", "support-agent"/)).toBeInTheDocument();
+
+		// Prerequisites: CLI + register against THIS instance on the AGENT
+		// machine (the stdio config encodes no base URL), or `jentic setup`.
+		// The instance URL resolves async from GET /instance, so wait for it.
+		expect(
+			await screen.findByText('jentic register --url "https://jentic.example.test"'),
+		).toBeInTheDocument();
+		expect(screen.getByText('agent machine')).toBeInTheDocument();
+		expect(screen.getByText('jentic setup')).toBeInTheDocument();
+
+		// Instance identity from GET /instance (which instance the snippet
+		// registers against).
+		expect(screen.getByText('jentic.example.test')).toBeInTheDocument();
+		expect(screen.getByText('local')).toBeInTheDocument();
+	});
+
+	it('falls back to the browser origin when no canonical base URL is configured', async () => {
+		const user = userEvent.setup();
+		worker.use(
+			http.get('/instance', () =>
+				HttpResponse.json({
+					backend: 'local',
+					canonical_base_url: '',
+					host: '',
+					instance_id: null,
+				}),
+			),
+		);
+		renderDetail('agnt_active_1');
+		await screen.findByRole('heading', { name: 'support-agent' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+		await screen.findByText('Connect via MCP');
+
+		// The operator is looking at a working address of this instance, so the
+		// register command targets the browser's origin.
+		expect(
+			await screen.findByText(`jentic register --url "${window.location.origin}"`),
+		).toBeInTheDocument();
+	});
+
+	it('unconditionally hides the HTTP variant in phase 2 (test-pinned)', async () => {
+		const user = userEvent.setup();
+		renderDetail('agnt_active_1');
+		await screen.findByRole('heading', { name: 'support-agent' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+		await screen.findByText('Connect via MCP');
+
+		// The pin itself: `server.mcp` doesn't exist until phase 3 — flipping
+		// this constant before the backend capability lands would advertise a
+		// transport that 404s. Un-hiding is a deliberate phase-3 follow-up.
+		expect(SHOW_HTTP_VARIANT).toBe(false);
+		expect(screen.queryByText(/Streamable HTTP/i)).not.toBeInTheDocument();
+		// No URL-based server entry is offered anywhere on the card.
+		expect(screen.queryByText(/"url"/)).not.toBeInTheDocument();
+	});
+
+	it('lists MCP sessions with client / transport / started — never "connected"', async () => {
+		const user = userEvent.setup();
+		const { container } = renderDetail('agnt_active_1');
+		await screen.findByRole('heading', { name: 'support-agent' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+
+		// Client name + version from the event's data; a version-less client
+		// and a clientInfo-less one degrade honestly (SHOULD in the MCP spec).
+		expect(await screen.findByText('claude-desktop 1.5.2')).toBeInTheDocument();
+		expect(screen.getByText('cursor')).toBeInTheDocument();
+		expect(screen.getByText('unknown client')).toBeInTheDocument();
+		// Transport renders verbatim from the emitter.
+		expect(screen.getAllByText('stdio')).toHaveLength(3);
+
+		// "started / last active" is the vocabulary — last active reads off the
+		// newest MCP-origin execution (5 min ago in the fixture).
+		expect(screen.getByText('started / last active')).toBeInTheDocument();
+		expect(await screen.findByText(/Last active/)).toBeInTheDocument();
+		// NEVER "connected": stdio liveness is unknowable server-side.
+		expect(screen.queryByText(/connected/i)).not.toBeInTheDocument();
+
+		await checkA11y(container);
+	});
+
+	it('shows an honest empty state for an agent with no MCP sessions', async () => {
+		const user = userEvent.setup();
+		renderDetail('agnt_pending_1');
+		await screen.findByRole('heading', { name: 'inbox-triage-bot' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+		expect(
+			await screen.findByText(/No MCP sessions recorded for this agent yet/),
+		).toBeInTheDocument();
+	});
+
+	it('shows a quiet permission note when the events read is gated (403)', async () => {
+		const user = userEvent.setup();
+		worker.use(createErrorHandler('get', '/events', { status: 403 }));
+		renderDetail('agnt_active_1');
+		await screen.findByRole('heading', { name: 'support-agent' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+		expect(
+			await screen.findByText('MCP session history requires event-read permissions.'),
+		).toBeInTheDocument();
+		// A permission gate is not an error — the config card still renders.
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+		expect(screen.getByText('Connect via MCP')).toBeInTheDocument();
 	});
 
 	// --- #607: agent-side bind / unbind toolkit ---------------------------

--- a/ui/src/modules/agents/__tests__/AgentsPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentsPage.test.tsx
@@ -95,6 +95,42 @@ describe('AgentsPage — agents lifecycle', () => {
 		await checkA11y(container);
 	});
 
+	// --- local-MCP 2-E2 (#1188): "last seen via MCP" roster enrichment ------
+
+	it('shows "Last seen via MCP" from the mcp.session_started events', async () => {
+		renderPage();
+		await screen.findAllByText('inbox-triage-bot');
+
+		// Column appears once the events page resolves; support-agent's newest
+		// session is claude-desktop 1.5.2.
+		expect(await screen.findByText('Last seen via MCP')).toBeInTheDocument();
+		const row = tableRowFor('support-agent');
+		expect(await within(row).findByText('claude-desktop 1.5.2')).toBeInTheDocument();
+	});
+
+	it('hides the MCP column entirely when the events read is gated (403)', async () => {
+		worker.use(createErrorHandler('get', '/events', { status: 403 }));
+		renderPage();
+		await screen.findAllByText('inbox-triage-bot');
+
+		// The usage enrichment settles independently; once the table is fully
+		// enriched the MCP column must still be absent — a permission gate is
+		// not an error (no alert), the roster just narrows.
+		await screen.findByText('Activity (7d)');
+		expect(screen.queryByText('Last seen via MCP')).not.toBeInTheDocument();
+	});
+
+	it('keeps the MCP column off the service-accounts roster (agents-only transport)', async () => {
+		const user = userEvent.setup();
+		renderPage();
+		await screen.findAllByText('inbox-triage-bot');
+		await screen.findByText('Last seen via MCP');
+
+		await user.click(screen.getByRole('button', { name: 'Service accounts' }));
+		await screen.findAllByText('metrics-exporter');
+		expect(screen.queryByText('Last seen via MCP')).not.toBeInTheDocument();
+	});
+
 	it('approves a pending agent from the queue → status flips to active', async () => {
 		const user = userEvent.setup();
 		renderPage();
@@ -308,10 +344,11 @@ describe('AgentsPage — agents lifecycle', () => {
 		// Actors absent from the top-50 aggregate are UNKNOWN, not idle — the
 		// three activity columns degrade to em-dashes (f2: the backend caps
 		// `top_limit` at 50, so absence never proves zero executions). Plus the
-		// pending row's empty Approved cell → 4 dashes total.
+		// pending row's empty Approved cell and its empty "Last seen via MCP"
+		// cell (no session event in the fixture) → 5 dashes total.
 		const pending = tableRowFor('inbox-triage-bot');
 		expect(within(pending).queryByText('idle')).not.toBeInTheDocument();
-		expect(within(pending).getAllByText('—')).toHaveLength(4);
+		await waitFor(() => expect(within(pending).getAllByText('—')).toHaveLength(5));
 	});
 
 	it('renders the plain roster when the usage aggregate is admin-gated (403)', async () => {

--- a/ui/src/modules/agents/api/client.ts
+++ b/ui/src/modules/agents/api/client.ts
@@ -15,14 +15,17 @@ import {
 	AgentsService,
 	AuditService,
 	AuditTargetType,
+	EventsService,
 	ExecutionsService,
 	GroupBy,
 	MonitoringService,
 	PermissionsService,
 	ServiceAccountsService,
+	SystemService,
 	ToolkitsService,
 	type AgentResponse,
 	type AuditResponse,
+	type EventResponse,
 	type ServiceAccountResponse,
 } from '@/shared/api';
 import {
@@ -32,7 +35,10 @@ import {
 	type ApiKeyHistoryEntry,
 	type ApiKeyInfoEntity,
 	type ApiKeyResult,
+	type InstanceIdentityEntity,
 	type LinkableToolkit,
+	type McpLastSeen,
+	type McpSessionEntity,
 	type PermissionCatalogEntry,
 	type ServiceAccountEntity,
 	type ToolkitBindingEntity,
@@ -790,5 +796,134 @@ export async function listActorAudit(
 			return [];
 		}
 		throw toAgentsError(error, 'Failed to load the audit log.');
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MCP transport visibility (local-MCP 2-E2, #1188).
+//
+// No new backend surface: the sessions read is the existing
+// `GET /events?event_type=mcp.session_started[&actor_id=…]` (behind
+// `events:read`), last-active is the latest MCP-origin execution
+// (`GET /executions?origin=mcp&actor_id=…`), and instance identity is the
+// unauthenticated `GET /instance`. Event reads follow the enrichment degrade
+// contract (`fetchActorsUsage`): 401/403 resolve to `null` and the caller
+// hides the surface — a permission gate is not an error.
+// ---------------------------------------------------------------------------
+
+/** Wire value of the MCP session event type (`EventType.MCP_SESSION_STARTED`). */
+export const MCP_SESSION_STARTED_EVENT = 'mcp.session_started';
+
+/** The `origin` wire value stamped on MCP executions (`Origin.MCP`). */
+export const MCP_ORIGIN = 'mcp';
+
+function eventToMcpSession(e: EventResponse): McpSessionEntity {
+	// The emitter writes clientInfo + transport + session id into the internal
+	// event's `data` (two-plane pattern: the telemetry wire is property-free,
+	// the UI reads the events table). `data` is a free JSON bag on the wire, so
+	// read defensively — a missing key degrades to null, never a crash.
+	const data = (e.data ?? {}) as Record<string, unknown>;
+	const str = (v: unknown): string | null => (typeof v === 'string' && v !== '' ? v : null);
+	return {
+		eventId: e.event_id,
+		sessionId: str(data.session_id),
+		transport: str(data.transport),
+		clientName: str(data.client_name),
+		clientVersion: str(data.client_version),
+		startedAt: e.created_at,
+	};
+}
+
+/**
+ * One agent's MCP session history, newest first (single page — the backend
+ * caps `limit` at 100; older sessions fall off, which is fine for a
+ * recent-history card). `null` when events are permission-gated (401/403).
+ */
+export async function fetchMcpSessions(actorId: string): Promise<McpSessionEntity[] | null> {
+	try {
+		const res = await EventsService.listEvents({
+			eventType: [MCP_SESSION_STARTED_EVENT],
+			actorId,
+			limit: 100,
+		});
+		return res.data.map(eventToMcpSession);
+	} catch (error) {
+		if (error instanceof ApiError && (error.status === 403 || error.status === 401)) {
+			return null;
+		}
+		throw toAgentsError(error, 'Failed to load MCP sessions.');
+	}
+}
+
+/**
+ * Latest MCP session per agent for the roster's "last seen via MCP" cell,
+ * from ONE page of `mcp.session_started` events. The feed is newest-first, so
+ * the first row per `actor_id` is that agent's latest session. Like the
+ * usage top-50 leaderboard, this is bounded enrichment: an agent absent from
+ * the newest 100 session events means "no recent MCP session known", not
+ * "never" — callers render an em-dash. `null` when permission-gated.
+ */
+export async function fetchMcpLastSeenByActor(): Promise<Map<string, McpLastSeen> | null> {
+	try {
+		const res = await EventsService.listEvents({
+			eventType: [MCP_SESSION_STARTED_EVENT],
+			limit: 100,
+		});
+		const out = new Map<string, McpLastSeen>();
+		for (const e of res.data) {
+			if (!e.actor_id || out.has(e.actor_id)) continue;
+			const s = eventToMcpSession(e);
+			out.set(e.actor_id, {
+				clientName: s.clientName,
+				clientVersion: s.clientVersion,
+				startedAt: s.startedAt,
+			});
+		}
+		return out;
+	} catch (error) {
+		if (error instanceof ApiError && (error.status === 403 || error.status === 401)) {
+			return null;
+		}
+		throw toAgentsError(error, 'Failed to load MCP session events.');
+	}
+}
+
+/**
+ * When this agent last executed over MCP (`started_at` of the newest
+ * MCP-origin execution) — the "last active" half of the sessions card's
+ * "started / last active" story. `null` result covers both "no MCP
+ * executions yet" and the 403 gate; the caller renders a quiet dash either
+ * way, so the two need no distinct copy.
+ */
+export async function fetchLatestMcpActivity(actorId: string): Promise<string | null> {
+	try {
+		const res = await ExecutionsService.listExecutions({
+			actorId,
+			origin: MCP_ORIGIN,
+			limit: 1,
+		});
+		return res.data[0]?.started_at ?? null;
+	} catch (error) {
+		if (error instanceof ApiError && (error.status === 403 || error.status === 401)) {
+			return null;
+		}
+		throw toAgentsError(error, 'Failed to load MCP activity.');
+	}
+}
+
+/**
+ * This backend's self-described identity (`GET /instance`, unauthenticated) —
+ * the config card shows which instance a pasted snippet registers against.
+ */
+export async function fetchInstanceIdentity(): Promise<InstanceIdentityEntity> {
+	try {
+		const res = await SystemService.getInstance();
+		return {
+			backend: res.backend,
+			baseUrl: res.canonical_base_url,
+			host: res.host,
+		};
+	} catch (error) {
+		throw toAgentsError(error, 'Failed to load the instance identity.');
 	}
 }

--- a/ui/src/modules/agents/api/hooks.ts
+++ b/ui/src/modules/agents/api/hooks.ts
@@ -57,6 +57,10 @@ import {
 	fetchActorsUsage,
 	fetchActorUsageDetail,
 	fetchActorExecutions,
+	fetchInstanceIdentity,
+	fetchLatestMcpActivity,
+	fetchMcpLastSeenByActor,
+	fetchMcpSessions,
 	listActorAudit,
 	type ActorAuditEntry,
 	type ActorUsage,
@@ -69,7 +73,10 @@ import type {
 	ApiKeyHistoryEntry,
 	ApiKeyInfoEntity,
 	ApiKeyResult,
+	InstanceIdentityEntity,
 	LinkableToolkit,
+	McpLastSeen,
+	McpSessionEntity,
 	PermissionCatalogEntry,
 	ServiceAccountEntity,
 	ToolkitBindingEntity,
@@ -761,5 +768,73 @@ export function useActorAudit(actorKind: 'agent' | 'service-account', actorId: s
 		queryFn: () => listActorAudit(actorKind, actorId as string),
 		enabled: actorId != null,
 		staleTime: 30 * 1000,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// MCP transport visibility (local-MCP 2-E2, #1188).
+//
+// Keyed under their OWN `agents-mcp` root (like `linkableToolkitsKey` /
+// `agents-usage`) so agent lifecycle mutations — which sweep the broad
+// `sharedQueryKeys.agentsRoot` on approve/deny/create — don't pointlessly
+// refetch the events table. All are enrichment reads with the same
+// `null`-on-403 / `retry: false` degrade contract as `useActorsUsage`.
+// ---------------------------------------------------------------------------
+
+/**
+ * One agent's MCP session history (`mcp.session_started` internal events) —
+ * the detail page's MCP sessions card. `null` for viewers without
+ * `events:read` (the card renders a quiet permission note).
+ */
+export function useMcpSessions(actorId: string | null) {
+	return useQuery<McpSessionEntity[] | null>({
+		queryKey: ['agents-mcp', 'sessions', actorId],
+		queryFn: () => fetchMcpSessions(actorId as string),
+		enabled: actorId != null,
+		staleTime: 30 * 1000,
+		retry: false,
+	});
+}
+
+/**
+ * Latest MCP session per agent for the roster's "last seen via MCP" cell.
+ * One events-page read for the whole fleet (never per-row). `null` on 403 —
+ * the table hides the column entirely, mirroring the usage columns.
+ */
+export function useMcpLastSeen() {
+	return useQuery<Map<string, McpLastSeen> | null>({
+		queryKey: ['agents-mcp', 'last-seen'],
+		queryFn: () => fetchMcpLastSeenByActor(),
+		staleTime: 60 * 1000,
+		retry: false,
+	});
+}
+
+/**
+ * When this agent last executed over MCP — the "last active" line on the
+ * sessions card. `null` means no MCP execution known (or gated); the card
+ * shows a dash, never an error.
+ */
+export function useLatestMcpActivity(actorId: string | null) {
+	return useQuery<string | null>({
+		queryKey: ['agents-mcp', 'last-activity', actorId],
+		queryFn: () => fetchLatestMcpActivity(actorId as string),
+		enabled: actorId != null,
+		staleTime: 30 * 1000,
+		retry: false,
+	});
+}
+
+/**
+ * The instance's self-described identity (`GET /instance`) for the MCP config
+ * card. Slow-changing (it's deploy config), so cached generously; a failure
+ * resolves `undefined` and the card falls back to the browser origin.
+ */
+export function useInstanceIdentity() {
+	return useQuery<InstanceIdentityEntity>({
+		queryKey: ['instance-identity'],
+		queryFn: () => fetchInstanceIdentity(),
+		staleTime: 5 * 60 * 1000,
+		retry: false,
 	});
 }

--- a/ui/src/modules/agents/api/index.ts
+++ b/ui/src/modules/agents/api/index.ts
@@ -42,6 +42,10 @@ export {
 	useActorExecutions,
 	useActorAudit,
 	useUpdateAgent,
+	useMcpSessions,
+	useMcpLastSeen,
+	useLatestMcpActivity,
+	useInstanceIdentity,
 	actorAccessRequestsKey,
 	actorAccessRequestsRootKey,
 } from '@/modules/agents/api/hooks';
@@ -75,11 +79,16 @@ export type {
 	ApiKeyHistoryEntry,
 	ApiKeyInfoEntity,
 	ApiKeyResult,
+	InstanceIdentityEntity,
 	LinkableToolkit,
+	McpLastSeen,
+	McpSessionEntity,
 	PermissionCatalogEntry,
 	ServiceAccountEntity,
 	ToolkitBindingEntity,
 	Attribution,
 } from '@/modules/agents/api/types';
+
+export { mcpClientLabel } from '@/modules/agents/api/types';
 
 export type { AccessRequest } from '@/shared/lib';

--- a/ui/src/modules/agents/api/types.ts
+++ b/ui/src/modules/agents/api/types.ts
@@ -196,3 +196,58 @@ export interface PermissionCatalogEntry {
 	implies: string[];
 	grantableByCaller: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// MCP transport visibility (local-MCP 2-E2, #1188).
+//
+// MCP is a TRANSPORT of an existing agent, not a new entity — nothing new in
+// the data model. These shapes are read straight off existing surfaces: the
+// `mcp.session_started` internal event's `data` (`GET /events`) and the
+// MCP-origin execution records (`GET /executions?origin=mcp`).
+// ---------------------------------------------------------------------------
+
+/**
+ * One MCP session recorded for an agent — a projection of the
+ * `mcp.session_started` internal event. `transport` is what the emitter knew
+ * (`stdio` today; `http` when phase 3's mounted app lands) and renders
+ * verbatim so a future value degrades gracefully. `clientName`/`clientVersion`
+ * come from the relayed MCP clientInfo and are null when the client didn't
+ * send it (a SHOULD in the MCP spec) — "client unknown", not an error.
+ */
+export interface McpSessionEntity {
+	eventId: string;
+	sessionId: string | null;
+	transport: string | null;
+	clientName: string | null;
+	clientVersion: string | null;
+	startedAt: string;
+}
+
+/** The latest MCP session per agent — the roster's "last seen via MCP" cell. */
+export interface McpLastSeen {
+	clientName: string | null;
+	clientVersion: string | null;
+	startedAt: string;
+}
+
+/** "claude-desktop 1.5.2" (or "unknown client") — one label rule everywhere. */
+export function mcpClientLabel(s: {
+	clientName: string | null;
+	clientVersion: string | null;
+}): string {
+	if (!s.clientName) return 'unknown client';
+	return s.clientVersion ? `${s.clientName} ${s.clientVersion}` : s.clientName;
+}
+
+/**
+ * The backend's self-described identity (`GET /instance`) — which install a
+ * pasted MCP snippet will talk to. `baseUrl`/`host` are '' when the operator
+ * never configured a canonical base URL; callers fall back to the browser's
+ * origin (the URL the operator is looking at IS an address of this instance).
+ */
+export interface InstanceIdentityEntity {
+	/** 'local' | 'remote' — operator-declared locality hint. */
+	backend: string;
+	baseUrl: string;
+	host: string;
+}

--- a/ui/src/modules/agents/components/ActorTable.tsx
+++ b/ui/src/modules/agents/components/ActorTable.tsx
@@ -32,9 +32,11 @@ import { cn, formatTimestamp, timeAgo } from '@/shared/lib/utils';
 import {
 	ACTIONS_FOR_STATUS,
 	ACTION_LABEL,
+	mcpClientLabel,
 	type ActorStatus,
 	type ActorUsage,
 	type AgentAction,
+	type McpLastSeen,
 } from '@/modules/agents/api';
 import { successShare } from '@/modules/agents/components/detail/shared';
 
@@ -63,6 +65,14 @@ interface ActorTableProps<T extends ActorRow> {
 	 * "unknown", not "zero" — those cells render an em-dash.
 	 */
 	usage?: Map<string, ActorUsage> | null;
+	/**
+	 * Latest MCP session per actor (local-MCP 2-E2) — renders the "Last seen
+	 * via MCP" column. Same enrichment contract as `usage`: `undefined`/`null`
+	 * (agents-only column, loading, or events permission-gated) hides the
+	 * column; an actor missing from the newest-100 events page renders an
+	 * em-dash ("no recent session known", not "never").
+	 */
+	mcpLastSeen?: Map<string, McpLastSeen> | null;
 	onAction: (item: T, action: AgentAction) => void;
 	detailHref: (item: T) => string;
 }
@@ -176,6 +186,7 @@ export function ActorTable<T extends ActorRow>({
 	emptyMessage,
 	pendingId,
 	usage,
+	mcpLastSeen,
 	onAction,
 	detailHref,
 }: ActorTableProps<T>) {
@@ -244,6 +255,28 @@ export function ActorTable<T extends ActorRow>({
 					},
 				] satisfies Column<T>[])
 			: []),
+		...(mcpLastSeen
+			? ([
+					{
+						key: 'mcp',
+						header: 'Last seen via MCP',
+						className: 'w-44 whitespace-nowrap',
+						render: (row) => {
+							const s = mcpLastSeen.get(row.id);
+							// Missing from the newest events page: unknown, not never.
+							if (!s) return <span aria-hidden>—</span>;
+							return (
+								<span className="flex flex-col leading-tight">
+									<span className="text-foreground text-xs">
+										{mcpClientLabel(s)}
+									</span>
+									{timeCell(s.startedAt)}
+								</span>
+							);
+						},
+					},
+				] satisfies Column<T>[])
+			: []),
 		{
 			key: 'approvedAt',
 			header: 'Approved',
@@ -275,6 +308,7 @@ export function ActorTable<T extends ActorRow>({
 			ariaLabel={`${kindLabel} list`}
 			renderCard={(row) => {
 				const u = usage?.get(row.id);
+				const mcp = mcpLastSeen?.get(row.id);
 				return (
 					<div className="space-y-2">
 						<div className="flex items-start justify-between gap-2">
@@ -300,6 +334,11 @@ export function ActorTable<T extends ActorRow>({
 							<span className="text-muted-foreground text-[11px]">
 								Registered {timeAgo(row.createdAt)}
 							</span>
+							{mcp && (
+								<span className="text-muted-foreground text-[11px]">
+									MCP: {mcpClientLabel(mcp)} · {timeAgo(mcp.startedAt)}
+								</span>
+							)}
 						</div>
 					</div>
 				);

--- a/ui/src/modules/agents/components/detail/McpPanel.tsx
+++ b/ui/src/modules/agents/components/detail/McpPanel.tsx
@@ -23,7 +23,14 @@
  * Un-hiding is a phase-3 follow-up; a test pins it hidden until then.
  */
 import { Plug, Terminal } from 'lucide-react';
-import { CopyButton, DataTable, DetailSection, LoadingState, type Column } from '@/shared/ui';
+import {
+	CodeSnippet,
+	DataTable,
+	DetailSection,
+	ErrorAlert,
+	LoadingState,
+	type Column,
+} from '@/shared/ui';
 import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
 import {
 	mcpClientLabel,
@@ -52,28 +59,25 @@ function shellArg(value: string): string {
 	return /^[A-Za-z0-9._-]+$/.test(value) ? value : `"${value.replace(/"/g, '\\"')}"`;
 }
 
+/**
+ * Host portion of a URL, or the raw string when it doesn't parse. The backend
+ * serves `host: ""` alongside a set-but-unparseable `canonical_base_url`
+ * (e.g. a scheme-less "jentic.example.com" — instance_identity.py), and
+ * `new URL(...)` throwing during render would take out the whole agent detail
+ * page via the error boundary. Degrading to the raw value is the honest
+ * fallback — it's still the address the operator configured.
+ */
+function safeHost(url: string): string {
+	try {
+		return new URL(url).host;
+	} catch {
+		return url;
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Config card
 // ---------------------------------------------------------------------------
-
-/** One copyable snippet block — same chrome as the DcrQuickstart snippet. */
-function SnippetBlock({ label, code }: { label: string; code: string }) {
-	return (
-		<div>
-			<p className="text-muted-foreground/70 mb-1 text-[10px] tracking-wider uppercase">
-				{label}
-			</p>
-			<div className="bg-muted/60 border-border/60 relative rounded-lg border p-3">
-				<pre className="text-foreground/90 overflow-x-auto pr-8 font-mono text-xs leading-relaxed">
-					{code}
-				</pre>
-				<div className="absolute top-2 right-2">
-					<CopyButton value={code} />
-				</div>
-			</div>
-		</div>
-	);
-}
 
 export function McpConfigCard({ agentName }: { agentName: string }) {
 	const identity = useInstanceIdentity();
@@ -82,14 +86,21 @@ export function McpConfigCard({ agentName }: { agentName: string }) {
 	// browser origin is the honest fallback when no canonical base URL is
 	// configured (or `GET /instance` failed).
 	const instanceUrl = identity.data?.baseUrl || window.location.origin;
-	const instanceHost = identity.data?.host || new URL(instanceUrl).host;
+	const instanceHost = identity.data?.host || safeHost(instanceUrl);
+	// On a remote install the broker lives on its own host and is never derived
+	// from the control-plane URL — without --broker-url the environment has no
+	// broker and `jentic execute` fail-closes (register.go). The UI can't know
+	// the broker URL, so the snippet carries an explicit placeholder.
+	const isRemote = identity.data?.backend === 'remote';
 
 	// §3.10 one-agent-per-runtime: the context name is whatever binding the
 	// operator created on the agent machine — the agent's name is the
 	// suggested (and `jentic setup`-default) convention, so pre-fill it.
 	const context = shellArg(agentName);
 	const command = `jentic mcp --context ${context}`;
-	const registerCommand = `jentic register --url ${shellArg(instanceUrl)}`;
+	const registerCommand = `jentic register --url ${shellArg(instanceUrl)}${
+		isRemote ? ' --broker-url <broker-url>' : ''
+	}`;
 	const jsonConfig = JSON.stringify(
 		{ mcpServers: { jentic: { command: 'jentic', args: ['mcp', '--context', agentName] } } },
 		null,
@@ -104,17 +115,28 @@ export function McpConfigCard({ agentName }: { agentName: string }) {
 				<code className="font-mono text-xs">{registerCommand}</code> on the{' '}
 				<strong>agent machine</strong> — or{' '}
 				<code className="font-mono text-xs">jentic setup</code> for the guided path.
+				{isRemote && (
+					<>
+						{' '}
+						On a remote install <code className="font-mono text-xs">
+							--broker-url
+						</code>{' '}
+						is required — without it{' '}
+						<code className="font-mono text-xs">jentic execute</code> fail-closes. Ask
+						your operator for the broker (data plane) URL.
+					</>
+				)}
 			</p>
 
 			<div className="space-y-3">
-				<SnippetBlock label="MCP server command (stdio)" code={command} />
-				<SnippetBlock
+				<CodeSnippet label="MCP server command (stdio)" code={command} />
+				<CodeSnippet
 					label=".cursor/mcp.json · claude_desktop_config.json"
 					code={jsonConfig}
 				/>
 				{/* Phase-3 follow-up: the streamable-HTTP variant renders here once
 				    `server.mcp.enabled` exists and is true. Test-pinned hidden. */}
-				{SHOW_HTTP_VARIANT && <SnippetBlock label="Streamable HTTP" code="" />}
+				{SHOW_HTTP_VARIANT && <CodeSnippet label="Streamable HTTP" code="" />}
 			</div>
 
 			<p className="text-muted-foreground text-xs">
@@ -217,6 +239,11 @@ export function McpSessionsCard({ agentId }: { agentId: string }) {
 		>
 			{sessions.isPending ? (
 				<LoadingState size="sm" message="Loading MCP sessions…" />
+			) : sessions.isError ? (
+				// A real failure (5xx / network) must not masquerade as "no
+				// sessions yet" — same error passthrough convention as
+				// ActorAuditPanel. 401/403 resolve to `null` below, not here.
+				<ErrorAlert message="Failed to load MCP sessions." className="m-5" />
 			) : sessions.data === null ? (
 				<p className="text-muted-foreground px-5 py-6 text-center text-sm">
 					MCP session history requires event-read permissions.

--- a/ui/src/modules/agents/components/detail/McpPanel.tsx
+++ b/ui/src/modules/agents/components/detail/McpPanel.tsx
@@ -1,0 +1,245 @@
+/**
+ * McpPanel — the agent detail console's MCP tab (local-MCP 2-E2, #1188).
+ *
+ * MCP is a TRANSPORT of this agent, not a separate entity (master plan §3.10),
+ * so the surface lives here inside the agent console rather than behind any
+ * new top-level nav. Two cards:
+ *
+ *   - McpConfigCard    → the exact copy-paste wiring for THIS agent
+ *     (`jentic mcp --context <name>`, pinned — a bare `jentic mcp` follows the
+ *     operator's active context and would silently re-point the runtime),
+ *     plus the prerequisites and the instance identity the snippet registers
+ *     against. The stdio config encodes no base URL: the target instance comes
+ *     from the context's environment on the AGENT machine, which is why the
+ *     prerequisites lead with `jentic register --url <this instance>`.
+ *   - McpSessionsCard  → session history from `mcp.session_started` internal
+ *     events plus "last active" from the newest MCP-origin execution. The
+ *     label vocabulary is "started / last active" — NEVER "connected":
+ *     stdio liveness is unknowable server-side and phase 3's `/mcp` is
+ *     stateless by design, so request-level recency is the honest signal.
+ *
+ * The HTTP variant is unconditionally hidden in phase 2: `server.mcp` config
+ * doesn't exist yet (phase 3 creates it and exposes `server.mcp.enabled`).
+ * Un-hiding is a phase-3 follow-up; a test pins it hidden until then.
+ */
+import { Plug, Terminal } from 'lucide-react';
+import { CopyButton, DataTable, DetailSection, LoadingState, type Column } from '@/shared/ui';
+import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
+import {
+	mcpClientLabel,
+	useInstanceIdentity,
+	useLatestMcpActivity,
+	useMcpSessions,
+	type McpSessionEntity,
+} from '@/modules/agents/api';
+import { MetaItem } from '@/modules/agents/components/detail/shared';
+
+/**
+ * Phase-2 pin: the streamable-HTTP variant stays hidden until phase 3 lands
+ * `server.mcp` and exposes `server.mcp.enabled` to the UI. Exported so the
+ * test suite can assert the pin still holds (flipping this without the
+ * backend capability would advertise a transport that 404s).
+ */
+export const SHOW_HTTP_VARIANT = false;
+
+interface McpPanelProps {
+	agentName: string;
+	agentId: string;
+}
+
+/** Quote a shell argument when it needs it (agent names may contain spaces). */
+function shellArg(value: string): string {
+	return /^[A-Za-z0-9._-]+$/.test(value) ? value : `"${value.replace(/"/g, '\\"')}"`;
+}
+
+// ---------------------------------------------------------------------------
+// Config card
+// ---------------------------------------------------------------------------
+
+/** One copyable snippet block — same chrome as the DcrQuickstart snippet. */
+function SnippetBlock({ label, code }: { label: string; code: string }) {
+	return (
+		<div>
+			<p className="text-muted-foreground/70 mb-1 text-[10px] tracking-wider uppercase">
+				{label}
+			</p>
+			<div className="bg-muted/60 border-border/60 relative rounded-lg border p-3">
+				<pre className="text-foreground/90 overflow-x-auto pr-8 font-mono text-xs leading-relaxed">
+					{code}
+				</pre>
+				<div className="absolute top-2 right-2">
+					<CopyButton value={code} />
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function McpConfigCard({ agentName }: { agentName: string }) {
+	const identity = useInstanceIdentity();
+
+	// The operator is looking at a working address of this instance, so the
+	// browser origin is the honest fallback when no canonical base URL is
+	// configured (or `GET /instance` failed).
+	const instanceUrl = identity.data?.baseUrl || window.location.origin;
+	const instanceHost = identity.data?.host || new URL(instanceUrl).host;
+
+	// §3.10 one-agent-per-runtime: the context name is whatever binding the
+	// operator created on the agent machine — the agent's name is the
+	// suggested (and `jentic setup`-default) convention, so pre-fill it.
+	const context = shellArg(agentName);
+	const command = `jentic mcp --context ${context}`;
+	const registerCommand = `jentic register --url ${shellArg(instanceUrl)}`;
+	const jsonConfig = JSON.stringify(
+		{ mcpServers: { jentic: { command: 'jentic', args: ['mcp', '--context', agentName] } } },
+		null,
+		2,
+	);
+
+	return (
+		<DetailSection title="Connect via MCP" icon={<Terminal className="h-4 w-4" />}>
+			<p className="text-muted-foreground text-sm">
+				Wire an MCP client to this instance as <strong>{agentName}</strong>. Prerequisites:{' '}
+				<code className="font-mono text-xs">jentic</code> CLI installed +{' '}
+				<code className="font-mono text-xs">{registerCommand}</code> on the{' '}
+				<strong>agent machine</strong> — or{' '}
+				<code className="font-mono text-xs">jentic setup</code> for the guided path.
+			</p>
+
+			<div className="space-y-3">
+				<SnippetBlock label="MCP server command (stdio)" code={command} />
+				<SnippetBlock
+					label=".cursor/mcp.json · claude_desktop_config.json"
+					code={jsonConfig}
+				/>
+				{/* Phase-3 follow-up: the streamable-HTTP variant renders here once
+				    `server.mcp.enabled` exists and is true. Test-pinned hidden. */}
+				{SHOW_HTTP_VARIANT && <SnippetBlock label="Streamable HTTP" code="" />}
+			</div>
+
+			<p className="text-muted-foreground text-xs">
+				<code className="font-mono">--context</code> is pinned on purpose: a bare{' '}
+				<code className="font-mono">jentic mcp</code> follows the machine's <em>active</em>{' '}
+				context, so a later context switch would silently re-point the runtime at a
+				different agent or instance. Use the context bound to this agent on the agent
+				machine (its name is the suggested convention).
+			</p>
+
+			<dl className="border-border/60 grid grid-cols-2 gap-x-4 gap-y-3 border-t pt-3 sm:grid-cols-3">
+				<MetaItem
+					label="Instance"
+					value={<span className="font-mono">{instanceHost}</span>}
+				/>
+				<MetaItem
+					label="Register URL"
+					value={<span className="font-mono">{instanceUrl}</span>}
+				/>
+				{identity.data?.backend && (
+					<MetaItem label="Backend" value={identity.data.backend} />
+				)}
+			</dl>
+		</DetailSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Sessions card
+// ---------------------------------------------------------------------------
+
+function timeCell(value: string) {
+	return (
+		<span className="text-muted-foreground text-xs" title={formatTimestamp(value)}>
+			{timeAgo(value)}
+		</span>
+	);
+}
+
+export function McpSessionsCard({ agentId }: { agentId: string }) {
+	const sessions = useMcpSessions(agentId);
+	const lastActivity = useLatestMcpActivity(agentId);
+
+	const columns: Column<McpSessionEntity>[] = [
+		{
+			key: 'client',
+			header: 'Client',
+			render: (row) => <span className="text-foreground text-sm">{mcpClientLabel(row)}</span>,
+		},
+		{
+			key: 'transport',
+			header: 'Transport',
+			className: 'w-28',
+			// Rendered verbatim (`stdio` today, `http` when phase 3 lands) so a
+			// future transport value degrades gracefully instead of breaking.
+			render: (row) => (
+				<span className="text-muted-foreground font-mono text-xs">
+					{row.transport ?? '—'}
+				</span>
+			),
+		},
+		{
+			key: 'sessionId',
+			header: 'Session',
+			className: 'max-w-[160px]',
+			render: (row) => (
+				<code className="text-muted-foreground block truncate font-mono text-xs">
+					{row.sessionId ?? '—'}
+				</code>
+			),
+		},
+		{
+			key: 'startedAt',
+			header: 'Started',
+			className: 'w-32 text-right',
+			render: (row) => timeCell(row.startedAt),
+		},
+	];
+
+	return (
+		<DetailSection
+			title="MCP sessions"
+			icon={<Plug className="h-4 w-4" />}
+			titleExtra={
+				<span className="text-muted-foreground text-xs">started / last active</span>
+			}
+			trailing={
+				// "Last active" = the newest MCP-origin execution — request-level
+				// recency, the only liveness signal the server honestly has.
+				lastActivity.data ? (
+					<span
+						className="text-muted-foreground text-xs"
+						title={formatTimestamp(lastActivity.data)}
+					>
+						Last active {timeAgo(lastActivity.data)}
+					</span>
+				) : undefined
+			}
+			bodyClassName="px-0 py-0"
+		>
+			{sessions.isPending ? (
+				<LoadingState size="sm" message="Loading MCP sessions…" />
+			) : sessions.data === null ? (
+				<p className="text-muted-foreground px-5 py-6 text-center text-sm">
+					MCP session history requires event-read permissions.
+				</p>
+			) : (
+				<DataTable<McpSessionEntity>
+					columns={columns}
+					data={sessions.data ?? []}
+					getRowKey={(row) => row.eventId}
+					ariaLabel="MCP sessions"
+					emptyMessage="No MCP sessions recorded for this agent yet. Sessions appear when an MCP client first talks to this instance as this agent."
+				/>
+			)}
+		</DetailSection>
+	);
+}
+
+/** The MCP tab panel: config card + session history. */
+export function McpPanel({ agentName, agentId }: McpPanelProps) {
+	return (
+		<div className="space-y-4">
+			<McpConfigCard agentName={agentName} />
+			<McpSessionsCard agentId={agentId} />
+		</div>
+	);
+}

--- a/ui/src/modules/agents/mocks/handlers.ts
+++ b/ui/src/modules/agents/mocks/handlers.ts
@@ -512,6 +512,7 @@ function executionRow(opts: {
 	httpStatus: number;
 	minutesAgo: number;
 	error?: string;
+	origin?: string;
 }) {
 	return {
 		_links: { self: `/executions/${opts.id}` },
@@ -524,7 +525,7 @@ function executionRow(opts: {
 		execution_id: opts.id,
 		http_status: opts.httpStatus,
 		operation_id: opts.operationId,
-		origin: 'api',
+		origin: opts.origin ?? 'api',
 		pinned_revisions: null,
 		started_at: now(-opts.minutesAgo),
 		status: opts.status,
@@ -551,6 +552,20 @@ const ACTOR_EXECUTIONS: Record<string, ReturnType<typeof executionRow>[]> = {
 			durationMs: 412,
 			httpStatus: 200,
 			minutesAgo: 2,
+		}),
+		// MCP-origin run — the newest one is the MCP sessions card's
+		// "last active" signal (local-MCP 2-E2).
+		executionRow({
+			id: 'exec_agnt_mcp_1',
+			actorId: 'agnt_active_1',
+			status: 'completed',
+			toolkitId: 'github',
+			toolkitName: 'github',
+			operationId: 'search_issues',
+			durationMs: 180,
+			httpStatus: 200,
+			minutesAgo: 5,
+			origin: 'mcp',
 		}),
 		executionRow({
 			id: 'exec_agnt_2',
@@ -685,6 +700,74 @@ const ACTOR_AUDIT: Record<string, ReturnType<typeof auditRow>[]> = {
 	],
 };
 
+/**
+ * `mcp.session_started` internal-event fixture (`GET /events?event_type=…`,
+ * local-MCP 2-E2). Shapes mirror the generated `EventResponse`; `data` carries
+ * what the emitter writes (session_id / transport / client_name /
+ * client_version — see shared/events/mcp_session.py). Newest first, like the
+ * real feed. Only agnt_active_1 has sessions; other agents render the honest
+ * empty state.
+ */
+const MCP_SESSION_STARTED = 'mcp.session_started';
+
+function mcpSessionEvent(opts: {
+	id: string;
+	actorId: string;
+	sessionId: string;
+	minutesAgo: number;
+	clientName?: string;
+	clientVersion?: string;
+}) {
+	return {
+		_links: { self: `/events/${opts.id}` },
+		acknowledged: false,
+		acknowledged_at: null,
+		acknowledged_by: null,
+		actor_id: opts.actorId,
+		actor_type: 'agent',
+		created_at: now(-opts.minutesAgo),
+		data: {
+			session_id: opts.sessionId,
+			transport: 'stdio',
+			client_name: opts.clientName ?? null,
+			client_version: opts.clientVersion ?? null,
+		},
+		detail: null,
+		event_id: opts.id,
+		requires_action: false,
+		severity: 'info',
+		summary: `MCP session started for ${opts.actorId}`,
+		trace_id: null,
+		type: MCP_SESSION_STARTED,
+	};
+}
+
+const MCP_SESSION_EVENTS = [
+	mcpSessionEvent({
+		id: 'evt_mcp_3',
+		actorId: 'agnt_active_1',
+		sessionId: 'sess-uuid-3',
+		minutesAgo: 30,
+		clientName: 'claude-desktop',
+		clientVersion: '1.5.2',
+	}),
+	// clientInfo is a SHOULD in the MCP spec — a client that sent only a name
+	// (no version) and one that sent nothing both render, not error.
+	mcpSessionEvent({
+		id: 'evt_mcp_2',
+		actorId: 'agnt_active_1',
+		sessionId: 'sess-uuid-2',
+		minutesAgo: 60 * 24,
+		clientName: 'cursor',
+	}),
+	mcpSessionEvent({
+		id: 'evt_mcp_1',
+		actorId: 'agnt_active_1',
+		sessionId: 'sess-uuid-1',
+		minutesAgo: 60 * 24 * 3,
+	}),
+];
+
 export const agentsHandlers = [
 	// ---- Platform permission catalogue (#615) ----
 	http.get('/permissions', () => HttpResponse.json({ data: PERMISSION_CATALOGUE })),
@@ -734,9 +817,26 @@ export const agentsHandlers = [
 		});
 	}),
 	http.get('/executions', ({ request }) => {
-		const actorId = new URL(request.url).searchParams.get('actor_id');
+		const url = new URL(request.url);
+		const actorId = url.searchParams.get('actor_id');
 		if (!actorId || !findActor(actorId)) return undefined;
-		const rows = ACTOR_EXECUTIONS[actorId] ?? [];
+		// Origin scoping (local-MCP 2-E2): the sessions card asks for the
+		// newest MCP-origin run (`?origin=mcp&limit=1`) as its "last active".
+		const origin = url.searchParams.get('origin');
+		const rows = (ACTOR_EXECUTIONS[actorId] ?? []).filter(
+			(r) => !origin || r.origin === origin,
+		);
+		return HttpResponse.json({ data: rows, has_more: false, next_cursor: null });
+	}),
+	// MCP session history (local-MCP 2-E2): answer ONLY the
+	// `event_type=mcp.session_started` reads this module's MCP surfaces make;
+	// any other /events query falls through to the rail/monitor fixtures.
+	http.get('/events', ({ request }) => {
+		const url = new URL(request.url);
+		const eventTypes = url.searchParams.getAll('event_type');
+		if (!eventTypes.includes(MCP_SESSION_STARTED)) return undefined;
+		const actorId = url.searchParams.get('actor_id');
+		const rows = MCP_SESSION_EVENTS.filter((e) => !actorId || e.actor_id === actorId);
 		return HttpResponse.json({ data: rows, has_more: false, next_cursor: null });
 	}),
 	// Actor-scoped audit slice ("Recent changes"): answer only for targets in

--- a/ui/src/modules/agents/pages/AgentDetailPage.tsx
+++ b/ui/src/modules/agents/pages/AgentDetailPage.tsx
@@ -6,13 +6,15 @@
  * agent's badge as icon, its name as title, its own description as subtitle,
  * with the kill switch for the reversible active/disabled flip plus the
  * constructive Approve / Deny actions in the header action slot), a back row,
- * a denial banner when rejected, the KPI strip, then five tab panels:
+ * a denial banner when rejected, the KPI strip, then six tab panels:
  *   - Overview  → attribution meta + bound toolkits + audit slice
  *   - Activity  → this agent's execution volume + recent executions
  *                 (GET /monitoring/usage?agent_id=…, GET /executions?actor_id=…)
  *                 with a pre-filtered "Open Monitor" deep-link
  *   - Access    → platform scopes (#615) + filed access requests (#619)
  *   - Keys      → API-key metadata, generate/regenerate/revoke, rotation history
+ *   - MCP       → per-agent MCP config card + session history (local-MCP 2-E2:
+ *                 MCP is a transport of this agent, so the surface lives here)
  *   - Settings  → the copyable agent id + editable metadata (PATCH
  *                 /agents/{id}) + danger zone hosting the terminal Archive
  *
@@ -27,6 +29,7 @@ import {
 	Fingerprint,
 	Key,
 	LayoutDashboard,
+	Plug,
 	Settings,
 	ShieldCheck,
 	ShieldX,
@@ -77,9 +80,10 @@ import { ActorAuditPanel } from '@/modules/agents/components/detail/ActorAuditPa
 import { AgentKeysPanel } from '@/modules/agents/components/detail/AgentKeysPanel';
 import { AgentSettingsPanel } from '@/modules/agents/components/detail/AgentSettingsPanel';
 import { BoundToolkitsCard } from '@/modules/agents/components/detail/BoundToolkitsCard';
+import { McpPanel } from '@/modules/agents/components/detail/McpPanel';
 import { ROUTES, ROUTE_PATHS } from '@/shared/app/routes';
 
-const DETAIL_TABS = ['overview', 'activity', 'access', 'keys', 'settings'] as const;
+const DETAIL_TABS = ['overview', 'activity', 'access', 'keys', 'mcp', 'settings'] as const;
 type DetailTab = (typeof DETAIL_TABS)[number];
 
 /** Tab options for the console shell — same icon grammar as the toolkit console. */
@@ -88,6 +92,9 @@ const TAB_OPTIONS: TabNavOption<DetailTab>[] = [
 	{ value: 'activity', label: 'Activity', icon: <ActivityIcon className="h-4 w-4" /> },
 	{ value: 'access', label: 'Access', icon: <ShieldCheck className="h-4 w-4" /> },
 	{ value: 'keys', label: 'Keys', icon: <Key className="h-4 w-4" /> },
+	// MCP is a transport of this agent (local-MCP §3.10), so its config card
+	// and session history live here in the console — no top-level nav.
+	{ value: 'mcp', label: 'MCP', icon: <Plug className="h-4 w-4" /> },
 	{ value: 'settings', label: 'Settings', icon: <Settings className="h-4 w-4" /> },
 ];
 
@@ -403,6 +410,8 @@ export default function AgentDetailPage() {
 				)}
 
 				{activeTab === 'keys' && <AgentKeysPanel agent={agent} />}
+
+				{activeTab === 'mcp' && <McpPanel agentName={agent.name} agentId={agent.id} />}
 
 				{activeTab === 'settings' && (
 					<AgentSettingsPanel

--- a/ui/src/modules/agents/pages/AgentsPage.tsx
+++ b/ui/src/modules/agents/pages/AgentsPage.tsx
@@ -40,10 +40,12 @@ import {
 	useEnableServiceAccount,
 	useArchiveServiceAccount,
 	useActorsUsage,
+	useMcpLastSeen,
 	ACTOR_STATUSES,
 	STATUS_LABELS,
 	type ActorStatus,
 	type AgentAction,
+	type McpLastSeen,
 } from '@/modules/agents/api';
 import { ActorTable, type ActorRow } from '@/modules/agents/components/ActorTable';
 import { ApprovalQueue } from '@/modules/agents/components/ApprovalQueue';
@@ -195,6 +197,12 @@ interface ActorsSectionProps<T extends ActorRow> {
 	emptyAction?: React.ReactNode;
 	/** Extra first-run content below the empty state (e.g. DCR quickstart). */
 	emptyExtra?: React.ReactNode;
+	/**
+	 * "Last seen via MCP" enrichment (agents tab only — MCP is an agent
+	 * transport; service accounts never appear in the session events).
+	 * Omitted/`null` renders the roster without the column.
+	 */
+	mcpLastSeen?: Map<string, McpLastSeen> | null;
 	detailHref: (item: T) => string;
 }
 
@@ -211,6 +219,7 @@ function ActorsSection<T extends ActorRow>({
 	emptyBody,
 	emptyAction,
 	emptyExtra,
+	mcpLastSeen,
 	detailHref,
 }: ActorsSectionProps<T>) {
 	const [confirm, setConfirm] = useState<PendingConfirm>(null);
@@ -331,6 +340,7 @@ function ActorsSection<T extends ActorRow>({
 					emptyMessage={`No ${nounPlural} match your filter.`}
 					pendingId={pendingId}
 					usage={usage.data}
+					mcpLastSeen={mcpLastSeen}
 					onAction={handleAction}
 					detailHref={detailHref}
 				/>
@@ -376,6 +386,9 @@ function AgentsSection({
 		() => query.data?.pages.flatMap((p) => p.entities) ?? [],
 		[query.data],
 	);
+	// "Last seen via MCP" enrichment (local-MCP 2-E2): one events-page read for
+	// the fleet, `null` for viewers without `events:read` (column hidden).
+	const mcpLastSeen = useMcpLastSeen();
 
 	const mutations: LifecycleMutations = {
 		approve: useApproveAgent(),
@@ -405,6 +418,7 @@ function AgentsSection({
 					</Button>
 				}
 				emptyExtra={<DcrQuickstart />}
+				mcpLastSeen={mcpLastSeen.data}
 				detailHref={(a) => ROUTE_PATHS.agent(a.id)}
 			/>
 			<AgentCreateSheet open={createOpen} onClose={() => setCreateOpen(false)} />

--- a/ui/src/modules/monitor/__tests__/MonitorPage.test.tsx
+++ b/ui/src/modules/monitor/__tests__/MonitorPage.test.tsx
@@ -114,6 +114,49 @@ describe('MonitorPage', () => {
 		expect(screen.getByText('POST /v1/charges')).toBeInTheDocument();
 	});
 
+	// --- local-MCP 2-E2 (#1188): origin filter on the executions lens -------
+
+	it('filters Executions by origin from the filter bar', async () => {
+		const user = userEvent.setup();
+		renderMonitor();
+		await screen.findByText('POST /v1/charges');
+
+		// The picker offers the closed origin set; selecting MCP narrows the
+		// log to the MCP-origin refund row and writes the deep-linkable param.
+		const originSelect = screen.getByRole('combobox', { name: 'Filter by origin' });
+		await user.selectOptions(originSelect, screen.getByRole('option', { name: 'MCP' }));
+
+		expect(await screen.findByText('POST /v1/refunds')).toBeInTheDocument();
+		await waitFor(() => {
+			expect(screen.queryByText('POST /v1/charges')).not.toBeInTheDocument();
+		});
+		expect(screen.getByTestId('location-search').textContent).toContain('origin=mcp');
+
+		// Back to "All origins": the full log returns, the param leaves the URL.
+		await user.selectOptions(originSelect, screen.getByRole('option', { name: 'All origins' }));
+		expect(await screen.findByText('POST /v1/charges')).toBeInTheDocument();
+		expect(screen.getByTestId('location-search').textContent).not.toContain('origin');
+	});
+
+	it('honours an ?origin deep-link and drops it on a lens switch (executions-only scope)', async () => {
+		const user = userEvent.setup();
+		renderMonitor('/app/monitor?tab=executions&origin=mcp');
+
+		// Pre-filtered on arrival — the deep-link contract.
+		expect(await screen.findByText('POST /v1/refunds')).toBeInTheDocument();
+		expect(screen.queryByText('POST /v1/charges')).not.toBeInTheDocument();
+
+		// No other lens supports origin, so a lens switch clears it (same rule
+		// as toolkit_id) — and the picker only renders on Executions.
+		await user.click(screen.getByRole('tab', { name: 'Events' }));
+		await waitFor(() => {
+			expect(screen.getByTestId('location-search').textContent).not.toContain('origin');
+		});
+		expect(
+			screen.queryByRole('combobox', { name: 'Filter by origin' }),
+		).not.toBeInTheDocument();
+	});
+
 	it('goes live on the Events tab without crashing on heartbeat frames', async () => {
 		const user = userEvent.setup();
 		renderMonitor();

--- a/ui/src/modules/monitor/api/client.ts
+++ b/ui/src/modules/monitor/api/client.ts
@@ -77,6 +77,8 @@ export interface ListExecutionsParams {
 	traceId?: string | null;
 	toolkitId?: string | null;
 	actorId?: string | null;
+	/** Origin surface filter (backend `Origin` wire value, e.g. `mcp`). */
+	origin?: string | null;
 	status?: string[] | null;
 	from?: string | null;
 	to?: string | null;
@@ -92,6 +94,7 @@ export async function listExecutions(
 			traceId: params.traceId ?? null,
 			toolkitId: params.toolkitId ?? null,
 			actorId: params.actorId ?? null,
+			origin: params.origin ?? null,
 			status: params.status ?? null,
 			from: params.from ?? null,
 			to: params.to ?? null,

--- a/ui/src/modules/monitor/components/ExecutionsTab.tsx
+++ b/ui/src/modules/monitor/components/ExecutionsTab.tsx
@@ -94,6 +94,7 @@ export function ExecutionsTab() {
 		from: filters.from,
 		actorId: filters.actorId,
 		toolkitId: filters.toolkitId,
+		origin: filters.origin,
 	});
 	const pager = useCursorStack(filterKey);
 	const query = useExecutions({
@@ -101,6 +102,7 @@ export function ExecutionsTab() {
 		from: filters.from,
 		actorId: filters.actorId,
 		toolkitId: filters.toolkitId,
+		origin: filters.origin,
 		cursor: pager.cursor,
 	});
 	const rows = query.data?.data ?? [];

--- a/ui/src/modules/monitor/components/MonitorFilterBar.tsx
+++ b/ui/src/modules/monitor/components/MonitorFilterBar.tsx
@@ -18,6 +18,7 @@ import { SegmentedToggle } from '@/shared/ui';
 import { useActors, type MonitorTab } from '@/modules/monitor/api';
 import {
 	useMonitorFilters,
+	ORIGIN_OPTIONS,
 	WINDOW_OPTIONS,
 	type WindowValue,
 } from '@/modules/monitor/lib/useMonitorFilters';
@@ -83,6 +84,28 @@ export function MonitorFilterBar({ tab }: MonitorFilterBarProps) {
 					))}
 				</Select>
 			</div>
+
+			{/* Origin scope — executions-only (local-MCP 2-E2): the executions
+			    endpoint is the one list with an `origin` query param. A picker
+			    (not a chip): origins are a small closed set worth browsing —
+			    "show me everything that arrived over MCP" is the headline ask. */}
+			{tab === 'executions' && (
+				<div className="flex items-center gap-2">
+					<span className="text-muted-foreground text-xs font-medium">Origin</span>
+					<Select
+						aria-label="Filter by origin"
+						value={filters.origin ?? ''}
+						onChange={(e) => filters.setOrigin(e.target.value || null)}
+					>
+						<option value="">All origins</option>
+						{ORIGIN_OPTIONS.map((o) => (
+							<option key={o.value} value={o.value}>
+								{o.label}
+							</option>
+						))}
+					</Select>
+				</div>
+			)}
 
 			{/* Toolkit scope — an executions-only deep-link filter (written by the
 			    toolkit detail's "Open in Monitor" link). Rendered as a removable

--- a/ui/src/modules/monitor/lib/useMonitorFilters.ts
+++ b/ui/src/modules/monitor/lib/useMonitorFilters.ts
@@ -14,6 +14,11 @@
  *               deep-link param (the toolkit detail's "Open in Monitor" link
  *               writes it) and is dropped on lens switches, unlike the global
  *               filters above.
+ *   origin      request origin surface (cli | dashboard | api | agent |
+ *               system | mcp — the backend `Origin` enum; absent = all).
+ *               Executions-only like toolkit_id (the executions endpoint is
+ *               the one list with an `origin` query param), so it's likewise
+ *               dropped on lens switches.
  *
  * `from` is derived from `days` as an ISO timestamp `days` before now; "All"
  * omits it. Tabs fold `{ from, actorId, actorType }` into their list params.
@@ -34,6 +39,21 @@ function isWindowValue(value: string | null): value is WindowValue {
 	return value === '1' || value === '7' || value === '30' || value === 'all';
 }
 
+/**
+ * The backend `Origin` enum's wire values (shared/models/actors.py) — how a
+ * request reached the platform. `mcp` landed with the local-MCP telemetry
+ * work (#1178); an unknown value in the URL is preserved and sent as-is (the
+ * backend validates), but the picker only offers the known set.
+ */
+export const ORIGIN_OPTIONS: { value: string; label: string }[] = [
+	{ value: 'cli', label: 'CLI' },
+	{ value: 'dashboard', label: 'Dashboard' },
+	{ value: 'api', label: 'API' },
+	{ value: 'agent', label: 'Agent' },
+	{ value: 'system', label: 'System' },
+	{ value: 'mcp', label: 'MCP' },
+];
+
 export interface MonitorFilters {
 	/** Raw window selection (defaults to "All"). */
 	window: WindowValue;
@@ -45,9 +65,12 @@ export interface MonitorFilters {
 	actorType: string | null;
 	/** Toolkit scope for the executions lens (deep-linked from toolkit detail). */
 	toolkitId: string | null;
+	/** Origin scope for the executions lens (null = all origins). */
+	origin: string | null;
 	setWindow: (value: WindowValue) => void;
 	setActor: (actorId: string | null, actorType: string | null) => void;
 	setToolkit: (toolkitId: string | null) => void;
+	setOrigin: (origin: string | null) => void;
 }
 
 export function useMonitorFilters(): MonitorFilters {
@@ -58,6 +81,7 @@ export function useMonitorFilters(): MonitorFilters {
 	const actorId = searchParams.get('actor_id');
 	const actorType = searchParams.get('actor_type');
 	const toolkitId = searchParams.get('toolkit_id');
+	const origin = searchParams.get('origin');
 
 	const { from, days } = useMemo(() => {
 		if (windowValue === 'all') return { from: null, days: null };
@@ -113,6 +137,21 @@ export function useMonitorFilters(): MonitorFilters {
 		[setSearchParams],
 	);
 
+	const setOrigin = useCallback(
+		(nextOrigin: string | null) => {
+			setSearchParams(
+				(prev) => {
+					const next = new URLSearchParams(prev);
+					if (nextOrigin) next.set('origin', nextOrigin);
+					else next.delete('origin');
+					return next;
+				},
+				{ replace: true },
+			);
+		},
+		[setSearchParams],
+	);
+
 	return {
 		window: windowValue,
 		from,
@@ -120,8 +159,10 @@ export function useMonitorFilters(): MonitorFilters {
 		actorId,
 		actorType,
 		toolkitId,
+		origin,
 		setWindow,
 		setActor,
 		setToolkit,
+		setOrigin,
 	};
 }

--- a/ui/src/modules/monitor/mocks/handlers.ts
+++ b/ui/src/modules/monitor/mocks/handlers.ts
@@ -70,6 +70,7 @@ const EXECUTIONS = rebaseFixture([
 		execution_id: 'exec_1',
 		http_status: 200,
 		operation_id: 'POST /v1/charges',
+		origin: 'api',
 		pinned_revisions: null,
 		started_at: '2026-06-19T10:00:00Z',
 		status: 'completed',
@@ -87,6 +88,7 @@ const EXECUTIONS = rebaseFixture([
 		execution_id: 'exec_2',
 		http_status: 503,
 		operation_id: 'GET /repos/{owner}/{repo}',
+		origin: 'cli',
 		pinned_revisions: null,
 		started_at: '2026-06-19T10:05:00Z',
 		status: 'failed',
@@ -104,6 +106,8 @@ const EXECUTIONS = rebaseFixture([
 		execution_id: 'exec_3',
 		http_status: 200,
 		operation_id: 'POST /v1/refunds',
+		// MCP-origin run (local-MCP #1178) — the origin-filter specs pivot on it.
+		origin: 'mcp',
 		pinned_revisions: null,
 		started_at: '2026-06-19T10:06:00Z',
 		status: 'completed',
@@ -462,6 +466,7 @@ export const monitorHandlers = [
 		const traceId = url.searchParams.get('trace_id');
 		const actorId = url.searchParams.get('actor_id');
 		const toolkitId = url.searchParams.get('toolkit_id');
+		const origin = url.searchParams.get('origin');
 		const from = url.searchParams.get('from');
 		const statuses = url.searchParams.getAll('status');
 		const cursor = url.searchParams.get('cursor');
@@ -472,6 +477,7 @@ export const monitorHandlers = [
 		if (traceId) rows = rows.filter((r) => r.trace_id === traceId);
 		if (actorId) rows = rows.filter((r) => r.actor_id === actorId);
 		if (toolkitId) rows = rows.filter((r) => r.toolkit_id === toolkitId);
+		if (origin) rows = rows.filter((r) => (r as { origin?: string }).origin === origin);
 		if (from) rows = rows.filter((r) => r.started_at >= from);
 		if (statuses.length) rows = rows.filter((r) => statuses.includes(r.status));
 		return HttpResponse.json(paginateCursor(rows, cursor, limit));

--- a/ui/src/modules/monitor/pages/MonitorPage.tsx
+++ b/ui/src/modules/monitor/pages/MonitorPage.tsx
@@ -84,6 +84,8 @@ export default function MonitorPage() {
 					// Executions-only scope (deep-linked from toolkit detail);
 					// no other lens supports it, so it doesn't survive a switch.
 					'toolkit_id',
+					// Executions-only origin scope (local-MCP 2-E2) — same rule.
+					'origin',
 				]) {
 					next.delete(k);
 				}

--- a/ui/src/shared/api/index.ts
+++ b/ui/src/shared/api/index.ts
@@ -265,6 +265,13 @@ export type { OAuthClientResponse } from '@/shared/api/generated/models/OAuthCli
 export type { OAuthClientRotateSecretResponse } from '@/shared/api/generated/models/OAuthClientRotateSecretResponse';
 export type { OAuthClientUpdateRequest } from '@/shared/api/generated/models/OAuthClientUpdateRequest';
 
+// Instance identity (local-MCP 2-E2, #1188). `GET /instance` self-describes
+// the backend (canonical base URL / host / locality) so the per-agent MCP
+// config card can show which instance a pasted snippet will talk to.
+// `SystemService` is already exported above; only the response model is added
+// here. Append-only.
+export type { InstanceIdentityResponse } from '@/shared/api/generated/models/InstanceIdentityResponse';
+
 // External-IdP (SSO) login. The public capability descriptor (`GET /auth/idp`)
 // tells the login page whether to show a "Continue with <provider>" button, and
 // the authorization-code + PKCE exchange (`POST /oauth/token`) yields the same

--- a/ui/src/shared/ui/CodeSnippet.tsx
+++ b/ui/src/shared/ui/CodeSnippet.tsx
@@ -1,0 +1,36 @@
+import { CopyButton } from '@/shared/ui/CopyButton';
+import { cn } from '@/shared/lib/utils';
+
+export interface CodeSnippetProps {
+	/** The copy-paste payload — rendered verbatim and fed to the copy button. */
+	code: string;
+	/** Optional tiny uppercase caption above the block (eyebrow style). */
+	label?: string;
+	className?: string;
+}
+
+/**
+ * One copyable code block: a bordered mono `<pre>` with a corner CopyButton
+ * and an optional eyebrow label. The shared chrome for CLI snippets and
+ * client-config JSON (the MCP config card; DcrQuickstart renders the same
+ * chrome and migrates here as a follow-up).
+ */
+export function CodeSnippet({ code, label, className }: CodeSnippetProps) {
+	return (
+		<div className={cn(className)}>
+			{label && (
+				<p className="text-muted-foreground/70 mb-1 text-[10px] tracking-wider uppercase">
+					{label}
+				</p>
+			)}
+			<div className="bg-muted/60 border-border/60 relative rounded-lg border p-3">
+				<pre className="text-foreground/90 overflow-x-auto pr-8 font-mono text-xs leading-relaxed">
+					{code}
+				</pre>
+				<div className="absolute top-2 right-2">
+					<CopyButton value={code} />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/ui/src/shared/ui/__tests__/CodeSnippet.test.tsx
+++ b/ui/src/shared/ui/__tests__/CodeSnippet.test.tsx
@@ -1,0 +1,51 @@
+import { renderWithProviders, screen, userEvent, waitFor, checkA11y } from '@/__tests__/test-utils';
+import { CodeSnippet } from '@/shared/ui/CodeSnippet';
+import { Toaster } from '@/shared/ui/Toaster';
+
+describe('CodeSnippet', () => {
+	it('renders the code verbatim in a pre block', () => {
+		renderWithProviders(<CodeSnippet code="jentic mcp --context my-agent" />);
+		const pre = screen.getByText('jentic mcp --context my-agent');
+		expect(pre.tagName).toBe('PRE');
+	});
+
+	it('renders the optional eyebrow label above the block', () => {
+		renderWithProviders(<CodeSnippet label="MCP server command (stdio)" code="jentic mcp" />);
+		expect(screen.getByText('MCP server command (stdio)')).toBeInTheDocument();
+	});
+
+	it('renders no label element when the label is omitted', () => {
+		const { container } = renderWithProviders(<CodeSnippet code="jentic mcp" />);
+		expect(container.querySelector('p')).toBeNull();
+	});
+
+	it('copies the code via the corner copy button', async () => {
+		const user = userEvent.setup();
+		renderWithProviders(
+			<>
+				<CodeSnippet code="copy-me" />
+				<Toaster />
+			</>,
+		);
+		await user.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
+		// The success toast firing proves the real clipboard write resolved
+		// (same assertion strategy as CopyButton.test.tsx — the clipboard
+		// global can't be reliably spied on in browser mode).
+		await waitFor(() => {
+			expect(screen.getByText('Copied to clipboard')).toBeInTheDocument();
+		});
+	});
+
+	it('preserves multi-line code (JSON config blocks)', () => {
+		const json = '{\n  "mcpServers": {}\n}';
+		renderWithProviders(<CodeSnippet code={json} />);
+		expect(screen.getByText(/"mcpServers": \{\}/)).toBeInTheDocument();
+	});
+
+	it('has no critical a11y violations', async () => {
+		const { container } = renderWithProviders(
+			<CodeSnippet label="Command" code="jentic register --url https://example.test" />,
+		);
+		await checkA11y(container);
+	});
+});

--- a/ui/src/shared/ui/index.ts
+++ b/ui/src/shared/ui/index.ts
@@ -103,6 +103,9 @@ export type { ToastEntry, ToastInput, ToastVariant } from '@/shared/ui/toastStor
 
 export { CopyButton } from '@/shared/ui/CopyButton';
 
+export { CodeSnippet } from '@/shared/ui/CodeSnippet';
+export type { CodeSnippetProps } from '@/shared/ui/CodeSnippet';
+
 export { BackButton } from '@/shared/ui/BackButton';
 
 export { RefreshButton } from '@/shared/ui/RefreshButton';


### PR DESCRIPTION
## Summary

Local-MCP 2-E2: give operators the per-agent MCP wiring and visibility story in the UI. MCP is a transport of an existing agent (master plan §3.10) — nothing new in the data model and no new backend endpoint — so everything here reads existing surfaces: the `mcp.session_started` internal events (`GET /events`), MCP-origin execution records (`GET /executions?origin=mcp`), and the instance identity (`GET /instance`). Plan: `jentic-one-plans/themes/local-mcp/phase-2.md` §2-E2.

## Changes

- **ui / agent console**: new MCP tab on the agent detail page hosting:
  - the config card — copy-paste `jentic mcp --context <name>` snippet (pinned `--context`, §3.10 one-agent-per-runtime) + client-config JSON, prerequisites ("`jentic` CLI installed + `jentic register --url <this instance>` on the **agent machine** — or `jentic setup`"), and the instance identity from `GET /instance` (browser-origin fallback when no canonical base URL is configured). The HTTP variant is **unconditionally hidden** in phase 2 and test-pinned (`SHOW_HTTP_VARIANT`) until phase 3 lands `server.mcp.enabled`.
  - the sessions card — client/version/transport/started from the `mcp.session_started` events, "last active" from the newest MCP-origin execution. Vocabulary is "started / last active", never "connected" (stdio liveness is unknowable server-side; a test pins the word out).
- **ui / agents roster**: "Last seen via MCP (<client> <version>)" column from one events-page read for the whole fleet; hidden entirely for viewers without `events:read` (same degrade contract as the usage columns).
- **ui / monitor**: origin picker in the executions filter bar (`?origin=` deep-linkable, dropped on lens switches like `toolkit_id`); origin per row already rendered. `origin` threaded through the monitor repository into `ExecutionsService.listExecutions`.
- Out of scope: the HTTP transport variant (phase 3 — `server.mcp` config doesn't exist yet) and any dedicated origin column in the execution table (origin already renders under the toolkit cell).

## Risk & rollback

- Low risk: additive UI-only change; event reads degrade to `null` on 401/403 and the surfaces hide rather than error. Revert the squash commit.

## Test plan

- `cd ui && npm run lint && npm run build && npm run test:run` — all green (126 files / 1150 tests).
- New component tests: config-card snippet + prerequisites + instance identity + browser-origin fallback, hidden-HTTP pin, sessions list rendering (incl. version-less / clientInfo-less degrade) + "never connected" pin, empty + 403 states, roster MCP column (present / 403-hidden / absent on service accounts), monitor origin filter (narrowing, URL param, deep-link, lens-switch drop).

Stacked on #1178; retarget to main after it merges. Closes #1188.

Made with [Cursor](https://cursor.com)


---

> Supersedes #1190, which GitHub auto-closed when its stacked base branch (`feat/mcp-telemetry-origin`, merged as #1178) was deleted before retargeting. Same branch, rebased onto `main`; carries the adversarial-review fixes (see https://github.com/jentic/jentic-one/pull/1190#issuecomment-5476813542).
