### PR TITLE
fix(db): linearize admin migration heads after parallel merges

### DIFF
--- a/src/jentic_one/migrations/admin/versions/f2a3b4c5d6e7_add_mcp_session_started_dedup_index.py
+++ b/src/jentic_one/migrations/admin/versions/f2a3b4c5d6e7_add_mcp_session_started_dedup_index.py
@@ -13,7 +13,7 @@ No data cleanup is needed: ``mcp.session_started`` ships in the same release
 as this index, so upgraded deployments cannot hold rows of this type yet.
 
 Revision ID: f2a3b4c5d6e7
-Revises: e1f2a3b4c5d6
+Revises: aa6b7c8d9e0f
 Create Date: 2026-08-31
 
 """
@@ -24,7 +24,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "f2a3b4c5d6e7"
-down_revision: str | None = "e1f2a3b4c5d6"
+down_revision: str | None = "aa6b7c8d9e0f"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Summary
- `main` is red: [#1151](https://github.com/jentic/jentic-one/pull/1151) (`aa6b7c8d9e0f`, `oauth_clients`) and [#1178](https://github.com/jentic/jentic-one/pull/1178) (`f2a3b4c5d6e7`, mcp session dedupe index) both revised `e1f2a3b4c5d6`, so the admin tree has two alembic heads and every `upgrade head` fails with `MultipleHeads` (UI e2e + install smoke jobs on main and all open PRs).
- Reparents `f2a3b4c5d6e7` onto `aa6b7c8d9e0f`. The two migrations touch unrelated tables (`oauth_clients` vs an index on `events`), so the forced order is inert; no deployed environment can hold `f2a3b4c5d6e7` without `aa6b7c8d9e0f` since both ship in the same unreleased window.

## Test plan
- [x] `ScriptDirectory.get_heads()` returns exactly one head per migration tree (admin/registry/control)
- [ ] CI: UI e2e (real backend) + E2E install & smoke green on this branch

Made with [Cursor](https://cursor.com)