### PR TITLE
fix(ui): use --url in the DCR quickstart register snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Six steps from a running instance to a response from a real API.
    (e.g. `httpbin.org`, used in step 6), or upload your own specification.
 3. **Store a credential** for that API. It is encrypted at rest and is never returned to a
    caller.
-4. **Register the agent:** `jentic register` (add `--base-url <URL>` when the agent runs on a
+4. **Register the agent:** `jentic register` (add `--url <URL>` when the agent runs on a
    different machine). Registration waits for an operator to approve the
    agent. On a single-operator install, approve it in the UI and the command completes.
 5. **Grant access** by binding the agent to a toolkit. A rule-less binding blocks everything;

--- a/ui/src/modules/agents/__tests__/AgentsPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentsPage.test.tsx
@@ -378,7 +378,9 @@ describe('AgentsPage — agents lifecycle', () => {
 		// (raw POST /register needs an Ed25519 JWKS, so the CLI is the teachable path).
 		expect(screen.getByRole('button', { name: /Create one manually/ })).toBeInTheDocument();
 		expect(screen.getByText('Register an agent from the command line')).toBeInTheDocument();
-		expect(screen.getByText(/jentic register --base-url/)).toBeInTheDocument();
+		// Pin the real CLI flag: `jentic register` takes --url, not --base-url (#1204).
+		expect(screen.getByText(/jentic register --url /)).toBeInTheDocument();
+		expect(screen.queryByText(/--base-url/)).not.toBeInTheDocument();
 		expect(screen.getByText(/--name my-first-agent/)).toBeInTheDocument();
 	});
 

--- a/ui/src/modules/agents/components/DcrQuickstart.tsx
+++ b/ui/src/modules/agents/components/DcrQuickstart.tsx
@@ -9,11 +9,11 @@
  * plan).
  */
 import { Terminal } from 'lucide-react';
-import { Card, CardBody, CopyButton } from '@/shared/ui';
+import { Card, CardBody, CodeSnippet } from '@/shared/ui';
 
 /** The command the operator can paste — targets the current origin's API. */
 function snippet(): string {
-	return `jentic register --base-url "${window.location.origin}" --name my-first-agent`;
+	return `jentic register --url "${window.location.origin}" --name my-first-agent`;
 }
 
 export function DcrQuickstart() {
@@ -32,14 +32,7 @@ export function DcrQuickstart() {
 					<strong>pending</strong> for you to approve. The CLI generates the agent's
 					Ed25519 keypair and registers it in one step.
 				</p>
-				<div className="bg-muted/60 border-border/60 relative rounded-lg border p-3">
-					<pre className="text-foreground/90 overflow-x-auto pr-8 font-mono text-xs leading-relaxed">
-						{code}
-					</pre>
-					<div className="absolute top-2 right-2">
-						<CopyButton value={code} />
-					</div>
-				</div>
+				<CodeSnippet code={code} />
 			</CardBody>
 		</Card>
 	);

--- a/ui/src/shared/ui/CodeSnippet.tsx
+++ b/ui/src/shared/ui/CodeSnippet.tsx
@@ -12,8 +12,7 @@ export interface CodeSnippetProps {
 /**
  * One copyable code block: a bordered mono `<pre>` with a corner CopyButton
  * and an optional eyebrow label. The shared chrome for CLI snippets and
- * client-config JSON (the MCP config card; DcrQuickstart renders the same
- * chrome and migrates here as a follow-up).
+ * client-config JSON (the MCP config card and DcrQuickstart).
  */
 export function CodeSnippet({ code, label, className }: CodeSnippetProps) {
 	return (


### PR DESCRIPTION
## Summary

Closes #1204 (surfaced by the local-MCP self-review wave, PR #1190's review): the DCR quickstart rendered `jentic register --base-url …`, but V2 removed that flag — the real one is `--url` (`cli/internal/cli/cmdcore/register.go:67`; the removal is pinned by `TestRegister_LegacyFlagsRemoved`). Operators copy-pasting the snippet got an "unknown flag" error.

- `DcrQuickstart.tsx`: snippet now emits `jentic register --url "…" --name my-first-agent`, and the hand-rolled `pre` + `CopyButton` chrome is replaced with the shared `CodeSnippet` primitive (the follow-up its doc comment promised).
- `README.md`: the register step had the same `--base-url` bug in a rendered snippet — corrected.
- Other `--base-url` hits checked and deliberately left: `jenticctl status/doctor` and `skill init/update` genuinely take `--base-url`; the remaining references are historical notes about the removed V1 flag.

## Test plan

- [x] `AgentsPage.test.tsx` now pins `jentic register --url` and asserts `--base-url` is absent
- [x] `npm run lint:fix` clean, `npm run build` (tsc + vite) passes
- [x] Browser-mode vitest on `AgentsPage.test.tsx` + `CodeSnippet.test.tsx`: 27/27
