### PR TITLE
feat(auth): /mcp-scoped RFC 8414 + RFC 9728 discovery + 401 resource_metadata (3a-4)

### DIFF
--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -4469,6 +4469,44 @@ type ClientInterface interface {
 	// Corresponds with GET /.well-known/oauth-authorization-server (the `OauthAuthorizationServer` operationId).
 	OauthAuthorizationServer(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// McpOauthAuthorizationServer OAuth authorization server metadata for the MCP resource
+	//
+	// RFC 8414 metadata for the path-scoped issuer `{base}/mcp` (phase-3a §4.7).
+	//
+	// RFC 8414 §3.1 path insertion: this is the metadata URL clients derive for
+	// the issuer `{base}/mcp` named by the protected-resource document. It
+	// advertises the anonymous OAuth-client registration door (`/oauth-clients`)
+	// and the public-client profile (`none` + PKCE S256) — the root document is a
+	// separate, unchanged surface whose `registration_endpoint` remains the agent
+	// `/register`.
+	//
+	// Corresponds with GET /.well-known/oauth-authorization-server/mcp (the `McpOauthAuthorizationServer` operationId).
+	McpOauthAuthorizationServer(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// OauthProtectedResource OAuth protected resource metadata (root alias)
+	//
+	// Root-path alias of the MCP protected-resource document (phase-3a §4.7).
+	//
+	// Compatibility fallback for clients that probe the root
+	// `/.well-known/oauth-protected-resource` instead of following the 401's
+	// `resource_metadata` pointer (the documented Claude Code behaviour). Safe
+	// because this deployment has exactly one OAuth-protected resource, so the
+	// root and path-scoped documents are the same body.
+	//
+	// Corresponds with GET /.well-known/oauth-protected-resource (the `OauthProtectedResource` operationId).
+	OauthProtectedResource(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// McpOauthProtectedResource OAuth protected resource metadata for the MCP resource
+	//
+	// RFC 9728 protected-resource metadata for `{base}/mcp` (phase-3a §4.7).
+	//
+	// Names the /mcp-scoped authorization server and the MCP tool scopes. The
+	// same body is also served at the root well-known path for clients that
+	// ignore the 401's `resource_metadata` pointer.
+	//
+	// Corresponds with GET /.well-known/oauth-protected-resource/mcp (the `McpOauthProtectedResource` operationId).
+	McpOauthProtectedResource(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListAccessRequests List access requests
 	//
 	// List access requests with cursor-based pagination.
@@ -6547,6 +6585,74 @@ func (c *Client) Jwks(ctx context.Context, reqEditors ...RequestEditorFn) (*http
 // Corresponds with GET /.well-known/oauth-authorization-server (the `OauthAuthorizationServer` operationId).
 func (c *Client) OauthAuthorizationServer(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewOauthAuthorizationServerRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// McpOauthAuthorizationServer OAuth authorization server metadata for the MCP resource
+//
+// RFC 8414 metadata for the path-scoped issuer `{base}/mcp` (phase-3a §4.7).
+//
+// RFC 8414 §3.1 path insertion: this is the metadata URL clients derive for
+// the issuer `{base}/mcp` named by the protected-resource document. It
+// advertises the anonymous OAuth-client registration door (`/oauth-clients`)
+// and the public-client profile (`none` + PKCE S256) — the root document is a
+// separate, unchanged surface whose `registration_endpoint` remains the agent
+// `/register`.
+//
+// Corresponds with GET /.well-known/oauth-authorization-server/mcp (the `McpOauthAuthorizationServer` operationId).
+func (c *Client) McpOauthAuthorizationServer(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMcpOauthAuthorizationServerRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// OauthProtectedResource OAuth protected resource metadata (root alias)
+//
+// Root-path alias of the MCP protected-resource document (phase-3a §4.7).
+//
+// Compatibility fallback for clients that probe the root
+// `/.well-known/oauth-protected-resource` instead of following the 401's
+// `resource_metadata` pointer (the documented Claude Code behaviour). Safe
+// because this deployment has exactly one OAuth-protected resource, so the
+// root and path-scoped documents are the same body.
+//
+// Corresponds with GET /.well-known/oauth-protected-resource (the `OauthProtectedResource` operationId).
+func (c *Client) OauthProtectedResource(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewOauthProtectedResourceRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// McpOauthProtectedResource OAuth protected resource metadata for the MCP resource
+//
+// RFC 9728 protected-resource metadata for `{base}/mcp` (phase-3a §4.7).
+//
+// Names the /mcp-scoped authorization server and the MCP tool scopes. The
+// same body is also served at the root well-known path for clients that
+// ignore the 401's `resource_metadata` pointer.
+//
+// Corresponds with GET /.well-known/oauth-protected-resource/mcp (the `McpOauthProtectedResource` operationId).
+func (c *Client) McpOauthProtectedResource(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMcpOauthProtectedResourceRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -10837,6 +10943,87 @@ func NewOauthAuthorizationServerRequest(server string) (*http.Request, error) {
 	}
 
 	operationPath := fmt.Sprintf("/.well-known/oauth-authorization-server")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewMcpOauthAuthorizationServerRequest constructs an http.Request for the McpOauthAuthorizationServer method
+func NewMcpOauthAuthorizationServerRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/.well-known/oauth-authorization-server/mcp")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewOauthProtectedResourceRequest constructs an http.Request for the OauthProtectedResource method
+func NewOauthProtectedResourceRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/.well-known/oauth-protected-resource")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewMcpOauthProtectedResourceRequest constructs an http.Request for the McpOauthProtectedResource method
+func NewMcpOauthProtectedResourceRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/.well-known/oauth-protected-resource/mcp")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -19319,6 +19506,50 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with GET /.well-known/oauth-authorization-server (the `OauthAuthorizationServer` operationId).
 	OauthAuthorizationServerWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*OauthAuthorizationServerHTTPResp, error)
 
+	// McpOauthAuthorizationServerWithResponse OAuth authorization server metadata for the MCP resource
+	//
+	// RFC 8414 metadata for the path-scoped issuer `{base}/mcp` (phase-3a §4.7).
+	//
+	// RFC 8414 §3.1 path insertion: this is the metadata URL clients derive for
+	// the issuer `{base}/mcp` named by the protected-resource document. It
+	// advertises the anonymous OAuth-client registration door (`/oauth-clients`)
+	// and the public-client profile (`none` + PKCE S256) — the root document is a
+	// separate, unchanged surface whose `registration_endpoint` remains the agent
+	// `/register`.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /.well-known/oauth-authorization-server/mcp (the `McpOauthAuthorizationServer` operationId).
+	McpOauthAuthorizationServerWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*McpOauthAuthorizationServerHTTPResp, error)
+
+	// OauthProtectedResourceWithResponse OAuth protected resource metadata (root alias)
+	//
+	// Root-path alias of the MCP protected-resource document (phase-3a §4.7).
+	//
+	// Compatibility fallback for clients that probe the root
+	// `/.well-known/oauth-protected-resource` instead of following the 401's
+	// `resource_metadata` pointer (the documented Claude Code behaviour). Safe
+	// because this deployment has exactly one OAuth-protected resource, so the
+	// root and path-scoped documents are the same body.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /.well-known/oauth-protected-resource (the `OauthProtectedResource` operationId).
+	OauthProtectedResourceWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*OauthProtectedResourceHTTPResp, error)
+
+	// McpOauthProtectedResourceWithResponse OAuth protected resource metadata for the MCP resource
+	//
+	// RFC 9728 protected-resource metadata for `{base}/mcp` (phase-3a §4.7).
+	//
+	// Names the /mcp-scoped authorization server and the MCP tool scopes. The
+	// same body is also served at the root well-known path for clients that
+	// ignore the 401's `resource_metadata` pointer.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /.well-known/oauth-protected-resource/mcp (the `McpOauthProtectedResource` operationId).
+	McpOauthProtectedResourceWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*McpOauthProtectedResourceHTTPResp, error)
+
 	// ListAccessRequestsWithResponse List access requests
 	//
 	// List access requests with cursor-based pagination.
@@ -21729,6 +21960,213 @@ func (r OauthAuthorizationServerHTTPResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r OauthAuthorizationServerHTTPResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type McpOauthAuthorizationServerHTTPResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *map[string]interface{}
+	// ApplicationproblemJSON400 the response for an HTTP 400 `application/problem+json` response
+	ApplicationproblemJSON400 *ProblemDetail
+	// ApplicationproblemJSON422 the response for an HTTP 422 `application/problem+json` response
+	ApplicationproblemJSON422 *ProblemDetail
+	// ApplicationproblemJSON500 the response for an HTTP 500 `application/problem+json` response
+	ApplicationproblemJSON500 *ProblemDetail
+	// ApplicationproblemJSON503 the response for an HTTP 503 `application/problem+json` response
+	ApplicationproblemJSON503 *ProblemDetail
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r McpOauthAuthorizationServerHTTPResp) GetJSON200() *map[string]interface{} {
+	return r.JSON200
+}
+
+// GetApplicationproblemJSON400 returns the response for an HTTP 400 `application/problem+json` response
+func (r McpOauthAuthorizationServerHTTPResp) GetApplicationproblemJSON400() *ProblemDetail {
+	return r.ApplicationproblemJSON400
+}
+
+// GetApplicationproblemJSON422 returns the response for an HTTP 422 `application/problem+json` response
+func (r McpOauthAuthorizationServerHTTPResp) GetApplicationproblemJSON422() *ProblemDetail {
+	return r.ApplicationproblemJSON422
+}
+
+// GetApplicationproblemJSON500 returns the response for an HTTP 500 `application/problem+json` response
+func (r McpOauthAuthorizationServerHTTPResp) GetApplicationproblemJSON500() *ProblemDetail {
+	return r.ApplicationproblemJSON500
+}
+
+// GetApplicationproblemJSON503 returns the response for an HTTP 503 `application/problem+json` response
+func (r McpOauthAuthorizationServerHTTPResp) GetApplicationproblemJSON503() *ProblemDetail {
+	return r.ApplicationproblemJSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r McpOauthAuthorizationServerHTTPResp) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r McpOauthAuthorizationServerHTTPResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r McpOauthAuthorizationServerHTTPResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r McpOauthAuthorizationServerHTTPResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type OauthProtectedResourceHTTPResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *map[string]interface{}
+	// ApplicationproblemJSON400 the response for an HTTP 400 `application/problem+json` response
+	ApplicationproblemJSON400 *ProblemDetail
+	// ApplicationproblemJSON422 the response for an HTTP 422 `application/problem+json` response
+	ApplicationproblemJSON422 *ProblemDetail
+	// ApplicationproblemJSON500 the response for an HTTP 500 `application/problem+json` response
+	ApplicationproblemJSON500 *ProblemDetail
+	// ApplicationproblemJSON503 the response for an HTTP 503 `application/problem+json` response
+	ApplicationproblemJSON503 *ProblemDetail
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r OauthProtectedResourceHTTPResp) GetJSON200() *map[string]interface{} {
+	return r.JSON200
+}
+
+// GetApplicationproblemJSON400 returns the response for an HTTP 400 `application/problem+json` response
+func (r OauthProtectedResourceHTTPResp) GetApplicationproblemJSON400() *ProblemDetail {
+	return r.ApplicationproblemJSON400
+}
+
+// GetApplicationproblemJSON422 returns the response for an HTTP 422 `application/problem+json` response
+func (r OauthProtectedResourceHTTPResp) GetApplicationproblemJSON422() *ProblemDetail {
+	return r.ApplicationproblemJSON422
+}
+
+// GetApplicationproblemJSON500 returns the response for an HTTP 500 `application/problem+json` response
+func (r OauthProtectedResourceHTTPResp) GetApplicationproblemJSON500() *ProblemDetail {
+	return r.ApplicationproblemJSON500
+}
+
+// GetApplicationproblemJSON503 returns the response for an HTTP 503 `application/problem+json` response
+func (r OauthProtectedResourceHTTPResp) GetApplicationproblemJSON503() *ProblemDetail {
+	return r.ApplicationproblemJSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r OauthProtectedResourceHTTPResp) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r OauthProtectedResourceHTTPResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r OauthProtectedResourceHTTPResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r OauthProtectedResourceHTTPResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type McpOauthProtectedResourceHTTPResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *map[string]interface{}
+	// ApplicationproblemJSON400 the response for an HTTP 400 `application/problem+json` response
+	ApplicationproblemJSON400 *ProblemDetail
+	// ApplicationproblemJSON422 the response for an HTTP 422 `application/problem+json` response
+	ApplicationproblemJSON422 *ProblemDetail
+	// ApplicationproblemJSON500 the response for an HTTP 500 `application/problem+json` response
+	ApplicationproblemJSON500 *ProblemDetail
+	// ApplicationproblemJSON503 the response for an HTTP 503 `application/problem+json` response
+	ApplicationproblemJSON503 *ProblemDetail
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r McpOauthProtectedResourceHTTPResp) GetJSON200() *map[string]interface{} {
+	return r.JSON200
+}
+
+// GetApplicationproblemJSON400 returns the response for an HTTP 400 `application/problem+json` response
+func (r McpOauthProtectedResourceHTTPResp) GetApplicationproblemJSON400() *ProblemDetail {
+	return r.ApplicationproblemJSON400
+}
+
+// GetApplicationproblemJSON422 returns the response for an HTTP 422 `application/problem+json` response
+func (r McpOauthProtectedResourceHTTPResp) GetApplicationproblemJSON422() *ProblemDetail {
+	return r.ApplicationproblemJSON422
+}
+
+// GetApplicationproblemJSON500 returns the response for an HTTP 500 `application/problem+json` response
+func (r McpOauthProtectedResourceHTTPResp) GetApplicationproblemJSON500() *ProblemDetail {
+	return r.ApplicationproblemJSON500
+}
+
+// GetApplicationproblemJSON503 returns the response for an HTTP 503 `application/problem+json` response
+func (r McpOauthProtectedResourceHTTPResp) GetApplicationproblemJSON503() *ProblemDetail {
+	return r.ApplicationproblemJSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r McpOauthProtectedResourceHTTPResp) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r McpOauthProtectedResourceHTTPResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r McpOauthProtectedResourceHTTPResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r McpOauthProtectedResourceHTTPResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -35131,6 +35569,68 @@ func (c *ClientWithResponses) OauthAuthorizationServerWithResponse(ctx context.C
 	return ParseOauthAuthorizationServerHTTPResp(rsp)
 }
 
+// McpOauthAuthorizationServerWithResponse OAuth authorization server metadata for the MCP resource
+//
+// RFC 8414 metadata for the path-scoped issuer `{base}/mcp` (phase-3a §4.7).
+//
+// RFC 8414 §3.1 path insertion: this is the metadata URL clients derive for
+// the issuer `{base}/mcp` named by the protected-resource document. It
+// advertises the anonymous OAuth-client registration door (`/oauth-clients`)
+// and the public-client profile (`none` + PKCE S256) — the root document is a
+// separate, unchanged surface whose `registration_endpoint` remains the agent
+// `/register`.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /.well-known/oauth-authorization-server/mcp (the `McpOauthAuthorizationServer` operationId).
+func (c *ClientWithResponses) McpOauthAuthorizationServerWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*McpOauthAuthorizationServerHTTPResp, error) {
+	rsp, err := c.McpOauthAuthorizationServer(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMcpOauthAuthorizationServerHTTPResp(rsp)
+}
+
+// OauthProtectedResourceWithResponse OAuth protected resource metadata (root alias)
+//
+// Root-path alias of the MCP protected-resource document (phase-3a §4.7).
+//
+// Compatibility fallback for clients that probe the root
+// `/.well-known/oauth-protected-resource` instead of following the 401's
+// `resource_metadata` pointer (the documented Claude Code behaviour). Safe
+// because this deployment has exactly one OAuth-protected resource, so the
+// root and path-scoped documents are the same body.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /.well-known/oauth-protected-resource (the `OauthProtectedResource` operationId).
+func (c *ClientWithResponses) OauthProtectedResourceWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*OauthProtectedResourceHTTPResp, error) {
+	rsp, err := c.OauthProtectedResource(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseOauthProtectedResourceHTTPResp(rsp)
+}
+
+// McpOauthProtectedResourceWithResponse OAuth protected resource metadata for the MCP resource
+//
+// RFC 9728 protected-resource metadata for `{base}/mcp` (phase-3a §4.7).
+//
+// Names the /mcp-scoped authorization server and the MCP tool scopes. The
+// same body is also served at the root well-known path for clients that
+// ignore the 401's `resource_metadata` pointer.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /.well-known/oauth-protected-resource/mcp (the `McpOauthProtectedResource` operationId).
+func (c *ClientWithResponses) McpOauthProtectedResourceWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*McpOauthProtectedResourceHTTPResp, error) {
+	rsp, err := c.McpOauthProtectedResource(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMcpOauthProtectedResourceHTTPResp(rsp)
+}
+
 // ListAccessRequestsWithResponse List access requests
 //
 // List access requests with cursor-based pagination.
@@ -38803,6 +39303,177 @@ func ParseOauthAuthorizationServerHTTPResp(rsp *http.Response) (*OauthAuthorizat
 			return nil, err
 		}
 		response.ApplicationproblemJSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseMcpOauthAuthorizationServerHTTPResp parses an HTTP response from a McpOauthAuthorizationServerWithResponse call
+func ParseMcpOauthAuthorizationServerHTTPResp(rsp *http.Response) (*McpOauthAuthorizationServerHTTPResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &McpOauthAuthorizationServerHTTPResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
+
+	case rsp.StatusCode == 404:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseOauthProtectedResourceHTTPResp parses an HTTP response from a OauthProtectedResourceWithResponse call
+func ParseOauthProtectedResourceHTTPResp(rsp *http.Response) (*OauthProtectedResourceHTTPResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &OauthProtectedResourceHTTPResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
+
+	case rsp.StatusCode == 404:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseMcpOauthProtectedResourceHTTPResp parses an HTTP response from a McpOauthProtectedResourceWithResponse call
+func ParseMcpOauthProtectedResourceHTTPResp(rsp *http.Response) (*McpOauthProtectedResourceHTTPResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &McpOauthProtectedResourceHTTPResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
+
+	case rsp.StatusCode == 404:
+		break // No content-type
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest ProblemDetail

--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -4483,7 +4483,7 @@ type ClientInterface interface {
 	// Corresponds with GET /.well-known/oauth-authorization-server/mcp (the `McpOauthAuthorizationServer` operationId).
 	McpOauthAuthorizationServer(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// OauthProtectedResource OAuth protected resource metadata (root alias)
+	// McpOauthProtectedResourceRootAlias OAuth protected resource metadata (root alias for the MCP resource)
 	//
 	// Root-path alias of the MCP protected-resource document (phase-3a §4.7).
 	//
@@ -4493,8 +4493,21 @@ type ClientInterface interface {
 	// because this deployment has exactly one OAuth-protected resource, so the
 	// root and path-scoped documents are the same body.
 	//
-	// Corresponds with GET /.well-known/oauth-protected-resource (the `OauthProtectedResource` operationId).
-	OauthProtectedResource(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// Two acknowledged trades (§4.7, review F6):
+	//
+	// - RFC 9728 §3 says this well-known path corresponds to resource identifier
+	//   ``{base}`` (no path), and §3.3 has clients validate ``resource`` against
+	//   the resource they queried. This body claims ``resource={base}/mcp`` — a
+	//   strict path-deriving validator would reject it, but Claude's fallback
+	//   validates against the MCP server URL (``{base}/mcp``), which is exactly
+	//   what the alias exists to satisfy. That is the intended trade.
+	// - The alias squats the deployment's only root PRM slot: a future non-MCP
+	//   protected resource at ``{base}`` cannot get its own root document
+	//   without breaking this fallback. Phase 3's mount must re-confirm the
+	//   "exactly one OAuth-protected resource" premise before adding one.
+	//
+	// Corresponds with GET /.well-known/oauth-protected-resource (the `McpOauthProtectedResourceRootAlias` operationId).
+	McpOauthProtectedResourceRootAlias(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// McpOauthProtectedResource OAuth protected resource metadata for the MCP resource
 	//
@@ -6619,7 +6632,7 @@ func (c *Client) McpOauthAuthorizationServer(ctx context.Context, reqEditors ...
 	return c.Client.Do(req)
 }
 
-// OauthProtectedResource OAuth protected resource metadata (root alias)
+// McpOauthProtectedResourceRootAlias OAuth protected resource metadata (root alias for the MCP resource)
 //
 // Root-path alias of the MCP protected-resource document (phase-3a §4.7).
 //
@@ -6629,9 +6642,22 @@ func (c *Client) McpOauthAuthorizationServer(ctx context.Context, reqEditors ...
 // because this deployment has exactly one OAuth-protected resource, so the
 // root and path-scoped documents are the same body.
 //
-// Corresponds with GET /.well-known/oauth-protected-resource (the `OauthProtectedResource` operationId).
-func (c *Client) OauthProtectedResource(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewOauthProtectedResourceRequest(c.Server)
+// Two acknowledged trades (§4.7, review F6):
+//
+//   - RFC 9728 §3 says this well-known path corresponds to resource identifier
+//     “{base}“ (no path), and §3.3 has clients validate “resource“ against
+//     the resource they queried. This body claims “resource={base}/mcp“ — a
+//     strict path-deriving validator would reject it, but Claude's fallback
+//     validates against the MCP server URL (“{base}/mcp“), which is exactly
+//     what the alias exists to satisfy. That is the intended trade.
+//   - The alias squats the deployment's only root PRM slot: a future non-MCP
+//     protected resource at “{base}“ cannot get its own root document
+//     without breaking this fallback. Phase 3's mount must re-confirm the
+//     "exactly one OAuth-protected resource" premise before adding one.
+//
+// Corresponds with GET /.well-known/oauth-protected-resource (the `McpOauthProtectedResourceRootAlias` operationId).
+func (c *Client) McpOauthProtectedResourceRootAlias(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMcpOauthProtectedResourceRootAliasRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -10987,8 +11013,8 @@ func NewMcpOauthAuthorizationServerRequest(server string) (*http.Request, error)
 	return req, nil
 }
 
-// NewOauthProtectedResourceRequest constructs an http.Request for the OauthProtectedResource method
-func NewOauthProtectedResourceRequest(server string) (*http.Request, error) {
+// NewMcpOauthProtectedResourceRootAliasRequest constructs an http.Request for the McpOauthProtectedResourceRootAlias method
+func NewMcpOauthProtectedResourceRootAliasRequest(server string) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -19522,7 +19548,7 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with GET /.well-known/oauth-authorization-server/mcp (the `McpOauthAuthorizationServer` operationId).
 	McpOauthAuthorizationServerWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*McpOauthAuthorizationServerHTTPResp, error)
 
-	// OauthProtectedResourceWithResponse OAuth protected resource metadata (root alias)
+	// McpOauthProtectedResourceRootAliasWithResponse OAuth protected resource metadata (root alias for the MCP resource)
 	//
 	// Root-path alias of the MCP protected-resource document (phase-3a §4.7).
 	//
@@ -19532,10 +19558,23 @@ type ClientWithResponsesInterface interface {
 	// because this deployment has exactly one OAuth-protected resource, so the
 	// root and path-scoped documents are the same body.
 	//
+	// Two acknowledged trades (§4.7, review F6):
+	//
+	// - RFC 9728 §3 says this well-known path corresponds to resource identifier
+	//   ``{base}`` (no path), and §3.3 has clients validate ``resource`` against
+	//   the resource they queried. This body claims ``resource={base}/mcp`` — a
+	//   strict path-deriving validator would reject it, but Claude's fallback
+	//   validates against the MCP server URL (``{base}/mcp``), which is exactly
+	//   what the alias exists to satisfy. That is the intended trade.
+	// - The alias squats the deployment's only root PRM slot: a future non-MCP
+	//   protected resource at ``{base}`` cannot get its own root document
+	//   without breaking this fallback. Phase 3's mount must re-confirm the
+	//   "exactly one OAuth-protected resource" premise before adding one.
+	//
 	// Returns a wrapper object for the known response body format(s).
 	//
-	// Corresponds with GET /.well-known/oauth-protected-resource (the `OauthProtectedResource` operationId).
-	OauthProtectedResourceWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*OauthProtectedResourceHTTPResp, error)
+	// Corresponds with GET /.well-known/oauth-protected-resource (the `McpOauthProtectedResourceRootAlias` operationId).
+	McpOauthProtectedResourceRootAliasWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*McpOauthProtectedResourceRootAliasHTTPResp, error)
 
 	// McpOauthProtectedResourceWithResponse OAuth protected resource metadata for the MCP resource
 	//
@@ -22035,7 +22074,7 @@ func (r McpOauthAuthorizationServerHTTPResp) ContentType() string {
 	return ""
 }
 
-type OauthProtectedResourceHTTPResp struct {
+type McpOauthProtectedResourceRootAliasHTTPResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	// JSON200 the response for an HTTP 200 `application/json` response
@@ -22051,37 +22090,37 @@ type OauthProtectedResourceHTTPResp struct {
 }
 
 // GetJSON200 returns the response for an HTTP 200 `application/json` response
-func (r OauthProtectedResourceHTTPResp) GetJSON200() *map[string]interface{} {
+func (r McpOauthProtectedResourceRootAliasHTTPResp) GetJSON200() *map[string]interface{} {
 	return r.JSON200
 }
 
 // GetApplicationproblemJSON400 returns the response for an HTTP 400 `application/problem+json` response
-func (r OauthProtectedResourceHTTPResp) GetApplicationproblemJSON400() *ProblemDetail {
+func (r McpOauthProtectedResourceRootAliasHTTPResp) GetApplicationproblemJSON400() *ProblemDetail {
 	return r.ApplicationproblemJSON400
 }
 
 // GetApplicationproblemJSON422 returns the response for an HTTP 422 `application/problem+json` response
-func (r OauthProtectedResourceHTTPResp) GetApplicationproblemJSON422() *ProblemDetail {
+func (r McpOauthProtectedResourceRootAliasHTTPResp) GetApplicationproblemJSON422() *ProblemDetail {
 	return r.ApplicationproblemJSON422
 }
 
 // GetApplicationproblemJSON500 returns the response for an HTTP 500 `application/problem+json` response
-func (r OauthProtectedResourceHTTPResp) GetApplicationproblemJSON500() *ProblemDetail {
+func (r McpOauthProtectedResourceRootAliasHTTPResp) GetApplicationproblemJSON500() *ProblemDetail {
 	return r.ApplicationproblemJSON500
 }
 
 // GetApplicationproblemJSON503 returns the response for an HTTP 503 `application/problem+json` response
-func (r OauthProtectedResourceHTTPResp) GetApplicationproblemJSON503() *ProblemDetail {
+func (r McpOauthProtectedResourceRootAliasHTTPResp) GetApplicationproblemJSON503() *ProblemDetail {
 	return r.ApplicationproblemJSON503
 }
 
 // GetBody returns the raw response body bytes
-func (r OauthProtectedResourceHTTPResp) GetBody() []byte {
+func (r McpOauthProtectedResourceRootAliasHTTPResp) GetBody() []byte {
 	return r.Body
 }
 
 // Status returns HTTPResponse.Status
-func (r OauthProtectedResourceHTTPResp) Status() string {
+func (r McpOauthProtectedResourceRootAliasHTTPResp) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -22089,7 +22128,7 @@ func (r OauthProtectedResourceHTTPResp) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r OauthProtectedResourceHTTPResp) StatusCode() int {
+func (r McpOauthProtectedResourceRootAliasHTTPResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -22097,7 +22136,7 @@ func (r OauthProtectedResourceHTTPResp) StatusCode() int {
 }
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r OauthProtectedResourceHTTPResp) ContentType() string {
+func (r McpOauthProtectedResourceRootAliasHTTPResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -35591,7 +35630,7 @@ func (c *ClientWithResponses) McpOauthAuthorizationServerWithResponse(ctx contex
 	return ParseMcpOauthAuthorizationServerHTTPResp(rsp)
 }
 
-// OauthProtectedResourceWithResponse OAuth protected resource metadata (root alias)
+// McpOauthProtectedResourceRootAliasWithResponse OAuth protected resource metadata (root alias for the MCP resource)
 //
 // Root-path alias of the MCP protected-resource document (phase-3a §4.7).
 //
@@ -35601,15 +35640,28 @@ func (c *ClientWithResponses) McpOauthAuthorizationServerWithResponse(ctx contex
 // because this deployment has exactly one OAuth-protected resource, so the
 // root and path-scoped documents are the same body.
 //
+// Two acknowledged trades (§4.7, review F6):
+//
+//   - RFC 9728 §3 says this well-known path corresponds to resource identifier
+//     “{base}“ (no path), and §3.3 has clients validate “resource“ against
+//     the resource they queried. This body claims “resource={base}/mcp“ — a
+//     strict path-deriving validator would reject it, but Claude's fallback
+//     validates against the MCP server URL (“{base}/mcp“), which is exactly
+//     what the alias exists to satisfy. That is the intended trade.
+//   - The alias squats the deployment's only root PRM slot: a future non-MCP
+//     protected resource at “{base}“ cannot get its own root document
+//     without breaking this fallback. Phase 3's mount must re-confirm the
+//     "exactly one OAuth-protected resource" premise before adding one.
+//
 // Returns a wrapper object for the known response body format(s).
 //
-// Corresponds with GET /.well-known/oauth-protected-resource (the `OauthProtectedResource` operationId).
-func (c *ClientWithResponses) OauthProtectedResourceWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*OauthProtectedResourceHTTPResp, error) {
-	rsp, err := c.OauthProtectedResource(ctx, reqEditors...)
+// Corresponds with GET /.well-known/oauth-protected-resource (the `McpOauthProtectedResourceRootAlias` operationId).
+func (c *ClientWithResponses) McpOauthProtectedResourceRootAliasWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*McpOauthProtectedResourceRootAliasHTTPResp, error) {
+	rsp, err := c.McpOauthProtectedResourceRootAlias(ctx, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOauthProtectedResourceHTTPResp(rsp)
+	return ParseMcpOauthProtectedResourceRootAliasHTTPResp(rsp)
 }
 
 // McpOauthProtectedResourceWithResponse OAuth protected resource metadata for the MCP resource
@@ -39387,15 +39439,15 @@ func ParseMcpOauthAuthorizationServerHTTPResp(rsp *http.Response) (*McpOauthAuth
 	return response, nil
 }
 
-// ParseOauthProtectedResourceHTTPResp parses an HTTP response from a OauthProtectedResourceWithResponse call
-func ParseOauthProtectedResourceHTTPResp(rsp *http.Response) (*OauthProtectedResourceHTTPResp, error) {
+// ParseMcpOauthProtectedResourceRootAliasHTTPResp parses an HTTP response from a McpOauthProtectedResourceRootAliasWithResponse call
+func ParseMcpOauthProtectedResourceRootAliasHTTPResp(rsp *http.Response) (*McpOauthProtectedResourceRootAliasHTTPResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OauthProtectedResourceHTTPResp{
+	response := &McpOauthProtectedResourceRootAliasHTTPResp{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -6603,7 +6603,7 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Bad Request
         '404':
-          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, so the gate state is unobservable.'
         '422':
           content:
             application/problem+json:
@@ -6639,14 +6639,27 @@ paths:
         `resource_metadata` pointer (the documented Claude Code behaviour). Safe
         because this deployment has exactly one OAuth-protected resource, so the
         root and path-scoped documents are the same body.
-      operationId: oauthProtectedResource
+
+        Two acknowledged trades (§4.7, review F6):
+
+        - RFC 9728 §3 says this well-known path corresponds to resource identifier
+          ``{base}`` (no path), and §3.3 has clients validate ``resource`` against
+          the resource they queried. This body claims ``resource={base}/mcp`` — a
+          strict path-deriving validator would reject it, but Claude's fallback
+          validates against the MCP server URL (``{base}/mcp``), which is exactly
+          what the alias exists to satisfy. That is the intended trade.
+        - The alias squats the deployment's only root PRM slot: a future non-MCP
+          protected resource at ``{base}`` cannot get its own root document
+          without breaking this fallback. Phase 3's mount must re-confirm the
+          "exactly one OAuth-protected resource" premise before adding one.
+      operationId: mcpOauthProtectedResourceRootAlias
       responses:
         '200':
           content:
             application/json:
               schema:
                 additionalProperties: true
-                title: Response Oauthprotectedresource
+                title: Response Mcpoauthprotectedresourcerootalias
                 type: object
           description: Successful Response
         '400':
@@ -6657,7 +6670,7 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Bad Request
         '404':
-          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, so the gate state is unobservable.'
         '422':
           content:
             application/problem+json:
@@ -6680,7 +6693,7 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Service Unavailable
       security: []
-      summary: OAuth protected resource metadata (root alias)
+      summary: OAuth protected resource metadata (root alias for the MCP resource)
       tags:
       - Discovery
   /.well-known/oauth-protected-resource/mcp:
@@ -6709,7 +6722,7 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Bad Request
         '404':
-          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, so the gate state is unobservable.'
         '422':
           content:
             application/problem+json:

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -6574,6 +6574,167 @@ paths:
       summary: OAuth authorization server metadata
       tags:
       - Discovery
+  /.well-known/oauth-authorization-server/mcp:
+    get:
+      description: |-
+        RFC 8414 metadata for the path-scoped issuer `{base}/mcp` (phase-3a §4.7).
+
+        RFC 8414 §3.1 path insertion: this is the metadata URL clients derive for
+        the issuer `{base}/mcp` named by the protected-resource document. It
+        advertises the anonymous OAuth-client registration door (`/oauth-clients`)
+        and the public-client profile (`none` + PKCE S256) — the root document is a
+        separate, unchanged surface whose `registration_endpoint` remains the agent
+        `/register`.
+      operationId: mcpOauthAuthorizationServer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Mcpoauthauthorizationserver
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '404':
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security: []
+      summary: OAuth authorization server metadata for the MCP resource
+      tags:
+      - Discovery
+  /.well-known/oauth-protected-resource:
+    get:
+      description: |-
+        Root-path alias of the MCP protected-resource document (phase-3a §4.7).
+
+        Compatibility fallback for clients that probe the root
+        `/.well-known/oauth-protected-resource` instead of following the 401's
+        `resource_metadata` pointer (the documented Claude Code behaviour). Safe
+        because this deployment has exactly one OAuth-protected resource, so the
+        root and path-scoped documents are the same body.
+      operationId: oauthProtectedResource
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Oauthprotectedresource
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '404':
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security: []
+      summary: OAuth protected resource metadata (root alias)
+      tags:
+      - Discovery
+  /.well-known/oauth-protected-resource/mcp:
+    get:
+      description: |-
+        RFC 9728 protected-resource metadata for `{base}/mcp` (phase-3a §4.7).
+
+        Names the /mcp-scoped authorization server and the MCP tool scopes. The
+        same body is also served at the root well-known path for clients that
+        ignore the 401's `resource_metadata` pointer.
+      operationId: mcpOauthProtectedResource
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Mcpoauthprotectedresource
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '404':
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security: []
+      summary: OAuth protected resource metadata for the MCP resource
+      tags:
+      - Discovery
   /access-requests:
     get:
       description: List access requests with cursor-based pagination.

--- a/docs/reference/endpoints.json
+++ b/docs/reference/endpoints.json
@@ -32,6 +32,51 @@
       "typical_caller": null
     },
     {
+      "actor_types": [],
+      "auth_note": null,
+      "authenticated": false,
+      "group": "Public (unauthenticated)",
+      "implied_scopes": {},
+      "method": "GET",
+      "operation_id": "mcpOauthAuthorizationServer",
+      "path": "/.well-known/oauth-authorization-server/mcp",
+      "public": true,
+      "required_scopes": [],
+      "summary": "OAuth authorization server metadata for the MCP resource",
+      "surface": ".well-known",
+      "typical_caller": null
+    },
+    {
+      "actor_types": [],
+      "auth_note": null,
+      "authenticated": false,
+      "group": "Public (unauthenticated)",
+      "implied_scopes": {},
+      "method": "GET",
+      "operation_id": "mcpOauthProtectedResourceRootAlias",
+      "path": "/.well-known/oauth-protected-resource",
+      "public": true,
+      "required_scopes": [],
+      "summary": "OAuth protected resource metadata (root alias for the MCP resource)",
+      "surface": ".well-known",
+      "typical_caller": null
+    },
+    {
+      "actor_types": [],
+      "auth_note": null,
+      "authenticated": false,
+      "group": "Public (unauthenticated)",
+      "implied_scopes": {},
+      "method": "GET",
+      "operation_id": "mcpOauthProtectedResource",
+      "path": "/.well-known/oauth-protected-resource/mcp",
+      "public": true,
+      "required_scopes": [],
+      "summary": "OAuth protected resource metadata for the MCP resource",
+      "surface": ".well-known",
+      "typical_caller": null
+    },
+    {
       "actor_types": [
         "user",
         "agent",
@@ -5060,5 +5105,5 @@
     ],
     "total": 33
   },
-  "total": 173
+  "total": 176
 }

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -27,7 +27,7 @@ Every API endpoint grouped by its **typical caller**, then by surface, annotated
 
 > The grouping and the _Typical caller_ column are an **advisory hint** at who usually calls a route, inferred from the scope family. They are **not** an enforced restriction: access is gated by the **scope**, not the actor kind, so any actor holding the required scope can call the endpoint.
 
-_Total endpoints: **173**._
+_Total endpoints: **176**._
 
 
 ## Agent-facing (typically agent / service-account / toolkit) (31)
@@ -380,7 +380,7 @@ _Total endpoints: **173**._
 | GET | `/users/me` | _any authenticated_ | any | Get current user |
 | POST | `/users/me:change-password` | _any authenticated_ | any | Change own password |
 
-## Public (unauthenticated) (22)
+## Public (unauthenticated) (25)
 
 
 ### `.well-known`
@@ -389,6 +389,9 @@ _Total endpoints: **173**._
 |---|---|---|---|---|
 | GET | `/.well-known/jwks.json` | _public — no auth_ | — | JSON Web Key Set |
 | GET | `/.well-known/oauth-authorization-server` | _public — no auth_ | — | OAuth authorization server metadata |
+| GET | `/.well-known/oauth-authorization-server/mcp` | _public — no auth_ | — | OAuth authorization server metadata for the MCP resource |
+| GET | `/.well-known/oauth-protected-resource` | _public — no auth_ | — | OAuth protected resource metadata (root alias for the MCP resource) |
+| GET | `/.well-known/oauth-protected-resource/mcp` | _public — no auth_ | — | OAuth protected resource metadata for the MCP resource |
 
 ### `admin`
 

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -6603,7 +6603,7 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Bad Request
         '404':
-          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, so the gate state is unobservable.'
         '422':
           content:
             application/problem+json:
@@ -6639,14 +6639,27 @@ paths:
         `resource_metadata` pointer (the documented Claude Code behaviour). Safe
         because this deployment has exactly one OAuth-protected resource, so the
         root and path-scoped documents are the same body.
-      operationId: oauthProtectedResource
+
+        Two acknowledged trades (§4.7, review F6):
+
+        - RFC 9728 §3 says this well-known path corresponds to resource identifier
+          ``{base}`` (no path), and §3.3 has clients validate ``resource`` against
+          the resource they queried. This body claims ``resource={base}/mcp`` — a
+          strict path-deriving validator would reject it, but Claude's fallback
+          validates against the MCP server URL (``{base}/mcp``), which is exactly
+          what the alias exists to satisfy. That is the intended trade.
+        - The alias squats the deployment's only root PRM slot: a future non-MCP
+          protected resource at ``{base}`` cannot get its own root document
+          without breaking this fallback. Phase 3's mount must re-confirm the
+          "exactly one OAuth-protected resource" premise before adding one.
+      operationId: mcpOauthProtectedResourceRootAlias
       responses:
         '200':
           content:
             application/json:
               schema:
                 additionalProperties: true
-                title: Response Oauthprotectedresource
+                title: Response Mcpoauthprotectedresourcerootalias
                 type: object
           description: Successful Response
         '400':
@@ -6657,7 +6670,7 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Bad Request
         '404':
-          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, so the gate state is unobservable.'
         '422':
           content:
             application/problem+json:
@@ -6680,7 +6693,7 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Service Unavailable
       security: []
-      summary: OAuth protected resource metadata (root alias)
+      summary: OAuth protected resource metadata (root alias for the MCP resource)
       tags:
       - Discovery
   /.well-known/oauth-protected-resource/mcp:
@@ -6709,7 +6722,7 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Bad Request
         '404':
-          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, so the gate state is unobservable.'
         '422':
           content:
             application/problem+json:

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -6574,6 +6574,167 @@ paths:
       summary: OAuth authorization server metadata
       tags:
       - Discovery
+  /.well-known/oauth-authorization-server/mcp:
+    get:
+      description: |-
+        RFC 8414 metadata for the path-scoped issuer `{base}/mcp` (phase-3a §4.7).
+
+        RFC 8414 §3.1 path insertion: this is the metadata URL clients derive for
+        the issuer `{base}/mcp` named by the protected-resource document. It
+        advertises the anonymous OAuth-client registration door (`/oauth-clients`)
+        and the public-client profile (`none` + PKCE S256) — the root document is a
+        separate, unchanged surface whose `registration_endpoint` remains the agent
+        `/register`.
+      operationId: mcpOauthAuthorizationServer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Mcpoauthauthorizationserver
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '404':
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security: []
+      summary: OAuth authorization server metadata for the MCP resource
+      tags:
+      - Discovery
+  /.well-known/oauth-protected-resource:
+    get:
+      description: |-
+        Root-path alias of the MCP protected-resource document (phase-3a §4.7).
+
+        Compatibility fallback for clients that probe the root
+        `/.well-known/oauth-protected-resource` instead of following the 401's
+        `resource_metadata` pointer (the documented Claude Code behaviour). Safe
+        because this deployment has exactly one OAuth-protected resource, so the
+        root and path-scoped documents are the same body.
+      operationId: oauthProtectedResource
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Oauthprotectedresource
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '404':
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security: []
+      summary: OAuth protected resource metadata (root alias)
+      tags:
+      - Discovery
+  /.well-known/oauth-protected-resource/mcp:
+    get:
+      description: |-
+        RFC 9728 protected-resource metadata for `{base}/mcp` (phase-3a §4.7).
+
+        Names the /mcp-scoped authorization server and the MCP tool scopes. The
+        same body is also served at the root well-known path for clients that
+        ignore the 401's `resource_metadata` pointer.
+      operationId: mcpOauthProtectedResource
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Mcpoauthprotectedresource
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '404':
+          description: 'Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework''s plain route-not-found 404, indistinguishable from not-shipped.'
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security: []
+      summary: OAuth protected resource metadata for the MCP resource
+      tags:
+      - Discovery
   /access-requests:
     get:
       description: List access requests with cursor-based pagination.

--- a/src/jentic_one/auth/web/app.py
+++ b/src/jentic_one/auth/web/app.py
@@ -48,6 +48,10 @@ def get_routers() -> list[tuple[APIRouter, str, list[str]]]:
     return [
         (make_health_router("auth"), "/auth", []),
         (discovery.router, "", []),
+        # /mcp-scoped OAuth discovery (phase-3a §4.7): RFC 8414 + RFC 9728 docs,
+        # the root protected-resource alias, and the /mcp 401 challenge. All
+        # gated by server.mcp.oauth.enabled (404 when off).
+        (discovery.mcp_router, "", []),
         (authorize.router, "", []),
         (identity.router, "", []),
         (agents.router, "", []),

--- a/src/jentic_one/auth/web/routers/discovery.py
+++ b/src/jentic_one/auth/web/routers/discovery.py
@@ -1,14 +1,33 @@
-"""OAuth discovery and JWKS endpoints (RFC 8414)."""
+"""OAuth discovery and JWKS endpoints (RFC 8414 + RFC 9728).
+
+Two discovery surfaces live here:
+
+- The **root** RFC 8414 document (``/.well-known/oauth-authorization-server``)
+  — the platform AS metadata whose ``registration_endpoint`` is the *agent*
+  DCR door ``/register``. Its body is pinned byte-identical by a golden
+  regression test (phase-3a acceptance): do not change it when touching the
+  MCP-scoped documents below.
+- The **/mcp-scoped** documents (phase-3a §4.7, D10): a path-scoped RFC 8414
+  doc for the logical issuer ``{base}/mcp`` plus the RFC 9728
+  protected-resource doc (path-scoped and a root alias), and the ``/mcp``
+  401 challenge that starts the discovery chain. All are gated by
+  ``server.mcp.oauth.enabled`` — off (the default) they 404 exactly like a
+  build that never shipped them.
+"""
 
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
 
 from jentic_one.shared.auth import CachedJWKSPublisher
 from jentic_one.shared.config import AuthConfig
 from jentic_one.shared.context import Context
+from jentic_one.shared.scopes import MCP_TOOL_SCOPES
 from jentic_one.shared.web.deps import get_ctx
 from jentic_one.shared.web.links import deployment_base_url
 
@@ -90,3 +109,161 @@ async def auth_idp_descriptor(ctx: Context = Depends(get_ctx)) -> dict[str, Any]
         "enabled": idp.enabled,
         "provider": idp.provider if idp.enabled else None,
     }
+
+
+class _McpDiscoveryRoute(APIRoute):
+    """Route class owning the ``server.mcp.oauth.enabled`` gate (§4.7).
+
+    Runs *before* the FastAPI dependency machinery so a disabled surface is
+    byte-identical to a build that never shipped these routes: every request
+    gets the framework's own route-not-found 404, and no handler, dependency,
+    or ``WWW-Authenticate`` header can reveal the feature exists (same posture
+    as the DCR front door's ``_Rfc7591Route``, §4.2).
+    """
+
+    def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+        original = super().get_route_handler()
+
+        async def handler(request: Request) -> Response:
+            ctx: Context = request.app.state.ctx
+            if not ctx.config.server.mcp.oauth.enabled:
+                # Mirror the framework's route-not-found body exactly.
+                return JSONResponse(status_code=404, content={"detail": "Not Found"})
+            return await original(request)
+
+        return handler
+
+
+mcp_router = APIRouter(route_class=_McpDiscoveryRoute)
+
+#: The RFC 9728 protected-resource metadata path for the ``/mcp`` resource —
+#: RFC 9728 §3 well-known path insertion for a resource with path ``/mcp``.
+#: Single source for the document routes and the 401 challenge pointer.
+_MCP_PRM_PATH = "/.well-known/oauth-protected-resource/mcp"
+
+_GATED_404_RESPONSE: dict[int | str, dict[str, Any]] = {
+    404: {
+        "description": "Interactive OAuth for MCP is disabled "
+        "(`server.mcp.oauth.enabled=false`): the route answers the framework's "
+        "plain route-not-found 404, indistinguishable from not-shipped."
+    }
+}
+
+
+def _mcp_authorization_server_document(base: str) -> dict[str, Any]:
+    """The /mcp-scoped RFC 8414 document, exactly per D10.
+
+    A *logical* second AS for the path-scoped issuer ``{base}/mcp``: the
+    endpoints are shared with the root AS — only the metadata doc is scoped.
+    ``registration_endpoint`` is the anonymous OAuth-client DCR door
+    ``/oauth-clients`` (D1), never the agent ``/register``. Only the public
+    secret-less client profile is advertised (``none`` + PKCE S256, D5); CIMD
+    (``client_id_metadata_document_supported``) is deliberately **not**
+    advertised yet — flipping it on is the §6 follow-on and non-breaking.
+    """
+    return {
+        "issuer": f"{base}/mcp",
+        "authorization_endpoint": f"{base}/authorize",
+        "token_endpoint": f"{base}/oauth/token",
+        "registration_endpoint": f"{base}/oauth-clients",
+        "revocation_endpoint": f"{base}/oauth/revoke",
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "response_types_supported": ["code"],
+        "code_challenge_methods_supported": ["S256"],
+        "scopes_supported": sorted(MCP_TOOL_SCOPES),
+    }
+
+
+def _mcp_protected_resource_document(base: str) -> dict[str, Any]:
+    """The RFC 9728 protected-resource document for the ``/mcp`` resource (D10)."""
+    return {
+        "resource": f"{base}/mcp",
+        "authorization_servers": [f"{base}/mcp"],
+        "scopes_supported": sorted(MCP_TOOL_SCOPES),
+        "bearer_methods_supported": ["header"],
+    }
+
+
+@mcp_router.get(
+    "/.well-known/oauth-authorization-server/mcp",
+    summary="OAuth authorization server metadata for the MCP resource",
+    responses=_GATED_404_RESPONSE,
+)
+async def mcp_oauth_authorization_server(
+    request: Request, ctx: Context = Depends(get_ctx)
+) -> dict[str, Any]:
+    """RFC 8414 metadata for the path-scoped issuer `{base}/mcp` (phase-3a §4.7).
+
+    RFC 8414 §3.1 path insertion: this is the metadata URL clients derive for
+    the issuer `{base}/mcp` named by the protected-resource document. It
+    advertises the anonymous OAuth-client registration door (`/oauth-clients`)
+    and the public-client profile (`none` + PKCE S256) — the root document is a
+    separate, unchanged surface whose `registration_endpoint` remains the agent
+    `/register`.
+    """
+    base = deployment_base_url(ctx.config.auth, request)
+    return _mcp_authorization_server_document(base)
+
+
+@mcp_router.get(
+    _MCP_PRM_PATH,
+    summary="OAuth protected resource metadata for the MCP resource",
+    responses=_GATED_404_RESPONSE,
+)
+async def mcp_oauth_protected_resource(
+    request: Request, ctx: Context = Depends(get_ctx)
+) -> dict[str, Any]:
+    """RFC 9728 protected-resource metadata for `{base}/mcp` (phase-3a §4.7).
+
+    Names the /mcp-scoped authorization server and the MCP tool scopes. The
+    same body is also served at the root well-known path for clients that
+    ignore the 401's `resource_metadata` pointer.
+    """
+    base = deployment_base_url(ctx.config.auth, request)
+    return _mcp_protected_resource_document(base)
+
+
+@mcp_router.get(
+    "/.well-known/oauth-protected-resource",
+    summary="OAuth protected resource metadata (root alias)",
+    responses=_GATED_404_RESPONSE,
+)
+async def oauth_protected_resource(
+    request: Request, ctx: Context = Depends(get_ctx)
+) -> dict[str, Any]:
+    """Root-path alias of the MCP protected-resource document (phase-3a §4.7).
+
+    Compatibility fallback for clients that probe the root
+    `/.well-known/oauth-protected-resource` instead of following the 401's
+    `resource_metadata` pointer (the documented Claude Code behaviour). Safe
+    because this deployment has exactly one OAuth-protected resource, so the
+    root and path-scoped documents are the same body.
+    """
+    base = deployment_base_url(ctx.config.auth, request)
+    return _mcp_protected_resource_document(base)
+
+
+@mcp_router.api_route(
+    "/mcp",
+    methods=["GET", "POST", "DELETE"],
+    include_in_schema=False,
+)
+async def mcp_resource_challenge(request: Request, ctx: Context = Depends(get_ctx)) -> Response:
+    """The RFC 9728 discovery-chain entry point at the MCP resource path (§4.7).
+
+    Phase 3 mounts the actual MCP app here; until then this placeholder owns
+    the ``/mcp`` path so an unauthenticated (or any) probe answers ``401`` with
+    ``WWW-Authenticate: Bearer resource_metadata="…"`` — exactly what a
+    spec-following MCP client needs to start discovery. When the mounted app
+    lands it replaces this route and keeps the same challenge contract on
+    missing/invalid bearers. Schema-hidden: it is a protocol seam, not a
+    control-plane API operation. Gated with the documents by
+    ``server.mcp.oauth.enabled`` — off, the path 404s exactly as today.
+    """
+    base = deployment_base_url(ctx.config.auth, request)
+    return JSONResponse(
+        status_code=401,
+        content={"detail": "Unauthorized"},
+        headers={"WWW-Authenticate": f'Bearer resource_metadata="{base}{_MCP_PRM_PATH}"'},
+    )

--- a/src/jentic_one/auth/web/routers/discovery.py
+++ b/src/jentic_one/auth/web/routers/discovery.py
@@ -11,8 +11,11 @@ Two discovery surfaces live here:
   doc for the logical issuer ``{base}/mcp`` plus the RFC 9728
   protected-resource doc (path-scoped and a root alias), and the ``/mcp``
   401 challenge that starts the discovery chain. All are gated by
-  ``server.mcp.oauth.enabled`` — off (the default) they 404 exactly like a
-  build that never shipped them.
+  ``server.mcp.oauth.enabled`` — off (the default) they answer the
+  framework's plain route-not-found 404, so the *gate state* is unobservable.
+  (The *build* still shows routing-level tells — 405+``Allow`` on
+  non-registered methods, the slash redirect, the doc paths in the live
+  OpenAPI schema — identical in both gate arms; pinned by tests.)
 """
 
 from __future__ import annotations
@@ -114,11 +117,16 @@ async def auth_idp_descriptor(ctx: Context = Depends(get_ctx)) -> dict[str, Any]
 class _McpDiscoveryRoute(APIRoute):
     """Route class owning the ``server.mcp.oauth.enabled`` gate (§4.7).
 
-    Runs *before* the FastAPI dependency machinery so a disabled surface is
-    byte-identical to a build that never shipped these routes: every request
-    gets the framework's own route-not-found 404, and no handler, dependency,
-    or ``WWW-Authenticate`` header can reveal the feature exists (same posture
-    as the DCR front door's ``_Rfc7591Route``, §4.2).
+    Runs *before* the FastAPI dependency machinery so the **gate state is
+    unobservable**: on a full route match a disabled surface answers the
+    framework's own route-not-found 404, and no handler, dependency, or
+    ``WWW-Authenticate`` header runs (same posture as the DCR front door's
+    ``_Rfc7591Route``, §4.2). What remains observable is *build* state, not
+    gate state: Starlette answers partial matches (405 + ``Allow`` on
+    non-registered methods on the doc paths), issues the ``redirect_slashes``
+    307, and lists the doc paths in the live OpenAPI schema before this gate
+    can run — all identically in both gate arms, so nothing distinguishes
+    enabled-from-disabled. Pinned by tests so any change is deliberate.
     """
 
     def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
@@ -145,13 +153,13 @@ _GATED_404_RESPONSE: dict[int | str, dict[str, Any]] = {
     404: {
         "description": "Interactive OAuth for MCP is disabled "
         "(`server.mcp.oauth.enabled=false`): the route answers the framework's "
-        "plain route-not-found 404, indistinguishable from not-shipped."
+        "plain route-not-found 404, so the gate state is unobservable."
     }
 }
 
 
 def _mcp_authorization_server_document(base: str) -> dict[str, Any]:
-    """The /mcp-scoped RFC 8414 document, exactly per D10.
+    """The /mcp-scoped RFC 8414 document, per D10 (one deliberate deviation).
 
     A *logical* second AS for the path-scoped issuer ``{base}/mcp``: the
     endpoints are shared with the root AS — only the metadata doc is scoped.
@@ -160,13 +168,20 @@ def _mcp_authorization_server_document(base: str) -> dict[str, Any]:
     secret-less client profile is advertised (``none`` + PKCE S256, D5); CIMD
     (``client_id_metadata_document_supported``) is deliberately **not**
     advertised yet — flipping it on is the §6 follow-on and non-breaking.
+    Deviation from D10: no ``revocation_endpoint`` (see the field comment).
     """
     return {
         "issuer": f"{base}/mcp",
         "authorization_endpoint": f"{base}/authorize",
         "token_endpoint": f"{base}/oauth/token",
         "registration_endpoint": f"{base}/oauth-clients",
-        "revocation_endpoint": f"{base}/oauth/revoke",
+        # No revocation_endpoint (deliberate deviation from D10, which lists
+        # {base}/oauth/revoke): the platform's /oauth/revoke requires an
+        # authenticated platform Identity and a JSON body, so an RFC 7009
+        # public-client revoke (client_id only, form-encoded) can never
+        # succeed against it. RFC 8414 makes the field optional — omit it;
+        # public clients revoke by grant lifecycle (grant :revoke, client
+        # deactivation) until phase 3 decides otherwise.
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "token_endpoint_auth_methods_supported": ["none"],
         "response_types_supported": ["code"],
@@ -226,7 +241,11 @@ async def mcp_oauth_protected_resource(
 
 @mcp_router.get(
     "/.well-known/oauth-protected-resource",
-    summary="OAuth protected resource metadata (root alias)",
+    # MCP-specific operation_id: the body is the /mcp resource's document, so
+    # don't squat the generic root-doc name (a future root PRM for a non-MCP
+    # resource should get `oauthProtectedResource`, not fight this alias for it).
+    operation_id="mcpOauthProtectedResourceRootAlias",
+    summary="OAuth protected resource metadata (root alias for the MCP resource)",
     responses=_GATED_404_RESPONSE,
 )
 async def oauth_protected_resource(
@@ -239,6 +258,19 @@ async def oauth_protected_resource(
     `resource_metadata` pointer (the documented Claude Code behaviour). Safe
     because this deployment has exactly one OAuth-protected resource, so the
     root and path-scoped documents are the same body.
+
+    Two acknowledged trades (§4.7, review F6):
+
+    - RFC 9728 §3 says this well-known path corresponds to resource identifier
+      ``{base}`` (no path), and §3.3 has clients validate ``resource`` against
+      the resource they queried. This body claims ``resource={base}/mcp`` — a
+      strict path-deriving validator would reject it, but Claude's fallback
+      validates against the MCP server URL (``{base}/mcp``), which is exactly
+      what the alias exists to satisfy. That is the intended trade.
+    - The alias squats the deployment's only root PRM slot: a future non-MCP
+      protected resource at ``{base}`` cannot get its own root document
+      without breaking this fallback. Phase 3's mount must re-confirm the
+      "exactly one OAuth-protected resource" premise before adding one.
     """
     base = deployment_base_url(ctx.config.auth, request)
     return _mcp_protected_resource_document(base)
@@ -246,7 +278,12 @@ async def oauth_protected_resource(
 
 @mcp_router.api_route(
     "/mcp",
-    methods=["GET", "POST", "DELETE"],
+    # The full common method set, not just the streamable-HTTP verbs
+    # (GET/POST/DELETE): auth precedes method semantics on a protected
+    # resource, the phase-3 mounted ASGI app will cover all methods anyway,
+    # and registering them now keeps the disabled arm's answer a uniform 404
+    # (no 405 + Allow method tell on the resource path itself; review F3/F4).
+    methods=["GET", "POST", "DELETE", "HEAD", "OPTIONS", "PUT", "PATCH"],
     include_in_schema=False,
 )
 async def mcp_resource_challenge(request: Request, ctx: Context = Depends(get_ctx)) -> Response:
@@ -262,8 +299,9 @@ async def mcp_resource_challenge(request: Request, ctx: Context = Depends(get_ct
     ``server.mcp.oauth.enabled`` — off, the path 404s exactly as today.
     """
     base = deployment_base_url(ctx.config.auth, request)
-    return JSONResponse(
-        status_code=401,
-        content={"detail": "Unauthorized"},
-        headers={"WWW-Authenticate": f'Bearer resource_metadata="{base}{_MCP_PRM_PATH}"'},
-    )
+    headers = {"WWW-Authenticate": f'Bearer resource_metadata="{base}{_MCP_PRM_PATH}"'}
+    if request.method == "HEAD":
+        # HEAD carries the same status and headers as GET but no body
+        # (RFC 9110 §9.3.2).
+        return Response(status_code=401, headers=headers)
+    return JSONResponse(status_code=401, content={"detail": "Unauthorized"}, headers=headers)

--- a/src/jentic_one/auth/web/routers/oauth_client_registration.py
+++ b/src/jentic_one/auth/web/routers/oauth_client_registration.py
@@ -78,10 +78,14 @@ class _Rfc7591Route(APIRoute):
 
     Both concerns must run *outside* the FastAPI dependency/validation
     machinery: the ``enabled`` gate has to precede body parsing and the
-    rate-limit dependency so a disabled door is byte-identical to a missing
-    route (F2), and schema rejections have to be reshaped from FastAPI's 422
-    into the RFC's 400 ``invalid_client_metadata`` (F3). Scoped to this
-    router only — the platform Problem Details handler is untouched.
+    rate-limit dependency so the gate state is unobservable — a disabled door
+    answers the framework's own route-not-found 404 on a full route match
+    (F2; routing-level tells like 405 on non-registered methods are
+    build-level and identical in both gate arms, same as the /mcp discovery
+    gate's ``_McpDiscoveryRoute``) — and schema rejections have to be
+    reshaped from FastAPI's 422 into the RFC's 400 ``invalid_client_metadata``
+    (F3). Scoped to this router only — the platform Problem Details handler
+    is untouched.
     """
 
     def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
@@ -90,10 +94,10 @@ class _Rfc7591Route(APIRoute):
         async def handler(request: Request) -> Response:
             ctx: Context = request.app.state.ctx
             if not ctx.config.server.mcp.oauth.enabled:
-                # Mirror the framework's route-not-found body exactly so a
-                # disabled door is indistinguishable from a build that never
-                # shipped it (§4.2). Runs before rate limiting and body
-                # validation: a 429 or 422 would reveal the endpoint exists.
+                # Mirror the framework's route-not-found body exactly so the
+                # gate state stays unobservable (§4.2). Runs before rate
+                # limiting and body validation: a 429 or 422 would reveal the
+                # gate is on.
                 return JSONResponse(status_code=404, content={"detail": "Not Found"})
 
             content_length = request.headers.get("content-length")

--- a/src/jentic_one/shared/config.py
+++ b/src/jentic_one/shared/config.py
@@ -313,6 +313,10 @@ class OAuthRateLimitConfig(BaseModel):
 class AuthConfig(BaseModel):
     """Platform-actors OAuth surface configuration."""
 
+    # Expected shape: scheme://host[:port] with NO path. Unvalidated — a
+    # path-bearing value (e.g. https://host/jentic) silently breaks the fixed
+    # RFC 8414/9728 well-known routes: path-insertion metadata URLs derived
+    # from a path-bearing issuer are not served (root and /mcp docs alike).
     canonical_base_url: str = ""
     access_ttl_seconds: int = 3600
     refresh_ttl_seconds: int = 604800

--- a/src/jentic_one/shared/web/agent_discovery.py
+++ b/src/jentic_one/shared/web/agent_discovery.py
@@ -200,9 +200,10 @@ This deployment is reachable over **MCP** via the local `jentic mcp` stdio
 server — available in the `jentic` CLI from the next release; check
 `jentic mcp --help`. It exposes the same discover → execute loop as the CLI
 tools against this deployment. MCP access runs through that local server, not
-an HTTP endpoint here: probing `/mcp` still returns 404 on the control plane,
-and a 401 from the broker is its auth-gated forward proxy, not a hidden MCP
-server.
+an HTTP endpoint here: `/mcp` on the control plane serves no MCP server today —
+it answers either 404 or, on deployments preparing interactive OAuth, a 401
+OAuth discovery challenge — and a 401 from the broker is its auth-gated
+forward proxy, not a hidden MCP server.
 
 If your session has `jentic` MCP tools, prefer them; use the `jentic` CLI for
 `setup`/`access` recovery and anything not exposed over MCP. Both surfaces

--- a/src/jentic_one/shared/web/openapi_meta.py
+++ b/src/jentic_one/shared/web/openapi_meta.py
@@ -809,7 +809,7 @@ PUBLIC_OPERATION_IDS: frozenset[str] = frozenset(
         # root-path alias. Unauthenticated by spec; config-gated (404) instead.
         "mcpOauthAuthorizationServer",
         "mcpOauthProtectedResource",
-        "oauthProtectedResource",
+        "mcpOauthProtectedResourceRootAlias",
         # Public IdP-login capability hint (enabled flag + provider name only;
         # no secrets). The SPA reads this pre-login to render the SSO button.
         "authIdpDescriptor",

--- a/src/jentic_one/shared/web/openapi_meta.py
+++ b/src/jentic_one/shared/web/openapi_meta.py
@@ -804,6 +804,12 @@ PUBLIC_OPERATION_IDS: frozenset[str] = frozenset(
         # Unauthenticated discovery metadata.
         "jwks",
         "oauthAuthorizationServer",
+        # /mcp-scoped discovery documents (phase-3a §4.7): RFC 8414 for the
+        # path-scoped issuer, RFC 9728 protected-resource metadata, and its
+        # root-path alias. Unauthenticated by spec; config-gated (404) instead.
+        "mcpOauthAuthorizationServer",
+        "mcpOauthProtectedResource",
+        "oauthProtectedResource",
         # Public IdP-login capability hint (enabled flag + provider name only;
         # no secrets). The SPA reads this pre-login to render the SSO button.
         "authIdpDescriptor",

--- a/tests/unit/auth/web/test_mcp_discovery.py
+++ b/tests/unit/auth/web/test_mcp_discovery.py
@@ -29,6 +29,20 @@ _MCP_DOC_PATHS = (
     "/.well-known/oauth-protected-resource",
 )
 
+#: Every method registered on the /mcp placeholder (the full common set, so
+#: the disabled arm answers a uniform 404 with no 405/Allow method tell and
+#: the enabled arm challenges before method semantics — review F3/F4).
+_MCP_METHODS = ("GET", "POST", "DELETE", "HEAD", "OPTIONS", "PUT", "PATCH")
+
+#: RFC 8414/OIDC discovery variants MCP clients probe (§2) that this surface
+#: deliberately does NOT serve: path-appending and OIDC arms must fall through
+#: to 404 in both gate arms so clients land on the served path-insertion doc.
+_UNSERVED_PROBE_PATHS = (
+    "/mcp/.well-known/openid-configuration",
+    "/mcp/.well-known/oauth-authorization-server",
+    "/.well-known/openid-configuration/mcp",
+)
+
 #: Byte-identical golden of the ROOT RFC 8414 document (§9 regression pin):
 #: the agent ``/register`` stays the advertised agent-DCR endpoint and nothing
 #: the /mcp-scoped documents add may reshape this body.
@@ -95,21 +109,27 @@ def test_disabled_mcp_discovery_docs_are_plain_404(disabled_client: TestClient, 
     assert resp.json() == {"detail": "Not Found"}
 
 
-@pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+@pytest.mark.parametrize("method", _MCP_METHODS)
 def test_disabled_mcp_probe_is_plain_404_without_challenge(
     disabled_client: TestClient, method: str
 ) -> None:
-    """When off, /mcp keeps today's behaviour: 404 and no WWW-Authenticate."""
+    """When off, /mcp keeps today's behaviour on every registered method:
+    the framework's own 404 body and no WWW-Authenticate."""
     resp = disabled_client.request(method, "/mcp")
     assert resp.status_code == 404
-    assert resp.json() == {"detail": "Not Found"}
     assert "www-authenticate" not in resp.headers
+    if method != "HEAD":
+        assert resp.json() == {"detail": "Not Found"}
 
 
 # --- the /mcp-scoped RFC 8414 document (D10) --------------------------------
 
 
-def test_mcp_as_document_matches_d10_exactly(enabled_client: TestClient) -> None:
+def test_mcp_as_document_matches_d10_with_revocation_deviation(
+    enabled_client: TestClient,
+) -> None:
+    """The D10 document shape, minus the deliberately omitted
+    revocation_endpoint (see test_mcp_as_document_omits_revocation_endpoint)."""
     resp = enabled_client.get("/.well-known/oauth-authorization-server/mcp")
     assert resp.status_code == 200
     assert resp.json() == {
@@ -117,13 +137,24 @@ def test_mcp_as_document_matches_d10_exactly(enabled_client: TestClient) -> None
         "authorization_endpoint": f"{_BASE}/authorize",
         "token_endpoint": f"{_BASE}/oauth/token",
         "registration_endpoint": f"{_BASE}/oauth-clients",
-        "revocation_endpoint": f"{_BASE}/oauth/revoke",
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "token_endpoint_auth_methods_supported": ["none"],
         "response_types_supported": ["code"],
         "code_challenge_methods_supported": ["S256"],
         "scopes_supported": sorted(MCP_TOOL_SCOPES),
     }
+
+
+def test_mcp_as_document_omits_revocation_endpoint(enabled_client: TestClient) -> None:
+    """Deliberate deviation from D10: /oauth/revoke requires an authenticated
+    platform Identity and a JSON body, so an RFC 7009 public-client revoke
+    (client_id only, form-encoded) can never succeed against it. RFC 8414
+    makes the field optional — the /mcp doc omits it (public clients revoke by
+    grant lifecycle); the root doc's advertisement is a separate, pre-existing
+    surface pinned by the golden test."""
+    data = enabled_client.get("/.well-known/oauth-authorization-server/mcp").json()
+    assert "revocation_endpoint" not in data
+    assert "revocation_endpoint_auth_methods_supported" not in data
 
 
 def test_mcp_as_document_advertises_only_the_public_client_profile(
@@ -180,16 +211,23 @@ def test_mcp_docs_are_json_like_existing_well_known_endpoints(
 # --- the /mcp 401 challenge + discovery chain -------------------------------
 
 
-@pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+@pytest.mark.parametrize("method", _MCP_METHODS)
 def test_mcp_probe_answers_401_with_resource_metadata(
     enabled_client: TestClient, method: str
 ) -> None:
+    """Every registered method challenges: auth precedes method semantics on a
+    protected resource (the phase-3 mounted app covers all methods too)."""
     resp = enabled_client.request(method, "/mcp")
     assert resp.status_code == 401
     assert (
         resp.headers["www-authenticate"]
         == f'Bearer resource_metadata="{_BASE}/.well-known/oauth-protected-resource/mcp"'
     )
+    if method == "HEAD":
+        # RFC 9110 §9.3.2: same status and headers as GET, no body.
+        assert resp.content == b""
+    else:
+        assert resp.json() == {"detail": "Unauthorized"}
 
 
 def test_discovery_chain_e2e_from_unauthenticated_probe() -> None:
@@ -244,6 +282,80 @@ def test_mcp_docs_fall_back_to_request_host_when_canonical_empty() -> None:
     assert probe.headers["www-authenticate"] == (
         'Bearer resource_metadata="http://testserver/.well-known/oauth-protected-resource/mcp"'
     )
+
+
+# --- build-level tells: identical in both gate arms (review F3) -------------
+#
+# The _McpDiscoveryRoute gate only runs on a full route match, so Starlette
+# answers partial matches (405 + Allow), issues the redirect_slashes 307, and
+# lists the doc paths in the live OpenAPI schema before the gate can run.
+# These reveal BUILD state ("this build ships the routes"), never GATE state —
+# they are identical in both arms. Pinned so any change is deliberate.
+
+
+@pytest.mark.parametrize("path", _MCP_DOC_PATHS)
+def test_doc_path_method_tell_is_identical_in_both_arms(path: str) -> None:
+    """POST to a GET-only doc path → 405 + Allow, byte-identical across arms."""
+    by_arm = {}
+    for enabled in (True, False):
+        resp = _make_client(oauth_enabled=enabled).post(path)
+        by_arm[enabled] = (resp.status_code, resp.headers.get("allow"), resp.content)
+    assert by_arm[True] == by_arm[False]
+    status, allow, _body = by_arm[True]
+    assert status == 405
+    assert allow is not None and set(allow.replace(" ", "").split(",")) == {"GET"}
+
+
+def test_mcp_trailing_slash_redirect_tell_is_identical_in_both_arms() -> None:
+    """GET /mcp/ → redirect_slashes 307 to /mcp in both arms (never a 404)."""
+    by_arm = {}
+    for enabled in (True, False):
+        client = _make_client(oauth_enabled=enabled)
+        resp = client.get("/mcp/", follow_redirects=False)
+        by_arm[enabled] = (resp.status_code, resp.headers.get("location"))
+    assert by_arm[True] == by_arm[False]
+    status, location = by_arm[True]
+    assert status == 307
+    assert location is not None and location.endswith("/mcp")
+
+
+def test_mcp_probe_method_answer_is_uniform_in_the_disabled_arm() -> None:
+    """No 405/Allow method tell on /mcp itself: the placeholder registers the
+    full common method set, so a disabled deployment answers the same 404 on
+    every method instead of leaking an Allow list."""
+    client = _make_client(oauth_enabled=False)
+    for method in _MCP_METHODS:
+        resp = client.request(method, "/mcp")
+        assert resp.status_code == 404
+        assert "allow" not in resp.headers
+
+
+@pytest.mark.parametrize("oauth_enabled", [True, False])
+def test_doc_paths_listed_in_live_openapi_in_both_arms(oauth_enabled: bool) -> None:
+    """The live /openapi.json lists the three doc paths (build-level, like the
+    root discovery doc) in both arms; the /mcp placeholder stays schema-hidden."""
+    client = _make_client(oauth_enabled=oauth_enabled)
+    paths = client.get("/openapi.json").json()["paths"]
+    for path in _MCP_DOC_PATHS:
+        assert path in paths
+    assert "/mcp" not in paths
+
+
+# --- unserved discovery probe arms fall through to 404 (review F7) ----------
+
+
+@pytest.mark.parametrize("oauth_enabled", [True, False])
+@pytest.mark.parametrize("path", _UNSERVED_PROBE_PATHS)
+def test_unserved_discovery_probe_arms_fall_through_404(oauth_enabled: bool, path: str) -> None:
+    """Path-appending and OIDC probe variants 404 in both arms, against the
+    real auth-surface wiring — the fall-through that lands clients on the
+    served RFC 8414 path-insertion doc. A future /mcp/* mount answering
+    401/405 on /mcp/.well-known/... sub-paths would break this order."""
+    client = _make_client(oauth_enabled=oauth_enabled, full_wiring=True)
+    resp = client.get(path)
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Not Found"}
+    assert "www-authenticate" not in resp.headers
 
 
 # --- the acceptance-critical root-document regression pins ------------------

--- a/tests/unit/auth/web/test_mcp_discovery.py
+++ b/tests/unit/auth/web/test_mcp_discovery.py
@@ -1,0 +1,264 @@
+"""Unit tests for the /mcp-scoped OAuth discovery surface (phase-3a §4.7, D10).
+
+Covers both arms of the ``server.mcp.oauth.enabled`` gate, the D10 document
+shapes, the ``/mcp`` 401 challenge, the RFC 9728 → RFC 8414 discovery chain,
+and the acceptance-critical regression pin: the **root** RFC 8414 document
+stays byte-identical (the agent ``/register`` remains its advertised DCR
+endpoint).
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from jentic_one.auth.web import app as auth_app
+from jentic_one.auth.web.routers import discovery
+from jentic_one.shared.config import AuthConfig, ServerConfig
+from jentic_one.shared.scopes import MCP_TOOL_SCOPES
+
+_BASE = "https://auth.example.com"
+
+_MCP_DOC_PATHS = (
+    "/.well-known/oauth-authorization-server/mcp",
+    "/.well-known/oauth-protected-resource/mcp",
+    "/.well-known/oauth-protected-resource",
+)
+
+#: Byte-identical golden of the ROOT RFC 8414 document (§9 regression pin):
+#: the agent ``/register`` stays the advertised agent-DCR endpoint and nothing
+#: the /mcp-scoped documents add may reshape this body.
+_ROOT_AS_GOLDEN = (
+    b'{"issuer":"https://auth.example.com",'
+    b'"authorization_endpoint":"https://auth.example.com/authorize",'
+    b'"token_endpoint":"https://auth.example.com/oauth/token",'
+    b'"registration_endpoint":"https://auth.example.com/register",'
+    b'"revocation_endpoint":"https://auth.example.com/oauth/revoke",'
+    b'"introspection_endpoint":"https://auth.example.com/oauth/introspect",'
+    b'"jwks_uri":"https://auth.example.com/.well-known/jwks.json",'
+    b'"grant_types_supported":["authorization_code",'
+    b'"urn:ietf:params:oauth:grant-type:jwt-bearer","refresh_token",'
+    b'"client_credentials"],'
+    b'"token_endpoint_auth_methods_supported":["private_key_jwt",'
+    b'"client_secret_basic","client_secret_post","none"],'
+    b'"response_types_supported":["code"],'
+    b'"code_challenge_methods_supported":["S256"],'
+    b'"id_token_signing_alg_values_supported":["ES256"],'
+    b'"token_endpoint_auth_signing_alg_values_supported":["EdDSA"]}'
+)
+
+
+def _make_client(
+    *, oauth_enabled: bool = True, canonical_base_url: str = _BASE, full_wiring: bool = False
+) -> TestClient:
+    app = FastAPI()
+    if full_wiring:
+        # The real auth-surface router set, in its real order — proves the
+        # mcp_router is actually wired (not just unit-testable in isolation).
+        for router, prefix, _tags in auth_app.get_routers():
+            app.include_router(router, prefix=prefix)
+    else:
+        app.include_router(discovery.router)
+        app.include_router(discovery.mcp_router)
+
+    mock_ctx = MagicMock()
+    mock_ctx.config.auth = AuthConfig(canonical_base_url=canonical_base_url)
+    server = ServerConfig()
+    server.mcp.oauth.enabled = oauth_enabled
+    mock_ctx.config.server = server
+    app.state.ctx = mock_ctx
+    return TestClient(app)
+
+
+@pytest.fixture()
+def enabled_client() -> TestClient:
+    return _make_client(oauth_enabled=True)
+
+
+@pytest.fixture()
+def disabled_client() -> TestClient:
+    return _make_client(oauth_enabled=False)
+
+
+# --- the disabled arm: indistinguishable from not-shipped -------------------
+
+
+@pytest.mark.parametrize("path", _MCP_DOC_PATHS)
+def test_disabled_mcp_discovery_docs_are_plain_404(disabled_client: TestClient, path: str) -> None:
+    """server.mcp.oauth.enabled=false → the framework's own route-not-found."""
+    resp = disabled_client.get(path)
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Not Found"}
+
+
+@pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+def test_disabled_mcp_probe_is_plain_404_without_challenge(
+    disabled_client: TestClient, method: str
+) -> None:
+    """When off, /mcp keeps today's behaviour: 404 and no WWW-Authenticate."""
+    resp = disabled_client.request(method, "/mcp")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Not Found"}
+    assert "www-authenticate" not in resp.headers
+
+
+# --- the /mcp-scoped RFC 8414 document (D10) --------------------------------
+
+
+def test_mcp_as_document_matches_d10_exactly(enabled_client: TestClient) -> None:
+    resp = enabled_client.get("/.well-known/oauth-authorization-server/mcp")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "issuer": f"{_BASE}/mcp",
+        "authorization_endpoint": f"{_BASE}/authorize",
+        "token_endpoint": f"{_BASE}/oauth/token",
+        "registration_endpoint": f"{_BASE}/oauth-clients",
+        "revocation_endpoint": f"{_BASE}/oauth/revoke",
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "response_types_supported": ["code"],
+        "code_challenge_methods_supported": ["S256"],
+        "scopes_supported": sorted(MCP_TOOL_SCOPES),
+    }
+
+
+def test_mcp_as_document_advertises_only_the_public_client_profile(
+    enabled_client: TestClient,
+) -> None:
+    """No CIMD flag yet (§6 follow-on), no confidential/JWT profiles, and the
+    registration endpoint is the OAuth-client door — never the agent /register."""
+    data = enabled_client.get("/.well-known/oauth-authorization-server/mcp").json()
+    assert "client_id_metadata_document_supported" not in data
+    assert data["token_endpoint_auth_methods_supported"] == ["none"]
+    assert "urn:ietf:params:oauth:grant-type:jwt-bearer" not in data["grant_types_supported"]
+    assert "client_credentials" not in data["grant_types_supported"]
+    assert data["registration_endpoint"] != f"{_BASE}/register"
+
+
+# --- the RFC 9728 protected-resource documents ------------------------------
+
+
+def test_prm_document_matches_d10_exactly(enabled_client: TestClient) -> None:
+    resp = enabled_client.get("/.well-known/oauth-protected-resource/mcp")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "resource": f"{_BASE}/mcp",
+        "authorization_servers": [f"{_BASE}/mcp"],
+        "scopes_supported": sorted(MCP_TOOL_SCOPES),
+        "bearer_methods_supported": ["header"],
+    }
+
+
+def test_root_prm_alias_serves_the_same_body(enabled_client: TestClient) -> None:
+    """claude-code#58802 fallback: root and path-scoped PRM docs are one body."""
+    scoped = enabled_client.get("/.well-known/oauth-protected-resource/mcp")
+    root = enabled_client.get("/.well-known/oauth-protected-resource")
+    assert root.status_code == 200
+    assert root.content == scoped.content
+
+
+@pytest.mark.parametrize("path", _MCP_DOC_PATHS)
+def test_mcp_docs_are_json_like_existing_well_known_endpoints(
+    enabled_client: TestClient, path: str
+) -> None:
+    """Header posture matches the root discovery docs: plain application/json,
+    no auth challenge, no bespoke CORS/cache headers."""
+    resp = enabled_client.get(path)
+    root = enabled_client.get("/.well-known/oauth-authorization-server")
+    assert "application/json" in resp.headers["content-type"]
+    assert "www-authenticate" not in resp.headers
+    assert ("access-control-allow-origin" in resp.headers) == (
+        "access-control-allow-origin" in root.headers
+    )
+    assert ("cache-control" in resp.headers) == ("cache-control" in root.headers)
+
+
+# --- the /mcp 401 challenge + discovery chain -------------------------------
+
+
+@pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+def test_mcp_probe_answers_401_with_resource_metadata(
+    enabled_client: TestClient, method: str
+) -> None:
+    resp = enabled_client.request(method, "/mcp")
+    assert resp.status_code == 401
+    assert (
+        resp.headers["www-authenticate"]
+        == f'Bearer resource_metadata="{_BASE}/.well-known/oauth-protected-resource/mcp"'
+    )
+
+
+def test_discovery_chain_e2e_from_unauthenticated_probe() -> None:
+    """§9 chain: unauthenticated /mcp → 401 resource_metadata → PRM → AS doc.
+
+    Follows the pointers the way a spec-following MCP client does (RFC 9728
+    then RFC 8414 §3.1 path insertion for the path-scoped issuer), against the
+    real auth-surface wiring (get_routers order).
+    """
+    client = _make_client(oauth_enabled=True, full_wiring=True)
+
+    probe = client.post("/mcp")
+    assert probe.status_code == 401
+    match = re.search(r'resource_metadata="([^"]+)"', probe.headers["www-authenticate"])
+    assert match is not None
+    prm_url = match.group(1)
+    assert prm_url.startswith(_BASE)
+
+    prm = client.get(prm_url.removeprefix(_BASE))
+    assert prm.status_code == 200
+    prm_doc = prm.json()
+    assert prm_doc["resource"] == f"{_BASE}/mcp"
+    (authorization_server,) = prm_doc["authorization_servers"]
+    assert authorization_server == f"{_BASE}/mcp"
+
+    # RFC 8414 §3.1: insert the well-known segment between host and path.
+    issuer_path = authorization_server.removeprefix(_BASE)
+    as_doc = client.get(f"/.well-known/oauth-authorization-server{issuer_path}")
+    assert as_doc.status_code == 200
+    data = as_doc.json()
+    assert data["issuer"] == authorization_server
+    assert data["registration_endpoint"] == f"{_BASE}/oauth-clients"
+    assert data["token_endpoint_auth_methods_supported"] == ["none"]
+    assert data["code_challenge_methods_supported"] == ["S256"]
+
+
+# --- base-URL posture (same rules as the root discovery doc) ----------------
+
+
+def test_mcp_docs_ignore_spoofed_host_header(enabled_client: TestClient) -> None:
+    resp = enabled_client.get(
+        "/.well-known/oauth-authorization-server/mcp", headers={"Host": "evil.com"}
+    )
+    assert resp.json()["issuer"] == f"{_BASE}/mcp"
+
+
+def test_mcp_docs_fall_back_to_request_host_when_canonical_empty() -> None:
+    client = _make_client(oauth_enabled=True, canonical_base_url="")
+    resp = client.get("/.well-known/oauth-protected-resource/mcp")
+    assert resp.json()["resource"] == "http://testserver/mcp"
+    probe = client.get("/mcp")
+    assert probe.headers["www-authenticate"] == (
+        'Bearer resource_metadata="http://testserver/.well-known/oauth-protected-resource/mcp"'
+    )
+
+
+# --- the acceptance-critical root-document regression pins ------------------
+
+
+@pytest.mark.parametrize("oauth_enabled", [True, False])
+def test_root_as_document_is_byte_identical_golden(oauth_enabled: bool) -> None:
+    """The ROOT RFC 8414 document must not change in either gate arm (§9):
+    its registration_endpoint stays the agent /register, byte for byte."""
+    client = _make_client(oauth_enabled=oauth_enabled)
+    resp = client.get("/.well-known/oauth-authorization-server")
+    assert resp.status_code == 200
+    assert resp.content == _ROOT_AS_GOLDEN
+
+
+def test_root_as_document_still_advertises_agent_register(enabled_client: TestClient) -> None:
+    data = enabled_client.get("/.well-known/oauth-authorization-server").json()
+    assert data["registration_endpoint"] == f"{_BASE}/register"

--- a/tests/unit/shared/web/test_agent_discovery.py
+++ b/tests/unit/shared/web/test_agent_discovery.py
@@ -266,7 +266,9 @@ def test_llms_txt_advertises_mcp_server(client: TestClient) -> None:
     reach the same instance (verifiable via ``backend``/``host`` in the
     identity stamp), and still preempt the ``/mcp``-probe misdiagnosis (#753):
     MCP runs through the local stdio server, not an HTTP endpoint on the
-    deployment.
+    deployment. The ``/mcp`` wording must stay accurate in *both*
+    ``server.mcp.oauth.enabled`` arms (phase-3a: enabled deployments answer a
+    401 OAuth discovery challenge there, not a 404).
     """
     body = client.get(LLMS_TXT_PATH).text
     assert "no MCP endpoint" not in body
@@ -277,8 +279,12 @@ def test_llms_txt_advertises_mcp_server(client: TestClient) -> None:
     assert "`setup`/`access` recovery" in body
     assert "same instance" in body
     assert "`backend`/`host`" in body
-    # The /mcp probe still 404s — the advertisement must not imply an HTTP endpoint.
-    assert "probing `/mcp` still returns 404" in body
+    # The /mcp probe answers 404 or the phase-3a 401 discovery challenge — the
+    # advertisement must not imply a live HTTP MCP endpoint in either arm.
+    assert "`/mcp` on the control plane serves no MCP server today" in body
+    assert "401 OAuth discovery challenge" in " ".join(body.split())
+    # The stale single-arm claim must not come back.
+    assert "still returns 404" not in body
 
 
 def test_render_llms_txt_stamps_base_everywhere() -> None:

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -9992,7 +9992,7 @@
             "description": "Bad Request"
           },
           "404": {
-            "description": "Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped."
+            "description": "Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework's plain route-not-found 404, so the gate state is unobservable."
           },
           "422": {
             "content": {
@@ -10061,15 +10061,15 @@
     },
     "/.well-known/oauth-protected-resource": {
       "get": {
-        "description": "Root-path alias of the MCP protected-resource document (phase-3a §4.7).\n\nCompatibility fallback for clients that probe the root\n`/.well-known/oauth-protected-resource` instead of following the 401's\n`resource_metadata` pointer (the documented Claude Code behaviour). Safe\nbecause this deployment has exactly one OAuth-protected resource, so the\nroot and path-scoped documents are the same body.",
-        "operationId": "oauthProtectedResource",
+        "description": "Root-path alias of the MCP protected-resource document (phase-3a §4.7).\n\nCompatibility fallback for clients that probe the root\n`/.well-known/oauth-protected-resource` instead of following the 401's\n`resource_metadata` pointer (the documented Claude Code behaviour). Safe\nbecause this deployment has exactly one OAuth-protected resource, so the\nroot and path-scoped documents are the same body.\n\nTwo acknowledged trades (§4.7, review F6):\n\n- RFC 9728 §3 says this well-known path corresponds to resource identifier\n  ``{base}`` (no path), and §3.3 has clients validate ``resource`` against\n  the resource they queried. This body claims ``resource={base}/mcp`` — a\n  strict path-deriving validator would reject it, but Claude's fallback\n  validates against the MCP server URL (``{base}/mcp``), which is exactly\n  what the alias exists to satisfy. That is the intended trade.\n- The alias squats the deployment's only root PRM slot: a future non-MCP\n  protected resource at ``{base}`` cannot get its own root document\n  without breaking this fallback. Phase 3's mount must re-confirm the\n  \"exactly one OAuth-protected resource\" premise before adding one.",
+        "operationId": "mcpOauthProtectedResourceRootAlias",
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
                   "additionalProperties": true,
-                  "title": "Response Oauthprotectedresource",
+                  "title": "Response Mcpoauthprotectedresourcerootalias",
                   "type": "object"
                 }
               }
@@ -10094,7 +10094,7 @@
             "description": "Bad Request"
           },
           "404": {
-            "description": "Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped."
+            "description": "Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework's plain route-not-found 404, so the gate state is unobservable."
           },
           "422": {
             "content": {
@@ -10155,7 +10155,7 @@
           }
         },
         "security": [],
-        "summary": "OAuth protected resource metadata (root alias)",
+        "summary": "OAuth protected resource metadata (root alias for the MCP resource)",
         "tags": [
           "Discovery"
         ]
@@ -10196,7 +10196,7 @@
             "description": "Bad Request"
           },
           "404": {
-            "description": "Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped."
+            "description": "Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework's plain route-not-found 404, so the gate state is unobservable."
           },
           "422": {
             "content": {

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -9957,6 +9957,312 @@
         ]
       }
     },
+    "/.well-known/oauth-authorization-server/mcp": {
+      "get": {
+        "description": "RFC 8414 metadata for the path-scoped issuer `{base}/mcp` (phase-3a §4.7).\n\nRFC 8414 §3.1 path insertion: this is the metadata URL clients derive for\nthe issuer `{base}/mcp` named by the protected-resource document. It\nadvertises the anonymous OAuth-client registration door (`/oauth-clients`)\nand the public-client profile (`none` + PKCE S256) — the root document is a\nseparate, unchanged surface whose `registration_endpoint` remains the agent\n`/register`.",
+        "operationId": "mcpOauthAuthorizationServer",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Mcpoauthauthorizationserver",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request was malformed or failed a precondition.",
+                  "instance": "/example/path",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "bad_request"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped."
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Request validation failed; see errors[] for details.",
+                  "errors": [
+                    {
+                      "detail": "Field 'name' must not be blank.",
+                      "pointer": "#/name"
+                    }
+                  ],
+                  "instance": "/example/path",
+                  "status": 422,
+                  "title": "Unprocessable Entity",
+                  "type": "validation_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "An unexpected error occurred.",
+                  "instance": "/example/path",
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "type": "server_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The database is temporarily unavailable; please retry.",
+                  "instance": "/example/path",
+                  "status": 503,
+                  "title": "Service Unavailable",
+                  "type": "database_unavailable"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [],
+        "summary": "OAuth authorization server metadata for the MCP resource",
+        "tags": [
+          "Discovery"
+        ]
+      }
+    },
+    "/.well-known/oauth-protected-resource": {
+      "get": {
+        "description": "Root-path alias of the MCP protected-resource document (phase-3a §4.7).\n\nCompatibility fallback for clients that probe the root\n`/.well-known/oauth-protected-resource` instead of following the 401's\n`resource_metadata` pointer (the documented Claude Code behaviour). Safe\nbecause this deployment has exactly one OAuth-protected resource, so the\nroot and path-scoped documents are the same body.",
+        "operationId": "oauthProtectedResource",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Oauthprotectedresource",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request was malformed or failed a precondition.",
+                  "instance": "/example/path",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "bad_request"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped."
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Request validation failed; see errors[] for details.",
+                  "errors": [
+                    {
+                      "detail": "Field 'name' must not be blank.",
+                      "pointer": "#/name"
+                    }
+                  ],
+                  "instance": "/example/path",
+                  "status": 422,
+                  "title": "Unprocessable Entity",
+                  "type": "validation_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "An unexpected error occurred.",
+                  "instance": "/example/path",
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "type": "server_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The database is temporarily unavailable; please retry.",
+                  "instance": "/example/path",
+                  "status": 503,
+                  "title": "Service Unavailable",
+                  "type": "database_unavailable"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [],
+        "summary": "OAuth protected resource metadata (root alias)",
+        "tags": [
+          "Discovery"
+        ]
+      }
+    },
+    "/.well-known/oauth-protected-resource/mcp": {
+      "get": {
+        "description": "RFC 9728 protected-resource metadata for `{base}/mcp` (phase-3a §4.7).\n\nNames the /mcp-scoped authorization server and the MCP tool scopes. The\nsame body is also served at the root well-known path for clients that\nignore the 401's `resource_metadata` pointer.",
+        "operationId": "mcpOauthProtectedResource",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Mcpoauthprotectedresource",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request was malformed or failed a precondition.",
+                  "instance": "/example/path",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "bad_request"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Interactive OAuth for MCP is disabled (`server.mcp.oauth.enabled=false`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped."
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Request validation failed; see errors[] for details.",
+                  "errors": [
+                    {
+                      "detail": "Field 'name' must not be blank.",
+                      "pointer": "#/name"
+                    }
+                  ],
+                  "instance": "/example/path",
+                  "status": 422,
+                  "title": "Unprocessable Entity",
+                  "type": "validation_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "An unexpected error occurred.",
+                  "instance": "/example/path",
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "type": "server_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The database is temporarily unavailable; please retry.",
+                  "instance": "/example/path",
+                  "status": 503,
+                  "title": "Service Unavailable",
+                  "type": "database_unavailable"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [],
+        "summary": "OAuth protected resource metadata for the MCP resource",
+        "tags": [
+          "Discovery"
+        ]
+      }
+    },
     "/access-requests": {
       "get": {
         "description": "List access requests with cursor-based pagination.",

--- a/ui/src/shared/api/generated/services/DiscoveryService.ts
+++ b/ui/src/shared/api/generated/services/DiscoveryService.ts
@@ -61,7 +61,7 @@ export class DiscoveryService {
             url: '/.well-known/oauth-authorization-server/mcp',
             errors: {
                 400: `Bad Request`,
-                404: `Interactive OAuth for MCP is disabled (\`server.mcp.oauth.enabled=false\`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped.`,
+                404: `Interactive OAuth for MCP is disabled (\`server.mcp.oauth.enabled=false\`): the route answers the framework's plain route-not-found 404, so the gate state is unobservable.`,
                 422: `Unprocessable Entity`,
                 500: `Internal Server Error`,
                 503: `Service Unavailable`,
@@ -69,7 +69,7 @@ export class DiscoveryService {
         });
     }
     /**
-     * OAuth protected resource metadata (root alias)
+     * OAuth protected resource metadata (root alias for the MCP resource)
      * Root-path alias of the MCP protected-resource document (phase-3a §4.7).
      *
      * Compatibility fallback for clients that probe the root
@@ -77,16 +77,29 @@ export class DiscoveryService {
      * `resource_metadata` pointer (the documented Claude Code behaviour). Safe
      * because this deployment has exactly one OAuth-protected resource, so the
      * root and path-scoped documents are the same body.
+     *
+     * Two acknowledged trades (§4.7, review F6):
+     *
+     * - RFC 9728 §3 says this well-known path corresponds to resource identifier
+     * ``{base}`` (no path), and §3.3 has clients validate ``resource`` against
+     * the resource they queried. This body claims ``resource={base}/mcp`` — a
+     * strict path-deriving validator would reject it, but Claude's fallback
+     * validates against the MCP server URL (``{base}/mcp``), which is exactly
+     * what the alias exists to satisfy. That is the intended trade.
+     * - The alias squats the deployment's only root PRM slot: a future non-MCP
+     * protected resource at ``{base}`` cannot get its own root document
+     * without breaking this fallback. Phase 3's mount must re-confirm the
+     * "exactly one OAuth-protected resource" premise before adding one.
      * @returns any Successful Response
      * @throws ApiError
      */
-    public static oauthProtectedResource(): CancelablePromise<Record<string, any>> {
+    public static mcpOauthProtectedResourceRootAlias(): CancelablePromise<Record<string, any>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/.well-known/oauth-protected-resource',
             errors: {
                 400: `Bad Request`,
-                404: `Interactive OAuth for MCP is disabled (\`server.mcp.oauth.enabled=false\`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped.`,
+                404: `Interactive OAuth for MCP is disabled (\`server.mcp.oauth.enabled=false\`): the route answers the framework's plain route-not-found 404, so the gate state is unobservable.`,
                 422: `Unprocessable Entity`,
                 500: `Internal Server Error`,
                 503: `Service Unavailable`,
@@ -109,7 +122,7 @@ export class DiscoveryService {
             url: '/.well-known/oauth-protected-resource/mcp',
             errors: {
                 400: `Bad Request`,
-                404: `Interactive OAuth for MCP is disabled (\`server.mcp.oauth.enabled=false\`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped.`,
+                404: `Interactive OAuth for MCP is disabled (\`server.mcp.oauth.enabled=false\`): the route answers the framework's plain route-not-found 404, so the gate state is unobservable.`,
                 422: `Unprocessable Entity`,
                 500: `Internal Server Error`,
                 503: `Service Unavailable`,

--- a/ui/src/shared/api/generated/services/DiscoveryService.ts
+++ b/ui/src/shared/api/generated/services/DiscoveryService.ts
@@ -43,6 +43,80 @@ export class DiscoveryService {
         });
     }
     /**
+     * OAuth authorization server metadata for the MCP resource
+     * RFC 8414 metadata for the path-scoped issuer `{base}/mcp` (phase-3a §4.7).
+     *
+     * RFC 8414 §3.1 path insertion: this is the metadata URL clients derive for
+     * the issuer `{base}/mcp` named by the protected-resource document. It
+     * advertises the anonymous OAuth-client registration door (`/oauth-clients`)
+     * and the public-client profile (`none` + PKCE S256) — the root document is a
+     * separate, unchanged surface whose `registration_endpoint` remains the agent
+     * `/register`.
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static mcpOauthAuthorizationServer(): CancelablePromise<Record<string, any>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/.well-known/oauth-authorization-server/mcp',
+            errors: {
+                400: `Bad Request`,
+                404: `Interactive OAuth for MCP is disabled (\`server.mcp.oauth.enabled=false\`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped.`,
+                422: `Unprocessable Entity`,
+                500: `Internal Server Error`,
+                503: `Service Unavailable`,
+            },
+        });
+    }
+    /**
+     * OAuth protected resource metadata (root alias)
+     * Root-path alias of the MCP protected-resource document (phase-3a §4.7).
+     *
+     * Compatibility fallback for clients that probe the root
+     * `/.well-known/oauth-protected-resource` instead of following the 401's
+     * `resource_metadata` pointer (the documented Claude Code behaviour). Safe
+     * because this deployment has exactly one OAuth-protected resource, so the
+     * root and path-scoped documents are the same body.
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static oauthProtectedResource(): CancelablePromise<Record<string, any>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/.well-known/oauth-protected-resource',
+            errors: {
+                400: `Bad Request`,
+                404: `Interactive OAuth for MCP is disabled (\`server.mcp.oauth.enabled=false\`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped.`,
+                422: `Unprocessable Entity`,
+                500: `Internal Server Error`,
+                503: `Service Unavailable`,
+            },
+        });
+    }
+    /**
+     * OAuth protected resource metadata for the MCP resource
+     * RFC 9728 protected-resource metadata for `{base}/mcp` (phase-3a §4.7).
+     *
+     * Names the /mcp-scoped authorization server and the MCP tool scopes. The
+     * same body is also served at the root well-known path for clients that
+     * ignore the 401's `resource_metadata` pointer.
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static mcpOauthProtectedResource(): CancelablePromise<Record<string, any>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/.well-known/oauth-protected-resource/mcp',
+            errors: {
+                400: `Bad Request`,
+                404: `Interactive OAuth for MCP is disabled (\`server.mcp.oauth.enabled=false\`): the route answers the framework's plain route-not-found 404, indistinguishable from not-shipped.`,
+                422: `Unprocessable Entity`,
+                500: `Internal Server Error`,
+                503: `Service Unavailable`,
+            },
+        });
+    }
+    /**
      * External IdP login descriptor
      * Public capability hint: whether IdP login is enabled, and which provider.
      *


### PR DESCRIPTION
## Summary

Fourth slice of the phase-3a interactive-OAuth work (design: plans `themes/local-mcp/phase-3a-design.md` §4.7/D10, signed off on plans PR #25). Bases on main — 3a-1 (#1218), 3a-2 (#1219), 3a-3 (#1220) all merged beneath it.

- **`GET /.well-known/oauth-authorization-server/mcp`** (RFC 8414, path-insertion) — issuer `{base}/mcp`, shared `/authorize` + `/oauth/token`, `registration_endpoint={base}/oauth-clients` (the DCR door, never agent `/register`), `token_endpoint_auth_methods_supported=["none"]`, S256 only, scopes = the MCP tool-scope set.
- **`GET /.well-known/oauth-protected-resource/mcp`** (RFC 9728) + a root alias with identical body (claude-code path-fallback), MCP-specific operation_id, path-derivation trade documented.
- **`/mcp` placeholder** (schema-hidden, all methods): 401 with `WWW-Authenticate: Bearer resource_metadata="…"` so the discovery chain works before phase 3 mounts the real MCP app (same challenge contract).
- **Gate**: everything above is served only when `server.mcp.oauth.enabled` (shipped in 3a-2 — no config changes needed, resolving design escalation E2 as a non-issue); disabled → framework 404s.
- **Regression pins**: root RFC 8414 doc byte-identical golden (both gate arms); agent `/register` untouched.
- **CIMD flag deliberately not advertised** (per the design's §2 client-landscape verification: steers Claude to DCR alongside Cursor; the flip is the designed follow-on).

**Design deviation (recorded as plans gap G11):** D10 prescribes advertising `revocation_endpoint={base}/oauth/revoke`, but that endpoint requires an authenticated platform Identity + JSON body — unusable for an RFC 7009 public-client revoke — so this PR omits the optional field and pins the omission. Phase 3 should bless or fix.

Adversarial review + fix wave ran pre-push (same discipline as the rest of the stack): both MAJORs (the unusable revocation advertisement; stale base vs 3a-3) and all actionable minors fixed — full-method challenge coverage, honest gate-observability claims with tell-pinning tests, accurate `llms.txt`, path-appending probe arms.

## Test plan

- [x] ruff + mypy clean
- [x] Unit 2965 + arch 152 passed (42-test discovery suite: chain e2e over real router wiring, both gate arms, host-spoof, byte-golden root pin, tell pins, probe arms)
- [x] SQLite integration: 695 passed
- [x] Go client build + tests; UI type-check
- [ ] Postgres integration on CI (no local Docker)

Made with [Cursor](https://cursor.com)