### PR TITLE
fix(cli): pin CA on cobra execute and refuse redirects on the broker leg

### DIFF
--- a/cli/client/auth/oauth.go
+++ b/cli/client/auth/oauth.go
@@ -33,27 +33,44 @@ const exchangeTimeout = 30 * time.Second
 
 // httpClient is the exchange's fallback client when Credentials carries no
 // environment-specific one: explicit timeout, never the zero-timeout
-// http.DefaultClient (rules/05).
-var httpClient = &http.Client{Timeout: exchangeTimeout}
+// http.DefaultClient (rules/05), and never following redirects (#1207 — see
+// noFollowRedirects). Also the client behind the other hand-rolled auth-server
+// calls (Register, RevokeToken).
+var httpClient = &http.Client{Timeout: exchangeTimeout, CheckRedirect: noFollowRedirects}
+
+// noFollowRedirects is the auth leg's redirect posture (#1207): the CLI's
+// auth-server POSTs (/oauth/token, /register, /oauth/revoke) are answered
+// directly by the control plane — nothing in the CLI relies on following a
+// redirect there (browser-facing OAuth redirects happen in the operator's
+// browser, never through this client, and the register/approval wait loops
+// poll by re-attempting the exchange, not via 3xx). Following one could only
+// mislead: Go would convert the redirected POST to a body-less GET, and a
+// hostile/misconfigured middlebox could bounce the call — attribution headers
+// attached — at an arbitrary address. Surface the 3xx as the final response
+// so classifyTokenError can name it.
+func noFollowRedirects(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
 // exchangeClient resolves the *http.Client a token exchange for creds goes
 // through. Credentials.HTTPClient wins when set — that is how the
 // environment's SEC-20 CA-pinned transport and the attribution hook
 // (User-Agent / session headers) reach the mint, which previously always went
-// out on the package default and so bypassed both (#1205). A caller client
-// with no Timeout of its own gets exchangeTimeout applied on a COPY (the
-// caller's client is shared with the plane clients and must not be mutated;
-// a zero-timeout mint could hang a whole command).
+// out on the package default and so bypassed both (#1205). The mint always
+// rides a COPY (the caller's client is shared with the plane clients and must
+// not be mutated) carrying the exchange invariants: a timeout when the caller
+// set none (a zero-timeout mint could hang a whole command — rules/05), and
+// the never-follow-redirects posture (#1207), enforced here at the mint's
+// single choke point so no caller-supplied client can silently reintroduce
+// redirect-following on a token POST.
 func exchangeClient(creds Credentials) *http.Client {
 	hc := creds.HTTPClient
 	if hc == nil {
 		return httpClient
 	}
-	if hc.Timeout > 0 {
-		return hc
-	}
 	cp := *hc
-	cp.Timeout = exchangeTimeout
+	if cp.Timeout == 0 {
+		cp.Timeout = exchangeTimeout
+	}
+	cp.CheckRedirect = noFollowRedirects
 	return &cp
 }
 
@@ -272,6 +289,16 @@ func performOAuthExchange(creds Credentials) (*TokenSet, error) {
 // shape ({"error": ..., "error_description": ...}) is also accepted so an
 // RFC-compliant server classifies identically.
 func classifyTokenError(resp *http.Response) error {
+	// #1207: redirects are never followed on auth calls (noFollowRedirects), so
+	// a 3xx lands here as the final response. Name it explicitly — "token
+	// exchange failed (status 302)" with an empty body would read like a server
+	// bug, when the actual problem is something between the CLI and the control
+	// plane trying to send the token POST elsewhere.
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return fmt.Errorf(
+			"token endpoint answered an unexpected redirect (status %d to %q); the CLI never follows redirects on auth calls — point base_url directly at the control plane",
+			resp.StatusCode, resp.Header.Get("Location"))
+	}
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 	var body struct {
 		Type        string `json:"type"`  // RFC 7807 problem details (the shipped backend)

--- a/cli/client/auth/oauth_test.go
+++ b/cli/client/auth/oauth_test.go
@@ -3,8 +3,10 @@ package auth
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -96,24 +98,73 @@ func TestBearerToken_MintHonorsPinnedCAAndAttribution(t *testing.T) {
 	}
 }
 
-// TestExchangeClient_Resolution pins the client-resolution rules: nil falls
-// back to the package default; a caller client with its own timeout is used
-// as-is; a zero-timeout caller client gets exchangeTimeout applied on a COPY
-// (the shared plane client must never be mutated, and a mint must never ride
-// a zero-timeout client — rules/05).
+// TestBearerToken_MintRefusesRedirect is the #1207 auth-leg regression: a
+// token endpoint that answers the exchange POST with a redirect must NOT be
+// followed — the redirect target never receives a request — and the surfaced
+// failure names the redirect instead of a bare "status 302".
+func TestBearerToken_MintRefusesRedirect(t *testing.T) {
+	withConfigDir(t)
+	registerTestIdentity(t, "a2", "e2", "client_2")
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path == "/stolen" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"tok_evil","expires_in":3600}`))
+			return
+		}
+		http.Redirect(w, r, "/stolen", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := BearerToken(Credentials{BaseURL: srv.URL, IdentityName: "a2", EnvironmentName: "e2"})
+	if err == nil {
+		t.Fatal("a redirected token exchange must fail, never mint through the redirect target")
+	}
+	if !strings.Contains(err.Error(), "redirect") || !strings.Contains(err.Error(), "/stolen") {
+		t.Errorf("error %q should name the refused redirect and its Location", err)
+	}
+	if len(paths) != 1 || paths[0] != "/oauth/token" {
+		t.Errorf("requested paths = %v, want only /oauth/token (the redirect target must never be fetched)", paths)
+	}
+}
+
+// back to the package default; a caller client always yields a COPY (the
+// shared plane client must never be mutated) that keeps the caller's own
+// timeout and transport, gets exchangeTimeout when the caller set none (a
+// mint must never ride a zero-timeout client — rules/05), and carries the
+// never-follow-redirects posture regardless of what the caller configured
+// (#1207).
 func TestExchangeClient_Resolution(t *testing.T) {
 	if got := exchangeClient(Credentials{}); got != httpClient {
 		t.Errorf("nil HTTPClient must resolve to the package default")
 	}
+	if httpClient.CheckRedirect == nil {
+		t.Error("the package default client must refuse redirects (#1207)")
+	}
 
 	withTimeout := &http.Client{Timeout: 5 * time.Second}
-	if got := exchangeClient(Credentials{HTTPClient: withTimeout}); got != withTimeout {
-		t.Errorf("a caller client with its own timeout must be used as-is")
+	got := exchangeClient(Credentials{HTTPClient: withTimeout})
+	if got == withTimeout {
+		t.Fatal("a caller client must be copied, not returned as-is (the redirect posture is stamped on the copy)")
+	}
+	if got.Timeout != 5*time.Second {
+		t.Errorf("copy timeout = %v, want the caller's own 5s", got.Timeout)
+	}
+	if got.CheckRedirect == nil {
+		t.Error("the exchange copy must refuse redirects (#1207)")
+	}
+	if err := got.CheckRedirect(nil, nil); !errors.Is(err, http.ErrUseLastResponse) {
+		t.Errorf("CheckRedirect returned %v, want http.ErrUseLastResponse", err)
+	}
+	if withTimeout.CheckRedirect != nil {
+		t.Error("the caller's client must not be mutated")
 	}
 
 	rt := headerStampingTransport{base: http.DefaultTransport, userAgent: "x"}
 	zeroTimeout := &http.Client{Transport: rt}
-	got := exchangeClient(Credentials{HTTPClient: zeroTimeout})
+	got = exchangeClient(Credentials{HTTPClient: zeroTimeout})
 	if got == zeroTimeout {
 		t.Fatal("a zero-timeout caller client must be copied, not returned as-is")
 	}

--- a/cli/internal/agentops/execute.go
+++ b/cli/internal/agentops/execute.go
@@ -235,6 +235,17 @@ func DoWith(hc *http.Client, req *http.Request) (*ExecuteResult, error) {
 	if base.Timeout == 0 {
 		base.Timeout = 60 * time.Second
 	}
+	// #1207: never follow a redirect on the broker leg. The CLI never
+	// legitimately expects the broker to redirect it, and following one would
+	// let a compromised/MITM'd broker 302 this request — bearer, correlation
+	// and attribution headers attached — at an arbitrary (possibly internal /
+	// link-local) address, the same SSRF primitive the hosted-skills fetch
+	// closed in #1192. The 3xx surfaces as the final response and is mapped to
+	// a coded error below (unless it is a mirrored UPSTREAM response — the
+	// transparent-proxy contract). Set here, at the single send choke point,
+	// so every execute surface (cobra, MCP, embedders, the nil-client default)
+	// carries the posture regardless of how its base client was built.
+	base.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 	httpClient := sdkclient.BrokerTransport(sdkclient.Config{HTTPClient: &base})
 	// G704 (SSRF) is intentional, not a finding: dialing a caller-chosen broker
 	// target IS this function's contract. The URL is guarded upstream —
@@ -269,12 +280,46 @@ func DoWith(hc *http.Client, req *http.Request) (*ExecuteResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
 	}
-	return &ExecuteResult{
+	res := &ExecuteResult{
 		Status:      resp.StatusCode,
 		Headers:     resp.Header,
 		Body:        body,
 		ExecutionID: resp.Header.Get("Jentic-Execution-Id"),
-	}, nil
+	}
+	// #1207: a redirect the BROKER itself answered (CheckRedirect
+	// above surfaced it as the final response) must be a coded error, never a
+	// confusing "HTTP 302" success/pass-through the exit taxonomy reads as a
+	// non-denial response. A redirect the broker merely MIRRORED from the
+	// upstream (Jentic-Error-Origin: upstream) is a successfully proxied
+	// response and passes through untouched — the broker is a transparent
+	// forward proxy and the upstream's 3xx is the caller's data. Only the
+	// Location-following statuses count; a 304 conditional-read answer is not
+	// a redirect and keeps flowing as a normal result.
+	if brokerRedirect(res) {
+		return nil, &ux.CodedError{
+			Code: ux.CodeTransportError,
+			Msg: fmt.Sprintf("broker answered an unexpected redirect (HTTP %d to %q); redirects are never followed on the broker leg",
+				res.Status, res.Headers.Get("Location")),
+			Actionable: "The broker must answer directly. Verify the environment's broker_url points at the actual broker " +
+				"(no redirecting proxy in front): `jentic env add <env> --broker-url https://<broker-host>:<port> --force`.",
+		}
+	}
+	return res, nil
+}
+
+// brokerRedirect reports whether res is a Location-following redirect
+// (301/302/303/307/308) the broker itself emitted, as opposed to one it
+// mirrored from the upstream (Jentic-Error-Origin: upstream). A missing
+// origin header is treated as broker, matching IsBrokerDenial's fail-closed
+// disambiguation.
+func brokerRedirect(res *ExecuteResult) bool {
+	switch res.Status {
+	case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther,
+		http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+		return errorOrigin(res) != errorOriginUpstream
+	default:
+		return false
+	}
 }
 
 // Execute is the one-call UX-free core (ExecuteRequest → ExecuteResult):

--- a/cli/internal/agentops/execute_test.go
+++ b/cli/internal/agentops/execute_test.go
@@ -127,6 +127,95 @@ func TestDo_DialClosedPortIsBareTransportError(t *testing.T) {
 	}
 }
 
+// TestDoWith_RefusesBrokerRedirect is the #1207 broker-leg regression: a
+// broker that answers with a redirect must NOT be followed — no second
+// request lands anywhere — and the surfaced 3xx maps to a coded
+// TRANSPORT_ERROR naming the redirect, never a confusing "HTTP 302" success.
+func TestDoWith_RefusesBrokerRedirect(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path == "/internal-admin" {
+			_, _ = w.Write([]byte(`{"should":"never be seen"}`))
+			return
+		}
+		http.Redirect(w, r, "/internal-admin", http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := BuildRequest(context.Background(), ExecuteRequest{
+		Method:       http.MethodGet,
+		Path:         "/v1/pets",
+		BrokerScheme: "http",
+		BrokerHost:   srv.Listener.Addr().String(),
+		Token:        "tok_abc",
+	})
+	if err != nil {
+		t.Fatalf("BuildRequest: %v", err)
+	}
+
+	_, err = Do(req)
+	if err == nil {
+		t.Fatal("a broker redirect must surface as an error, not be followed or pass as a result")
+	}
+	var coded *ux.CodedError
+	if !errors.As(err, &coded) {
+		t.Fatalf("Do returned %T (%v), want *ux.CodedError", err, err)
+	}
+	if coded.Code != ux.CodeTransportError {
+		t.Errorf("code = %q, want %q", coded.Code, ux.CodeTransportError)
+	}
+	if !strings.Contains(coded.Msg, "redirect") || !strings.Contains(coded.Msg, "302") ||
+		!strings.Contains(coded.Msg, "/internal-admin") {
+		t.Errorf("msg %q should name the refused redirect, its status, and its Location", coded.Msg)
+	}
+	if !strings.Contains(coded.Actionable, "broker_url") {
+		t.Errorf("actionable %q should point at the broker_url configuration", coded.Actionable)
+	}
+	if len(paths) != 1 || paths[0] != "/v1/pets" {
+		t.Errorf("requested paths = %v, want only the broker path (the redirect target must never be fetched)", paths)
+	}
+}
+
+// TestDoWith_UpstreamRedirectPassesThrough pins the transparent-proxy carve-out
+// of the #1207 refusal: a 3xx the broker MIRRORED from the upstream
+// (Jentic-Error-Origin: upstream) is a successfully proxied response — the
+// caller's data, not a broker transport violation. It is still never
+// FOLLOWED (the Location may be internal to the upstream's own topology and
+// must be the agent's decision), but it flows through as a normal result.
+func TestDoWith_UpstreamRedirectPassesThrough(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.Header().Set("Jentic-Error-Origin", "upstream")
+		w.Header().Set("Location", "https://upstream.example/moved")
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := BuildRequest(context.Background(), ExecuteRequest{
+		Method:       http.MethodGet,
+		Path:         "/v1/pets",
+		BrokerScheme: "http",
+		BrokerHost:   srv.Listener.Addr().String(),
+		Token:        "tok_abc",
+	})
+	if err != nil {
+		t.Fatalf("BuildRequest: %v", err)
+	}
+
+	res, err := Do(req)
+	if err != nil {
+		t.Fatalf("a mirrored upstream 302 is the caller's data, not an error: %v", err)
+	}
+	if res.Status != http.StatusFound {
+		t.Errorf("status = %d, want the upstream's 302 surfaced verbatim", res.Status)
+	}
+	if hits != 1 {
+		t.Errorf("broker hits = %d, want 1 (the Location must never be fetched)", hits)
+	}
+}
+
 func TestTransportFailurePreSend(t *testing.T) {
 	cases := []struct {
 		name string

--- a/cli/internal/cli/api/execute.go
+++ b/cli/internal/cli/api/execute.go
@@ -273,9 +273,20 @@ func (a *app) executeE(cmd *cobra.Command, opts *executeOptions, target string) 
 		return nil
 	}
 
-	// Send phase (agentops.Do): the SDK broker transport with its response
-	// policy, and a bounded body read into the UX-free result.
-	result, err := agentops.Do(req)
+	// Send phase (agentops.DoWith): the SDK broker transport with its response
+	// policy, and a bounded body read into the UX-free result. The broker leg
+	// rides clictx's SEC-20 CA-pinned client — fail closed on a broken
+	// ca_cert_path — with the context's TransportHook composed over it, exactly
+	// like the MCP path (§3.7.2). Previously this called agentops.Do, whose
+	// default client ignored the environment's ca_cert_path, so the cobra
+	// execute silently dropped the operator's trust decision (#1206). Resolved
+	// AFTER the dry-run gate: rendering a plan needs no transport, so --dry-run
+	// keeps working on a machine whose CA bundle is momentarily broken.
+	hc, err := clictx.BrokerHTTPClient(cmd.Context())
+	if err != nil {
+		return err
+	}
+	result, err := agentops.DoWith(hc, req)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/cli/api/execute_test.go
+++ b/cli/internal/cli/api/execute_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1216,6 +1219,73 @@ func TestExecuteRemoteBrokerGuardHonoursExplicitLoopback(t *testing.T) {
 	if errors.As(err, &coded) && coded.Code == ux.CodeResolveFailed &&
 		strings.Contains(coded.Msg, "no broker is configured") {
 		t.Errorf("explicit loopback broker must be honoured, not refused by the guard: %v", err)
+	}
+}
+
+// TestExecuteCmdBrokerLegHonorsCAPin is the #1206 regression, modeled on
+// TestMCPExecute_BrokerLegHonorsCAPinAndHook (§3.7.2): the COBRA execute
+// path's broker leg must ride clictx's SEC-20 CA-pinned client — previously it
+// fell through agentops.Do's default, un-pinned client, silently ignoring the
+// environment's ca_cert_path. The broker here serves a cert only the
+// environment's bundle trusts, so success proves the pinned client carried the
+// request; the un-pinned default would fail TLS verification.
+func TestExecuteCmdBrokerLegHonorsCAPin(t *testing.T) {
+	var brokerHits int
+	broker := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		brokerHits++
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer broker.Close()
+
+	// Write the test server's own CA cert as the environment's bundle.
+	pemPath := filepath.Join(t.TempDir(), "ca.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: broker.Certificate().Raw})
+	if err := os.WriteFile(pemPath, pemBytes, 0o600); err != nil {
+		t.Fatalf("write ca bundle: %v", err)
+	}
+
+	state := &clictx.ActiveState{
+		ResolvedState: &sdkconfig.ResolvedState{
+			IdentityName:        "test-agent",
+			EnvironmentName:     "test",
+			BaseURL:             "https://127.0.0.1:8000", // loopback so the remote-broker guard stays quiet
+			BrokerURL:           broker.URL,
+			CACertPath:          pemPath,
+			InjectedBearerToken: "tok_abc",
+		},
+		Mode: clictx.ModeHuman,
+	}
+
+	app := testApp(t)
+	cmd := newExecuteCmd(app)
+	cmd.SetContext(clictx.WithActiveState(context.Background(), state))
+
+	// Default broker flags: the environment's broker_url (the TLS server) wins.
+	opts := &executeOptions{
+		brokerHost:   config.DefaultBrokerHost,
+		brokerScheme: config.DefaultBrokerScheme,
+		json:         true,
+	}
+	if err := app.executeE(cmd, opts, "GET:/v1/pets"); err != nil {
+		t.Fatalf("CA-pinned broker call must succeed against the pinned cert: %v", err)
+	}
+	if brokerHits != 1 {
+		t.Fatalf("broker hits = %d, want 1", brokerHits)
+	}
+
+	// SEC-20 fail-closed: a set-but-broken bundle is an error, never a silent
+	// fallback to system roots (which is exactly what the un-pinned default
+	// client used to do).
+	state.CACertPath = filepath.Join(t.TempDir(), "missing.pem")
+	err := app.executeE(cmd, opts, "GET:/v1/pets")
+	if err == nil {
+		t.Fatal("a broken ca_cert_path must fail closed on the cobra execute broker leg")
+	}
+	if !strings.Contains(err.Error(), "ca_cert_path") {
+		t.Errorf("error %q must name the broken ca_cert_path", err)
+	}
+	if brokerHits != 1 {
+		t.Errorf("broker hits = %d after fail-closed error, want still 1 (no un-pinned fallback request)", brokerHits)
 	}
 }
 

--- a/cli/internal/cli/api/execute_test.go
+++ b/cli/internal/cli/api/execute_test.go
@@ -1289,6 +1289,55 @@ func TestExecuteCmdBrokerLegHonorsCAPin(t *testing.T) {
 	}
 }
 
+// TestExecuteCmdBrokerRedirectRefused is the cobra-path #1207 regression: a
+// broker answering with a 302 must not be followed (the redirect target never
+// receives a request) and must surface as a coded TRANSPORT_ERROR (exit 1)
+// naming the redirect — not as a confusing "HTTP 302" success envelope.
+func TestExecuteCmdBrokerRedirectRefused(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path == "/internal-admin" {
+			_, _ = w.Write([]byte(`{"should":"never be seen"}`))
+			return
+		}
+		http.Redirect(w, r, "/internal-admin", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	app := testApp(t)
+	seedRegistered(t, app, "default", srv.URL)
+	app.Out = new(bytes.Buffer)
+	app.Err = new(bytes.Buffer)
+	root := newAPIRootCmd(app.App)
+	root.SetOut(app.Out)
+	root.SetErr(app.Err)
+	root.SetArgs([]string{
+		"execute", "GET:/v1/pets",
+		"--json",
+		"--broker-scheme", "http",
+		"--broker-host", srv.Listener.Addr().String(),
+	})
+
+	err := root.Execute()
+	var coded *ux.CodedError
+	if !errors.As(err, &coded) {
+		t.Fatalf("a broker redirect returned %T (%v), want *ux.CodedError", err, err)
+	}
+	if coded.Code != ux.CodeTransportError {
+		t.Errorf("code = %q, want %q", coded.Code, ux.CodeTransportError)
+	}
+	if coded.ExitCode() != 1 {
+		t.Errorf("exit = %d, want 1 (transport failure)", coded.ExitCode())
+	}
+	if !strings.Contains(coded.Msg, "redirect") {
+		t.Errorf("msg %q should name the refused redirect", coded.Msg)
+	}
+	if len(paths) != 1 || paths[0] != "/v1/pets" {
+		t.Errorf("requested paths = %v, want only the broker path (the redirect target must never be fetched)", paths)
+	}
+}
+
 // TestExecuteMalformedBrokerURLErrors pins M2 (review round-3 #3): a broker_url
 // that is SET but malformed (no scheme/host) must fail closed with a coded
 // RESOLVE_FAILED naming the bad value, not silently fall through to dialing the

--- a/cli/internal/cli/clictx/client.go
+++ b/cli/internal/cli/clictx/client.go
@@ -137,6 +137,14 @@ func AuthHTTPClient(ctx context.Context, caCertPath string) (*http.Client, error
 	if hc == nil {
 		hc = &http.Client{}
 	}
+	// #1207: raw plane calls never follow redirects. Every consumer of this
+	// constructor — the token mint, the broker leg (BrokerHTTPClient), the raw
+	// control fetches (ControlHTTPClient) — talks to an endpoint that answers
+	// directly, so a 3xx is only ever a misconfigured/hostile middlebox trying
+	// to point the CLI (headers attached) somewhere else. Surface it as the
+	// final response; each call site classifies it (the mint's classifier, the
+	// broker leg's coded error, the skills fetch's bundled fallback).
+	hc.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 	if hook := transportHookFrom(ctx); hook != nil {
 		base := hc.Transport
 		if base == nil {

--- a/cli/internal/cli/clictx/client_test.go
+++ b/cli/internal/cli/clictx/client_test.go
@@ -3,6 +3,7 @@ package clictx
 import (
 	"context"
 	"encoding/pem"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -174,5 +175,13 @@ func TestAuthHTTPClient_PinnedAndHooked(t *testing.T) {
 	}
 	if hc.Transport != nil {
 		t.Errorf("transport = %T, want nil (default transport on system roots)", hc.Transport)
+	}
+	// #1207: every client this constructor hands out — the mint, the broker
+	// leg, the raw control fetches — refuses to follow redirects.
+	if hc.CheckRedirect == nil {
+		t.Fatal("AuthHTTPClient must refuse redirects (#1207)")
+	}
+	if rerr := hc.CheckRedirect(nil, nil); !errors.Is(rerr, http.ErrUseLastResponse) {
+		t.Errorf("CheckRedirect returned %v, want http.ErrUseLastResponse", rerr)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1206 and #1207 — the last two transport-hardening leftovers from the local-MCP review wave, one commit each (rebased onto main after #1215's merge).

**#1206 — cobra execute path rides the pinned client.** `jentic execute` reached `agentops.Do(req)`, which falls back to a default broker client with no per-environment `ca_cert_path` handling. It now resolves `clictx.BrokerHTTPClient` (SEC-20 pinned, fail-closed, attribution hook composed) and sends via `agentops.DoWith` — same construction as the MCP path. Client resolution happens after the `--dry-run` gate, so plan rendering never needs a transport.

**#1207 — the broker leg refuses redirects.** #1192 set `CheckRedirect = http.ErrUseLastResponse` on the hosted skills fetch; the broker leg shared the exposure (a compromised broker could 302 the CLI toward internal addresses). Now:

- `agentops.DoWith` — the single choke point for every execute surface — refuses redirects; a broker-origin 3xx maps to a coded `TRANSPORT_ERROR` naming the status and `Location` (never a confusing "success").
- Carve-out: a 3xx the broker **mirrored from the upstream** (`Jentic-Error-Origin: upstream`) passes through verbatim as caller data (still never followed) — preserving the transparent-proxy contract. 304 flows normally.
- The auth/mint leg gets the same posture (`exchangeClient`, the auth package default client, `clictx.AuthHTTPClient`): nothing in the codebase relies on following a redirect on control-plane or broker calls — OAuth/claim redirects happen in the operator's browser, and Go would convert a followed token-POST redirect into a body-less GET.
- Deliberately out of scope (in the commit body): the generated control-plane clients keep Go's default following — auth rides the request editor, and a same-host redirecting front (trailing-slash 307) is plausible deployment reality.

## Test plan

- [x] `TestExecuteCmdBrokerLegHonorsCAPin` — pinned-CA TLS broker succeeds, broken bundle fails closed naming `ca_cert_path`
- [x] `TestDoWith_RefusesBrokerRedirect` + `TestExecuteCmdBrokerRedirectRefused` — exactly one request lands, target never fetched, coded error
- [x] `TestDoWith_UpstreamRedirectPassesThrough` — mirrored upstream 302 is a normal, un-followed result
- [x] `TestBearerToken_MintRefusesRedirect` + posture pins on `exchangeClient` / `AuthHTTPClient`
- [x] `gofmt` clean, `go vet`, `go build`, `go test ./...` (29 packages) all green locally; re-verified build+vet after the rebase onto main
