### PR TITLE
fix(cli): route token mint through pinned CA transport + attribution hook

### DIFF
--- a/cli/client/auth/middleware.go
+++ b/cli/client/auth/middleware.go
@@ -17,6 +17,17 @@ type Credentials struct {
 	IdentityName        string
 	EnvironmentName     string
 	InjectedBearerToken string // file-less / bring-your-own-token override
+
+	// HTTPClient, when set, is the client the RFC 7523 token exchange (the
+	// mint) rides — the seam that carries the environment's SEC-20 CA-pinned
+	// transport and the attribution hook (User-Agent / session headers) into
+	// the exchange, so a mint shares the exact transport posture of every
+	// other backend call (#1205). Nil falls back to the package's default
+	// exchange client (system roots, no attribution). Callers must supply the
+	// BASE plane client, never one wrapped in the SDK's retry policy: the
+	// mint is what the policy's 401 re-exchange arm invokes, so routing it
+	// back through that policy could recurse.
+	HTTPClient *http.Client
 }
 
 // IdentityRef extracts the (identity, environment) pair keys/tokens are stored

--- a/cli/client/auth/oauth.go
+++ b/cli/client/auth/oauth.go
@@ -26,9 +26,36 @@ import (
 // while still tolerating real-world skew (the shipped CLI used 120s; impl/4.2 §4).
 const assertionTTL = 270 * time.Second
 
-// httpClient is the exchange's dedicated client: explicit timeout, never the
-// zero-timeout http.DefaultClient (rules/05).
-var httpClient = &http.Client{Timeout: 30 * time.Second}
+// exchangeTimeout bounds a single token exchange. It is also stamped onto a
+// copy of a caller-supplied Credentials.HTTPClient that has no timeout of its
+// own, so the mint never rides a zero-timeout client (rules/05).
+const exchangeTimeout = 30 * time.Second
+
+// httpClient is the exchange's fallback client when Credentials carries no
+// environment-specific one: explicit timeout, never the zero-timeout
+// http.DefaultClient (rules/05).
+var httpClient = &http.Client{Timeout: exchangeTimeout}
+
+// exchangeClient resolves the *http.Client a token exchange for creds goes
+// through. Credentials.HTTPClient wins when set — that is how the
+// environment's SEC-20 CA-pinned transport and the attribution hook
+// (User-Agent / session headers) reach the mint, which previously always went
+// out on the package default and so bypassed both (#1205). A caller client
+// with no Timeout of its own gets exchangeTimeout applied on a COPY (the
+// caller's client is shared with the plane clients and must not be mutated;
+// a zero-timeout mint could hang a whole command).
+func exchangeClient(creds Credentials) *http.Client {
+	hc := creds.HTTPClient
+	if hc == nil {
+		return httpClient
+	}
+	if hc.Timeout > 0 {
+		return hc
+	}
+	cp := *hc
+	cp.Timeout = exchangeTimeout
+	return &cp
+}
 
 // PendingError indicates the agent is registered but not yet approved: the token
 // endpoint returns 400 invalid_grant while approval is pending. Callers can
@@ -210,7 +237,7 @@ func performOAuthExchange(creds Credentials) (*TokenSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("encoding token request: %w", err)
 	}
-	resp, err := httpClient.Post(endpoint, "application/json", bytes.NewReader(reqBody))
+	resp, err := exchangeClient(creds).Post(endpoint, "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("token exchange request failed: %w", err)
 	}

--- a/cli/client/auth/oauth_test.go
+++ b/cli/client/auth/oauth_test.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jentic/jentic-one/cli/client/config"
+)
+
+// registerTestIdentity provisions the key + client-id registration BearerToken
+// needs before it can reach the exchange (mirrors the middleware_test setup).
+func registerTestIdentity(t *testing.T, identity, env, clientID string) {
+	t.Helper()
+	ref := IdentityRef{Identity: identity, Environment: env}
+	if _, err := GetOrGenerateKey(ref); err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	if err := config.MutateConfig(func(c *config.Config) error {
+		c.Identities[identity] = config.Identity{
+			Type: "agent",
+			Environments: map[string]config.EnvRegState{
+				env: {ClientID: clientID, Status: "approved"},
+			},
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("persist registration: %v", err)
+	}
+}
+
+// headerStampingTransport models the CLI's attribution TransportHook: it stamps
+// a User-Agent and delegates to base (wrap, never displace — SEC-20).
+type headerStampingTransport struct {
+	base      http.RoundTripper
+	userAgent string
+}
+
+func (t headerStampingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", t.userAgent)
+	return t.base.RoundTrip(req)
+}
+
+// TestBearerToken_MintHonorsPinnedCAAndAttribution is the #1205 regression:
+// the RFC 7523 token exchange must ride Credentials.HTTPClient — the seam that
+// carries the environment's SEC-20 CA-pinned transport and the attribution
+// hook — instead of the package-global default client. The token endpoint here
+// serves a cert the system roots do NOT trust, so the default-client mint must
+// fail while the pinned client's mint succeeds AND carries the attribution
+// User-Agent the hook stamps.
+func TestBearerToken_MintHonorsPinnedCAAndAttribution(t *testing.T) {
+	withConfigDir(t)
+	registerTestIdentity(t, "a1", "e1", "client_1")
+
+	var lastUA atomic.Value
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastUA.Store(r.Header.Get("User-Agent"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok_pinned","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	// Without a credential client the mint rides the package default (system
+	// roots) and must fail against the untrusted test CA — this is what proves
+	// the pinned success below actually went through Credentials.HTTPClient.
+	if _, err := BearerToken(Credentials{BaseURL: srv.URL, IdentityName: "a1", EnvironmentName: "e1"}); err == nil {
+		t.Fatal("mint on the default client must fail against a CA the system roots do not trust")
+	}
+
+	// The environment's client: CA-pinned transport (SEC-20) with the
+	// attribution RoundTripper composed over it, exactly as clictx builds it.
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	pinned := &http.Client{
+		Transport: headerStampingTransport{
+			base:      &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}},
+			userAgent: "jentic-mcp/test",
+		},
+	}
+	tok, err := BearerToken(Credentials{
+		BaseURL: srv.URL, IdentityName: "a1", EnvironmentName: "e1",
+		HTTPClient: pinned,
+	})
+	if err != nil {
+		t.Fatalf("mint through the pinned credential client: %v", err)
+	}
+	if tok != "tok_pinned" {
+		t.Errorf("token = %q, want the pinned mint's token", tok)
+	}
+	if ua, _ := lastUA.Load().(string); ua != "jentic-mcp/test" {
+		t.Errorf("exchange User-Agent = %q, want the attribution hook's value", ua)
+	}
+}
+
+// TestExchangeClient_Resolution pins the client-resolution rules: nil falls
+// back to the package default; a caller client with its own timeout is used
+// as-is; a zero-timeout caller client gets exchangeTimeout applied on a COPY
+// (the shared plane client must never be mutated, and a mint must never ride
+// a zero-timeout client — rules/05).
+func TestExchangeClient_Resolution(t *testing.T) {
+	if got := exchangeClient(Credentials{}); got != httpClient {
+		t.Errorf("nil HTTPClient must resolve to the package default")
+	}
+
+	withTimeout := &http.Client{Timeout: 5 * time.Second}
+	if got := exchangeClient(Credentials{HTTPClient: withTimeout}); got != withTimeout {
+		t.Errorf("a caller client with its own timeout must be used as-is")
+	}
+
+	rt := headerStampingTransport{base: http.DefaultTransport, userAgent: "x"}
+	zeroTimeout := &http.Client{Transport: rt}
+	got := exchangeClient(Credentials{HTTPClient: zeroTimeout})
+	if got == zeroTimeout {
+		t.Fatal("a zero-timeout caller client must be copied, not returned as-is")
+	}
+	if got.Timeout != exchangeTimeout {
+		t.Errorf("copy timeout = %v, want %v", got.Timeout, exchangeTimeout)
+	}
+	if got.Transport != http.RoundTripper(rt) {
+		t.Error("the copy must keep the caller's transport (the pinned+hooked one)")
+	}
+	if zeroTimeout.Timeout != 0 {
+		t.Error("the caller's client must not be mutated")
+	}
+}

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -56,8 +56,10 @@ type Config struct {
 	// attached verbatim (file-less / bring-your-own-token mode).
 	InjectedBearerToken string
 
-	// HTTPClient overrides the transport used by BOTH planes. Optional; a nil value
-	// uses the generated clients' default. Supply one to inject timeouts, a custom
+	// HTTPClient overrides the transport used by BOTH planes AND the RFC 7523
+	// token exchange (the mint inherits it via credentials() — #1205). Optional;
+	// a nil value uses the generated clients' default and the auth package's
+	// default exchange client. Supply one to inject timeouts, a custom
 	// CA pool (env ca_cert), or test doubles.
 	HTTPClient *http.Client
 
@@ -74,6 +76,12 @@ func (c Config) credentials() auth.Credentials {
 		IdentityName:        c.IdentityName,
 		EnvironmentName:     c.EnvironmentName,
 		InjectedBearerToken: c.InjectedBearerToken,
+		// The caller's base client rides into the RFC 7523 token exchange, so a
+		// mint honors the same custom CA pool / attribution transport as every
+		// other call on this config (#1205). Deliberately the BASE client, not
+		// the retry-wrapped one httpClient() builds: the mint is what the retry
+		// policy's 401 arm invokes, so wrapping it in that policy could recurse.
+		HTTPClient: c.HTTPClient,
 	}
 }
 

--- a/cli/client/client_test.go
+++ b/cli/client/client_test.go
@@ -169,3 +169,25 @@ func TestSessionEditor_AbsentWhenUnset(t *testing.T) {
 		t.Errorf("X-Jentic-Session-Id = %q, want empty", got)
 	}
 }
+
+// TestConfigCredentials_ThreadsHTTPClient is the SDK half of the #1205
+// regression: the caller-supplied base client (the SEC-20 CA-pinned,
+// attribution-hooked transport clictx builds) must ride into the projected
+// auth.Credentials, so the RFC 7523 token exchange shares the transport
+// posture of every other call on this config instead of the auth package's
+// unpinned default.
+func TestConfigCredentials_ThreadsHTTPClient(t *testing.T) {
+	hc := &http.Client{}
+	creds := Config{
+		ControlBaseURL: "https://ctl.example",
+		IdentityName:   "ci",
+		HTTPClient:     hc,
+	}.credentials()
+	if creds.HTTPClient != hc {
+		t.Error("Config.credentials() must thread the base HTTPClient into the mint seam (#1205)")
+	}
+
+	if creds := (Config{ControlBaseURL: "https://ctl.example"}).credentials(); creds.HTTPClient != nil {
+		t.Error("a nil Config.HTTPClient must stay nil (auth falls back to its default exchange client)")
+	}
+}

--- a/cli/internal/cli/api/access_run.go
+++ b/cli/internal/cli/api/access_run.go
@@ -272,7 +272,12 @@ func (a *app) refreshIfScopeGranted(cmd *cobra.Command, req *control.AccessReque
 	if st == nil {
 		return
 	}
-	creds := credsFromState(st)
+	creds, err := credsFromState(cmd.Context(), st)
+	if err != nil {
+		// Best-effort: a broken CA bundle already fails the command's real
+		// calls with an actionable error; don't duplicate it here.
+		return
+	}
 	// Static credentials (injected token, jak_* API key) have no mintable
 	// token — nothing to refresh.
 	if creds.InjectedBearerToken != "" {
@@ -420,7 +425,10 @@ func (a *app) accessRefreshE(cmd *cobra.Command, jsonFlag bool) error {
 // token carries the current scope grants, then confirm with /me. Same
 // fresh-mint-not-refresh-token semantics as the legacy arm (issue #673).
 func (a *app) accessRefreshContextE(cmd *cobra.Command, st *clictx.ActiveState, jsonFlag bool) error {
-	creds := credsFromState(st)
+	creds, err := credsFromState(cmd.Context(), st)
+	if err != nil {
+		return err
+	}
 	if creds.InjectedBearerToken != "" {
 		return errors.New("this session uses an injected bearer token ($JENTIC_BEARER_TOKEN), which the CLI cannot re-mint; " +
 			"obtain a fresh token from your orchestrator")

--- a/cli/internal/cli/api/logout.go
+++ b/cli/internal/cli/api/logout.go
@@ -36,12 +36,14 @@ func (a *app) logoutE(ctx context.Context) error {
 }
 
 func (a *app) logoutContextE(_ context.Context, st *clictx.ActiveState) error {
-	creds := credsFromState(st)
-	if creds.InjectedBearerToken != "" {
+	// No mint happens here (logout only reads/clears local state and revokes),
+	// so this deliberately does NOT go through credsFromState: a broken
+	// ca_cert_path must never block clearing local tokens.
+	if st.InjectedBearerToken != "" {
 		return errors.New("this session uses an injected bearer token ($JENTIC_BEARER_TOKEN); " +
 			"there is no CLI-stored token to clear — unset the variable instead")
 	}
-	ref := creds.IdentityRef()
+	ref := auth.IdentityRef{Identity: st.IdentityName, Environment: st.EnvironmentName}
 	tokens, err := auth.ReadTokens(ref)
 	if err == nil && tokens != nil && tokens.AccessToken != "" && st.BaseURL != "" {
 		// Best-effort revoke; report but do not fail on server/transport errors.

--- a/cli/internal/cli/api/mcp.go
+++ b/cli/internal/cli/api/mcp.go
@@ -85,15 +85,11 @@ func (a *app) mcpE(cmd *cobra.Command, opts *mcpOptions) error {
 	srv := newMCPServer(a, version, opts, logger)
 	// Every control-plane client built during this session composes the
 	// server's attribution RoundTripper (User-Agent + session-id fallback)
-	// over the SEC-20 resolved transport.
-	//
-	// KNOWN GAP (predates this command; follow-up tracked): the RFC 7523
-	// token-mint exchange uses the package-global client in
-	// client/auth/oauth.go, which is built outside clictx — mints go out
-	// without these attribution headers AND without the SEC-20 CA-pinned
-	// transport (a pinned-CA environment's mints fail closed through the
-	// untrusted-roots path). Fixing it belongs to the oauth client / DoWith
-	// seam work, not here.
+	// over the SEC-20 resolved transport. The RFC 7523 token-mint exchange
+	// rides the same pinned+hooked client: it is threaded into
+	// auth.Credentials.HTTPClient by the SDK constructors and the clictx
+	// credential builders (#1205), so mints carry these attribution headers
+	// and honor a pinned-CA environment's bundle like every other call.
 	ctx := clictx.WithTransportHook(cmd.Context(), srv.transportHook())
 
 	logger.Info("mcp server starting", "version", version, "read_only", opts.readOnly, "exclude_tools", opts.excludeTools)

--- a/cli/internal/cli/api/mcp_access.go
+++ b/cli/internal/cli/api/mcp_access.go
@@ -608,7 +608,11 @@ func (s *mcpServer) refreshTokenIfScopeGranted(ctx context.Context, st *clictx.A
 	if !requestGrantedScope(req) {
 		return
 	}
-	creds := credsFromState(st)
+	creds, err := credsFromState(ctx, st)
+	if err != nil {
+		s.logger.Warn("skipping token re-mint; mint transport unavailable", "error", redactedErr(err))
+		return
+	}
 	if creds.InjectedBearerToken != "" {
 		return // static credential: nothing mintable to refresh
 	}

--- a/cli/internal/cli/api/mcp_execute.go
+++ b/cli/internal/cli/api/mcp_execute.go
@@ -157,7 +157,7 @@ func (s *mcpServer) executeTool(ctx context.Context, req *mcp.CallToolRequest, r
 	}
 	// Auth failures (not registered / pending / revoked) map to their coded
 	// soft errors with the default get_started pointer (§3.7 table).
-	_, token, err := s.app.contextSession(st)
+	_, token, err := s.app.contextSession(cctx, st)
 	if err != nil {
 		s.logger.Warn(toolName+" auth failed", "error", err)
 		return s.softError(cctx, err), nil

--- a/cli/internal/cli/api/session.go
+++ b/cli/internal/cli/api/session.go
@@ -37,7 +37,7 @@ func (a *app) agentSession(ctx context.Context) (baseURL, token string, err erro
 	if err != nil {
 		return "", "", err
 	}
-	return a.contextSession(st)
+	return a.contextSession(ctx, st)
 }
 
 // requireState returns the active state or the canonical "no active
@@ -63,7 +63,7 @@ func (a *app) controlClient(ctx context.Context) (*control.ClientWithResponses, 
 	if err != nil {
 		return nil, err
 	}
-	if _, _, err := a.contextSession(st); err != nil {
+	if _, _, err := a.contextSession(ctx, st); err != nil {
 		return nil, err
 	}
 	return clictx.GetControlClient(ctx)
@@ -82,7 +82,7 @@ func noContextErr() *ux.CodedError {
 // SDK's credential-resolution order (injected token > jak_* API key > cached/
 // exchanged token) — byte-for-byte the credential the SDK request editor would
 // attach, so hand-rolled clients and generated clients can never disagree.
-func (a *app) contextSession(st *clictx.ActiveState) (baseURL, token string, err error) {
+func (a *app) contextSession(ctx context.Context, st *clictx.ActiveState) (baseURL, token string, err error) {
 	if st.BaseURL == "" {
 		return "", "", &ux.CodedError{
 			Code:       ux.CodeResolveFailed,
@@ -90,7 +90,11 @@ func (a *app) contextSession(st *clictx.ActiveState) (baseURL, token string, err
 			Actionable: "Set it with `jentic env add` / edit the environment.",
 		}
 	}
-	tok, err := auth.BearerToken(credsFromState(st))
+	creds, err := credsFromState(ctx, st)
+	if err != nil {
+		return "", "", err
+	}
+	tok, err := auth.BearerToken(creds)
 	if err != nil {
 		return "", "", contextAuthErr(err, st)
 	}
@@ -98,14 +102,24 @@ func (a *app) contextSession(st *clictx.ActiveState) (baseURL, token string, err
 }
 
 // credsFromState maps the resolved context onto the SDK's UX-free credential
-// input — the same mapping the SDK constructors apply to client.Config.
-func credsFromState(st *clictx.ActiveState) auth.Credentials {
+// input — the same mapping the SDK constructors apply to client.Config —
+// including the transport a mint must ride: the SEC-20 CA-pinned client when
+// the environment declares ca_cert_path (fail closed on a broken bundle), with
+// the context's attribution TransportHook composed over it (#1205). Without
+// that client the token exchange would fall back to the auth package's
+// unpinned, unattributed default.
+func credsFromState(ctx context.Context, st *clictx.ActiveState) (auth.Credentials, error) {
+	hc, err := clictx.AuthHTTPClient(ctx, st.CACertPath)
+	if err != nil {
+		return auth.Credentials{}, err
+	}
 	return auth.Credentials{
 		BaseURL:             st.BaseURL,
 		IdentityName:        st.IdentityName,
 		EnvironmentName:     st.EnvironmentName,
 		InjectedBearerToken: st.InjectedBearerToken,
-	}
+		HTTPClient:          hc,
+	}, nil
 }
 
 // contextAuthErr turns a credential-resolution failure into an actionable,

--- a/cli/internal/cli/clictx/client.go
+++ b/cli/internal/cli/clictx/client.go
@@ -119,18 +119,18 @@ func ControlHTTPClient(ctx context.Context) (*http.Client, error) {
 	return hookedPlaneHTTPClient(ctx)
 }
 
-// hookedPlaneHTTPClient is the shared constructor behind the raw plane
-// clients: the SEC-20 CA-pinned transport when the environment declares
-// ca_cert_path (fail closed on a broken bundle, exactly like the generated
-// clients), the default transport otherwise, with the context's TransportHook
-// composed over it (wrap, never displace — the pinning decision stays the
-// inner RoundTripper).
-func hookedPlaneHTTPClient(ctx context.Context) (*http.Client, error) {
-	state, err := stateForClient(FromContext(ctx))
-	if err != nil {
-		return nil, err
-	}
-	hc, err := caCertHTTPClient(state.CACertPath)
+// AuthHTTPClient builds the *http.Client backend auth calls made OUTSIDE a
+// generated plane client — the RFC 7523 token mint (auth.Credentials.HTTPClient)
+// — must ride for an environment whose custom CA bundle is caCertPath: the
+// SEC-20 CA-pinned transport when set (fail closed on a broken bundle, exactly
+// like the generated clients), the default transport otherwise, with the
+// context's TransportHook composed over it (wrap, never displace). This is the
+// same construction path every plane client goes through, extracted so the
+// direct BearerToken/RefreshBearerToken call sites (the session bridge, access
+// refresh, the register wait loop) mint through the identical transport
+// posture instead of the auth package's unpinned default (#1205).
+func AuthHTTPClient(ctx context.Context, caCertPath string) (*http.Client, error) {
+	hc, err := caCertHTTPClient(caCertPath)
 	if err != nil {
 		return nil, err
 	}
@@ -145,6 +145,20 @@ func hookedPlaneHTTPClient(ctx context.Context) (*http.Client, error) {
 		hc.Transport = hook(base)
 	}
 	return hc, nil
+}
+
+// hookedPlaneHTTPClient is the shared constructor behind the raw plane
+// clients: the SEC-20 CA-pinned transport when the environment declares
+// ca_cert_path (fail closed on a broken bundle, exactly like the generated
+// clients), the default transport otherwise, with the context's TransportHook
+// composed over it (wrap, never displace — the pinning decision stays the
+// inner RoundTripper).
+func hookedPlaneHTTPClient(ctx context.Context) (*http.Client, error) {
+	state, err := stateForClient(FromContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	return AuthHTTPClient(ctx, state.CACertPath)
 }
 
 // GetControlClient is the single constructor every Control Plane command uses. It

--- a/cli/internal/cli/clictx/client_test.go
+++ b/cli/internal/cli/clictx/client_test.go
@@ -2,7 +2,11 @@ package clictx
 
 import (
 	"context"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
@@ -105,5 +109,70 @@ func TestGetControlClient_BuildsWithState(t *testing.T) {
 	}
 	if c == nil {
 		t.Fatal("nil control client")
+	}
+}
+
+// markerTransport tags a wrapped RoundTripper so tests can prove the hook
+// composed over (never displaced) the resolved base transport.
+type markerTransport struct{ base http.RoundTripper }
+
+func (m markerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.base.RoundTrip(req)
+}
+
+// TestAuthHTTPClient_PinnedAndHooked pins the #1205 mint-transport builder:
+// the client the RFC 7523 exchange rides must carry the SEC-20 CA-pinned
+// transport (fail closed on a broken bundle) with the context's TransportHook
+// composed over it — the same construction path every plane client uses.
+func TestAuthHTTPClient_PinnedAndHooked(t *testing.T) {
+	// A set-but-broken bundle fails closed (SEC-20), exactly like the
+	// generated clients.
+	if _, err := AuthHTTPClient(context.Background(), "/definitely/not/a/real/ca-bundle.pem"); err == nil {
+		t.Fatal("AuthHTTPClient must fail closed on an unreadable ca_cert_path (SEC-20)")
+	}
+
+	// A valid bundle yields a transport pinned to that pool.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer srv.Close()
+	pemPath := filepath.Join(t.TempDir(), "ca.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+	if err := os.WriteFile(pemPath, pemBytes, 0o600); err != nil {
+		t.Fatalf("write ca bundle: %v", err)
+	}
+	hc, err := AuthHTTPClient(context.Background(), pemPath)
+	if err != nil {
+		t.Fatalf("AuthHTTPClient with a valid bundle: %v", err)
+	}
+	pinned, ok := hc.Transport.(*http.Transport)
+	if !ok || pinned.TLSClientConfig == nil || pinned.TLSClientConfig.RootCAs == nil {
+		t.Fatalf("transport = %T, want an *http.Transport pinned to the custom CA pool", hc.Transport)
+	}
+
+	// The context's TransportHook composes OVER the pinned transport: the hook
+	// receives the pinning decision as its base (wrap, never displace).
+	var hookBase http.RoundTripper
+	ctx := WithTransportHook(context.Background(), func(base http.RoundTripper) http.RoundTripper {
+		hookBase = base
+		return markerTransport{base: base}
+	})
+	hc, err = AuthHTTPClient(ctx, pemPath)
+	if err != nil {
+		t.Fatalf("AuthHTTPClient with hook: %v", err)
+	}
+	if _, ok := hc.Transport.(markerTransport); !ok {
+		t.Fatalf("transport = %T, want the hook's wrapper", hc.Transport)
+	}
+	base, ok := hookBase.(*http.Transport)
+	if !ok || base.TLSClientConfig == nil || base.TLSClientConfig.RootCAs == nil {
+		t.Errorf("hook base = %T, want the CA-pinned transport as the inner RoundTripper", hookBase)
+	}
+
+	// No bundle and no hook: a plain default client (system roots).
+	hc, err = AuthHTTPClient(context.Background(), "")
+	if err != nil {
+		t.Fatalf("AuthHTTPClient with no bundle: %v", err)
+	}
+	if hc.Transport != nil {
+		t.Errorf("transport = %T, want nil (default transport on system roots)", hc.Transport)
 	}
 }

--- a/cli/internal/cli/cmdcore/register_flow.go
+++ b/cli/internal/cli/cmdcore/register_flow.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jentic/jentic-one/cli/client/auth"
 	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 	"github.com/jentic/jentic-one/cli/internal/theme"
 )
@@ -105,6 +106,16 @@ func (a *App) registerAndWait(ctx context.Context, identity, envName, baseURL, c
 	a.presentClaimAffordance(ctx, baseURL, clientID, claimToken)
 
 	creds := auth.Credentials{BaseURL: baseURL, IdentityName: identity, EnvironmentName: envName}
+	// The approval wait proves approval by MINTING (the exact credential path
+	// every data command uses), so the mint must ride the same transport those
+	// commands will: the SEC-20 CA-pinned client when this environment declares
+	// ca_cert_path, fail closed on a broken bundle (#1205). cfg was loaded
+	// above; an env registered without a custom CA yields the default client.
+	hc, err := clictx.AuthHTTPClient(ctx, cfg.Environments[envName].CACertPath)
+	if err != nil {
+		return err
+	}
+	creds.HTTPClient = hc
 	if err := a.waitForApproval(ctx, creds, clientID, timeout, claimToken != ""); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Closes #1205 (MAJOR from the 2-E1/#1213 review wave): the RFC 7523 token mint (`POST /oauth/token`) went through a package-global `http.Client`, bypassing both the SEC-20 CA-pinned transport built from the environment's `ca_cert_path` and the attribution `TransportHook` (User-Agent + `X-Jentic-Session-Id`). In a pinned-CA environment every mint was validated against system roots instead of the pinned bundle — the exact known-gap comment in `cli/internal/cli/api/mcp.go`.

- New `auth.Credentials.HTTPClient` seam; `exchangeClient()` resolves it with a safe fallback (stamps the 30s exchange timeout on a copy, never mutates the shared plane client).
- `client.Config.credentials()` threads the caller's **base** client (not the retry-wrapped one — the mint is what the 401 re-exchange invokes; wrapping it in the retry policy could recurse).
- Extracted `clictx.AuthHTTPClient(ctx, caCertPath)` (pinned fail-closed, hook composed over it, wrap-never-displace); rewired all direct mint call sites: session bridge, `access refresh` (both arms), the MCP access-loop re-mint, and the register approval wait loop.
- `logout` deliberately no longer routes through the minting path — it never mints, and a broken CA bundle must not block clearing local tokens.
- Out of scope (noted in the commit): `Register`/`RevokeToken` (DCR / RFC 7009) keep the package default client.

## Test plan

- [x] `TestBearerToken_MintHonorsPinnedCAAndAttribution` — mint fails via default client against an untrusted-CA TLS server, succeeds through the pinned credential client, carries the hooked User-Agent
- [x] `TestExchangeClient_Resolution` — fallback/timeout-copy/no-mutation rules
- [x] `TestConfigCredentials_ThreadsHTTPClient` — SDK threading
- [x] `TestAuthHTTPClient_PinnedAndHooked` — fail-closed on broken bundle, hook wraps (never displaces) the pinned transport
- [x] `gofmt` clean, `go vet ./...`, `go build ./...`, `go test ./...` all green locally
