### PR TITLE
feat(cli): add search_catalog + import_api + request_access MCP tools

### DIFF
--- a/cli/internal/cli/api/access_run.go
+++ b/cli/internal/cli/api/access_run.go
@@ -488,8 +488,15 @@ func (a *app) pollAccessRequest(ctx context.Context, client *control.ClientWithR
 // URL so the value the CLI prints (or emits as JSON) is directly openable, rather
 // than a path fragment the operator has to guess a host for (impl/5.0 §6b,
 // jentic-one#777). An already-absolute URL and an empty value are left untouched.
+// A scheme-relative value ("//evil.example/x") is refused outright: resolving it
+// would graft the base URL's scheme onto a FOREIGN host — a link-hijack shape no
+// legitimate backend emits — so it is cleared rather than absolutized.
 func absolutizeApproveURL(baseURL string, r *control.AccessRequestResponse) {
 	if r == nil || r.ApproveUrl == "" {
+		return
+	}
+	if strings.HasPrefix(r.ApproveUrl, "//") {
+		r.ApproveUrl = ""
 		return
 	}
 	if u, err := url.Parse(r.ApproveUrl); err == nil && u.IsAbs() {

--- a/cli/internal/cli/api/mcp_access.go
+++ b/cli/internal/cli/api/mcp_access.go
@@ -1,0 +1,773 @@
+package api
+
+// mcp_access.go holds the 2-E1 access-loop tools (lane A's tail): the catalog
+// pair (search_catalog / import_api) and request_access. They ride the exact
+// client seams the cobra commands use — the catalogClient wrapper for
+// GET /catalog and POST /catalog/{api_id:path}:import (rawPathEditor and all),
+// and the generated control client's FileAccessRequest/GetAccessRequest for
+// POST /access-requests — so the envelopes stay byte-consistent with
+// `jentic catalog … --json` / `jentic access … --json`, with schema_version
+// and the sibling instance stamp joined like every other tool result.
+//
+// request_access NEVER approves: it files intent and polls the decision; the
+// approve_url in every result is for the HUMAN operator's dashboard (master
+// §3.2 — "files the plan, returns approve_url; never self-approves").
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jentic/jentic-one/cli/client/auth"
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// defaultImportWaitBudget bounds how long import_api tracks the import job
+// before handing the still-running job back to the model. It sits well inside
+// the 30s mcpCallTimeout so the terminal legs (result fetch + promotes) keep
+// headroom; a slower import converges on the next import_api call (the
+// idempotentHint contract — re-import of the same api_id converges).
+const defaultImportWaitBudget = 20 * time.Second
+
+// defaultAccessPollBudget is request_access's short post-file poll: long
+// enough to catch a server-side auto-decision (a bare toolkit:bind for an
+// unserved API auto-denies), far too short to sit out a human approval —
+// that wait belongs to the model's own request_id polling, never inside one
+// tool call (client-side tool timeouts, §3.4).
+const defaultAccessPollBudget = 8 * time.Second
+
+// searchCatalogParams mirrors the `jentic catalog search` surface: keyword
+// query plus the pagination knobs.
+var searchCatalogParams = []paramSpec{
+	{name: "query", aliases: []string{"q"}, kind: paramString},
+	{name: "limit", kind: paramInt},
+	// Same next_cursor fold as search_apis: a model copying the response key
+	// back as the argument name must not silently re-serve page 1.
+	{name: "cursor", aliases: []string{"next_cursor"}, kind: paramString},
+}
+
+// importAPIParams: the catalog entry identity. `id` is a safe alias here —
+// this tool has no operation_id for it to collide with.
+var importAPIParams = []paramSpec{
+	{name: "api_id", aliases: []string{"id", "api"}, kind: paramString},
+}
+
+// requestAccessParams mirrors `jentic access request`'s flag surface (the
+// compose() plan builder is reused verbatim) plus the request_id poll arm.
+// rules_json is paramJSON, not paramStringList: a JSON rules array carries
+// commas, and the string-list coercion would comma-split a bare string value.
+var requestAccessParams = []paramSpec{
+	{name: "request_id", aliases: []string{"id"}, kind: paramString},
+	{name: "provision", aliases: []string{"provisions"}, kind: paramStringList},
+	{name: "toolkits", aliases: []string{"toolkit"}, kind: paramStringList},
+	{name: "toolkit_ids", aliases: []string{"toolkit_id"}, kind: paramStringList},
+	{name: "scopes", aliases: []string{"scope"}, kind: paramStringList},
+	{name: "auth", aliases: []string{"auths"}, kind: paramStringList},
+	{name: "rules_json", aliases: []string{"rules"}, kind: paramJSON},
+	{name: "reason", kind: paramString},
+}
+
+// ── search_catalog ────────────────────────────────────────────────────────────
+
+func (s *mcpServer) handleSearchCatalog(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	s.noteClient(req.ClientInfo())
+	cctx, cancel := s.callContext(ctx)
+	defer cancel()
+
+	args, err := normalizeToolArgs(req.Params.Arguments, searchCatalogParams)
+	if err != nil {
+		return nil, invalidParams(err)
+	}
+	limit, _ := args["limit"].(int)
+	if limit != 0 && (limit < 1 || limit > 200) {
+		// The docstring promises 1-200 (the server's own page bound); an
+		// out-of-range value is a correctable protocol error, not a soft
+		// INTERNAL_ERROR round-tripped from the backend's 422.
+		return nil, invalidParams(fmt.Errorf("limit must be between 1 and 200, got %d", limit))
+	}
+
+	client, err := s.app.catalogSession(cctx)
+	if err != nil {
+		s.logger.Warn("search_catalog failed", "error", redactedErr(err))
+		return s.softError(cctx, err), nil
+	}
+	query, _ := args["query"].(string)
+	cursor, _ := args["cursor"].(string)
+	page, err := client.List(cctx, catalogListParams{Q: query, Cursor: cursor, Limit: limit})
+	if err != nil {
+		s.logger.Warn("search_catalog failed", "error", redactedErr(err))
+		// The same missing-route mapping catalogListErr makes: no catalog on
+		// this deployment is a deployment fact, not a malformed call.
+		var he *HTTPError
+		if errors.As(err, &he) && (he.StatusCode == http.StatusNotFound || he.StatusCode == http.StatusNotImplemented) {
+			return s.softError(cctx, &ux.CodedError{
+				Code: ux.CodeInternalError,
+				Msg:  fmt.Sprintf("catalog not available on this server (HTTP %d)", he.StatusCode),
+			}), nil
+		}
+		return s.softError(cctx, classifyTransportErr(err)), nil
+	}
+
+	// Envelope: the same entries + counters `jentic catalog search --json`
+	// emits, with the shared pagination invariant applied — has_more is
+	// DERIVED from cursor presence and an empty next_cursor is omitted, so
+	// the page-1-loop trap is unrepresentable here too.
+	nextCursor := ""
+	if page.HasMore {
+		nextCursor = page.NextCursor
+	}
+	payload := map[string]any{
+		"schema_version":       mcpSchemaVersion,
+		"data":                 page.Data,
+		"catalog_total":        page.CatalogTotal,
+		"registered_count":     page.RegisteredCount,
+		"outdated_count":       page.OutdatedCount,
+		"manifest_age_seconds": page.ManifestAgeSeconds,
+		"has_more":             nextCursor != "",
+	}
+	if nextCursor != "" {
+		payload["next_cursor"] = nextCursor
+	}
+	return s.result(cctx, payload), nil
+}
+
+// ── import_api ────────────────────────────────────────────────────────────────
+
+func (s *mcpServer) handleImportAPI(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	s.noteClient(req.ClientInfo())
+	cctx, cancel := s.callContext(ctx)
+	defer cancel()
+
+	args, err := normalizeToolArgs(req.Params.Arguments, importAPIParams)
+	if err != nil {
+		return nil, invalidParams(err)
+	}
+	apiID, _ := args["api_id"].(string)
+	if apiID == "" {
+		return nil, invalidParams(errors.New(`import_api requires "api_id" (aliases: "id", "api"): ` +
+			`a catalog entry id from a search_catalog hit, e.g. "googleapis.com/sheets"`))
+	}
+
+	client, err := s.app.catalogSession(cctx)
+	if err != nil {
+		s.logger.Warn("import_api failed", "error", redactedErr(err))
+		return s.softError(cctx, err), nil
+	}
+	jobID, err := client.Import(cctx, apiID)
+	if err != nil {
+		return s.importAPIError(cctx, apiID, err), nil
+	}
+
+	job, done := s.trackImportJob(cctx, client, jobID)
+	if !done {
+		// Budget lapsed with the job still running: a normal result — the
+		// model converges by re-calling import_api (idempotent) or watches
+		// the job with get_execution_result. Never block out the call.
+		status := "queued"
+		if job != nil {
+			status = job.Status
+		}
+		s.logger.Info("import_api still running past the wait budget", "api_id", apiID, "job_id", jobID, "status", status)
+		return s.result(cctx, map[string]any{
+			"schema_version": mcpSchemaVersion,
+			"job_id":         jobID,
+			"status":         status,
+		}), nil
+	}
+	if job.Status != catJobCompleted {
+		return s.softErrorExtra(cctx, &ux.CodedError{
+			Code: ux.CodeInternalError,
+			Msg:  fmt.Sprintf("import of %s %s: %s", apiID, job.Status, valueOr(job.Error, "no detail")),
+			Actionable: "Re-check the api_id against a search_catalog hit and retry import_api; " +
+				"if the import keeps failing, relay this error to your operator.",
+		}, "search_catalog", map[string]any{"job_id": jobID, "job_status": job.Status}), nil
+	}
+
+	result, err := client.JobResult(cctx, jobID)
+	if err != nil {
+		s.logger.Warn("import_api result fetch failed", "job_id", jobID, "error", redactedErr(err))
+		return s.softError(cctx, classifyTransportErr(err)), nil
+	}
+	// Auto-promote the imported revisions to live, exactly like the CLI's
+	// default (`jentic catalog import` without --no-promote): unpromoted
+	// drafts are invisible to search/execute, which would strand the loop.
+	promoted := s.app.promoteRevisions(cctx, client, result)
+	s.logger.Info("import_api", "api_id", apiID, "job_id", jobID, "revisions", len(result.Revisions))
+	return s.result(cctx, map[string]any{
+		"schema_version": mcpSchemaVersion,
+		"job_id":         jobID,
+		"status":         job.Status,
+		"revisions":      result.Revisions,
+		"promoted":       promoted,
+	}), nil
+}
+
+// trackImportJob polls the import job until it is terminal or the wait budget
+// (importWaitBudget, test-injectable) lapses. Returns the last-seen job and
+// whether it reached a terminal state. Poll cadence is the App's shared
+// schedule so tests shrink it without mutating globals.
+func (s *mcpServer) trackImportJob(ctx context.Context, client *catalogClient, jobID string) (*catalogJob, bool) {
+	budget := s.importWaitBudget
+	if budget <= 0 {
+		budget = defaultImportWaitBudget
+	}
+	deadline := time.Now().Add(budget)
+	_, pollMax, pollStep := s.app.PollCadence()
+	delay := pollStep // the first poll is immediate; back off from the step
+	var last *catalogJob
+	for {
+		job, err := client.Job(ctx, jobID)
+		if err != nil {
+			s.logger.Warn("import_api job poll failed", "job_id", jobID, "error", redactedErr(err))
+			return last, false
+		}
+		last = job
+		switch job.Status {
+		case catJobCompleted, catJobFailed, catJobCancelled, catJobDeadLetter:
+			return job, true
+		}
+		if time.Now().After(deadline) {
+			return last, false
+		}
+		select {
+		case <-ctx.Done():
+			return last, false
+		case <-time.After(delay):
+		}
+		if delay < pollMax {
+			delay += pollStep
+		}
+	}
+}
+
+// importAPIError maps the import-specific failures: a 404 is an unknown
+// catalog entry (rediscover via search_catalog — the identity is fine); a
+// control-plane 403 on THIS route is a missing catalog:import scope, and the
+// recovery is requesting the scope (skill wording), not get_started.
+func (s *mcpServer) importAPIError(ctx context.Context, apiID string, err error) *mcp.CallToolResult {
+	s.logger.Warn("import_api failed", "api_id", apiID, "error", redactedErr(err))
+	var he *HTTPError
+	if errors.As(err, &he) {
+		switch he.StatusCode {
+		case http.StatusNotFound:
+			return s.softErrorNext(ctx, &ux.CodedError{
+				Code: ux.CodeResolveFailed,
+				Msg:  fmt.Sprintf("catalog entry %q not found", apiID),
+				Actionable: "Call search_catalog with a keyword for the API you need and use the " +
+					"api_id from one of its hits.",
+			}, "search_catalog")
+		case http.StatusForbidden:
+			return s.softErrorNext(ctx, &ux.CodedError{
+				Code: ux.CodeBrokerDenied,
+				Msg:  fmt.Sprintf("importing a cataloged API requires the catalog:import scope: %v", err),
+				Actionable: `Request the scope with request_access, e.g. {"scopes": ["catalog:import"], ` +
+					`"reason": "import the API needed for this task"}, wait for your operator's approval, then retry import_api.`,
+			}, "request_access")
+		}
+	}
+	return s.softError(ctx, classifyTransportErr(err))
+}
+
+// valueOr returns v, or fallback when v is empty (local twin of
+// cmdcore.ValueOr to keep this file free of the cmdcore import).
+func valueOr(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}
+
+// ── request_access ────────────────────────────────────────────────────────────
+
+// pendingAccessInstruction is the human-in-the-loop wording every pending
+// request_access result carries: the tool files and polls, a HUMAN approves.
+const pendingAccessInstruction = "Relay approve_url to your human operator — granting is always a human " +
+	"action in the dashboard; this tool never approves. Poll the decision by calling request_access " +
+	`with {"request_id": "<id>"}; never re-file the same request while one is pending.`
+
+func (s *mcpServer) handleRequestAccess(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	s.noteClient(req.ClientInfo())
+	cctx, cancel := s.callContext(ctx)
+	defer cancel()
+
+	args, err := normalizeToolArgs(req.Params.Arguments, requestAccessParams)
+	if err != nil {
+		return nil, invalidParams(err)
+	}
+
+	st := clictx.ActiveContext(cctx)
+	if st == nil {
+		return s.softError(cctx, noContextErr()), nil
+	}
+	client, err := s.app.controlClient(cctx)
+	if err != nil {
+		s.logger.Warn("request_access failed", "error", redactedErr(err))
+		return s.softError(cctx, err), nil
+	}
+
+	// The poll arm: a request_id fetches the decision state and nothing else.
+	if requestID, _ := args["request_id"].(string); requestID != "" {
+		opts, optsErr := requestAccessOptions(args)
+		if optsErr == nil && opts.targetCount() > 0 {
+			return nil, invalidParams(errors.New(`pass EITHER "request_id" (to poll an existing request) ` +
+				`OR targets ("provision"/"toolkits"/"toolkit_ids"/"scopes") to file a new one, not both`))
+		}
+		reqState, getErr := s.app.getAccessRequest(cctx, client, requestID)
+		if getErr != nil {
+			var he *HTTPError
+			if errors.As(getErr, &he) && he.StatusCode == http.StatusNotFound {
+				// The identity resolved — the id is wrong; the recovery is
+				// re-reading the earlier request_access result (self-pointer).
+				return s.softErrorNext(cctx, &ux.CodedError{
+					Code: ux.CodeResolveFailed,
+					Msg:  fmt.Sprintf("access request %q not found", requestID),
+					Actionable: "Re-check the request id — it is the `id` in the request_access result that " +
+						"filed it — and call request_access again with the exact value.",
+				}, "request_access"), nil
+			}
+			s.logger.Warn("request_access poll failed", "request_id", requestID, "error", redactedErr(getErr))
+			return s.softError(cctx, classifyTransportErr(getErr)), nil
+		}
+		return s.accessRequestResult(cctx, st, reqState, nil), nil
+	}
+
+	// The filing arm: compose the same item list `jentic access request`
+	// builds (provisioning plans first, then binds, then scope grants), file
+	// it, and short-poll for a server-side auto-decision.
+	opts, err := requestAccessOptions(args)
+	if err != nil {
+		return nil, invalidParams(err)
+	}
+	items, err := opts.compose()
+	if err != nil {
+		if errors.Is(err, errAccessTargetRequired) {
+			return nil, invalidParams(errors.New(`request_access requires a target: "provision" (vendor/name plans), ` +
+				`"toolkits" (vendor/name binds), "toolkit_ids" (tk_… binds), or "scopes" — or "request_id" to poll ` +
+				`an existing request`))
+		}
+		// compose()'s messages name the CLI spellings (--provision, --auth,
+		// --rules-json); they match this tool's parameter names closely
+		// enough to correct the call.
+		return nil, invalidParams(err)
+	}
+
+	fileResp, err := client.FileAccessRequestWithResponse(cctx, control.AccessRequestFileRequest{
+		Reason: strEmptyToNil(opts.reason),
+		Items:  items,
+	})
+	if err != nil {
+		s.logger.Warn("request_access failed", "error", redactedErr(err))
+		return s.softError(cctx, classifyTransportErr(err)), nil
+	}
+	var reqState *control.AccessRequestResponse
+	var extra map[string]any
+	switch {
+	case fileResp.JSON202 != nil:
+		reqState = fileResp.JSON202
+	case fileResp.ApplicationproblemJSON409 != nil:
+		dup := fileResp.ApplicationproblemJSON409
+		if opts.targetCount() > 1 {
+			// Filing is all-or-nothing (same reasoning as accessRequestE): a
+			// 409 on a composite means NOTHING was filed — attaching would
+			// silently swap the composite for the older, smaller request.
+			return s.softErrorNext(cctx, &ux.CodedError{
+				Code: ux.CodeResolveFailed,
+				Msg: fmt.Sprintf("nothing was filed: one of the requested targets already has a pending request (%s)",
+					dup.ExistingRequestId),
+				Actionable: fmt.Sprintf("Poll the pending request with request_access {\"request_id\": %q} to see what "+
+					"it covers, then either drop that target from this composite and re-file, or ask your operator "+
+					"to decide the pending request first.", dup.ExistingRequestId),
+				Details: map[string]any{"existing_request_id": dup.ExistingRequestId},
+			}, "request_access"), nil
+		}
+		// Single target: attach to the existing pending request, like the CLI.
+		attached, getErr := s.app.getAccessRequest(cctx, client, dup.ExistingRequestId)
+		if getErr != nil {
+			s.logger.Warn("request_access attach failed", "request_id", dup.ExistingRequestId, "error", redactedErr(getErr))
+			return s.softError(cctx, classifyTransportErr(getErr)), nil
+		}
+		reqState = attached
+		extra = map[string]any{"attached_to_existing": true}
+	default:
+		if aerr := apiErrorFor(fileResp, nil); aerr != nil {
+			s.logger.Warn("request_access failed", "error", redactedErr(aerr))
+			return s.softError(cctx, aerr), nil
+		}
+		return s.softError(cctx, &ux.CodedError{
+			Code: ux.CodeInternalError,
+			Msg:  fmt.Sprintf("unexpected backend response (status %d)", fileResp.StatusCode()),
+		}), nil
+	}
+
+	if !requestIsTerminal(reqState) {
+		reqState = s.awaitAutoDecision(cctx, client, reqState)
+	}
+	s.logger.Info("request_access", "request_id", reqState.Id, "status", reqState.Status, "items", len(reqState.Items))
+	return s.accessRequestResult(cctx, st, reqState, extra), nil
+}
+
+// awaitAutoDecision short-polls a just-filed request so a server-side
+// auto-decision (e.g. the auto-deny of a bare toolkit:bind for an unserved
+// API) reaches the model in the SAME tool result. Bounded by
+// accessPollBudget — a human approval takes minutes and belongs to the
+// model's own request_id polling, never inside one call.
+func (s *mcpServer) awaitAutoDecision(ctx context.Context, client *control.ClientWithResponses, req *control.AccessRequestResponse) *control.AccessRequestResponse {
+	budget := s.accessPollBudget
+	if budget <= 0 {
+		budget = defaultAccessPollBudget
+	}
+	deadline := time.Now().Add(budget)
+	pollInitial, pollMax, pollStep := s.app.PollCadence()
+	delay := pollInitial
+	for {
+		if time.Now().After(deadline) {
+			return req
+		}
+		select {
+		case <-ctx.Done():
+			return req
+		case <-time.After(delay):
+		}
+		if delay < pollMax {
+			delay += pollStep
+		}
+		polled, err := s.app.getAccessRequest(ctx, client, req.Id)
+		if err != nil {
+			s.logger.Warn("request_access status poll failed", "request_id", req.Id, "error", redactedErr(err))
+			return req
+		}
+		req = polled
+		if requestIsTerminal(req) {
+			return req
+		}
+	}
+}
+
+// accessRequestResult renders one access request as the tool result: the
+// verbatim AccessRequestResponse `jentic access … --json` prints (approve_url
+// absolutized onto the environment's base URL) with schema_version and the
+// instance stamp joined. Terminal non-approved states map to the same coded
+// taxonomy the CLI's exit codes come from (terminalAccessError), phrased for
+// a model that polls tools instead of running shell commands.
+func (s *mcpServer) accessRequestResult(ctx context.Context, st *clictx.ActiveState, req *control.AccessRequestResponse, extra map[string]any) *mcp.CallToolResult {
+	absolutizeApproveURL(st.BaseURL, req)
+	payload, err := structToMap(req)
+	if err != nil {
+		return s.softError(ctx, &ux.CodedError{Code: ux.CodeInternalError, Msg: "encode access request: " + err.Error()})
+	}
+	payload["schema_version"] = mcpSchemaVersion
+	for k, v := range extra {
+		if _, taken := payload[k]; !taken {
+			payload[k] = v
+		}
+	}
+
+	switch req.Status {
+	case statusDenied:
+		return s.softErrorExtra(ctx, &ux.CodedError{
+			Code: ux.CodeBrokerDenied,
+			Msg:  fmt.Sprintf("access request %s was denied", req.Id),
+			Actionable: "Read the items' decision_reason in this result to learn why before giving up. A bare " +
+				"toolkit bind for an API nothing serves auto-denies — file a provisioning plan " +
+				`({"provision": ["vendor/name"], …}) instead. Only re-file if something material changed.`,
+		}, "whoami", map[string]any{"request": payload})
+	case statusExpired, statusWithdrawn:
+		return s.softErrorExtra(ctx, &ux.CodedError{
+			Code:       ux.CodeBrokerDenied,
+			Msg:        fmt.Sprintf("request %s is %s, not approved; nothing was granted", req.Id, req.Status),
+			Actionable: "File a fresh request_access naming what you still need, with a clear reason.",
+		}, "", map[string]any{"request": payload})
+	case statusPartiallyApproved:
+		// A granted scope only takes effect once re-minted into the token —
+		// do it now, like the CLI, so the model needn't know about refresh.
+		s.refreshTokenIfScopeGranted(st, req)
+		return s.softErrorExtra(ctx, &ux.CodedError{
+			Code: ux.CodePartialApproval,
+			Msg:  "partially approved — not all requested items were granted",
+			Actionable: "Check items[].status in this result: proceed only with what was approved, and do not " +
+				"assume the rest is available.",
+		}, "whoami", map[string]any{"request": payload})
+	case statusApproved:
+		s.refreshTokenIfScopeGranted(st, req)
+		return s.result(ctx, payload)
+	default: // pending
+		payload["instruction"] = pendingAccessInstruction
+		return s.result(ctx, payload)
+	}
+}
+
+// refreshTokenIfScopeGranted is refreshIfScopeGranted for the MCP surface:
+// when a decided request granted a scope, re-mint the agent token so the next
+// tool call already carries it (the catalog:import loop depends on this).
+// Best-effort and silent to the wire — a mint failure only logs; bindings
+// take effect live server-side and need no re-mint.
+func (s *mcpServer) refreshTokenIfScopeGranted(st *clictx.ActiveState, req *control.AccessRequestResponse) {
+	if !requestGrantedScope(req) {
+		return
+	}
+	creds := credsFromState(st)
+	if creds.InjectedBearerToken != "" {
+		return // static credential: nothing mintable to refresh
+	}
+	if key, err := auth.ReadAPIKey(creds.IdentityRef()); err == nil && key != "" {
+		return
+	}
+	if _, err := auth.RefreshBearerToken(creds); err != nil {
+		s.logger.Warn("granted scope not yet on the token; re-mint failed", "error", redactedErr(err))
+	}
+}
+
+// requestAccessOptions folds the normalized arguments onto the CLI's
+// accessRequestOptions so compose() — the one plan builder — is reused
+// verbatim (provisioning chains, keyed --auth/--rules-json resolution,
+// duplicate/conflict validation).
+func requestAccessOptions(args map[string]any) (*accessRequestOptions, error) {
+	opts := &accessRequestOptions{}
+	if v, ok := args["provision"].([]string); ok {
+		opts.provisions = v
+	}
+	if v, ok := args["toolkits"].([]string); ok {
+		opts.toolkits = v
+	}
+	if v, ok := args["toolkit_ids"].([]string); ok {
+		opts.toolkitIDs = v
+	}
+	if v, ok := args["scopes"].([]string); ok {
+		opts.scopes = v
+	}
+	if v, ok := args["auth"].([]string); ok {
+		opts.auths = v
+	}
+	if v, ok := args["reason"].(string); ok {
+		opts.reason = v
+	}
+	rules, err := rulesJSONValues(args["rules_json"])
+	if err != nil {
+		return nil, err
+	}
+	opts.rulesJSONs = rules
+	return opts, nil
+}
+
+// rulesJSONValues normalizes the rules_json argument onto compose()'s
+// repeatable string values. Models send it three ways: the natural JSON array
+// of rule objects (kept whole as ONE stringified value — commas inside rules
+// must never split), a single string (bare or keyed), or a list of keyed
+// strings for multi-provision requests.
+func rulesJSONValues(v any) ([]string, error) {
+	raw, ok := v.(json.RawMessage)
+	if !ok || len(raw) == 0 {
+		return nil, nil
+	}
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, fmt.Errorf(`parameter "rules_json": %w`, err)
+	}
+	switch t := decoded.(type) {
+	case string:
+		return []string{t}, nil
+	case []any:
+		values := make([]string, 0, len(t))
+		for _, e := range t {
+			s, isStr := e.(string)
+			if !isStr {
+				// An array carrying rule OBJECTS is the rules document
+				// itself: one bare value, verbatim.
+				return []string{string(raw)}, nil
+			}
+			values = append(values, s)
+		}
+		return values, nil
+	case map[string]any:
+		// A single rule object: wrap it into the array compose expects.
+		return []string{"[" + string(raw) + "]"}, nil
+	default:
+		return nil, fmt.Errorf(`parameter "rules_json": expected a JSON array of rules, a string, or a list of keyed strings, got %T`, decoded)
+	}
+}
+
+// structToMap re-projects a typed response onto a map so schema_version and
+// the instance stamp can join it as top-level siblings (the whoami pattern).
+func structToMap(v any) (map[string]any, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// ── registration ─────────────────────────────────────────────────────────────
+
+// The access-loop tools' input schemas. Permissive like every other schema
+// (no additionalProperties:false, no alias properties — the normalizer
+// resolves them handler-side); the declared shapes are the canonical
+// spellings.
+var searchCatalogSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"query": map[string]any{
+			"type":        "string",
+			"description": "Keyword to search the catalog for, e.g. \"spreadsheets\". Omit to list the catalog.",
+		},
+		"limit": map[string]any{
+			"type":        "integer",
+			"description": "Max entries per page (1-200, server default 50).",
+		},
+		"cursor": map[string]any{
+			"type":        "string",
+			"description": "next_cursor from the previous page, to fetch the next one.",
+		},
+	},
+}
+
+var importAPISchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"api_id": map[string]any{
+			"type": "string",
+			"description": "The catalog entry to import (required; \"id\" and \"api\" are accepted aliases): " +
+				"an api_id from a search_catalog hit, e.g. \"googleapis.com/sheets\".",
+		},
+	},
+	"required": []string{"api_id"},
+}
+
+var requestAccessSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"request_id": map[string]any{
+			"type": "string",
+			"description": "Poll an existing request instead of filing a new one: the id from an earlier " +
+				"request_access result. Mutually exclusive with the target parameters.",
+		},
+		"provision": map[string]any{
+			"type":  "array",
+			"items": map[string]any{"type": "string"},
+			"description": "APIs to file full provisioning plans for, as vendor/name[/version] references " +
+				"(e.g. \"stripe.com/api\"). Use when NOTHING you're bound to serves the API yet: the plan " +
+				"describes the whole path to first execution (create toolkit, provision + bind a credential " +
+				"with your proposed rules, bind you), which a human fulfils and approves.",
+		},
+		"toolkits": map[string]any{
+			"type":  "array",
+			"items": map[string]any{"type": "string"},
+			"description": "Toolkits to be bound to, as vendor/name[/version] API references. The LAST MILE only: " +
+				"use when a toolkit already serves the API and you just aren't bound to it — for an unserved " +
+				"API this auto-denies; use provision instead.",
+		},
+		"toolkit_ids": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "Toolkits to be bound to, by id (tk_…).",
+		},
+		"scopes": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "Token scopes to request, e.g. \"catalog:import\".",
+		},
+		"auth": map[string]any{
+			"type":  "array",
+			"items": map[string]any{"type": "string"},
+			"description": "Credential auth type for a provision plan, read from the API's security schemes: " +
+				"bearer, api_key, basic, oauth2, or none (default bearer). With several provisions, key each " +
+				"value by API: \"vendor/name=bearer\".",
+		},
+		"rules_json": map[string]any{
+			"description": "Proposed permission rules for a provision plan, as a JSON array of rules, e.g. " +
+				`[{"effect":"allow","methods":["GET"],"path":".*"}]. A human reviews and edits them before ` +
+				"approving. With several provisions, pass a list of keyed strings: \"vendor/name=<json>\".",
+		},
+		"reason": map[string]any{
+			"type": "string",
+			"description": "Why you need this — ALWAYS include it: the human who approves reads it, and a clear " +
+				"one-liner is what gets you approved faster.",
+		},
+	},
+}
+
+// accessToolSpecs declares the 2-E1 tool surface. Annotations per master
+// §3.2: search_catalog is read-only; import_api carries idempotentHint and NO
+// readOnlyHint (re-import of the same api_id converges); request_access
+// carries neither readOnlyHint nor destructiveHint (additive: it files
+// intent, destroys nothing, and duplicate filings are deduped server-side —
+// but each filing pages a human, so it is not annotated idempotent either).
+// --read-only therefore serves search_catalog and withholds the other two.
+func (s *mcpServer) accessToolSpecs() []mcpToolSpec {
+	return []mcpToolSpec{
+		{
+			tool: &mcp.Tool{
+				Name:  "search_catalog",
+				Title: "Search the public API catalog",
+				Description: "Search the public API catalog for importable APIs by keyword. The registry that " +
+					"search_apis reads only sees IMPORTED APIs — when search_apis returns an empty data " +
+					"array, the API probably isn't imported yet: find it here, import it with import_api, " +
+					"then search_apis again (reading the registry and importing need no access request). " +
+					`Example: {"query": "spreadsheets", "limit": 10}. Returns one page as ` +
+					"{data, catalog_total, registered_count, has_more, next_cursor}; each entry carries " +
+					"the api_id to pass to import_api and `registered` (true = already imported — skip " +
+					"the import). When has_more is true, pass next_cursor back as cursor.",
+				InputSchema: searchCatalogSchema,
+				Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+			},
+			handler:  s.handleSearchCatalog,
+			readOnly: true,
+		},
+		{
+			tool: &mcp.Tool{
+				Name:  "import_api",
+				Title: "Import a catalog API into the registry",
+				Description: "Import a catalog API into this instance's registry so its operations become " +
+					"searchable and executable. " +
+					`Example: {"api_id": "googleapis.com/sheets"} with an api_id from a search_catalog hit. ` +
+					"The import runs as a job: this call tracks it briefly and, on completion, promotes the " +
+					"imported revisions live, returning {job_id, status, revisions, promoted}. If it returns " +
+					"a non-terminal status, call import_api again with the same api_id — re-importing " +
+					"converges (idempotent) and finishes the promotion. Requires the catalog:import scope " +
+					"(agents hold it by default); on a denial, request it via request_access — do not guess " +
+					"other scopes. Importing makes an API discoverable but does NOT grant access to call " +
+					"it: check whoami for a toolkit binding serving it — never execute just to probe — and " +
+					"use request_access if nothing serves it.",
+				InputSchema: importAPISchema,
+				Annotations: &mcp.ToolAnnotations{IdempotentHint: true},
+			},
+			handler:  s.handleImportAPI,
+			readOnly: false,
+		},
+		{
+			tool: &mcp.Tool{
+				Name:  "request_access",
+				Title: "Request access from a human operator",
+				Description: "File one access request for the access you are missing, or poll a filed one by id. " +
+					"Decide from whoami FIRST — never execute an operation just to probe whether you have " +
+					"access. If a whoami binding already serves the API, you have access; if NOTHING serves " +
+					`it, file a provisioning plan: {"provision": ["vendor/name"], "auth": ["bearer"], ` +
+					`"rules_json": [{"effect":"allow","methods":["GET"],"path":".*"}], "reason": "…"} — it ` +
+					"describes the whole path to first execution (create toolkit, provision + bind a " +
+					"credential with your proposed rules, bind you), which a human fulfils in the dashboard " +
+					"(they enter the secret; it never rides in your request). A bare toolkit bind " +
+					`({"toolkits": ["vendor/name"]}) is only the last mile when a toolkit already serves the ` +
+					"API; for an unserved API it auto-denies — use provision. ALWAYS include reason. File " +
+					"once, richly: combine every target this task needs into ONE composite request instead " +
+					"of filing piecemeal. The result carries approve_url: relay it to your human operator — " +
+					"granting is always a human action and this tool NEVER approves. Poll the decision with " +
+					`{"request_id": "<id>"}; never re-file while a request is pending. Once approved, ` +
+					"bindings are live immediately — retry the execute that was denied.",
+				InputSchema: requestAccessSchema,
+				Annotations: &mcp.ToolAnnotations{},
+			},
+			handler:  s.handleRequestAccess,
+			readOnly: false,
+		},
+	}
+}

--- a/cli/internal/cli/api/mcp_access.go
+++ b/cli/internal/cli/api/mcp_access.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -74,6 +75,27 @@ var requestAccessParams = []paramSpec{
 	{name: "reason", kind: paramString},
 }
 
+// transportSoftError is the access-loop twin of executeTransportError
+// (mcp_execute.go): a transport failure must reach the model as a retryable
+// TRANSPORT_ERROR with the get_started pointer — never as INTERNAL_ERROR
+// ("stop, CLI bug") with no recovery. Unlike execute, retryable is safe to
+// hint unconditionally here: every access-loop call is a read or a
+// server-converging write (a re-import of the same api_id converges, a
+// duplicate filing answers 409 — nothing double-executes). Non-transport
+// failures (completed *HTTPError, auth, no-config) fall through to the
+// shared code-keyed mapping, keeping any caller-supplied extras.
+func (s *mcpServer) transportSoftError(ctx context.Context, err error, extra map[string]any) *mcp.CallToolResult {
+	err = classifyTransportErr(err)
+	if asCoded(err).Code != ux.CodeTransportError {
+		return s.softErrorExtra(ctx, err, "", extra)
+	}
+	merged := map[string]any{"retryable": true}
+	for k, v := range extra {
+		merged[k] = v
+	}
+	return s.softErrorExtra(ctx, err, "get_started", merged)
+}
+
 // ── search_catalog ────────────────────────────────────────────────────────────
 
 func (s *mcpServer) handleSearchCatalog(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -103,16 +125,31 @@ func (s *mcpServer) handleSearchCatalog(ctx context.Context, req *mcp.CallToolRe
 	page, err := client.List(cctx, catalogListParams{Q: query, Cursor: cursor, Limit: limit})
 	if err != nil {
 		s.logger.Warn("search_catalog failed", "error", redactedErr(err))
-		// The same missing-route mapping catalogListErr makes: no catalog on
-		// this deployment is a deployment fact, not a malformed call.
 		var he *HTTPError
-		if errors.As(err, &he) && (he.StatusCode == http.StatusNotFound || he.StatusCode == http.StatusNotImplemented) {
-			return s.softError(cctx, &ux.CodedError{
-				Code: ux.CodeInternalError,
-				Msg:  fmt.Sprintf("catalog not available on this server (HTTP %d)", he.StatusCode),
-			}), nil
+		if errors.As(err, &he) {
+			switch he.StatusCode {
+			case http.StatusNotFound, http.StatusNotImplemented:
+				// The same missing-route mapping catalogListErr makes: no
+				// catalog on this deployment is a deployment fact, not a
+				// malformed call.
+				return s.softError(cctx, &ux.CodedError{
+					Code: ux.CodeInternalError,
+					Msg:  fmt.Sprintf("catalog not available on this server (HTTP %d)", he.StatusCode),
+				}), nil
+			case http.StatusForbidden:
+				// A 403 on THIS route is the missing capabilities:read scope,
+				// not a revoked identity — the generic NOT_AUTHENTICATED +
+				// get_started mapping would dead-end an agent that can fix
+				// this itself via request_access (mirrors importAPIError).
+				return s.softErrorNext(cctx, &ux.CodedError{
+					Code: ux.CodeBrokerDenied,
+					Msg:  fmt.Sprintf("reading the catalog requires the capabilities:read scope: %v", err),
+					Actionable: `Request the scope with request_access, e.g. {"scopes": ["capabilities:read"], ` +
+						`"reason": "search the catalog for the API needed for this task"}, wait for your operator's approval, then retry search_catalog.`,
+				}, "request_access"), nil
+			}
 		}
-		return s.softError(cctx, classifyTransportErr(err)), nil
+		return s.transportSoftError(cctx, err, nil), nil
 	}
 
 	// Envelope: the same entries + counters `jentic catalog search --json`
@@ -154,6 +191,9 @@ func (s *mcpServer) handleImportAPI(ctx context.Context, req *mcp.CallToolReques
 		return nil, invalidParams(errors.New(`import_api requires "api_id" (aliases: "id", "api"): ` +
 			`a catalog entry id from a search_catalog hit, e.g. "googleapis.com/sheets"`))
 	}
+	if err := validateAPIID(apiID); err != nil {
+		return nil, invalidParams(err)
+	}
 
 	client, err := s.app.catalogSession(cctx)
 	if err != nil {
@@ -165,7 +205,15 @@ func (s *mcpServer) handleImportAPI(ctx context.Context, req *mcp.CallToolReques
 		return s.importAPIError(cctx, apiID, err), nil
 	}
 
-	job, done := s.trackImportJob(cctx, client, jobID)
+	job, done, pollErr := s.trackImportJob(cctx, client, jobID)
+	if pollErr != nil {
+		// A failing GET /jobs/{id} is NOT "still running": reporting it as a
+		// clean non-terminal result would send the model into a re-import
+		// loop against a backend that de-duplicates nothing. Surface the
+		// failure with the job_id so the model can keep watching THIS job.
+		s.logger.Warn("import_api job poll failed", "api_id", apiID, "job_id", jobID, "error", redactedErr(pollErr))
+		return s.transportSoftError(cctx, pollErr, map[string]any{"job_id": jobID}), nil
+	}
 	if !done {
 		// Budget lapsed with the job still running: a normal result — the
 		// model converges by re-calling import_api (idempotent) or watches
@@ -193,7 +241,7 @@ func (s *mcpServer) handleImportAPI(ctx context.Context, req *mcp.CallToolReques
 	result, err := client.JobResult(cctx, jobID)
 	if err != nil {
 		s.logger.Warn("import_api result fetch failed", "job_id", jobID, "error", redactedErr(err))
-		return s.softError(cctx, classifyTransportErr(err)), nil
+		return s.transportSoftError(cctx, err, map[string]any{"job_id": jobID}), nil
 	}
 	// Auto-promote the imported revisions to live, exactly like the CLI's
 	// default (`jentic catalog import` without --no-promote): unpromoted
@@ -209,11 +257,14 @@ func (s *mcpServer) handleImportAPI(ctx context.Context, req *mcp.CallToolReques
 	}), nil
 }
 
-// trackImportJob polls the import job until it is terminal or the wait budget
-// (importWaitBudget, test-injectable) lapses. Returns the last-seen job and
-// whether it reached a terminal state. Poll cadence is the App's shared
-// schedule so tests shrink it without mutating globals.
-func (s *mcpServer) trackImportJob(ctx context.Context, client *catalogClient, jobID string) (*catalogJob, bool) {
+// trackImportJob polls the import job until it is terminal, the wait budget
+// (importWaitBudget, test-injectable) lapses, or a poll fails. The three
+// outcomes are DISTINCT: (job, true, nil) is terminal, (last, false, nil) is
+// a genuine budget/cancellation lapse with the job still running, and a
+// non-nil error means the job's state is UNKNOWN — the caller must surface
+// that as a failure, never as a clean "still running" result. Poll cadence is
+// the App's shared schedule so tests shrink it without mutating globals.
+func (s *mcpServer) trackImportJob(ctx context.Context, client *catalogClient, jobID string) (*catalogJob, bool, error) {
 	budget := s.importWaitBudget
 	if budget <= 0 {
 		budget = defaultImportWaitBudget
@@ -225,20 +276,19 @@ func (s *mcpServer) trackImportJob(ctx context.Context, client *catalogClient, j
 	for {
 		job, err := client.Job(ctx, jobID)
 		if err != nil {
-			s.logger.Warn("import_api job poll failed", "job_id", jobID, "error", redactedErr(err))
-			return last, false
+			return last, false, err
 		}
 		last = job
 		switch job.Status {
 		case catJobCompleted, catJobFailed, catJobCancelled, catJobDeadLetter:
-			return job, true
+			return job, true, nil
 		}
 		if time.Now().After(deadline) {
-			return last, false
+			return last, false, nil
 		}
 		select {
 		case <-ctx.Done():
-			return last, false
+			return last, false, nil
 		case <-time.After(delay):
 		}
 		if delay < pollMax {
@@ -272,7 +322,25 @@ func (s *mcpServer) importAPIError(ctx context.Context, apiID string, err error)
 			}, "request_access")
 		}
 	}
-	return s.softError(ctx, classifyTransportErr(err))
+	return s.transportSoftError(ctx, err, nil)
+}
+
+// validateAPIID syntactically guards the {api_id:path} route: the api_id is
+// spliced into the request path VERBATIM (catalog_client.go's rawPathEditor —
+// deliberately unescaped so umbrella ids keep their literal slash), which
+// means a traversal-shaped model-supplied value ("../access-requests", a
+// leading "/", empty or dot segments) would otherwise rewrite the route.
+// Reject those before the wire as a correctable protocol error.
+func validateAPIID(apiID string) error {
+	if strings.HasPrefix(apiID, "/") {
+		return fmt.Errorf("invalid api_id %q: a leading %q is not allowed — pass the api_id from a search_catalog hit verbatim", apiID, "/")
+	}
+	for _, seg := range strings.Split(apiID, "/") {
+		if seg == "" || seg == "." || seg == ".." {
+			return fmt.Errorf("invalid api_id %q: empty, %q, or %q path segments are not allowed — pass the api_id from a search_catalog hit verbatim", apiID, ".", "..")
+		}
+	}
+	return nil
 }
 
 // valueOr returns v, or fallback when v is empty (local twin of
@@ -313,11 +381,18 @@ func (s *mcpServer) handleRequestAccess(ctx context.Context, req *mcp.CallToolRe
 	}
 
 	// The poll arm: a request_id fetches the decision state and nothing else.
+	// Filing parameters riding along are a confused call, not noise to drop:
+	// a malformed rules_json or a stray reason silently ignored would teach
+	// the model its arguments were accepted.
 	if requestID, _ := args["request_id"].(string); requestID != "" {
 		opts, optsErr := requestAccessOptions(args)
-		if optsErr == nil && opts.targetCount() > 0 {
+		if optsErr != nil {
+			return nil, invalidParams(optsErr)
+		}
+		if opts.targetCount() > 0 || opts.reason != "" || len(opts.auths) > 0 || len(opts.rulesJSONs) > 0 {
 			return nil, invalidParams(errors.New(`pass EITHER "request_id" (to poll an existing request) ` +
-				`OR targets ("provision"/"toolkits"/"toolkit_ids"/"scopes") to file a new one, not both`))
+				`OR filing parameters ("provision"/"toolkits"/"toolkit_ids"/"scopes" with "auth"/"rules_json"/"reason") ` +
+				`to file a new one, not both`))
 		}
 		reqState, getErr := s.app.getAccessRequest(cctx, client, requestID)
 		if getErr != nil {
@@ -333,9 +408,9 @@ func (s *mcpServer) handleRequestAccess(ctx context.Context, req *mcp.CallToolRe
 				}, "request_access"), nil
 			}
 			s.logger.Warn("request_access poll failed", "request_id", requestID, "error", redactedErr(getErr))
-			return s.softError(cctx, classifyTransportErr(getErr)), nil
+			return s.transportSoftError(cctx, getErr, nil), nil
 		}
-		return s.accessRequestResult(cctx, st, reqState, nil), nil
+		return s.accessRequestResult(cctx, st, reqState, nil, true), nil
 	}
 
 	// The filing arm: compose the same item list `jentic access request`
@@ -364,7 +439,7 @@ func (s *mcpServer) handleRequestAccess(ctx context.Context, req *mcp.CallToolRe
 	})
 	if err != nil {
 		s.logger.Warn("request_access failed", "error", redactedErr(err))
-		return s.softError(cctx, classifyTransportErr(err)), nil
+		return s.transportSoftError(cctx, err, nil), nil
 	}
 	var reqState *control.AccessRequestResponse
 	var extra map[string]any
@@ -391,11 +466,23 @@ func (s *mcpServer) handleRequestAccess(ctx context.Context, req *mcp.CallToolRe
 		attached, getErr := s.app.getAccessRequest(cctx, client, dup.ExistingRequestId)
 		if getErr != nil {
 			s.logger.Warn("request_access attach failed", "request_id", dup.ExistingRequestId, "error", redactedErr(getErr))
-			return s.softError(cctx, classifyTransportErr(getErr)), nil
+			return s.transportSoftError(cctx, getErr, nil), nil
 		}
 		reqState = attached
 		extra = map[string]any{"attached_to_existing": true}
 	default:
+		if fileResp.StatusCode() == http.StatusForbidden {
+			// The control plane refused the FILING itself. Not the generic
+			// NOT_AUTHENTICATED + get_started mapping (the identity is fine)
+			// — and not a request_access pointer either: an agent that may
+			// not file requests cannot request the right to file them.
+			return s.softErrorNext(cctx, &ux.CodedError{
+				Code: ux.CodeBrokerDenied,
+				Msg:  fmt.Sprintf("the control plane refused to accept this access request (HTTP 403): %v", apiErrorFor(fileResp, nil)),
+				Actionable: "This agent is not permitted to file access requests; relay this error to your " +
+					"human operator — they can grant what you need directly in the dashboard.",
+			}, "whoami"), nil
+		}
 		if aerr := apiErrorFor(fileResp, nil); aerr != nil {
 			s.logger.Warn("request_access failed", "error", redactedErr(aerr))
 			return s.softError(cctx, aerr), nil
@@ -410,7 +497,7 @@ func (s *mcpServer) handleRequestAccess(ctx context.Context, req *mcp.CallToolRe
 		reqState = s.awaitAutoDecision(cctx, client, reqState)
 	}
 	s.logger.Info("request_access", "request_id", reqState.Id, "status", reqState.Status, "items", len(reqState.Items))
-	return s.accessRequestResult(cctx, st, reqState, extra), nil
+	return s.accessRequestResult(cctx, st, reqState, extra, false), nil
 }
 
 // awaitAutoDecision short-polls a just-filed request so a server-side
@@ -455,8 +542,10 @@ func (s *mcpServer) awaitAutoDecision(ctx context.Context, client *control.Clien
 // absolutized onto the environment's base URL) with schema_version and the
 // instance stamp joined. Terminal non-approved states map to the same coded
 // taxonomy the CLI's exit codes come from (terminalAccessError), phrased for
-// a model that polls tools instead of running shell commands.
-func (s *mcpServer) accessRequestResult(ctx context.Context, st *clictx.ActiveState, req *control.AccessRequestResponse, extra map[string]any) *mcp.CallToolResult {
+// a model that polls tools instead of running shell commands. viaPoll marks
+// the request_id arm, whose token re-mint is verify-gated (see
+// refreshTokenIfScopeGranted).
+func (s *mcpServer) accessRequestResult(ctx context.Context, st *clictx.ActiveState, req *control.AccessRequestResponse, extra map[string]any, viaPoll bool) *mcp.CallToolResult {
 	absolutizeApproveURL(st.BaseURL, req)
 	payload, err := structToMap(req)
 	if err != nil {
@@ -483,11 +572,11 @@ func (s *mcpServer) accessRequestResult(ctx context.Context, st *clictx.ActiveSt
 			Code:       ux.CodeBrokerDenied,
 			Msg:        fmt.Sprintf("request %s is %s, not approved; nothing was granted", req.Id, req.Status),
 			Actionable: "File a fresh request_access naming what you still need, with a clear reason.",
-		}, "", map[string]any{"request": payload})
+		}, "request_access", map[string]any{"request": payload})
 	case statusPartiallyApproved:
 		// A granted scope only takes effect once re-minted into the token —
 		// do it now, like the CLI, so the model needn't know about refresh.
-		s.refreshTokenIfScopeGranted(st, req)
+		s.refreshTokenIfScopeGranted(ctx, st, req, viaPoll)
 		return s.softErrorExtra(ctx, &ux.CodedError{
 			Code: ux.CodePartialApproval,
 			Msg:  "partially approved — not all requested items were granted",
@@ -495,7 +584,7 @@ func (s *mcpServer) accessRequestResult(ctx context.Context, st *clictx.ActiveSt
 				"assume the rest is available.",
 		}, "whoami", map[string]any{"request": payload})
 	case statusApproved:
-		s.refreshTokenIfScopeGranted(st, req)
+		s.refreshTokenIfScopeGranted(ctx, st, req, viaPoll)
 		return s.result(ctx, payload)
 	default: // pending
 		payload["instruction"] = pendingAccessInstruction
@@ -508,7 +597,14 @@ func (s *mcpServer) accessRequestResult(ctx context.Context, st *clictx.ActiveSt
 // tool call already carries it (the catalog:import loop depends on this).
 // Best-effort and silent to the wire — a mint failure only logs; bindings
 // take effect live server-side and need no re-mint.
-func (s *mcpServer) refreshTokenIfScopeGranted(st *clictx.ActiveState, req *control.AccessRequestResponse) {
+//
+// viaPoll gates the request_id arm: a model may poll an already-decided
+// request any number of times, and an unconditional re-mint per poll is pure
+// churn (InvalidateTokens + an assertion exchange each time). On that arm the
+// mint runs only when GET /me shows the granted scope actually missing from
+// the presented token (staleScopes); the filing arm — which observes the
+// decision exactly once — keeps the unconditional CLI behavior.
+func (s *mcpServer) refreshTokenIfScopeGranted(ctx context.Context, st *clictx.ActiveState, req *control.AccessRequestResponse, viaPoll bool) {
 	if !requestGrantedScope(req) {
 		return
 	}
@@ -519,9 +615,43 @@ func (s *mcpServer) refreshTokenIfScopeGranted(st *clictx.ActiveState, req *cont
 	if key, err := auth.ReadAPIKey(creds.IdentityRef()); err == nil && key != "" {
 		return
 	}
+	if viaPoll {
+		me, err := s.app.getMe(ctx)
+		if err != nil {
+			s.logger.Warn("skipping token re-mint; staleness check failed", "error", redactedErr(err))
+			return
+		}
+		if !grantedScopeStale(req, me) {
+			return // token already carries every granted scope — nothing to do
+		}
+	}
 	if _, err := auth.RefreshBearerToken(creds); err != nil {
 		s.logger.Warn("granted scope not yet on the token; re-mint failed", "error", redactedErr(err))
 	}
+}
+
+// grantedScopeStale reports whether any scope this request granted is missing
+// from the token the agent presents (per staleScopes' semantics: a server
+// that reports no token scopes at all makes staleness unknowable, which reads
+// as not-stale — skip the mint rather than churn).
+func grantedScopeStale(req *control.AccessRequestResponse, me *control.MeAgent) bool {
+	stale := staleScopes(me.Scopes, me.TokenScopes)
+	if len(stale) == 0 {
+		return false
+	}
+	staleSet := make(map[string]struct{}, len(stale))
+	for _, sc := range stale {
+		staleSet[sc] = struct{}{}
+	}
+	for _, it := range req.Items {
+		if it.ResourceType != "scope" || it.Action != "grant" || it.Status != "approved" || it.ResourceId == nil {
+			continue
+		}
+		if _, missing := staleSet[*it.ResourceId]; missing {
+			return true
+		}
+	}
+	return false
 }
 
 // requestAccessOptions folds the normalized arguments onto the CLI's
@@ -720,8 +850,7 @@ func (s *mcpServer) accessToolSpecs() []mcpToolSpec {
 				InputSchema: searchCatalogSchema,
 				Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 			},
-			handler:  s.handleSearchCatalog,
-			readOnly: true,
+			handler: s.handleSearchCatalog,
 		},
 		{
 			tool: &mcp.Tool{
@@ -741,8 +870,7 @@ func (s *mcpServer) accessToolSpecs() []mcpToolSpec {
 				InputSchema: importAPISchema,
 				Annotations: &mcp.ToolAnnotations{IdempotentHint: true},
 			},
-			handler:  s.handleImportAPI,
-			readOnly: false,
+			handler: s.handleImportAPI,
 		},
 		{
 			tool: &mcp.Tool{
@@ -766,8 +894,7 @@ func (s *mcpServer) accessToolSpecs() []mcpToolSpec {
 				InputSchema: requestAccessSchema,
 				Annotations: &mcp.ToolAnnotations{},
 			},
-			handler:  s.handleRequestAccess,
-			readOnly: false,
+			handler: s.handleRequestAccess,
 		},
 	}
 }

--- a/cli/internal/cli/api/mcp_access_test.go
+++ b/cli/internal/cli/api/mcp_access_test.go
@@ -1,0 +1,667 @@
+package api
+
+// mcp_access_test.go exercises the 2-E1 access-loop tool handlers against an
+// httptest control plane, following the per-tool patterns of the 1-B/1-C
+// suites: envelope passthrough with the sibling instance stamp, alias
+// tolerance, the coded soft-error mappings with their recovery pointers, and
+// — for request_access — the never-self-approves invariant at the wire level.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// fastAccessServer is stampedTestMCPServer with the poll cadence and the
+// access-loop wait budgets shrunk so pending-path cases are near-instant.
+func fastAccessServer(t *testing.T) *mcpServer {
+	t.Helper()
+	s := stampedTestMCPServer(t)
+	s.app.SetPollCadence(time.Millisecond, 2*time.Millisecond, time.Millisecond)
+	s.importWaitBudget = 100 * time.Millisecond
+	s.accessPollBudget = 20 * time.Millisecond
+	return s
+}
+
+// --- search_catalog -----------------------------------------------------------
+
+func TestMCPSearchCatalog_EnvelopePassthroughWithStamp(t *testing.T) {
+	var gotQuery, gotCursor, gotLimit string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/catalog" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		gotQuery = r.URL.Query().Get("q")
+		gotCursor = r.URL.Query().Get("cursor")
+		gotLimit = r.URL.Query().Get("limit")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [{"api_id":"googleapis.com/sheets","vendor":"googleapis.com","path":"sheets","spec_url":"https://x/spec.json","registered":false,"update_available":false,"_links":{"self":"/catalog/googleapis.com/sheets","operations":"/catalog/googleapis.com/sheets/operations","import":"/catalog/googleapis.com/sheets:import"}}],
+			"catalog_total": 1200,
+			"registered_count": 3,
+			"has_more": true,
+			"next_cursor": "page2"
+		}`))
+	}))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	// `q` alias and a numeric-string limit must normalize before the wire.
+	res, err := s.handleSearchCatalog(activeCtx(srv.URL), callToolRequest("search_catalog", `{"q":"sheets","limit":"25","cursor":"c0"}`))
+	if err != nil {
+		t.Fatalf("handleSearchCatalog: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+	if gotQuery != "sheets" || gotCursor != "c0" || gotLimit != "25" {
+		t.Errorf("wire params = q %q cursor %q limit %q, want the normalized arguments", gotQuery, gotCursor, gotLimit)
+	}
+
+	payload := decodeToolJSON(t, res)
+	if payload["schema_version"] != mcpSchemaVersion {
+		t.Errorf("schema_version = %v, want %q", payload["schema_version"], mcpSchemaVersion)
+	}
+	data, ok := payload["data"].([]any)
+	if !ok || len(data) != 1 {
+		t.Fatalf("data = %v, want one entry", payload["data"])
+	}
+	entry := data[0].(map[string]any)
+	if entry["api_id"] != "googleapis.com/sheets" || entry["registered"] != false {
+		t.Errorf("entry = %v, want the catalog projection (api_id, registered)", entry)
+	}
+	if payload["catalog_total"] != float64(1200) || payload["registered_count"] != float64(3) {
+		t.Errorf("counters = %v/%v, want the CLI envelope extras mirrored", payload["catalog_total"], payload["registered_count"])
+	}
+	if payload["has_more"] != true || payload["next_cursor"] != "page2" {
+		t.Errorf("pagination = %v/%v, want passthrough true/page2", payload["has_more"], payload["next_cursor"])
+	}
+	if stamp, ok := payload["instance"].(map[string]any); !ok || stamp["backend"] != "local" {
+		t.Errorf("instance stamp = %v, want the fresh identity", payload["instance"])
+	}
+}
+
+func TestMCPSearchCatalog_EmptyResultsEmitEmptyArray(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"catalog_total":0,"registered_count":0,"has_more":false}`))
+	}))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleSearchCatalog(activeCtx(srv.URL), callToolRequest("search_catalog", `{"query":"nothing"}`))
+	if err != nil {
+		t.Fatalf("handleSearchCatalog: %v", err)
+	}
+	text := res.Content[0].(*mcp.TextContent).Text
+	if strings.Contains(text, `"data":null`) {
+		t.Fatalf("data serialized as null, want []: %s", text)
+	}
+	payload := decodeToolJSON(t, res)
+	if data, ok := payload["data"].([]any); !ok || len(data) != 0 {
+		t.Errorf("data = %v, want an empty array", payload["data"])
+	}
+	if payload["has_more"] != false {
+		t.Errorf("has_more = %v, want false", payload["has_more"])
+	}
+	if cursor, present := payload["next_cursor"]; present {
+		t.Errorf("next_cursor = %v, want the empty cursor omitted (CLI envelope shape)", cursor)
+	}
+}
+
+func TestMCPSearchCatalog_LimitOutOfRangeIsInvalidParams(t *testing.T) {
+	s := fastAccessServer(t)
+	res, err := s.handleSearchCatalog(activeCtx("http://127.0.0.1:0"), callToolRequest("search_catalog", `{"limit":500}`))
+	if res != nil {
+		t.Fatalf("want a protocol error, got a result: %v", res)
+	}
+	if err == nil || !strings.Contains(err.Error(), "between 1 and 200") {
+		t.Fatalf("err = %v, want an invalid-params error naming the 1-200 bound", err)
+	}
+}
+
+func TestMCPSearchCatalog_CatalogUnavailableIsSoftError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"no catalog here"}`))
+	}))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleSearchCatalog(activeCtx(srv.URL), callToolRequest("search_catalog", `{"query":"x"}`))
+	if err != nil {
+		t.Fatalf("a deployment fact must be a soft error, not a protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeInternalError {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeInternalError)
+	}
+	if msg, _ := payload["error"].(string); !strings.Contains(msg, "catalog not available") {
+		t.Errorf("error = %q, want the catalogListErr wording", msg)
+	}
+}
+
+// --- import_api ---------------------------------------------------------------
+
+// importControlPlane fakes the whole import loop: POST :import → 202 job,
+// GET /jobs/{id} answering per the script, GET /jobs/{id}/result, and the
+// promote route. It records the paths it saw for wire assertions.
+type importControlPlane struct {
+	mu         sync.Mutex
+	jobStatus  []string // successive GET /jobs answers; last repeats
+	jobIdx     int
+	paths      []string
+	promoted   int
+	importPath string
+}
+
+func (p *importControlPlane) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p.mu.Lock()
+		p.paths = append(p.paths, r.Method+" "+r.URL.Path)
+		p.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":import"):
+			p.mu.Lock()
+			p.importPath = r.URL.Path
+			p.mu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"job_id":"job_9","status":"queued","_links":{"job":"/jobs/job_9"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/jobs/job_9":
+			p.mu.Lock()
+			status := p.jobStatus[p.jobIdx]
+			if p.jobIdx < len(p.jobStatus)-1 {
+				p.jobIdx++
+			}
+			p.mu.Unlock()
+			_, _ = fmt.Fprintf(w, `{"job_id":"job_9","kind":"catalog_import","status":%q}`, status)
+		case r.Method == http.MethodGet && r.URL.Path == "/jobs/job_9/result":
+			_, _ = w.Write([]byte(`{"revisions":[{"api":{"vendor":"googleapis.com","name":"sheets","version":"v4"},"revision_id":"rev_1","state":"draft"}]}`))
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, ":promote"):
+			p.mu.Lock()
+			p.promoted++
+			p.mu.Unlock()
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected control-plane call: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func TestMCPImportAPI_CompletesAndPromotes(t *testing.T) {
+	plane := &importControlPlane{jobStatus: []string{"running", "completed"}}
+	srv := httptest.NewServer(plane.handler(t))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	// `id` alias for api_id; the umbrella api_id carries a literal "/".
+	res, err := s.handleImportAPI(activeCtx(srv.URL), callToolRequest("import_api", `{"id":"googleapis.com/sheets"}`))
+	if err != nil {
+		t.Fatalf("handleImportAPI: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected soft error: %v", res.Content)
+	}
+
+	// The rawPathEditor hazard: the umbrella api_id must reach the backend
+	// with its literal slash, not %2F (the Starlette {api_id:path} route).
+	if plane.importPath != "/catalog/googleapis.com/sheets:import" {
+		t.Errorf("import path = %q, want the literal-slash {api_id:path} form", plane.importPath)
+	}
+
+	payload := decodeToolJSON(t, res)
+	if payload["schema_version"] != mcpSchemaVersion || payload["job_id"] != "job_9" || payload["status"] != catJobCompleted {
+		t.Errorf("envelope = %v, want schema_version/job_id/status mirrored", payload)
+	}
+	revs, ok := payload["revisions"].([]any)
+	if !ok || len(revs) != 1 {
+		t.Fatalf("revisions = %v, want the import job result passed through", payload["revisions"])
+	}
+	promoted, ok := payload["promoted"].(map[string]any)
+	if !ok || promoted["rev_1"] != "live" {
+		t.Errorf("promoted = %v, want the draft revision auto-promoted live (CLI default)", payload["promoted"])
+	}
+	if plane.promoted != 1 {
+		t.Errorf("promote calls = %d, want 1", plane.promoted)
+	}
+	if stamp, ok := payload["instance"].(map[string]any); !ok || stamp["backend"] != "local" {
+		t.Errorf("instance stamp = %v, want the fresh identity", payload["instance"])
+	}
+}
+
+func TestMCPImportAPI_StillRunningReturnsJobForConvergence(t *testing.T) {
+	plane := &importControlPlane{jobStatus: []string{"running"}}
+	srv := httptest.NewServer(plane.handler(t))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	s.importWaitBudget = 5 * time.Millisecond
+	res, err := s.handleImportAPI(activeCtx(srv.URL), callToolRequest("import_api", `{"api_id":"googleapis.com/sheets"}`))
+	if err != nil {
+		t.Fatalf("handleImportAPI: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("a slow import is not an error — the model converges by re-calling: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["job_id"] != "job_9" || payload["status"] != "running" {
+		t.Errorf("payload = %v, want the in-flight job id + status", payload)
+	}
+	if _, ok := payload["promoted"]; ok {
+		t.Errorf("nothing completed, nothing may claim promotion: %v", payload)
+	}
+}
+
+func TestMCPImportAPI_FailedJobIsSoftError(t *testing.T) {
+	plane := &importControlPlane{jobStatus: []string{"failed"}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/jobs/job_9" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"job_id":"job_9","kind":"catalog_import","status":"failed","error":"spec fetch failed"}`))
+			return
+		}
+		plane.handler(t)(w, r)
+	}))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleImportAPI(activeCtx(srv.URL), callToolRequest("import_api", `{"api_id":"googleapis.com/sheets"}`))
+	if err != nil {
+		t.Fatalf("handleImportAPI: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result for a failed import")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeInternalError {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeInternalError)
+	}
+	if msg, _ := payload["error"].(string); !strings.Contains(msg, "spec fetch failed") {
+		t.Errorf("error %q must carry the job's failure detail", msg)
+	}
+	if payload["job_status"] != "failed" {
+		t.Errorf("job_status = %v, want failed", payload["job_status"])
+	}
+}
+
+func TestMCPImportAPI_404IsResolveFailedPointingAtSearchCatalog(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"unknown api"}`))
+	}))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleImportAPI(activeCtx(srv.URL), callToolRequest("import_api", `{"api_id":"nope/nothing"}`))
+	if err != nil {
+		t.Fatalf("a resolve failure must be a soft error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeResolveFailed {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeResolveFailed)
+	}
+	if payload["next_tool"] != "search_catalog" {
+		t.Errorf("next_tool = %v, want search_catalog (the id is wrong, not the identity)", payload["next_tool"])
+	}
+}
+
+func TestMCPImportAPI_403PointsAtRequestAccessForScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"requires one of: catalog:import"}`))
+	}))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleImportAPI(activeCtx(srv.URL), callToolRequest("import_api", `{"api_id":"googleapis.com/sheets"}`))
+	if err != nil {
+		t.Fatalf("handleImportAPI: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeBrokerDenied {
+		t.Errorf("error_code = %v, want %q (a missing scope is an access gap, not a revoked identity)", payload["error_code"], ux.CodeBrokerDenied)
+	}
+	if payload["next_tool"] != "request_access" {
+		t.Errorf("next_tool = %v, want request_access", payload["next_tool"])
+	}
+	if step, _ := payload["actionable_step"].(string); !strings.Contains(step, "catalog:import") {
+		t.Errorf("actionable_step %q must name the catalog:import scope (skill wording)", step)
+	}
+}
+
+func TestMCPImportAPI_MissingAPIIDIsInvalidParams(t *testing.T) {
+	s := fastAccessServer(t)
+	res, err := s.handleImportAPI(activeCtx("http://127.0.0.1:0"), callToolRequest("import_api", `{}`))
+	if res != nil {
+		t.Fatalf("want a protocol error, got a result: %v", res)
+	}
+	for _, spelling := range []string{"api_id", "id", "api"} {
+		if err == nil || !strings.Contains(err.Error(), spelling) {
+			t.Errorf("err %v must name the accepted spelling %q", err, spelling)
+		}
+	}
+}
+
+// --- request_access -----------------------------------------------------------
+
+// accessRequestJSON renders a minimal-but-valid AccessRequestResponse body.
+// approve_url is deliberately RELATIVE: the handler must absolutize it onto
+// the environment's base URL (jentic-one#777) before the model sees it.
+func accessRequestJSON(id, status, itemsJSON string) string {
+	return fmt.Sprintf(`{
+		"id": %q, "status": %q, "actor_id": "agent_1", "created_by": "agent_1", "requested_by": "agent_1",
+		"approve_url": "/console/access-requests/%s",
+		"filed_at": "2026-08-31T12:00:00Z", "expires_at": "2026-09-07T12:00:00Z",
+		"items": %s
+	}`, id, status, id, itemsJSON)
+}
+
+// accessControlPlane fakes POST /access-requests + GET /access-requests/{id},
+// recording every request it sees (the never-self-approves assertion reads
+// the log). fileStatus/pollStatus script the lifecycle; fileCode 409 turns
+// the filing into a duplicate-pending collision.
+type accessControlPlane struct {
+	mu         sync.Mutex
+	seen       []string
+	fileBody   []byte
+	fileCode   int
+	fileStatus string
+	pollStatus string
+	itemsJSON  string
+}
+
+func (p *accessControlPlane) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p.mu.Lock()
+		p.seen = append(p.seen, r.Method+" "+r.URL.Path)
+		p.mu.Unlock()
+		items := p.itemsJSON
+		if items == "" {
+			items = "[]"
+		}
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/access-requests":
+			body, _ := io.ReadAll(r.Body)
+			p.mu.Lock()
+			p.fileBody = body
+			p.mu.Unlock()
+			if p.fileCode == http.StatusConflict {
+				w.Header().Set("Content-Type", "application/problem+json")
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"title":"duplicate","detail":"a pending request exists","status":409,` +
+					`"existing_request_id":"acr_old","approve_url":"/console/access-requests/acr_old"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(accessRequestJSON("acr_1", p.fileStatus, items)))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/access-requests/"):
+			id := strings.TrimPrefix(r.URL.Path, "/access-requests/")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(accessRequestJSON(id, p.pollStatus, items)))
+		default:
+			t.Errorf("unexpected control-plane call: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func TestMCPRequestAccess_FilesComposedPlanPendingWithApproveURL(t *testing.T) {
+	plane := &accessControlPlane{fileStatus: statusPending, pollStatus: statusPending}
+	srv := httptest.NewServer(plane.handler(t))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleRequestAccess(activeCtx(srv.URL), callToolRequest("request_access", `{
+		"provision": ["stripe.com/api"],
+		"auth": ["bearer"],
+		"rules_json": [{"effect":"allow","methods":["GET"],"path":".*"}],
+		"toolkits": ["github.com/api"],
+		"scopes": ["catalog:import"],
+		"reason": "read invoices for the summary task"
+	}`))
+	if err != nil {
+		t.Fatalf("handleRequestAccess: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("a pending filing is a normal result, not an error: %v", res.Content)
+	}
+
+	// The wire body: compose()'s exact plan — the 4-item provisioning chain
+	// first, then the toolkit bind, then the scope grant — plus the reason.
+	var wire struct {
+		Reason string `json:"reason"`
+		Items  []struct {
+			ResourceType      string          `json:"resource_type"`
+			Action            string          `json:"action"`
+			ResourceReference map[string]any  `json:"resource_reference"`
+			ResourceID        *string         `json:"resource_id"`
+			Rules             json.RawMessage `json:"rules"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(plane.fileBody, &wire); err != nil {
+		t.Fatalf("decode filed body: %v\n%s", err, plane.fileBody)
+	}
+	if wire.Reason != "read invoices for the summary task" {
+		t.Errorf("reason on the wire = %q, want the argument mirrored", wire.Reason)
+	}
+	if len(wire.Items) != 6 {
+		t.Fatalf("items = %d, want the 4-item provision chain + toolkit bind + scope grant", len(wire.Items))
+	}
+	wantKinds := []string{"toolkit/create", "credential/provision", "credential/bind", "toolkit/bind", "toolkit/bind", "scope/grant"}
+	for i, want := range wantKinds {
+		if got := wire.Items[i].ResourceType + "/" + wire.Items[i].Action; got != want {
+			t.Errorf("item %d = %s, want %s (compose() fulfilment order)", i, got, want)
+		}
+	}
+	if ref := wire.Items[1].ResourceReference; ref["security_scheme"] != "bearer" || ref["vendor"] != "stripe.com" {
+		t.Errorf("provision item reference = %v, want the auth type + API stamped on", ref)
+	}
+	if len(wire.Items[2].Rules) == 0 || !strings.Contains(string(wire.Items[2].Rules), `"methods":["GET"]`) {
+		t.Errorf("credential:bind rules = %s, want the proposed rules_json intact (never comma-split)", wire.Items[2].Rules)
+	}
+	if wire.Items[5].ResourceID == nil || *wire.Items[5].ResourceID != "catalog:import" {
+		t.Errorf("scope item = %+v, want resource_id catalog:import", wire.Items[5])
+	}
+
+	payload := decodeToolJSON(t, res)
+	if payload["schema_version"] != mcpSchemaVersion || payload["id"] != "acr_1" || payload["status"] != statusPending {
+		t.Errorf("envelope = %v, want schema_version/id/status mirrored", payload)
+	}
+	// approve_url absolutized onto the environment base URL, for the HUMAN.
+	if got, _ := payload["approve_url"].(string); got != srv.URL+"/console/access-requests/acr_1" {
+		t.Errorf("approve_url = %q, want it absolutized onto the base URL", got)
+	}
+	instruction, _ := payload["instruction"].(string)
+	if !strings.Contains(instruction, "never approves") || !strings.Contains(instruction, "request_id") {
+		t.Errorf("pending instruction %q must route approval to the human and name the request_id poll", instruction)
+	}
+	if stamp, ok := payload["instance"].(map[string]any); !ok || stamp["backend"] != "local" {
+		t.Errorf("instance stamp = %v, want the fresh identity", payload["instance"])
+	}
+}
+
+// TestMCPRequestAccess_AutoDenialSurfacesInSameResult pins the status-poll
+// half of the tool: a server-side auto-decision landing within the short
+// post-file poll reaches the model in the SAME result, as the coded denial.
+func TestMCPRequestAccess_AutoDenialSurfacesInSameResult(t *testing.T) {
+	plane := &accessControlPlane{
+		fileStatus: statusPending,
+		pollStatus: statusDenied,
+		itemsJSON:  `[{"id":"item_1","resource_type":"toolkit","action":"bind","status":"denied","decision_reason":"No toolkit serves API acme/pets; provision and bind a credential for it first"}]`,
+	}
+	srv := httptest.NewServer(plane.handler(t))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleRequestAccess(activeCtx(srv.URL), callToolRequest("request_access", `{"toolkits":["acme/pets"],"reason":"r"}`))
+	if err != nil {
+		t.Fatalf("handleRequestAccess: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("a denied request must be an isError result, never look like success")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeBrokerDenied {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeBrokerDenied)
+	}
+	if step, _ := payload["actionable_step"].(string); !strings.Contains(step, "provision") {
+		t.Errorf("actionable_step %q must teach the provision-vs-bind recovery", step)
+	}
+	request, ok := payload["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("denial must carry the full request for its decision_reason: %v", payload)
+	}
+	items, _ := request["items"].([]any)
+	if len(items) != 1 || !strings.Contains(fmt.Sprint(items[0]), "No toolkit serves") {
+		t.Errorf("request.items = %v, want the decision_reason relayed", request["items"])
+	}
+}
+
+func TestMCPRequestAccess_DuplicatePendingSingleTargetAttaches(t *testing.T) {
+	plane := &accessControlPlane{fileCode: http.StatusConflict, pollStatus: statusPending}
+	srv := httptest.NewServer(plane.handler(t))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleRequestAccess(activeCtx(srv.URL), callToolRequest("request_access", `{"toolkits":["acme/pets"]}`))
+	if err != nil {
+		t.Fatalf("handleRequestAccess: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("a single-target duplicate attaches, like the CLI: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["id"] != "acr_old" || payload["attached_to_existing"] != true {
+		t.Errorf("payload = %v, want the existing request attached and flagged", payload)
+	}
+}
+
+func TestMCPRequestAccess_DuplicatePendingCompositeIsSoftError(t *testing.T) {
+	plane := &accessControlPlane{fileCode: http.StatusConflict}
+	srv := httptest.NewServer(plane.handler(t))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleRequestAccess(activeCtx(srv.URL),
+		callToolRequest("request_access", `{"toolkits":["acme/pets"],"scopes":["catalog:import"]}`))
+	if err != nil {
+		t.Fatalf("handleRequestAccess: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("a composite collision files NOTHING and must not read as success")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeResolveFailed {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeResolveFailed)
+	}
+	details, _ := payload["details"].(map[string]any)
+	if details["existing_request_id"] != "acr_old" {
+		t.Errorf("details = %v, want the colliding request id", payload["details"])
+	}
+	if msg, _ := payload["error"].(string); !strings.Contains(msg, "nothing was filed") {
+		t.Errorf("error %q must state that nothing was filed", msg)
+	}
+}
+
+func TestMCPRequestAccess_PollArmReportsApproved(t *testing.T) {
+	plane := &accessControlPlane{pollStatus: statusApproved}
+	srv := httptest.NewServer(plane.handler(t))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleRequestAccess(activeCtx(srv.URL), callToolRequest("request_access", `{"request_id":"acr_1"}`))
+	if err != nil {
+		t.Fatalf("handleRequestAccess: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("an approved request is a normal result: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["id"] != "acr_1" || payload["status"] != statusApproved {
+		t.Errorf("payload = %v, want the approved request passed through", payload)
+	}
+	if _, hasInstruction := payload["instruction"]; hasInstruction {
+		t.Errorf("an approved result must not carry the pending approve instruction")
+	}
+	// The poll arm is exactly one GET — no filing, no mutation.
+	for _, call := range plane.seen {
+		if !strings.HasPrefix(call, "GET /access-requests/") {
+			t.Errorf("poll arm made a non-GET call: %s", call)
+		}
+	}
+}
+
+func TestMCPRequestAccess_MissingTargetIsInvalidParams(t *testing.T) {
+	s := fastAccessServer(t)
+	res, err := s.handleRequestAccess(activeCtx("http://127.0.0.1:0"), callToolRequest("request_access", `{}`))
+	if res != nil {
+		t.Fatalf("want a protocol error, got a result: %v", res)
+	}
+	for _, name := range []string{"provision", "toolkits", "scopes", "request_id"} {
+		if err == nil || !strings.Contains(err.Error(), name) {
+			t.Errorf("err %v must name the parameter %q", err, name)
+		}
+	}
+}
+
+func TestMCPRequestAccess_RequestIDPlusTargetsIsInvalidParams(t *testing.T) {
+	s := fastAccessServer(t)
+	res, err := s.handleRequestAccess(activeCtx("http://127.0.0.1:0"),
+		callToolRequest("request_access", `{"request_id":"acr_1","toolkits":["acme/pets"]}`))
+	if res != nil {
+		t.Fatalf("want a protocol error, got a result: %v", res)
+	}
+	if err == nil || !strings.Contains(err.Error(), "not both") {
+		t.Fatalf("err = %v, want the either-or invalid-params error", err)
+	}
+}
+
+// TestMCPRequestAccess_NeverSelfApproves pins the §3.2 invariant at the wire
+// level: across the filing arm (with its status short-poll) AND the poll arm,
+// the tool only ever files (POST /access-requests) and reads
+// (GET /access-requests/{id}) — no decide/approve-shaped call exists.
+func TestMCPRequestAccess_NeverSelfApproves(t *testing.T) {
+	plane := &accessControlPlane{fileStatus: statusPending, pollStatus: statusPending}
+	srv := httptest.NewServer(plane.handler(t))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	ctx := activeCtx(srv.URL)
+	if res, err := s.handleRequestAccess(ctx, callToolRequest("request_access", `{"toolkits":["acme/pets"],"reason":"r"}`)); err != nil || res.IsError {
+		t.Fatalf("filing arm: err %v, res %v", err, res)
+	}
+	if res, err := s.handleRequestAccess(ctx, callToolRequest("request_access", `{"request_id":"acr_1"}`)); err != nil || res.IsError {
+		t.Fatalf("poll arm: err %v, res %v", err, res)
+	}
+	if len(plane.seen) == 0 {
+		t.Fatal("the control plane saw no calls")
+	}
+	for _, call := range plane.seen {
+		if call != "POST /access-requests" && !strings.HasPrefix(call, "GET /access-requests/") {
+			t.Errorf("request_access made a call that is neither file nor read: %s", call)
+		}
+	}
+}

--- a/cli/internal/cli/api/mcp_access_test.go
+++ b/cli/internal/cli/api/mcp_access_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/jentic/jentic-one/cli/client/generated/control"
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 )
 
@@ -407,11 +408,17 @@ func (p *accessControlPlane) handler(t *testing.T) http.HandlerFunc {
 			p.mu.Lock()
 			p.fileBody = body
 			p.mu.Unlock()
-			if p.fileCode == http.StatusConflict {
+			switch p.fileCode {
+			case http.StatusConflict:
 				w.Header().Set("Content-Type", "application/problem+json")
 				w.WriteHeader(http.StatusConflict)
 				_, _ = w.Write([]byte(`{"title":"duplicate","detail":"a pending request exists","status":409,` +
 					`"existing_request_id":"acr_old","approve_url":"/console/access-requests/acr_old"}`))
+				return
+			case http.StatusForbidden:
+				w.Header().Set("Content-Type", "application/problem+json")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"detail":"agents of this class may not file access requests"}`))
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -662,6 +669,204 @@ func TestMCPRequestAccess_NeverSelfApproves(t *testing.T) {
 	for _, call := range plane.seen {
 		if call != "POST /access-requests" && !strings.HasPrefix(call, "GET /access-requests/") {
 			t.Errorf("request_access made a call that is neither file nor read: %s", call)
+		}
+	}
+}
+
+// --- review-wave regressions ----------------------------------------------------
+
+// TestMCPImportAPI_JobPollFailureIsSoftErrorNotSuccess pins the MAJOR review
+// finding: a failing GET /jobs/{id} leaves the job's state UNKNOWN — reporting
+// it as a clean non-terminal success would send the model into a re-import
+// loop (the docstring says re-call on a non-terminal status, and the backend
+// does not de-duplicate in-flight imports).
+func TestMCPImportAPI_JobPollFailureIsSoftErrorNotSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":import"):
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"job_id":"job_9","status":"queued","_links":{"job":"/jobs/job_9"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/jobs/job_9":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"detail":"job store down"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleImportAPI(activeCtx(srv.URL), callToolRequest("import_api", `{"api_id":"googleapis.com/sheets"}`))
+	if err != nil {
+		t.Fatalf("handleImportAPI: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("a job-poll failure must be an isError result, never the still-running success shape: %v", res.Content)
+	}
+	payload := decodeToolJSON(t, res)
+	if code, _ := payload["error_code"].(string); code == "" {
+		t.Errorf("payload %v must carry a coded error", payload)
+	}
+	if payload["job_id"] != "job_9" {
+		t.Errorf("job_id = %v, want job_9 carried in extras so the model can keep watching this job", payload["job_id"])
+	}
+}
+
+// TestMCPImportAPI_TraversalAPIIDIsInvalidParams pins the syntactic guard in
+// front of the raw-path {api_id:path} route: traversal-shaped ids must never
+// reach the wire (rawPathEditor splices the value into the path VERBATIM).
+func TestMCPImportAPI_TraversalAPIIDIsInvalidParams(t *testing.T) {
+	s := fastAccessServer(t)
+	for _, bad := range []string{
+		"../access-requests",
+		"/catalog/x",
+		"a//b",
+		"a/./b",
+		"googleapis.com/sheets/..",
+		"googleapis.com/",
+	} {
+		res, err := s.handleImportAPI(activeCtx("http://127.0.0.1:0"),
+			callToolRequest("import_api", fmt.Sprintf(`{"api_id":%q}`, bad)))
+		if res != nil {
+			t.Fatalf("api_id %q: want a protocol error before the wire, got a result: %v", bad, res)
+		}
+		if err == nil || !strings.Contains(err.Error(), "search_catalog") {
+			t.Errorf("api_id %q: err %v must point back at search_catalog", bad, err)
+		}
+	}
+	// The legitimate umbrella shape (literal slash) must stay accepted.
+	if err := validateAPIID("googleapis.com/sheets"); err != nil {
+		t.Errorf("validateAPIID must accept a real umbrella api_id: %v", err)
+	}
+}
+
+// TestMCPSearchCatalog_403PointsAtRequestAccessForScope mirrors the import
+// mapping: a 403 on GET /catalog is the missing capabilities:read scope — an
+// access gap the agent can close itself — not a revoked identity.
+func TestMCPSearchCatalog_403PointsAtRequestAccessForScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"requires one of: capabilities:read"}`))
+	}))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleSearchCatalog(activeCtx(srv.URL), callToolRequest("search_catalog", `{"query":"x"}`))
+	if err != nil {
+		t.Fatalf("handleSearchCatalog: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeBrokerDenied {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeBrokerDenied)
+	}
+	if payload["next_tool"] != "request_access" {
+		t.Errorf("next_tool = %v, want request_access", payload["next_tool"])
+	}
+	if step, _ := payload["actionable_step"].(string); !strings.Contains(step, "capabilities:read") {
+		t.Errorf("actionable_step %q must name the capabilities:read scope", step)
+	}
+}
+
+// TestMCPSearchCatalog_TransportFailureIsRetryable pins the shared
+// transportSoftError contract on the access loop: a dead control plane comes
+// back as a retryable TRANSPORT_ERROR with the get_started pointer, never as
+// INTERNAL_ERROR with no recovery.
+func TestMCPSearchCatalog_TransportFailureIsRetryable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close() // the port is now provably closed: dial fails pre-send
+
+	s := fastAccessServer(t)
+	res, err := s.handleSearchCatalog(activeCtx(srv.URL), callToolRequest("search_catalog", `{"query":"x"}`))
+	if err != nil {
+		t.Fatalf("handleSearchCatalog: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeTransportError {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeTransportError)
+	}
+	if payload["retryable"] != true {
+		t.Errorf("retryable = %v, want true (access-loop calls are reads or server-converging writes)", payload["retryable"])
+	}
+	if payload["next_tool"] != "get_started" {
+		t.Errorf("next_tool = %v, want get_started", payload["next_tool"])
+	}
+}
+
+// TestMCPRequestAccess_FilingForbiddenIsBrokerDenied: a 403 on the FILING
+// itself must not fall into the generic revoked-identity mapping — and must
+// not point at request_access either (an agent that may not file requests
+// cannot request the right to file them).
+func TestMCPRequestAccess_FilingForbiddenIsBrokerDenied(t *testing.T) {
+	plane := &accessControlPlane{fileCode: http.StatusForbidden}
+	srv := httptest.NewServer(plane.handler(t))
+	defer srv.Close()
+
+	s := fastAccessServer(t)
+	res, err := s.handleRequestAccess(activeCtx(srv.URL), callToolRequest("request_access", `{"toolkits":["acme/pets"],"reason":"r"}`))
+	if err != nil {
+		t.Fatalf("handleRequestAccess: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError result")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeBrokerDenied {
+		t.Errorf("error_code = %v, want %q", payload["error_code"], ux.CodeBrokerDenied)
+	}
+	if payload["next_tool"] != "whoami" {
+		t.Errorf("next_tool = %v, want whoami (request_access would be circular here)", payload["next_tool"])
+	}
+	if step, _ := payload["actionable_step"].(string); !strings.Contains(step, "operator") {
+		t.Errorf("actionable_step %q must route to the human operator", step)
+	}
+}
+
+// TestMCPRequestAccess_PollArmRejectsStrayFilingParams pins the poll-arm
+// symmetry: request_id plus ANY filing parameter — a target, a stray reason,
+// or a malformed rules_json — is a confused call the handler must reject, not
+// silently drop.
+func TestMCPRequestAccess_PollArmRejectsStrayFilingParams(t *testing.T) {
+	s := fastAccessServer(t)
+	for name, argsJSON := range map[string]string{
+		"stray reason":        `{"request_id":"acr_1","reason":"please"}`,
+		"stray auth":          `{"request_id":"acr_1","auth":["bearer"]}`,
+		"stray rules_json":    `{"request_id":"acr_1","rules_json":[{"effect":"allow"}]}`,
+		"malformed rules":     `{"request_id":"acr_1","rules_json":42}`,
+		"target and poll mix": `{"request_id":"acr_1","toolkits":["acme/pets"]}`,
+	} {
+		res, err := s.handleRequestAccess(activeCtx("http://127.0.0.1:0"), callToolRequest("request_access", argsJSON))
+		if res != nil {
+			t.Fatalf("%s: want a protocol error, got a result: %v", name, res)
+		}
+		if err == nil {
+			t.Errorf("%s: want an invalid-params error", name)
+		}
+	}
+}
+
+// TestAbsolutizeApproveURL_SchemeRelativeCleared pins the shared helper's
+// link-hijack guard: a scheme-relative approve_url would resolve onto a
+// FOREIGN host, so it is cleared; genuine relative paths still absolutize and
+// absolute URLs pass through.
+func TestAbsolutizeApproveURL_SchemeRelativeCleared(t *testing.T) {
+	base := "https://control.example"
+	for _, tc := range []struct{ in, want string }{
+		{"//evil.example/console/x", ""},
+		{"/console/access-requests/acr_1", base + "/console/access-requests/acr_1"},
+		{"https://control.example/console/x", "https://control.example/console/x"},
+		{"", ""},
+	} {
+		req := &control.AccessRequestResponse{ApproveUrl: tc.in}
+		absolutizeApproveURL(base, req)
+		if req.ApproveUrl != tc.want {
+			t.Errorf("absolutizeApproveURL(%q) = %q, want %q", tc.in, req.ApproveUrl, tc.want)
 		}
 	}
 }

--- a/cli/internal/cli/api/mcp_execute.go
+++ b/cli/internal/cli/api/mcp_execute.go
@@ -704,8 +704,7 @@ func (s *mcpServer) executeToolSpecs() []mcpToolSpec {
 				InputSchema: executeInputSchema(true),
 				Annotations: &mcp.ToolAnnotations{DestructiveHint: &destructive, OpenWorldHint: &openWorld},
 			},
-			handler:  s.handleExecute,
-			readOnly: false,
+			handler: s.handleExecute,
 		},
 		{
 			tool: &mcp.Tool{
@@ -719,8 +718,7 @@ func (s *mcpServer) executeToolSpecs() []mcpToolSpec {
 				InputSchema: executeInputSchema(false),
 				Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
 			},
-			handler:  s.handleExecuteRead,
-			readOnly: true,
+			handler: s.handleExecuteRead,
 		},
 		{
 			tool: &mcp.Tool{
@@ -735,8 +733,7 @@ func (s *mcpServer) executeToolSpecs() []mcpToolSpec {
 				InputSchema: getExecutionResultSchema,
 				Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 			},
-			handler:  s.handleGetExecutionResult,
-			readOnly: true,
+			handler: s.handleGetExecutionResult,
 		},
 	}
 }

--- a/cli/internal/cli/api/mcp_server.go
+++ b/cli/internal/cli/api/mcp_server.go
@@ -56,6 +56,12 @@ type mcpServer struct {
 	// (mcp_resources.go); zero means the hostedSkillFetchTimeout default.
 	// It exists as a field only so tests can inject a short budget.
 	hostedFetchTimeout time.Duration
+	// importWaitBudget / accessPollBudget override the access-loop tools'
+	// bounded waits (mcp_access.go: import-job tracking, the post-file
+	// auto-decision poll); zero means the defaults. Fields only so tests can
+	// inject short budgets.
+	importWaitBudget time.Duration
+	accessPollBudget time.Duration
 
 	// sessionID is the per-process UUID fallback for X-Jentic-Session-Id. The
 	// RoundTripper stamps it ONLY when the header is absent, so an env-set
@@ -196,14 +202,17 @@ var inspectOperationSchema = map[string]any{
 
 // toolSpecs declares the served tool surface: the 1-A pre-auth pair
 // (get_started, whoami), the 1-B discovery pair (search_apis,
-// inspect_operation), and the 1-C execute surface (execute, execute_read,
-// get_execution_result — mcp_execute.go). Docstrings encode the flow
-// (get_started first, whoami before discovery, search → inspect → execute)
+// inspect_operation), the 1-C execute surface (execute, execute_read,
+// get_execution_result — mcp_execute.go), and the 2-E1 access-loop tools
+// (search_catalog, import_api, request_access — mcp_access.go). Docstrings
+// encode the flow (get_started first, whoami before discovery, search →
+// inspect → execute, request access via a human — never probe by executing)
 // per §3.2, with concrete argument examples a model can copy.
 func (s *mcpServer) toolSpecs() []mcpToolSpec {
 	readOnly := &mcp.ToolAnnotations{ReadOnlyHint: true}
 	execSpecs := s.executeToolSpecs()
-	specs := make([]mcpToolSpec, 0, 4+len(execSpecs))
+	accessSpecs := s.accessToolSpecs()
+	specs := make([]mcpToolSpec, 0, 4+len(execSpecs)+len(accessSpecs))
 	specs = append(specs, []mcpToolSpec{
 		{
 			tool: &mcp.Tool{
@@ -279,12 +288,14 @@ func (s *mcpServer) toolSpecs() []mcpToolSpec {
 			readOnly: true,
 		},
 	}...)
-	return append(specs, execSpecs...)
+	specs = append(specs, execSpecs...)
+	return append(specs, accessSpecs...)
 }
 
 // registerTools applies the serving filters. --exclude-tools drops by name;
-// --read-only drops everything not annotated read-only — from 1-C on that is
-// exactly the `execute` tool (execute_read and get_execution_result stay).
+// --read-only drops everything not annotated read-only — from 2-E1 on that is
+// exactly execute (1-C), import_api, and request_access (execute_read,
+// get_execution_result, and search_catalog stay).
 func (s *mcpServer) registerTools() {
 	for _, spec := range s.toolSpecs() {
 		if s.excluded[spec.tool.Name] {

--- a/cli/internal/cli/api/mcp_server.go
+++ b/cli/internal/cli/api/mcp_server.go
@@ -135,12 +135,12 @@ func (s *mcpServer) run(ctx context.Context) error {
 }
 
 // mcpToolSpec pairs a tool declaration with its handler for the registration
-// filters. readOnly mirrors the tool's ReadOnlyHint annotation: --read-only
-// serves only these (1-C's execute tool registers with readOnly=false).
+// filters. There is deliberately NO separate read-only flag: --read-only
+// filters on the tool's own ReadOnlyHint annotation, so the advertised
+// annotation and the serving filter can never drift apart.
 type mcpToolSpec struct {
-	tool     *mcp.Tool
-	handler  mcp.ToolHandler
-	readOnly bool
+	tool    *mcp.Tool
+	handler mcp.ToolHandler
 }
 
 // noArgsSchema is the input schema for the parameterless tools. Kept
@@ -229,8 +229,7 @@ func (s *mcpServer) toolSpecs() []mcpToolSpec {
 				InputSchema: noArgsSchema,
 				Annotations: readOnly,
 			},
-			handler:  s.handleGetStarted,
-			readOnly: true,
+			handler: s.handleGetStarted,
 		},
 		{
 			tool: &mcp.Tool{
@@ -244,8 +243,7 @@ func (s *mcpServer) toolSpecs() []mcpToolSpec {
 				InputSchema: noArgsSchema,
 				Annotations: readOnly,
 			},
-			handler:  s.handleWhoami,
-			readOnly: true,
+			handler: s.handleWhoami,
 		},
 		{
 			tool: &mcp.Tool{
@@ -265,8 +263,7 @@ func (s *mcpServer) toolSpecs() []mcpToolSpec {
 				InputSchema: searchAPIsSchema,
 				Annotations: readOnly,
 			},
-			handler:  s.handleSearchAPIs,
-			readOnly: true,
+			handler: s.handleSearchAPIs,
 		},
 		{
 			tool: &mcp.Tool{
@@ -284,8 +281,7 @@ func (s *mcpServer) toolSpecs() []mcpToolSpec {
 				InputSchema: inspectOperationSchema,
 				Annotations: readOnly,
 			},
-			handler:  s.handleInspectOperation,
-			readOnly: true,
+			handler: s.handleInspectOperation,
 		},
 	}...)
 	specs = append(specs, execSpecs...)
@@ -293,8 +289,9 @@ func (s *mcpServer) toolSpecs() []mcpToolSpec {
 }
 
 // registerTools applies the serving filters. --exclude-tools drops by name;
-// --read-only drops everything not annotated read-only — from 2-E1 on that is
-// exactly execute (1-C), import_api, and request_access (execute_read,
+// --read-only drops everything whose OWN ReadOnlyHint annotation is absent —
+// the advertised annotation is the single source of truth, so from 2-E1 on
+// that is exactly execute (1-C), import_api, and request_access (execute_read,
 // get_execution_result, and search_catalog stay).
 func (s *mcpServer) registerTools() {
 	for _, spec := range s.toolSpecs() {
@@ -302,7 +299,8 @@ func (s *mcpServer) registerTools() {
 			s.logger.Info("tool excluded by --exclude-tools", "tool", spec.tool.Name)
 			continue
 		}
-		if s.readOnly && !spec.readOnly {
+		annotatedReadOnly := spec.tool.Annotations != nil && spec.tool.Annotations.ReadOnlyHint
+		if s.readOnly && !annotatedReadOnly {
 			s.logger.Info("tool withheld by --read-only", "tool", spec.tool.Name)
 			continue
 		}

--- a/cli/internal/cli/api/mcp_session_test.go
+++ b/cli/internal/cli/api/mcp_session_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -101,7 +102,7 @@ func TestMCPSession_ToolsListWorksWithNoConfig(t *testing.T) {
 	for _, tool := range tools.Tools {
 		names[tool.Name] = tool
 	}
-	for _, want := range []string{"get_started", "whoami", "search_apis", "inspect_operation", "execute_read", "get_execution_result"} {
+	for _, want := range []string{"get_started", "whoami", "search_apis", "inspect_operation", "execute_read", "get_execution_result", "search_catalog"} {
 		tool, ok := names[want]
 		if !ok {
 			t.Fatalf("tools/list = %v, missing %q", keys(names), want)
@@ -130,16 +131,38 @@ func TestMCPSession_ToolsListWorksWithNoConfig(t *testing.T) {
 			t.Errorf("tool %q must not carry destructiveHint (execute alone does)", name)
 		}
 	}
-	if len(names) != 7 {
-		t.Errorf("PR 1-C serves exactly the 7 phase-1 tools, got %v", keys(names))
+	// The 2-E1 annotations (master §3.2): import_api is idempotent-not-read-
+	// only; request_access is additive — neither read-only nor destructive.
+	importTool, ok := names["import_api"]
+	if !ok {
+		t.Fatalf("tools/list = %v, missing import_api", keys(names))
+	}
+	if importTool.Annotations == nil || importTool.Annotations.ReadOnlyHint {
+		t.Errorf("import_api must not carry readOnlyHint")
+	}
+	if importTool.Annotations == nil || !importTool.Annotations.IdempotentHint {
+		t.Errorf("import_api must carry idempotentHint (re-import of the same api_id converges)")
+	}
+	requestTool, ok := names["request_access"]
+	if !ok {
+		t.Fatalf("tools/list = %v, missing request_access", keys(names))
+	}
+	if requestTool.Annotations == nil || requestTool.Annotations.ReadOnlyHint {
+		t.Errorf("request_access must not carry readOnlyHint")
+	}
+	if requestTool.Annotations != nil && requestTool.Annotations.IdempotentHint {
+		t.Errorf("request_access must not carry idempotentHint (each filing pages a human)")
+	}
+	if len(names) != 10 {
+		t.Errorf("2-E1 serves exactly the 10 phase-1/2 tools, got %v", keys(names))
 	}
 }
 
-// TestMCPSession_ReadOnlyWithholdsExactlyExecute pins the --read-only contract
-// on the 1-C surface: every tool except `execute` is annotated read-only, so
-// the flag withholds exactly that one (execute_read and get_execution_result
-// stay servable).
-func TestMCPSession_ReadOnlyWithholdsExactlyExecute(t *testing.T) {
+// TestMCPSession_ReadOnlyWithholdsMutatingTools pins the --read-only contract
+// on the 2-E1 surface: exactly execute, import_api, and request_access lack
+// the read-only annotation, so the flag withholds exactly those three
+// (execute_read, get_execution_result, and search_catalog stay servable).
+func TestMCPSession_ReadOnlyWithholdsMutatingTools(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
@@ -150,15 +173,23 @@ func TestMCPSession_ReadOnlyWithholdsExactlyExecute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tools/list: %v", err)
 	}
+	withheld := map[string]bool{"execute": true, "import_api": true, "request_access": true}
 	names := make([]string, 0, len(tools.Tools))
 	for _, tool := range tools.Tools {
 		names = append(names, tool.Name)
-		if tool.Name == "execute" {
-			t.Errorf("--read-only must withhold the execute tool")
+		if withheld[tool.Name] {
+			t.Errorf("--read-only must withhold the %s tool", tool.Name)
 		}
 	}
-	if len(tools.Tools) != 6 {
-		t.Errorf("--read-only must serve the 6 read-only tools, got %v", names)
+	served := make(map[string]bool, len(names))
+	for _, n := range names {
+		served[n] = true
+	}
+	if !served["search_catalog"] {
+		t.Errorf("--read-only must still serve search_catalog (readOnlyHint), got %v", names)
+	}
+	if len(tools.Tools) != 7 {
+		t.Errorf("--read-only must serve the 7 read-only tools, got %v", names)
 	}
 }
 
@@ -387,8 +418,8 @@ func TestMCPSession_ExcludeToolsFilters(t *testing.T) {
 			t.Errorf("--exclude-tools=whoami must withhold the tool")
 		}
 	}
-	if len(tools.Tools) != 6 {
-		t.Errorf("tools = %d, want 6 after exclusion", len(tools.Tools))
+	if len(tools.Tools) != 9 {
+		t.Errorf("tools = %d, want 9 after exclusion", len(tools.Tools))
 	}
 }
 
@@ -601,5 +632,191 @@ func TestMCPSession_RevokedIdentity401MapsToNotAuthenticated(t *testing.T) {
 	msg, _ := payload["error"].(string)
 	if !strings.Contains(msg, "identity revoked") {
 		t.Errorf("error %q should carry the control plane's detail", msg)
+	}
+}
+
+// TestMCPSession_AccessLoopDeniedToApprovedRetry drives the full phase-2
+// acceptance loop (master §5 item 3) over a real client session: a denied
+// execute → request_access files and returns approve_url + pending → the
+// HUMAN approves server-side (faked by flipping the doubles — the tool never
+// approves) → the request_id poll reports approved → the retried execute
+// succeeds.
+func TestMCPSession_AccessLoopDeniedToApprovedRetry(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	var approved atomic.Bool
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if !approved.Load() {
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.Header().Set("Jentic-Error-Origin", "broker")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"detail":"no toolkit binding","agent_directive":{"strategy":"prompt_human",` +
+				`"parameters":{"suggested_command":"jentic access request --toolkit acme/pets --wait"},` +
+				`"human_readable_instruction":"Ask your operator to bind this agent to acme/pets."}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Jentic-Execution-Id", "exec_ok")
+		_, _ = w.Write([]byte(`{"pets":[{"id":1}]}`))
+	}))
+	defer broker.Close()
+
+	requestBody := func(status string) string {
+		return `{"id":"acr_1","status":"` + status + `","actor_id":"agent_1","created_by":"agent_1",` +
+			`"requested_by":"agent_1","approve_url":"/console/access-requests/acr_1",` +
+			`"filed_at":"2026-08-31T12:00:00Z","expires_at":"2026-09-07T12:00:00Z",` +
+			`"items":[{"id":"item_1","resource_type":"toolkit","action":"bind","status":"` + status + `"}]}`
+	}
+	control := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/access-requests":
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(requestBody(statusPending)))
+		case r.Method == http.MethodGet && r.URL.Path == "/access-requests/acr_1":
+			status := statusPending
+			if approved.Load() {
+				status = statusApproved
+			}
+			_, _ = w.Write([]byte(requestBody(status)))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer control.Close()
+
+	s := newTestMCPServer(t, nil)
+	s.app.SetPollCadence(time.Millisecond, 2*time.Millisecond, time.Millisecond)
+	s.accessPollBudget = 10 * time.Millisecond
+	cs := connectTestClientWithContext(activeCtxWithBroker(control.URL, broker.URL), t, s)
+	ctx := context.Background()
+
+	// 1. The execute is DENIED: soft BROKER_DENIED with the verbatim directive.
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "execute",
+		Arguments: map[string]any{"operation_id": "GET:/v1/pets"},
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("the first execute must be denied")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeBrokerDenied {
+		t.Fatalf("error_code = %v, want %q", payload["error_code"], ux.CodeBrokerDenied)
+	}
+	if _, ok := payload["agent_directive"].(map[string]any); !ok {
+		t.Fatalf("denial must relay the agent_directive: %v", payload)
+	}
+
+	// 2. request_access files the bind and returns approve_url + pending.
+	res, err = cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "request_access",
+		Arguments: map[string]any{"toolkits": []string{"acme/pets"}, "reason": "list pets for the demo"},
+	})
+	if err != nil {
+		t.Fatalf("request_access: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("a pending filing is a normal result: %v", res.Content)
+	}
+	payload = decodeToolJSON(t, res)
+	if payload["status"] != statusPending || payload["id"] != "acr_1" {
+		t.Fatalf("filed request = %v, want pending acr_1", payload)
+	}
+	approveURL, _ := payload["approve_url"].(string)
+	if approveURL != control.URL+"/console/access-requests/acr_1" {
+		t.Errorf("approve_url = %q, want the absolutized dashboard link for the human", approveURL)
+	}
+	if instruction, _ := payload["instruction"].(string); !strings.Contains(instruction, "never approves") {
+		t.Errorf("pending instruction %q must state the tool never approves", instruction)
+	}
+
+	// 3. The HUMAN approves in the dashboard — faked server-side. The tool
+	// surface has no approval affordance to call.
+	approved.Store(true)
+
+	// 4. The request_id poll reports the decision.
+	res, err = cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "request_access",
+		Arguments: map[string]any{"request_id": "acr_1"},
+	})
+	if err != nil {
+		t.Fatalf("request_access poll: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("approved poll soft-errored: %v", res.Content)
+	}
+	payload = decodeToolJSON(t, res)
+	if payload["status"] != statusApproved {
+		t.Fatalf("polled status = %v, want approved", payload["status"])
+	}
+
+	// 5. The retried execute succeeds — the loop is closed.
+	res, err = cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "execute",
+		Arguments: map[string]any{"operation_id": "GET:/v1/pets"},
+	})
+	if err != nil {
+		t.Fatalf("execute retry: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("the retried execute must succeed after approval: %v", res.Content)
+	}
+	payload = decodeToolJSON(t, res)
+	if payload["status"] != float64(200) || payload["execution_id"] != "exec_ok" {
+		t.Errorf("retry envelope = %v, want status 200 + execution_id", payload)
+	}
+}
+
+// TestMCPSession_KillSwitchDisabledAgentExecuteDenied re-verifies the phase-2
+// acceptance kill-switch item on the MCP transport: the broker-side fail-
+// closed re-check is already tested on main (PR #1137) — here the broker
+// double answers as it does for a DISABLED agent's token (401, origin
+// broker), and the MCP surface must relay that as the coded denial envelope
+// (isError, BROKER_DENIED, retryable false), never as success or an opaque
+// internal error.
+func TestMCPSession_KillSwitchDisabledAgentExecuteDenied(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// The shape the broker's fail-closed token resolver produces once the
+		// verdict cache lapses for a disabled actor.
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.Header().Set("Jentic-Error-Origin", "broker")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"actor disabled or unknown"}`))
+	}))
+	defer broker.Close()
+
+	s := newTestMCPServer(t, nil)
+	cs := connectTestClientWithContext(activeCtxWithBroker("http://127.0.0.1:8000", broker.URL), t, s)
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "execute",
+		Arguments: map[string]any{"operation_id": "GET:/v1/pets"},
+	})
+	if err != nil {
+		t.Fatalf("a kill-switched execute must soft-error, not protocol-error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("a disabled agent's execute must surface as an isError denial")
+	}
+	payload := decodeToolJSON(t, res)
+	if payload["error_code"] != ux.CodeBrokerDenied {
+		t.Errorf("error_code = %v, want %q (the denial envelope must survive the MCP transport)", payload["error_code"], ux.CodeBrokerDenied)
+	}
+	if payload["retryable"] != false {
+		t.Errorf("retryable = %v, want false (re-sending cannot succeed while disabled)", payload["retryable"])
+	}
+	details, _ := payload["details"].(map[string]any)
+	if details["http_status"] != float64(http.StatusUnauthorized) {
+		t.Errorf("details = %v, want the denying http_status relayed", payload["details"])
+	}
+	if step, _ := payload["actionable_step"].(string); step == "" {
+		t.Errorf("the denial must carry a recovery step for the model to relay")
 	}
 }


### PR DESCRIPTION
## Summary

Phase-2 item **2-E1** (lane A's tail, plan §3.2/§3.4; extends [#1175](https://github.com/jentic/jentic-one/issues/1175)): the access-loop tools that let an MCP-connected agent go from "denied" to "usable" without leaving the conversation — while every approval stays with a human in the dashboard.

- **`search_catalog`** — GET `/catalog` (`capabilities:read`), `readOnlyHint`.
- **`import_api`** — POST `/catalog/{api_id:path}:import` (`catalog:import`, 202 job tracked ≤20s, revisions auto-promoted like the CLI default), `idempotentHint`, no `readOnlyHint`.
- **`request_access`** — POST `/access-requests` + short auto-decision poll, returns the dashboard `approve_url`; **never self-approves** (wire-level test pins that only file/read calls exist). Additive: no `readOnlyHint`/`destructiveHint`; deliberately no `idempotentHint` either — each filing pages a human, and duplicates are handled by the 409 attach path instead.

`--read-only` now withholds exactly `execute`, `import_api`, `request_access` (test-pinned); docstrings carry the whoami-first and provision-vs-bind guidance mirroring the skill.

## Tests

17 handler tests + 2 session tests, including the acceptance-list items:
- **Access loop e2e**: denied execute → `request_access` (approve_url, pending) → human approves server-side → poll approved → retried execute succeeds.
- **Kill-switch over MCP**: a disabled agent's execute relays the broker's denial as coded `BROKER_DENIED`, `retryable: false` (broker-side fail-closed re-check is #1137's tests; this pins the MCP transport surface).

## Gates

gofmt · go vet · go build · full `go test ./...` — green.

Made with [Cursor](https://cursor.com)