### PR TITLE
feat(ui): OAuth approval queue + per-agent connected-clients panel (3a-5)

### DIFF
--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -2306,6 +2306,9 @@ type OAuthGrantAdminResponse struct {
 	// AgentId The agent this grant binds the client to.
 	AgentId string `json:"agent_id"`
 
+	// CanRevoke Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. a read-only admin.
+	CanRevoke bool `json:"can_revoke"`
+
 	// ClientName Display name of the registered client, if the row still exists.
 	ClientName *string `json:"client_name"`
 
@@ -2344,6 +2347,9 @@ type OAuthGrantListResponse struct {
 type OAuthGrantResponse struct {
 	// AgentId The agent this grant binds the client to.
 	AgentId string `json:"agent_id"`
+
+	// CanRevoke Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. the agent's new owner after an ownership transfer, or a read-only admin.
+	CanRevoke bool `json:"can_revoke"`
 
 	// ClientName Display name of the registered client, if the row still exists.
 	ClientName *string `json:"client_name"`

--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -828,6 +828,42 @@ func (e JenticOneControlWebSchemasToolkitsPermissionRuleSchemaMatchMode) Valid()
 	}
 }
 
+// Defines values for ListOauthGrantsParamsStatus.
+const (
+	ListOauthGrantsParamsStatusActive  ListOauthGrantsParamsStatus = "active"
+	ListOauthGrantsParamsStatusRevoked ListOauthGrantsParamsStatus = "revoked"
+)
+
+// Valid indicates whether the value is a known member of the ListOauthGrantsParamsStatus enum.
+func (e ListOauthGrantsParamsStatus) Valid() bool {
+	switch e {
+	case ListOauthGrantsParamsStatusActive:
+		return true
+	case ListOauthGrantsParamsStatusRevoked:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListAgentOauthGrantsParamsStatus.
+const (
+	ListAgentOauthGrantsParamsStatusActive  ListAgentOauthGrantsParamsStatus = "active"
+	ListAgentOauthGrantsParamsStatusRevoked ListAgentOauthGrantsParamsStatus = "revoked"
+)
+
+// Valid indicates whether the value is a known member of the ListAgentOauthGrantsParamsStatus enum.
+func (e ListAgentOauthGrantsParamsStatus) Valid() bool {
+	switch e {
+	case ListAgentOauthGrantsParamsStatusActive:
+		return true
+	case ListAgentOauthGrantsParamsStatusRevoked:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for InspectOperationParamsDetail.
 const (
 	Full    InspectOperationParamsDetail = "full"
@@ -2102,6 +2138,9 @@ type OAuthClientCreateRequestTokenEndpointAuthMethod string
 type OAuthClientCreateResponse struct {
 	Active bool `json:"active"`
 
+	// ActiveGrantCount Number of active consent→agent grants for this client (§4.8 per-client grant count). Computed on the read endpoints (list/get); write-path responses report 0.
+	ActiveGrantCount *int `json:"active_grant_count,omitempty"`
+
 	// AllowedScopes Scopes this client may request. Null means unrestricted.
 	AllowedScopes *[]string `json:"allowed_scopes"`
 
@@ -2200,6 +2239,9 @@ type OAuthClientRegistrationResponse struct {
 type OAuthClientResponse struct {
 	Active bool `json:"active"`
 
+	// ActiveGrantCount Number of active consent→agent grants for this client (§4.8 per-client grant count). Computed on the read endpoints (list/get); write-path responses report 0.
+	ActiveGrantCount *int `json:"active_grant_count,omitempty"`
+
 	// AllowedScopes Scopes this client may request. Null means unrestricted.
 	AllowedScopes *[]string `json:"allowed_scopes"`
 
@@ -2250,6 +2292,84 @@ type OAuthClientUpdateRequest struct {
 	Name           *string   `json:"name,omitempty"`
 	RedirectUris   *[]string `json:"redirect_uris,omitempty"`
 	RequireConsent *bool     `json:"require_consent,omitempty"`
+}
+
+// OAuthGrantAdminListResponse A paginated list of OAuth grants (admin cross-view).
+type OAuthGrantAdminListResponse struct {
+	Data       []OAuthGrantAdminResponse `json:"data"`
+	HasMore    bool                      `json:"has_more"`
+	NextCursor *string                   `json:"next_cursor,omitempty"`
+}
+
+// OAuthGrantAdminResponse One consent→agent grant in the admin cross-view.
+type OAuthGrantAdminResponse struct {
+	// AgentId The agent this grant binds the client to.
+	AgentId string `json:"agent_id"`
+
+	// ClientName Display name of the registered client, if the row still exists.
+	ClientName *string `json:"client_name"`
+
+	// ClientOrigin Origin (scheme://host) of the client's first redirect URI — the 'authorized apps' display pattern.
+	ClientOrigin *string   `json:"client_origin"`
+	CreatedAt    time.Time `json:"created_at"`
+
+	// Id Grant ID (ksuid, `ocg_` prefix).
+	Id string `json:"id"`
+
+	// LastUsedAt Last time the client obtained tokens under this grant (stamped at exchange/refresh, not per request).
+	LastUsedAt *time.Time `json:"last_used_at"`
+
+	// OauthClientId The client's public client_id — the same identifier stamped on tokens minted under this grant.
+	OauthClientId string     `json:"oauth_client_id"`
+	RevokedAt     *time.Time `json:"revoked_at"`
+
+	// Scopes Scopes granted at consent (the D2 intersection).
+	Scopes []string `json:"scopes"`
+
+	// Status Grant lifecycle state: ``active`` or ``revoked``.
+	Status string `json:"status"`
+
+	// UserId The consenting user who approved this grant. Shown even after an agent ownership transfer: the grant stays with the original consenter (it is their consent, not the agent's).
+	UserId string `json:"user_id"`
+}
+
+// OAuthGrantListResponse A paginated list of OAuth grants.
+type OAuthGrantListResponse struct {
+	Data       []OAuthGrantResponse `json:"data"`
+	HasMore    bool                 `json:"has_more"`
+	NextCursor *string              `json:"next_cursor,omitempty"`
+}
+
+// OAuthGrantResponse One consent→agent grant in API responses.
+type OAuthGrantResponse struct {
+	// AgentId The agent this grant binds the client to.
+	AgentId string `json:"agent_id"`
+
+	// ClientName Display name of the registered client, if the row still exists.
+	ClientName *string `json:"client_name"`
+
+	// ClientOrigin Origin (scheme://host) of the client's first redirect URI — the 'authorized apps' display pattern.
+	ClientOrigin *string   `json:"client_origin"`
+	CreatedAt    time.Time `json:"created_at"`
+
+	// Id Grant ID (ksuid, `ocg_` prefix).
+	Id string `json:"id"`
+
+	// LastUsedAt Last time the client obtained tokens under this grant (stamped at exchange/refresh, not per request).
+	LastUsedAt *time.Time `json:"last_used_at"`
+
+	// OauthClientId The client's public client_id — the same identifier stamped on tokens minted under this grant.
+	OauthClientId string     `json:"oauth_client_id"`
+	RevokedAt     *time.Time `json:"revoked_at"`
+
+	// Scopes Scopes granted at consent (the D2 intersection).
+	Scopes []string `json:"scopes"`
+
+	// Status Grant lifecycle state: ``active`` or ``revoked``.
+	Status string `json:"status"`
+
+	// UserId The consenting user who approved this grant. Shown even after an agent ownership transfer: the grant stays with the original consenter (it is their consent, not the agent's).
+	UserId string `json:"user_id"`
 }
 
 // OperationPreviewListResponse Capped, offset-paginated operation preview for a catalog entry.
@@ -3214,12 +3334,43 @@ type ListOauthClientsParams struct {
 // DenyOauthClientJSONBody defines parameters for DenyOauthClient.
 type DenyOauthClientJSONBody = OAuthClientDenyRequest
 
+// ListOauthGrantsParams defines parameters for ListOauthGrants.
+type ListOauthGrantsParams struct {
+	// ClientId Filter by the client's public client_id.
+	ClientId *string `form:"client_id,omitempty" json:"client_id,omitempty"`
+
+	// AgentId Filter by bound agent.
+	AgentId *string `form:"agent_id,omitempty" json:"agent_id,omitempty"`
+
+	// UserId Filter by consenting user.
+	UserId *string `form:"user_id,omitempty" json:"user_id,omitempty"`
+
+	// Status Filter by grant lifecycle state.
+	Status *ListOauthGrantsParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	Limit  *int                         `form:"limit,omitempty" json:"limit,omitempty"`
+	Cursor *string                      `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// ListOauthGrantsParamsStatus defines parameters for ListOauthGrants.
+type ListOauthGrantsParamsStatus string
+
 // ListAgentsParams defines parameters for ListAgents.
 type ListAgentsParams struct {
 	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 	Limit  *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Status *string `form:"status,omitempty" json:"status,omitempty"`
 }
+
+// ListAgentOauthGrantsParams defines parameters for ListAgentOauthGrants.
+type ListAgentOauthGrantsParams struct {
+	// Status Filter by grant lifecycle state.
+	Status *ListAgentOauthGrantsParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	Limit  *int                              `form:"limit,omitempty" json:"limit,omitempty"`
+	Cursor *string                           `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// ListAgentOauthGrantsParamsStatus defines parameters for ListAgentOauthGrants.
+type ListAgentOauthGrantsParamsStatus string
 
 // ListApisParams defines parameters for ListApis.
 type ListApisParams struct {
@@ -4757,6 +4908,19 @@ type ClientInterface interface {
 	// Corresponds with POST /admin/oauth-clients/{id}:deny (the `DenyOauthClient` operationId).
 	DenyOauthClient(ctx context.Context, id string, body DenyOauthClientJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListOauthGrants List OAuth grants
+	//
+	// List consent→agent grants across all clients and agents (§4.8).
+	//
+	// The admin cross-view over the grant registry: filter by client, agent,
+	// consenting user, or status. Each item carries the client's display name
+	// and redirect-URI origin plus the consenting ``user_id`` — after an agent
+	// ownership transfer the grant stays with the original consenter, so this
+	// column is how an admin spots stranded grants.
+	//
+	// Corresponds with GET /admin/oauth-grants (the `ListOauthGrants` operationId).
+	ListOauthGrants(ctx context.Context, params *ListOauthGrantsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListAgents List Agents
 	//
 	// List agents — scoped by identity via dynamic query scoping.
@@ -4853,6 +5017,19 @@ type ClientInterface interface {
 	//
 	// Corresponds with PUT /agents/{agent_id}/jwks (the `UpdateAgentJwks` operationId).
 	UpdateAgentJwks(ctx context.Context, agentId string, body UpdateAgentJwksJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListAgentOauthGrants List agent OAuth grants
+	//
+	// List OAuth consent grants binding clients to this agent (§4.8).
+	//
+	// The "Connected clients" surface: every grant carries the client's display
+	// name and redirect-URI origin, the granted scopes, the consenting user,
+	// and created/last-used timestamps. Allowed for the agent's owner or an
+	// admin — authorization is enforced in the service layer, mirroring the
+	// ``:revoke`` semantics.
+	//
+	// Corresponds with GET /agents/{agent_id}/oauth-grants (the `ListAgentOauthGrants` operationId).
+	ListAgentOauthGrants(ctx context.Context, agentId string, params *ListAgentOauthGrantsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetAgentScopes Get Agent Scopes
 	//
@@ -7186,6 +7363,29 @@ func (c *Client) DenyOauthClient(ctx context.Context, id string, body DenyOauthC
 	return c.Client.Do(req)
 }
 
+// ListOauthGrants List OAuth grants
+//
+// List consent→agent grants across all clients and agents (§4.8).
+//
+// The admin cross-view over the grant registry: filter by client, agent,
+// consenting user, or status. Each item carries the client's display name
+// and redirect-URI origin plus the consenting “user_id“ — after an agent
+// ownership transfer the grant stays with the original consenter, so this
+// column is how an admin spots stranded grants.
+//
+// Corresponds with GET /admin/oauth-grants (the `ListOauthGrants` operationId).
+func (c *Client) ListOauthGrants(ctx context.Context, params *ListOauthGrantsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListOauthGrantsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 // ListAgents List Agents
 //
 // List agents — scoped by identity via dynamic query scoping.
@@ -7383,6 +7583,29 @@ func (c *Client) UpdateAgentJwksWithBody(ctx context.Context, agentId string, co
 // Corresponds with PUT /agents/{agent_id}/jwks (the `UpdateAgentJwks` operationId).
 func (c *Client) UpdateAgentJwks(ctx context.Context, agentId string, body UpdateAgentJwksJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateAgentJwksRequest(c.Server, agentId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// ListAgentOauthGrants List agent OAuth grants
+//
+// List OAuth consent grants binding clients to this agent (§4.8).
+//
+// The "Connected clients" surface: every grant carries the client's display
+// name and redirect-URI origin, the granted scopes, the consenting user,
+// and created/last-used timestamps. Allowed for the agent's owner or an
+// admin — authorization is enforced in the service layer, mirroring the
+// “:revoke“ semantics.
+//
+// Corresponds with GET /agents/{agent_id}/oauth-grants (the `ListAgentOauthGrants` operationId).
+func (c *Client) ListAgentOauthGrants(ctx context.Context, agentId string, params *ListAgentOauthGrantsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAgentOauthGrantsRequest(c.Server, agentId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -11896,6 +12119,120 @@ func NewDenyOauthClientRequestWithBody(server string, id string, contentType str
 	return req, nil
 }
 
+// NewListOauthGrantsRequest constructs an http.Request for the ListOauthGrants method
+func NewListOauthGrantsRequest(server string, params *ListOauthGrantsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/admin/oauth-grants")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.ClientId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "client_id", *params.ClientId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.AgentId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "agent_id", *params.AgentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.UserId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "user_id", *params.UserId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "status", *params.Status, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "cursor", *params.Cursor, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListAgentsRequest constructs an http.Request for the ListAgents method
 func NewListAgentsRequest(server string, params *ListAgentsParams) (*http.Request, error) {
 	var err error
@@ -12240,6 +12577,91 @@ func NewUpdateAgentJwksRequestWithBody(server string, agentId string, contentTyp
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListAgentOauthGrantsRequest constructs an http.Request for the ListAgentOauthGrants method
+func NewListAgentOauthGrantsRequest(server string, agentId string, params *ListAgentOauthGrantsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "agent_id", agentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/agents/%s/oauth-grants", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "status", *params.Status, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "cursor", *params.Cursor, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -19850,6 +20272,21 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with POST /admin/oauth-clients/{id}:deny (the `DenyOauthClient` operationId).
 	DenyOauthClientWithResponse(ctx context.Context, id string, body DenyOauthClientJSONRequestBody, reqEditors ...RequestEditorFn) (*DenyOauthClientHTTPResp, error)
 
+	// ListOauthGrantsWithResponse List OAuth grants
+	//
+	// List consent→agent grants across all clients and agents (§4.8).
+	//
+	// The admin cross-view over the grant registry: filter by client, agent,
+	// consenting user, or status. Each item carries the client's display name
+	// and redirect-URI origin plus the consenting ``user_id`` — after an agent
+	// ownership transfer the grant stays with the original consenter, so this
+	// column is how an admin spots stranded grants.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /admin/oauth-grants (the `ListOauthGrants` operationId).
+	ListOauthGrantsWithResponse(ctx context.Context, params *ListOauthGrantsParams, reqEditors ...RequestEditorFn) (*ListOauthGrantsHTTPResp, error)
+
 	// ListAgentsWithResponse List Agents
 	//
 	// List agents — scoped by identity via dynamic query scoping.
@@ -19956,6 +20393,21 @@ type ClientWithResponsesInterface interface {
 	//
 	// Corresponds with PUT /agents/{agent_id}/jwks (the `UpdateAgentJwks` operationId).
 	UpdateAgentJwksWithResponse(ctx context.Context, agentId string, body UpdateAgentJwksJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAgentJwksHTTPResp, error)
+
+	// ListAgentOauthGrantsWithResponse List agent OAuth grants
+	//
+	// List OAuth consent grants binding clients to this agent (§4.8).
+	//
+	// The "Connected clients" surface: every grant carries the client's display
+	// name and redirect-URI origin, the granted scopes, the consenting user,
+	// and created/last-used timestamps. Allowed for the agent's owner or an
+	// admin — authorization is enforced in the service layer, mirroring the
+	// ``:revoke`` semantics.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /agents/{agent_id}/oauth-grants (the `ListAgentOauthGrants` operationId).
+	ListAgentOauthGrantsWithResponse(ctx context.Context, agentId string, params *ListAgentOauthGrantsParams, reqEditors ...RequestEditorFn) (*ListAgentOauthGrantsHTTPResp, error)
 
 	// GetAgentScopesWithResponse Get Agent Scopes
 	//
@@ -23852,6 +24304,89 @@ func (r DenyOauthClientHTTPResp) ContentType() string {
 	return ""
 }
 
+type ListOauthGrantsHTTPResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *OAuthGrantAdminListResponse
+	// ApplicationproblemJSON400 the response for an HTTP 400 `application/problem+json` response
+	ApplicationproblemJSON400 *ProblemDetail
+	// ApplicationproblemJSON401 the response for an HTTP 401 `application/problem+json` response
+	ApplicationproblemJSON401 *ProblemDetail
+	// ApplicationproblemJSON403 the response for an HTTP 403 `application/problem+json` response
+	ApplicationproblemJSON403 *ProblemDetail
+	// ApplicationproblemJSON422 the response for an HTTP 422 `application/problem+json` response
+	ApplicationproblemJSON422 *ProblemDetail
+	// ApplicationproblemJSON500 the response for an HTTP 500 `application/problem+json` response
+	ApplicationproblemJSON500 *ProblemDetail
+	// ApplicationproblemJSON503 the response for an HTTP 503 `application/problem+json` response
+	ApplicationproblemJSON503 *ProblemDetail
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r ListOauthGrantsHTTPResp) GetJSON200() *OAuthGrantAdminListResponse {
+	return r.JSON200
+}
+
+// GetApplicationproblemJSON400 returns the response for an HTTP 400 `application/problem+json` response
+func (r ListOauthGrantsHTTPResp) GetApplicationproblemJSON400() *ProblemDetail {
+	return r.ApplicationproblemJSON400
+}
+
+// GetApplicationproblemJSON401 returns the response for an HTTP 401 `application/problem+json` response
+func (r ListOauthGrantsHTTPResp) GetApplicationproblemJSON401() *ProblemDetail {
+	return r.ApplicationproblemJSON401
+}
+
+// GetApplicationproblemJSON403 returns the response for an HTTP 403 `application/problem+json` response
+func (r ListOauthGrantsHTTPResp) GetApplicationproblemJSON403() *ProblemDetail {
+	return r.ApplicationproblemJSON403
+}
+
+// GetApplicationproblemJSON422 returns the response for an HTTP 422 `application/problem+json` response
+func (r ListOauthGrantsHTTPResp) GetApplicationproblemJSON422() *ProblemDetail {
+	return r.ApplicationproblemJSON422
+}
+
+// GetApplicationproblemJSON500 returns the response for an HTTP 500 `application/problem+json` response
+func (r ListOauthGrantsHTTPResp) GetApplicationproblemJSON500() *ProblemDetail {
+	return r.ApplicationproblemJSON500
+}
+
+// GetApplicationproblemJSON503 returns the response for an HTTP 503 `application/problem+json` response
+func (r ListOauthGrantsHTTPResp) GetApplicationproblemJSON503() *ProblemDetail {
+	return r.ApplicationproblemJSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r ListOauthGrantsHTTPResp) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r ListOauthGrantsHTTPResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListOauthGrantsHTTPResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListOauthGrantsHTTPResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListAgentsHTTPResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -24503,6 +25038,96 @@ func (r UpdateAgentJwksHTTPResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r UpdateAgentJwksHTTPResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListAgentOauthGrantsHTTPResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *OAuthGrantListResponse
+	// ApplicationproblemJSON400 the response for an HTTP 400 `application/problem+json` response
+	ApplicationproblemJSON400 *ProblemDetail
+	// ApplicationproblemJSON401 the response for an HTTP 401 `application/problem+json` response
+	ApplicationproblemJSON401 *ProblemDetail
+	// ApplicationproblemJSON403 the response for an HTTP 403 `application/problem+json` response
+	ApplicationproblemJSON403 *ProblemDetail
+	// ApplicationproblemJSON404 the response for an HTTP 404 `application/problem+json` response
+	ApplicationproblemJSON404 *ProblemDetail
+	// ApplicationproblemJSON422 the response for an HTTP 422 `application/problem+json` response
+	ApplicationproblemJSON422 *ProblemDetail
+	// ApplicationproblemJSON500 the response for an HTTP 500 `application/problem+json` response
+	ApplicationproblemJSON500 *ProblemDetail
+	// ApplicationproblemJSON503 the response for an HTTP 503 `application/problem+json` response
+	ApplicationproblemJSON503 *ProblemDetail
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r ListAgentOauthGrantsHTTPResp) GetJSON200() *OAuthGrantListResponse {
+	return r.JSON200
+}
+
+// GetApplicationproblemJSON400 returns the response for an HTTP 400 `application/problem+json` response
+func (r ListAgentOauthGrantsHTTPResp) GetApplicationproblemJSON400() *ProblemDetail {
+	return r.ApplicationproblemJSON400
+}
+
+// GetApplicationproblemJSON401 returns the response for an HTTP 401 `application/problem+json` response
+func (r ListAgentOauthGrantsHTTPResp) GetApplicationproblemJSON401() *ProblemDetail {
+	return r.ApplicationproblemJSON401
+}
+
+// GetApplicationproblemJSON403 returns the response for an HTTP 403 `application/problem+json` response
+func (r ListAgentOauthGrantsHTTPResp) GetApplicationproblemJSON403() *ProblemDetail {
+	return r.ApplicationproblemJSON403
+}
+
+// GetApplicationproblemJSON404 returns the response for an HTTP 404 `application/problem+json` response
+func (r ListAgentOauthGrantsHTTPResp) GetApplicationproblemJSON404() *ProblemDetail {
+	return r.ApplicationproblemJSON404
+}
+
+// GetApplicationproblemJSON422 returns the response for an HTTP 422 `application/problem+json` response
+func (r ListAgentOauthGrantsHTTPResp) GetApplicationproblemJSON422() *ProblemDetail {
+	return r.ApplicationproblemJSON422
+}
+
+// GetApplicationproblemJSON500 returns the response for an HTTP 500 `application/problem+json` response
+func (r ListAgentOauthGrantsHTTPResp) GetApplicationproblemJSON500() *ProblemDetail {
+	return r.ApplicationproblemJSON500
+}
+
+// GetApplicationproblemJSON503 returns the response for an HTTP 503 `application/problem+json` response
+func (r ListAgentOauthGrantsHTTPResp) GetApplicationproblemJSON503() *ProblemDetail {
+	return r.ApplicationproblemJSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r ListAgentOauthGrantsHTTPResp) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAgentOauthGrantsHTTPResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAgentOauthGrantsHTTPResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListAgentOauthGrantsHTTPResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -36100,6 +36725,27 @@ func (c *ClientWithResponses) DenyOauthClientWithResponse(ctx context.Context, i
 	return ParseDenyOauthClientHTTPResp(rsp)
 }
 
+// ListOauthGrantsWithResponse List OAuth grants
+//
+// List consent→agent grants across all clients and agents (§4.8).
+//
+// The admin cross-view over the grant registry: filter by client, agent,
+// consenting user, or status. Each item carries the client's display name
+// and redirect-URI origin plus the consenting “user_id“ — after an agent
+// ownership transfer the grant stays with the original consenter, so this
+// column is how an admin spots stranded grants.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /admin/oauth-grants (the `ListOauthGrants` operationId).
+func (c *ClientWithResponses) ListOauthGrantsWithResponse(ctx context.Context, params *ListOauthGrantsParams, reqEditors ...RequestEditorFn) (*ListOauthGrantsHTTPResp, error) {
+	rsp, err := c.ListOauthGrants(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListOauthGrantsHTTPResp(rsp)
+}
+
 // ListAgentsWithResponse List Agents
 //
 // List agents — scoped by identity via dynamic query scoping.
@@ -36271,6 +36917,27 @@ func (c *ClientWithResponses) UpdateAgentJwksWithResponse(ctx context.Context, a
 		return nil, err
 	}
 	return ParseUpdateAgentJwksHTTPResp(rsp)
+}
+
+// ListAgentOauthGrantsWithResponse List agent OAuth grants
+//
+// List OAuth consent grants binding clients to this agent (§4.8).
+//
+// The "Connected clients" surface: every grant carries the client's display
+// name and redirect-URI origin, the granted scopes, the consenting user,
+// and created/last-used timestamps. Allowed for the agent's owner or an
+// admin — authorization is enforced in the service layer, mirroring the
+// “:revoke“ semantics.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /agents/{agent_id}/oauth-grants (the `ListAgentOauthGrants` operationId).
+func (c *ClientWithResponses) ListAgentOauthGrantsWithResponse(ctx context.Context, agentId string, params *ListAgentOauthGrantsParams, reqEditors ...RequestEditorFn) (*ListAgentOauthGrantsHTTPResp, error) {
+	rsp, err := c.ListAgentOauthGrants(ctx, agentId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAgentOauthGrantsHTTPResp(rsp)
 }
 
 // GetAgentScopesWithResponse Get Agent Scopes
@@ -40911,6 +41578,74 @@ func ParseDenyOauthClientHTTPResp(rsp *http.Response) (*DenyOauthClientHTTPResp,
 	return response, nil
 }
 
+// ParseListOauthGrantsHTTPResp parses an HTTP response from a ListOauthGrantsWithResponse call
+func ParseListOauthGrantsHTTPResp(rsp *http.Response) (*ListOauthGrantsHTTPResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListOauthGrantsHTTPResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest OAuthGrantAdminListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListAgentsHTTPResp parses an HTTP response from a ListAgentsWithResponse call
 func ParseListAgentsHTTPResp(rsp *http.Response) (*ListAgentsHTTPResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -41424,6 +42159,81 @@ func ParseUpdateAgentJwksHTTPResp(rsp *http.Response) (*UpdateAgentJwksHTTPResp,
 			return nil, err
 		}
 		response.ApplicationproblemJSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAgentOauthGrantsHTTPResp parses an HTTP response from a ListAgentOauthGrantsWithResponse call
+func ParseListAgentOauthGrantsHTTPResp(rsp *http.Response) (*ListAgentOauthGrantsHTTPResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAgentOauthGrantsHTTPResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest OAuthGrantListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest ProblemDetail

--- a/cli/client/generated/control/required.gen.go
+++ b/cli/client/generated/control/required.gen.go
@@ -175,6 +175,14 @@ func (OAuthClientResponse) RequiredFields() []string {
 	return []string{"active", "allowed_scopes", "approval_status", "client_id", "consent_model", "created_at", "created_by", "description", "id", "name", "redirect_uris", "registration_source", "require_consent", "software_id", "token_endpoint_auth_method", "updated_at"}
 }
 func (OAuthClientRotateSecretResponse) RequiredFields() []string { return []string{"client_secret"} }
+func (OAuthGrantAdminListResponse) RequiredFields() []string     { return []string{"data", "has_more"} }
+func (OAuthGrantAdminResponse) RequiredFields() []string {
+	return []string{"agent_id", "client_name", "client_origin", "created_at", "id", "last_used_at", "oauth_client_id", "revoked_at", "scopes", "status", "user_id"}
+}
+func (OAuthGrantListResponse) RequiredFields() []string { return []string{"data", "has_more"} }
+func (OAuthGrantResponse) RequiredFields() []string {
+	return []string{"agent_id", "client_name", "client_origin", "created_at", "id", "last_used_at", "oauth_client_id", "revoked_at", "scopes", "status", "user_id"}
+}
 func (OperationPreviewListResponse) RequiredFields() []string {
 	return []string{"data", "info", "offset", "security_schemes", "total", "truncated"}
 }

--- a/cli/client/generated/control/required.gen.go
+++ b/cli/client/generated/control/required.gen.go
@@ -177,11 +177,11 @@ func (OAuthClientResponse) RequiredFields() []string {
 func (OAuthClientRotateSecretResponse) RequiredFields() []string { return []string{"client_secret"} }
 func (OAuthGrantAdminListResponse) RequiredFields() []string     { return []string{"data", "has_more"} }
 func (OAuthGrantAdminResponse) RequiredFields() []string {
-	return []string{"agent_id", "client_name", "client_origin", "created_at", "id", "last_used_at", "oauth_client_id", "revoked_at", "scopes", "status", "user_id"}
+	return []string{"agent_id", "can_revoke", "client_name", "client_origin", "created_at", "id", "last_used_at", "oauth_client_id", "revoked_at", "scopes", "status", "user_id"}
 }
 func (OAuthGrantListResponse) RequiredFields() []string { return []string{"data", "has_more"} }
 func (OAuthGrantResponse) RequiredFields() []string {
-	return []string{"agent_id", "client_name", "client_origin", "created_at", "id", "last_used_at", "oauth_client_id", "revoked_at", "scopes", "status", "user_id"}
+	return []string{"agent_id", "can_revoke", "client_name", "client_origin", "created_at", "id", "last_used_at", "oauth_client_id", "revoked_at", "scopes", "status", "user_id"}
 }
 func (OperationPreviewListResponse) RequiredFields() []string {
 	return []string{"data", "info", "offset", "security_schemes", "total", "truncated"}

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -3352,6 +3352,11 @@ components:
         active:
           title: Active
           type: boolean
+        active_grant_count:
+          default: 0
+          description: Number of active consent→agent grants for this client (§4.8 per-client grant count). Computed on the read endpoints (list/get); write-path responses report 0.
+          title: Active Grant Count
+          type: integer
         allowed_scopes:
           anyOf:
           - items:
@@ -3631,6 +3636,11 @@ components:
         active:
           title: Active
           type: boolean
+        active_grant_count:
+          default: 0
+          description: Number of active consent→agent grants for this client (§4.8 per-client grant count). Computed on the read endpoints (list/get); write-path responses report 0.
+          title: Active Grant Count
+          type: integer
         allowed_scopes:
           anyOf:
           - items:
@@ -3775,6 +3785,192 @@ components:
           - type: 'null'
           title: Require Consent
       title: OAuthClientUpdateRequest
+      type: object
+    OAuthGrantAdminListResponse:
+      description: A paginated list of OAuth grants (admin cross-view).
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/OAuthGrantAdminResponse'
+          title: Data
+          type: array
+        has_more:
+          title: Has More
+          type: boolean
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
+      required:
+      - data
+      - has_more
+      title: OAuthGrantAdminListResponse
+      type: object
+    OAuthGrantAdminResponse:
+      description: One consent→agent grant in the admin cross-view.
+      properties:
+        agent_id:
+          description: The agent this grant binds the client to.
+          title: Agent Id
+          type: string
+        client_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Display name of the registered client, if the row still exists.
+          title: Client Name
+        client_origin:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Origin (scheme://host) of the client's first redirect URI — the 'authorized apps' display pattern.
+          title: Client Origin
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        id:
+          description: Grant ID (ksuid, `ocg_` prefix).
+          title: Id
+          type: string
+        last_used_at:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          description: Last time the client obtained tokens under this grant (stamped at exchange/refresh, not per request).
+          title: Last Used At
+        oauth_client_id:
+          description: The client's public client_id — the same identifier stamped on tokens minted under this grant.
+          title: Oauth Client Id
+          type: string
+        revoked_at:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Revoked At
+        scopes:
+          description: Scopes granted at consent (the D2 intersection).
+          items:
+            type: string
+          title: Scopes
+          type: array
+        status:
+          description: 'Grant lifecycle state: ``active`` or ``revoked``.'
+          title: Status
+          type: string
+        user_id:
+          description: 'The consenting user who approved this grant. Shown even after an agent ownership transfer: the grant stays with the original consenter (it is their consent, not the agent''s).'
+          title: User Id
+          type: string
+      required:
+      - id
+      - oauth_client_id
+      - client_name
+      - client_origin
+      - user_id
+      - agent_id
+      - scopes
+      - status
+      - created_at
+      - revoked_at
+      - last_used_at
+      title: OAuthGrantAdminResponse
+      type: object
+    OAuthGrantListResponse:
+      description: A paginated list of OAuth grants.
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/OAuthGrantResponse'
+          title: Data
+          type: array
+        has_more:
+          title: Has More
+          type: boolean
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
+      required:
+      - data
+      - has_more
+      title: OAuthGrantListResponse
+      type: object
+    OAuthGrantResponse:
+      description: One consent→agent grant in API responses.
+      properties:
+        agent_id:
+          description: The agent this grant binds the client to.
+          title: Agent Id
+          type: string
+        client_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Display name of the registered client, if the row still exists.
+          title: Client Name
+        client_origin:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Origin (scheme://host) of the client's first redirect URI — the 'authorized apps' display pattern.
+          title: Client Origin
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        id:
+          description: Grant ID (ksuid, `ocg_` prefix).
+          title: Id
+          type: string
+        last_used_at:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          description: Last time the client obtained tokens under this grant (stamped at exchange/refresh, not per request).
+          title: Last Used At
+        oauth_client_id:
+          description: The client's public client_id — the same identifier stamped on tokens minted under this grant.
+          title: Oauth Client Id
+          type: string
+        revoked_at:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Revoked At
+        scopes:
+          description: Scopes granted at consent (the D2 intersection).
+          items:
+            type: string
+          title: Scopes
+          type: array
+        status:
+          description: 'Grant lifecycle state: ``active`` or ``revoked``.'
+          title: Status
+          type: string
+        user_id:
+          description: 'The consenting user who approved this grant. Shown even after an agent ownership transfer: the grant stays with the original consenter (it is their consent, not the agent''s).'
+          title: User Id
+          type: string
+      required:
+      - id
+      - oauth_client_id
+      - client_name
+      - client_origin
+      - user_id
+      - agent_id
+      - scopes
+      - status
+      - created_at
+      - revoked_at
+      - last_used_at
+      title: OAuthGrantResponse
       type: object
     OperationPreviewListResponse:
       description: |-
@@ -8151,6 +8347,132 @@ paths:
       summary: Deny OAuth client
       tags:
       - OAuth Clients
+  /admin/oauth-grants:
+    get:
+      description: |-
+        List consent→agent grants across all clients and agents (§4.8).
+
+        The admin cross-view over the grant registry: filter by client, agent,
+        consenting user, or status. Each item carries the client's display name
+        and redirect-URI origin plus the consenting ``user_id`` — after an agent
+        ownership transfer the grant stays with the original consenter, so this
+        column is how an admin spots stranded grants.
+      operationId: listOauthGrants
+      parameters:
+      - description: Filter by the client's public client_id.
+        in: query
+        name: client_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by the client's public client_id.
+          title: Client Id
+      - description: Filter by bound agent.
+        in: query
+        name: agent_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by bound agent.
+          title: Agent Id
+      - description: Filter by consenting user.
+        in: query
+        name: user_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by consenting user.
+          title: User Id
+      - description: Filter by grant lifecycle state.
+        in: query
+        name: status
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - active
+            - revoked
+            type: string
+          - type: 'null'
+          description: Filter by grant lifecycle state.
+          title: Status
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 50
+          maximum: 200
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: cursor
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthGrantAdminListResponse'
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '401':
+          content:
+            application/problem+json:
+              example: *id005
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unauthorized
+        '403':
+          content:
+            application/problem+json:
+              example: *id006
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Forbidden
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security:
+      - BearerAuth: []
+      summary: List OAuth grants
+      tags:
+      - OAuth
   /agents:
     get:
       description: List agents — scoped by identity via dynamic query scoping.
@@ -8700,6 +9022,115 @@ paths:
       security:
       - BearerAuth: []
       summary: Update Agent Jwks
+      tags:
+      - Agents
+  /agents/{agent_id}/oauth-grants:
+    get:
+      description: |-
+        List OAuth consent grants binding clients to this agent (§4.8).
+
+        The "Connected clients" surface: every grant carries the client's display
+        name and redirect-URI origin, the granted scopes, the consenting user,
+        and created/last-used timestamps. Allowed for the agent's owner or an
+        admin — authorization is enforced in the service layer, mirroring the
+        ``:revoke`` semantics.
+      operationId: listAgentOauthGrants
+      parameters:
+      - in: path
+        name: agent_id
+        required: true
+        schema:
+          title: Agent Id
+          type: string
+      - description: Filter by grant lifecycle state.
+        in: query
+        name: status
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - active
+            - revoked
+            type: string
+          - type: 'null'
+          description: Filter by grant lifecycle state.
+          title: Status
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 50
+          maximum: 200
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: cursor
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthGrantListResponse'
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '401':
+          content:
+            application/problem+json:
+              example: *id005
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unauthorized
+        '403':
+          content:
+            application/problem+json:
+              example: *id006
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Forbidden
+        '404':
+          content:
+            application/problem+json:
+              example: *id007
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Not Found
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security:
+      - BearerAuth: []
+      summary: List agent OAuth grants
       tags:
       - Agents
   /agents/{agent_id}/scopes:

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -3814,6 +3814,10 @@ components:
           description: The agent this grant binds the client to.
           title: Agent Id
           type: string
+        can_revoke:
+          description: Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. a read-only admin.
+          title: Can Revoke
+          type: boolean
         client_name:
           anyOf:
           - type: string
@@ -3877,6 +3881,7 @@ components:
       - created_at
       - revoked_at
       - last_used_at
+      - can_revoke
       title: OAuthGrantAdminResponse
       type: object
     OAuthGrantListResponse:
@@ -3907,6 +3912,10 @@ components:
           description: The agent this grant binds the client to.
           title: Agent Id
           type: string
+        can_revoke:
+          description: Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. the agent's new owner after an ownership transfer, or a read-only admin.
+          title: Can Revoke
+          type: boolean
         client_name:
           anyOf:
           - type: string
@@ -3970,6 +3979,7 @@ components:
       - created_at
       - revoked_at
       - last_used_at
+      - can_revoke
       title: OAuthGrantResponse
       type: object
     OperationPreviewListResponse:

--- a/docs/reference/endpoints.json
+++ b/docs/reference/endpoints.json
@@ -528,6 +528,30 @@
       ],
       "auth_note": null,
       "authenticated": true,
+      "group": "Any authenticated actor",
+      "implied_scopes": {
+        "oauth-clients:read": []
+      },
+      "method": "GET",
+      "operation_id": "listOauthGrants",
+      "path": "/admin/oauth-grants",
+      "public": false,
+      "required_scopes": [
+        "oauth-clients:read"
+      ],
+      "summary": "List OAuth grants",
+      "surface": "admin",
+      "typical_caller": "any"
+    },
+    {
+      "actor_types": [
+        "user",
+        "agent",
+        "service_account",
+        "toolkit"
+      ],
+      "auth_note": null,
+      "authenticated": true,
       "group": "Operator-facing (typically a human operator / admin)",
       "implied_scopes": {
         "agents:read": []
@@ -714,6 +738,26 @@
       "summary": "Update Agent Jwks",
       "surface": "agents",
       "typical_caller": "operator"
+    },
+    {
+      "actor_types": [
+        "user",
+        "agent",
+        "service_account",
+        "toolkit"
+      ],
+      "auth_note": null,
+      "authenticated": true,
+      "group": "Any authenticated actor",
+      "implied_scopes": {},
+      "method": "GET",
+      "operation_id": "listAgentOauthGrants",
+      "path": "/agents/{agent_id}/oauth-grants",
+      "public": false,
+      "required_scopes": [],
+      "summary": "List agent OAuth grants",
+      "surface": "agents",
+      "typical_caller": "any"
     },
     {
       "actor_types": [
@@ -5105,5 +5149,5 @@
     ],
     "total": 33
   },
-  "total": 176
+  "total": 178
 }

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -27,7 +27,7 @@ Every API endpoint grouped by its **typical caller**, then by surface, annotated
 
 > The grouping and the _Typical caller_ column are an **advisory hint** at who usually calls a route, inferred from the scope family. They are **not** an enforced restriction: access is gated by the **scope**, not the actor kind, so any actor holding the required scope can call the endpoint.
 
-_Total endpoints: **176**._
+_Total endpoints: **178**._
 
 
 ## Agent-facing (typically agent / service-account / toolkit) (31)
@@ -222,7 +222,7 @@ _Total endpoints: **176**._
 | POST | `/users/{user_id}:enable` | `users:write` | operator | Enable User |
 | POST | `/users/{user_id}:reissue-invite` | `users:write` | operator | Reissue Invite |
 
-## Any authenticated actor (70)
+## Any authenticated actor (72)
 
 
 ### `access-requests`
@@ -250,12 +250,14 @@ _Total endpoints: **176**._
 | POST | `/admin/oauth-clients/{id}/rotate-secret` | `oauth-clients:write` | any | Rotate client secret |
 | POST | `/admin/oauth-clients/{id}:approve` | `oauth-clients:write` | any | Approve OAuth client |
 | POST | `/admin/oauth-clients/{id}:deny` | `oauth-clients:write` | any | Deny OAuth client |
+| GET | `/admin/oauth-grants` | `oauth-clients:read` | any | List OAuth grants |
 
 ### `agents`
 
 | Method | Path | Scope(s) | Typical caller | Summary |
 |---|---|---|---|---|
 | GET | `/agents/{agent_id}` | _any authenticated_ | any | Get Agent |
+| GET | `/agents/{agent_id}/oauth-grants` | _any authenticated_ | any | List agent OAuth grants |
 | GET | `/agents/{agent_id}/toolkits` | _any authenticated_ | any | List Toolkits |
 
 ### `apis`

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -3352,6 +3352,11 @@ components:
         active:
           title: Active
           type: boolean
+        active_grant_count:
+          default: 0
+          description: Number of active consent→agent grants for this client (§4.8 per-client grant count). Computed on the read endpoints (list/get); write-path responses report 0.
+          title: Active Grant Count
+          type: integer
         allowed_scopes:
           anyOf:
           - items:
@@ -3631,6 +3636,11 @@ components:
         active:
           title: Active
           type: boolean
+        active_grant_count:
+          default: 0
+          description: Number of active consent→agent grants for this client (§4.8 per-client grant count). Computed on the read endpoints (list/get); write-path responses report 0.
+          title: Active Grant Count
+          type: integer
         allowed_scopes:
           anyOf:
           - items:
@@ -3775,6 +3785,192 @@ components:
           - type: 'null'
           title: Require Consent
       title: OAuthClientUpdateRequest
+      type: object
+    OAuthGrantAdminListResponse:
+      description: A paginated list of OAuth grants (admin cross-view).
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/OAuthGrantAdminResponse'
+          title: Data
+          type: array
+        has_more:
+          title: Has More
+          type: boolean
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
+      required:
+      - data
+      - has_more
+      title: OAuthGrantAdminListResponse
+      type: object
+    OAuthGrantAdminResponse:
+      description: One consent→agent grant in the admin cross-view.
+      properties:
+        agent_id:
+          description: The agent this grant binds the client to.
+          title: Agent Id
+          type: string
+        client_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Display name of the registered client, if the row still exists.
+          title: Client Name
+        client_origin:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Origin (scheme://host) of the client's first redirect URI — the 'authorized apps' display pattern.
+          title: Client Origin
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        id:
+          description: Grant ID (ksuid, `ocg_` prefix).
+          title: Id
+          type: string
+        last_used_at:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          description: Last time the client obtained tokens under this grant (stamped at exchange/refresh, not per request).
+          title: Last Used At
+        oauth_client_id:
+          description: The client's public client_id — the same identifier stamped on tokens minted under this grant.
+          title: Oauth Client Id
+          type: string
+        revoked_at:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Revoked At
+        scopes:
+          description: Scopes granted at consent (the D2 intersection).
+          items:
+            type: string
+          title: Scopes
+          type: array
+        status:
+          description: 'Grant lifecycle state: ``active`` or ``revoked``.'
+          title: Status
+          type: string
+        user_id:
+          description: 'The consenting user who approved this grant. Shown even after an agent ownership transfer: the grant stays with the original consenter (it is their consent, not the agent''s).'
+          title: User Id
+          type: string
+      required:
+      - id
+      - oauth_client_id
+      - client_name
+      - client_origin
+      - user_id
+      - agent_id
+      - scopes
+      - status
+      - created_at
+      - revoked_at
+      - last_used_at
+      title: OAuthGrantAdminResponse
+      type: object
+    OAuthGrantListResponse:
+      description: A paginated list of OAuth grants.
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/OAuthGrantResponse'
+          title: Data
+          type: array
+        has_more:
+          title: Has More
+          type: boolean
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
+      required:
+      - data
+      - has_more
+      title: OAuthGrantListResponse
+      type: object
+    OAuthGrantResponse:
+      description: One consent→agent grant in API responses.
+      properties:
+        agent_id:
+          description: The agent this grant binds the client to.
+          title: Agent Id
+          type: string
+        client_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Display name of the registered client, if the row still exists.
+          title: Client Name
+        client_origin:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Origin (scheme://host) of the client's first redirect URI — the 'authorized apps' display pattern.
+          title: Client Origin
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        id:
+          description: Grant ID (ksuid, `ocg_` prefix).
+          title: Id
+          type: string
+        last_used_at:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          description: Last time the client obtained tokens under this grant (stamped at exchange/refresh, not per request).
+          title: Last Used At
+        oauth_client_id:
+          description: The client's public client_id — the same identifier stamped on tokens minted under this grant.
+          title: Oauth Client Id
+          type: string
+        revoked_at:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Revoked At
+        scopes:
+          description: Scopes granted at consent (the D2 intersection).
+          items:
+            type: string
+          title: Scopes
+          type: array
+        status:
+          description: 'Grant lifecycle state: ``active`` or ``revoked``.'
+          title: Status
+          type: string
+        user_id:
+          description: 'The consenting user who approved this grant. Shown even after an agent ownership transfer: the grant stays with the original consenter (it is their consent, not the agent''s).'
+          title: User Id
+          type: string
+      required:
+      - id
+      - oauth_client_id
+      - client_name
+      - client_origin
+      - user_id
+      - agent_id
+      - scopes
+      - status
+      - created_at
+      - revoked_at
+      - last_used_at
+      title: OAuthGrantResponse
       type: object
     OperationPreviewListResponse:
       description: |-
@@ -8151,6 +8347,132 @@ paths:
       summary: Deny OAuth client
       tags:
       - OAuth Clients
+  /admin/oauth-grants:
+    get:
+      description: |-
+        List consent→agent grants across all clients and agents (§4.8).
+
+        The admin cross-view over the grant registry: filter by client, agent,
+        consenting user, or status. Each item carries the client's display name
+        and redirect-URI origin plus the consenting ``user_id`` — after an agent
+        ownership transfer the grant stays with the original consenter, so this
+        column is how an admin spots stranded grants.
+      operationId: listOauthGrants
+      parameters:
+      - description: Filter by the client's public client_id.
+        in: query
+        name: client_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by the client's public client_id.
+          title: Client Id
+      - description: Filter by bound agent.
+        in: query
+        name: agent_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by bound agent.
+          title: Agent Id
+      - description: Filter by consenting user.
+        in: query
+        name: user_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by consenting user.
+          title: User Id
+      - description: Filter by grant lifecycle state.
+        in: query
+        name: status
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - active
+            - revoked
+            type: string
+          - type: 'null'
+          description: Filter by grant lifecycle state.
+          title: Status
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 50
+          maximum: 200
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: cursor
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthGrantAdminListResponse'
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '401':
+          content:
+            application/problem+json:
+              example: *id005
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unauthorized
+        '403':
+          content:
+            application/problem+json:
+              example: *id006
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Forbidden
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security:
+      - BearerAuth: []
+      summary: List OAuth grants
+      tags:
+      - OAuth
   /agents:
     get:
       description: List agents — scoped by identity via dynamic query scoping.
@@ -8700,6 +9022,115 @@ paths:
       security:
       - BearerAuth: []
       summary: Update Agent Jwks
+      tags:
+      - Agents
+  /agents/{agent_id}/oauth-grants:
+    get:
+      description: |-
+        List OAuth consent grants binding clients to this agent (§4.8).
+
+        The "Connected clients" surface: every grant carries the client's display
+        name and redirect-URI origin, the granted scopes, the consenting user,
+        and created/last-used timestamps. Allowed for the agent's owner or an
+        admin — authorization is enforced in the service layer, mirroring the
+        ``:revoke`` semantics.
+      operationId: listAgentOauthGrants
+      parameters:
+      - in: path
+        name: agent_id
+        required: true
+        schema:
+          title: Agent Id
+          type: string
+      - description: Filter by grant lifecycle state.
+        in: query
+        name: status
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - active
+            - revoked
+            type: string
+          - type: 'null'
+          description: Filter by grant lifecycle state.
+          title: Status
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 50
+          maximum: 200
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: cursor
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthGrantListResponse'
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '401':
+          content:
+            application/problem+json:
+              example: *id005
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unauthorized
+        '403':
+          content:
+            application/problem+json:
+              example: *id006
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Forbidden
+        '404':
+          content:
+            application/problem+json:
+              example: *id007
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Not Found
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security:
+      - BearerAuth: []
+      summary: List agent OAuth grants
       tags:
       - Agents
   /agents/{agent_id}/scopes:

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -3814,6 +3814,10 @@ components:
           description: The agent this grant binds the client to.
           title: Agent Id
           type: string
+        can_revoke:
+          description: Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. a read-only admin.
+          title: Can Revoke
+          type: boolean
         client_name:
           anyOf:
           - type: string
@@ -3877,6 +3881,7 @@ components:
       - created_at
       - revoked_at
       - last_used_at
+      - can_revoke
       title: OAuthGrantAdminResponse
       type: object
     OAuthGrantListResponse:
@@ -3907,6 +3912,10 @@ components:
           description: The agent this grant binds the client to.
           title: Agent Id
           type: string
+        can_revoke:
+          description: Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. the agent's new owner after an ownership transfer, or a read-only admin.
+          title: Can Revoke
+          type: boolean
         client_name:
           anyOf:
           - type: string
@@ -3970,6 +3979,7 @@ components:
       - created_at
       - revoked_at
       - last_used_at
+      - can_revoke
       title: OAuthGrantResponse
       type: object
     OperationPreviewListResponse:

--- a/src/jentic_one/admin/repos/oauth_client_grant_repo.py
+++ b/src/jentic_one/admin/repos/oauth_client_grant_repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.admin.core.schema.oauth_client_grants import OAuthClientGrant
@@ -60,6 +60,52 @@ class OAuthClientGrantRepository:
         )
         result = await session.execute(stmt)
         return list(result.scalars().all())
+
+    @staticmethod
+    async def list_grants(
+        session: AsyncSession,
+        *,
+        agent_id: str | None = None,
+        oauth_client_id: str | None = None,
+        user_id: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+        cursor: datetime | None = None,
+    ) -> list[OAuthClientGrant]:
+        """List grant rows for the §4.8 surfaces, newest first.
+
+        Filterable by any combination of agent, client (public ``client_id``
+        string — the token-lineage join key, D3), consenting user, and status.
+        Keyset-paginated on ``created_at`` like the other list repos.
+        """
+        stmt = (
+            select(OAuthClientGrant)
+            .order_by(OAuthClientGrant.created_at.desc(), OAuthClientGrant.id.desc())
+            .limit(limit)
+        )
+        if agent_id is not None:
+            stmt = stmt.where(OAuthClientGrant.agent_id == agent_id)
+        if oauth_client_id is not None:
+            stmt = stmt.where(OAuthClientGrant.oauth_client_id == oauth_client_id)
+        if user_id is not None:
+            stmt = stmt.where(OAuthClientGrant.user_id == user_id)
+        if status is not None:
+            stmt = stmt.where(OAuthClientGrant.status == status)
+        if cursor is not None:
+            stmt = stmt.where(OAuthClientGrant.created_at < cursor)
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def count_active_by_client(session: AsyncSession) -> dict[str, int]:
+        """Active-grant counts keyed by public ``client_id`` (§4.8 per-client count)."""
+        stmt = (
+            select(OAuthClientGrant.oauth_client_id, func.count())
+            .where(OAuthClientGrant.status == OAuthGrantStatus.ACTIVE.value)
+            .group_by(OAuthClientGrant.oauth_client_id)
+        )
+        result = await session.execute(stmt)
+        return dict(result.all())  # type: ignore[arg-type]
 
     @staticmethod
     async def revoke(session: AsyncSession, grant_id: str) -> bool:

--- a/src/jentic_one/admin/repos/oauth_client_grant_repo.py
+++ b/src/jentic_one/admin/repos/oauth_client_grant_repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select, update
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.admin.core.schema.oauth_client_grants import OAuthClientGrant
@@ -70,13 +70,17 @@ class OAuthClientGrantRepository:
         user_id: str | None = None,
         status: str | None = None,
         limit: int = 50,
-        cursor: datetime | None = None,
+        cursor_created_at: datetime | None = None,
+        cursor_id: str | None = None,
     ) -> list[OAuthClientGrant]:
         """List grant rows for the §4.8 surfaces, newest first.
 
         Filterable by any combination of agent, client (public ``client_id``
         string — the token-lineage join key, D3), consenting user, and status.
-        Keyset-paginated on ``created_at`` like the other list repos.
+        Compound keyset on ``(created_at, id)`` matching the order-by, like
+        ``OverlayRepository.list_page``: the id tiebreaker keeps rows sharing
+        a boundary ``created_at`` (burst consents, coarse timestamp
+        precision) from being skipped between pages.
         """
         stmt = (
             select(OAuthClientGrant)
@@ -91,8 +95,16 @@ class OAuthClientGrantRepository:
             stmt = stmt.where(OAuthClientGrant.user_id == user_id)
         if status is not None:
             stmt = stmt.where(OAuthClientGrant.status == status)
-        if cursor is not None:
-            stmt = stmt.where(OAuthClientGrant.created_at < cursor)
+        if cursor_created_at is not None and cursor_id is not None:
+            stmt = stmt.where(
+                or_(
+                    OAuthClientGrant.created_at < cursor_created_at,
+                    and_(
+                        OAuthClientGrant.created_at == cursor_created_at,
+                        OAuthClientGrant.id < cursor_id,
+                    ),
+                )
+            )
         result = await session.execute(stmt)
         return list(result.scalars().all())
 
@@ -106,6 +118,24 @@ class OAuthClientGrantRepository:
         )
         result = await session.execute(stmt)
         return dict(result.all())  # type: ignore[arg-type]
+
+    @staticmethod
+    async def count_active_for_client(session: AsyncSession, oauth_client_id: str) -> int:
+        """Active-grant count for ONE public ``client_id``.
+
+        The single-client companion to :meth:`count_active_by_client` — a
+        per-client GET must not pay a whole-table aggregate for one row.
+        """
+        stmt = (
+            select(func.count())
+            .select_from(OAuthClientGrant)
+            .where(
+                OAuthClientGrant.oauth_client_id == oauth_client_id,
+                OAuthClientGrant.status == OAuthGrantStatus.ACTIVE.value,
+            )
+        )
+        result = await session.execute(stmt)
+        return int(result.scalar_one())
 
     @staticmethod
     async def revoke(session: AsyncSession, grant_id: str) -> bool:

--- a/src/jentic_one/admin/repos/oauth_client_repo.py
+++ b/src/jentic_one/admin/repos/oauth_client_repo.py
@@ -96,6 +96,19 @@ class OAuthClientRepository:
         return result.scalar_one_or_none()
 
     @staticmethod
+    async def list_by_client_ids(session: AsyncSession, client_ids: list[str]) -> list[OAuthClient]:
+        """Fetch client rows for a set of public ``client_id`` strings.
+
+        Used to enrich grant listings (§4.8: client name + redirect-URI
+        origin) without an N+1 per grant row.
+        """
+        if not client_ids:
+            return []
+        stmt = select(OAuthClient).where(OAuthClient.client_id.in_(client_ids))
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
     async def list_dcr_by_dedupe_key(
         session: AsyncSession, software_id: str, fingerprint: str
     ) -> list[OAuthClient]:

--- a/src/jentic_one/admin/services/oauth_client_service.py
+++ b/src/jentic_one/admin/services/oauth_client_service.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 import structlog
 
 from jentic_one.admin.core.schema.oauth_clients import OAuthClient
+from jentic_one.admin.repos.oauth_client_grant_repo import OAuthClientGrantRepository
 from jentic_one.admin.repos.oauth_client_repo import OAuthClientRepository
 from jentic_one.admin.services._support.passwords import hash_password, verify_password
 from jentic_one.admin.services._support.tokens import generate_client_id, generate_client_secret
@@ -212,12 +213,15 @@ class OAuthClientService:
             return OAuthClientCreateResult(**view.model_dump(), client_secret=client_secret)
 
     async def get(self, id: str) -> OAuthClientView:
-        """Get an OAuth client by internal ID."""
+        """Get an OAuth client by internal ID (with its active-grant count)."""
         async with self._ctx.admin_db.session() as session:
             client = await OAuthClientRepository.get_by_id(session, id)
-        if client is None:
-            raise OAuthClientNotFoundError(id)
-        return _to_view(client)
+            if client is None:
+                raise OAuthClientNotFoundError(id)
+            counts = await OAuthClientGrantRepository.count_active_by_client(session)
+        view = _to_view(client)
+        view.active_grant_count = counts.get(client.client_id, 0)
+        return view
 
     async def get_by_client_id(self, client_id: str) -> OAuthClientView | None:
         """Get an OAuth client by its public client_id. Returns None if not found."""
@@ -257,7 +261,13 @@ class OAuthClientService:
                 include_inactive=include_inactive,
                 approval_status=approval_status,
             )
-        return [_to_view(c) for c in clients]
+            counts = await OAuthClientGrantRepository.count_active_by_client(session)
+        views = []
+        for c in clients:
+            view = _to_view(c)
+            view.active_grant_count = counts.get(c.client_id, 0)
+            views.append(view)
+        return views
 
     async def update(
         self,

--- a/src/jentic_one/admin/services/oauth_client_service.py
+++ b/src/jentic_one/admin/services/oauth_client_service.py
@@ -218,9 +218,11 @@ class OAuthClientService:
             client = await OAuthClientRepository.get_by_id(session, id)
             if client is None:
                 raise OAuthClientNotFoundError(id)
-            counts = await OAuthClientGrantRepository.count_active_by_client(session)
+            count = await OAuthClientGrantRepository.count_active_for_client(
+                session, client.client_id
+            )
         view = _to_view(client)
-        view.active_grant_count = counts.get(client.client_id, 0)
+        view.active_grant_count = count
         return view
 
     async def get_by_client_id(self, client_id: str) -> OAuthClientView | None:

--- a/src/jentic_one/admin/services/oauth_grant_admin_service.py
+++ b/src/jentic_one/admin/services/oauth_grant_admin_service.py
@@ -13,9 +13,36 @@ from jentic_one.admin.repos.oauth_client_grant_repo import OAuthClientGrantRepos
 from jentic_one.admin.repos.oauth_client_repo import OAuthClientRepository
 from jentic_one.admin.services.errors import InvalidInputError
 from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView, grant_to_view
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.auth.permission_catalog import OAUTH_CLIENTS_WRITE, ORG_ADMIN
 from jentic_one.shared.context import Context
 from jentic_one.shared.models.oauth_clients import OAuthGrantStatus
 from jentic_one.shared.pagination import Page, decode_cursor_str, encode_cursor
+
+#: Permissions that make a non-owner an admin for grant WRITE operations
+#: (``:revoke``). Broader than the usual ``ORG_ADMIN``-only idiom on purpose:
+#: ``oauth-clients:write`` holders administer the client lifecycle (the same
+#: permission gating the admin oauth-clients router), and a grant is part of
+#: that lifecycle. Lives here (not in the auth tier) so both the revoke
+#: predicate and the per-item ``can_revoke`` capability read one definition.
+GRANT_REVOKE_ADMIN_PERMISSIONS: frozenset[str] = frozenset({ORG_ADMIN, OAUTH_CLIENTS_WRITE})
+
+
+def viewer_can_revoke(grant_user_id: str, identity: Identity) -> bool:
+    """The ``:revoke`` predicate: the grant's consenting user, or a write-set admin.
+
+    THE single definition — ``OAuthGrantService.revoke_grant`` enforces it and
+    the listing surfaces surface it per item as ``can_revoke``, so the two can
+    never drift. Note the deliberate divergence from the LIST predicate (gap
+    G10): listing keys on the agent's CURRENT owner, revoke on the grant's
+    consenting user — after an agent ownership transfer the new owner can see
+    the grant but not revoke it. That policy decision is still pending; until
+    it lands, ``can_revoke`` makes the divergence explicit instead of letting
+    the UI advertise a revoke that would 403.
+    """
+    return grant_user_id == identity.sub or bool(
+        GRANT_REVOKE_ADMIN_PERMISSIONS & set(identity.permissions)
+    )
 
 
 class OAuthGrantAdminService:
@@ -27,6 +54,7 @@ class OAuthGrantAdminService:
     async def list_grants(
         self,
         *,
+        identity: Identity,
         agent_id: str | None = None,
         client_id: str | None = None,
         user_id: str | None = None,
@@ -39,7 +67,8 @@ class OAuthGrantAdminService:
         ``client_id`` is the public client identifier (the join key grants
         store, D3). Each item carries the §4.8 display fields: client name,
         redirect-URI origin, scopes, consenting ``user_id`` (G10), created,
-        last-used, status.
+        last-used, status — plus ``can_revoke``, the viewer's ``:revoke``
+        capability computed per item via :func:`viewer_can_revoke`.
         """
         if status is not None and status not in (
             OAuthGrantStatus.ACTIVE.value,
@@ -48,8 +77,9 @@ class OAuthGrantAdminService:
             raise InvalidInputError(f"unsupported status filter: {status}")
 
         cursor_dt = None
+        cursor_id = None
         if cursor is not None:
-            cursor_dt, _ = decode_cursor_str(cursor)
+            cursor_dt, cursor_id = decode_cursor_str(cursor)
 
         async with self._ctx.admin_db.session() as session:
             grants = await OAuthClientGrantRepository.list_grants(
@@ -59,7 +89,8 @@ class OAuthGrantAdminService:
                 user_id=user_id,
                 status=status,
                 limit=limit + 1,
-                cursor=cursor_dt,
+                cursor_created_at=cursor_dt,
+                cursor_id=cursor_id,
             )
             has_more = len(grants) > limit
             if has_more:
@@ -69,7 +100,14 @@ class OAuthGrantAdminService:
             )
 
         clients_by_id = {c.client_id: c for c in clients}
-        views = [grant_to_view(g, clients_by_id.get(g.oauth_client_id)) for g in grants]
+        views = [
+            grant_to_view(
+                g,
+                clients_by_id.get(g.oauth_client_id),
+                can_revoke=viewer_can_revoke(g.user_id, identity),
+            )
+            for g in grants
+        ]
 
         next_cursor = None
         if has_more and grants:

--- a/src/jentic_one/admin/services/oauth_grant_admin_service.py
+++ b/src/jentic_one/admin/services/oauth_grant_admin_service.py
@@ -1,0 +1,78 @@
+"""Admin cross-view over OAuth consent→agent grants (phase-3a §4.8).
+
+The write side of the grant lifecycle (minting at consent, the ``:revoke``
+kill switch) lives in :mod:`jentic_one.auth.services.oauth_grant_service`;
+this service is the read side shared by the §4.8 listing surfaces — the
+``GET /admin/oauth-grants`` cross-view and (behind the auth tier's
+owner-or-admin check) the per-agent "Connected clients" panel.
+"""
+
+from __future__ import annotations
+
+from jentic_one.admin.repos.oauth_client_grant_repo import OAuthClientGrantRepository
+from jentic_one.admin.repos.oauth_client_repo import OAuthClientRepository
+from jentic_one.admin.services.errors import InvalidInputError
+from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView, grant_to_view
+from jentic_one.shared.context import Context
+from jentic_one.shared.models.oauth_clients import OAuthGrantStatus
+from jentic_one.shared.pagination import Page, decode_cursor_str, encode_cursor
+
+
+class OAuthGrantAdminService:
+    """Query consent→agent grant rows, enriched with client display fields."""
+
+    def __init__(self, ctx: Context) -> None:
+        self._ctx = ctx
+
+    async def list_grants(
+        self,
+        *,
+        agent_id: str | None = None,
+        client_id: str | None = None,
+        user_id: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> Page[OAuthGrantView]:
+        """List grants newest-first, filtered by agent/client/user/status.
+
+        ``client_id`` is the public client identifier (the join key grants
+        store, D3). Each item carries the §4.8 display fields: client name,
+        redirect-URI origin, scopes, consenting ``user_id`` (G10), created,
+        last-used, status.
+        """
+        if status is not None and status not in (
+            OAuthGrantStatus.ACTIVE.value,
+            OAuthGrantStatus.REVOKED.value,
+        ):
+            raise InvalidInputError(f"unsupported status filter: {status}")
+
+        cursor_dt = None
+        if cursor is not None:
+            cursor_dt, _ = decode_cursor_str(cursor)
+
+        async with self._ctx.admin_db.session() as session:
+            grants = await OAuthClientGrantRepository.list_grants(
+                session,
+                agent_id=agent_id,
+                oauth_client_id=client_id,
+                user_id=user_id,
+                status=status,
+                limit=limit + 1,
+                cursor=cursor_dt,
+            )
+            has_more = len(grants) > limit
+            if has_more:
+                grants = grants[:limit]
+            clients = await OAuthClientRepository.list_by_client_ids(
+                session, sorted({g.oauth_client_id for g in grants})
+            )
+
+        clients_by_id = {c.client_id: c for c in clients}
+        views = [grant_to_view(g, clients_by_id.get(g.oauth_client_id)) for g in grants]
+
+        next_cursor = None
+        if has_more and grants:
+            next_cursor = encode_cursor(grants[-1].created_at, grants[-1].id)
+
+        return Page(data=views, has_more=has_more, next_cursor=next_cursor)

--- a/src/jentic_one/admin/services/schemas/oauth_clients.py
+++ b/src/jentic_one/admin/services/schemas/oauth_clients.py
@@ -23,6 +23,7 @@ class OAuthClientView(BaseModel):
     registration_source: str
     software_id: str | None
     approval_status: str
+    active_grant_count: int = 0
     created_at: datetime
     updated_at: datetime | None
     created_by: str | None

--- a/src/jentic_one/admin/services/schemas/oauth_grants.py
+++ b/src/jentic_one/admin/services/schemas/oauth_grants.py
@@ -1,0 +1,59 @@
+"""Service-layer views for OAuth consent→agent grants (phase-3a §4.8)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from urllib.parse import urlparse
+
+from pydantic import BaseModel
+
+from jentic_one.admin.core.schema.oauth_client_grants import OAuthClientGrant
+from jentic_one.admin.core.schema.oauth_clients import OAuthClient
+
+
+class OAuthGrantView(BaseModel):
+    """One consent→agent grant row, enriched with client display fields.
+
+    ``user_id`` is the consenting owner — surfaced deliberately (gap G10:
+    agent ownership transfer strands the grant with the old owner, so
+    listings must show WHO consented, not just which agent is bound).
+    """
+
+    id: str
+    oauth_client_id: str
+    client_name: str | None
+    client_origin: str | None
+    user_id: str
+    agent_id: str
+    scopes: list[str]
+    status: str
+    created_at: datetime
+    revoked_at: datetime | None
+    last_used_at: datetime | None
+
+
+def redirect_uri_origin(client: OAuthClient | None) -> str | None:
+    """The client's first redirect-URI origin (§4.8 "authorized apps" pattern)."""
+    if client is None or not client.redirect_uris:
+        return None
+    parsed = urlparse(client.redirect_uris[0])
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def grant_to_view(grant: OAuthClientGrant, client: OAuthClient | None) -> OAuthGrantView:
+    """Build the enriched view; ``client`` may be None for a deleted row."""
+    return OAuthGrantView(
+        id=grant.id,
+        oauth_client_id=grant.oauth_client_id,
+        client_name=client.name if client is not None else None,
+        client_origin=redirect_uri_origin(client),
+        user_id=grant.user_id,
+        agent_id=grant.agent_id,
+        scopes=list(grant.scopes),
+        status=grant.status,
+        created_at=grant.created_at,
+        revoked_at=grant.revoked_at,
+        last_used_at=grant.last_used_at,
+    )

--- a/src/jentic_one/admin/services/schemas/oauth_grants.py
+++ b/src/jentic_one/admin/services/schemas/oauth_grants.py
@@ -17,6 +17,9 @@ class OAuthGrantView(BaseModel):
     ``user_id`` is the consenting owner — surfaced deliberately (gap G10:
     agent ownership transfer strands the grant with the old owner, so
     listings must show WHO consented, not just which agent is bound).
+    ``can_revoke`` is the viewer's per-item ``:revoke`` capability — computed
+    from the same predicate the revoke endpoint enforces, so the UI never
+    advertises a revoke that would 403 (the G10 list/revoke divergence).
     """
 
     id: str
@@ -30,6 +33,7 @@ class OAuthGrantView(BaseModel):
     created_at: datetime
     revoked_at: datetime | None
     last_used_at: datetime | None
+    can_revoke: bool
 
 
 def redirect_uri_origin(client: OAuthClient | None) -> str | None:
@@ -42,7 +46,9 @@ def redirect_uri_origin(client: OAuthClient | None) -> str | None:
     return f"{parsed.scheme}://{parsed.netloc}"
 
 
-def grant_to_view(grant: OAuthClientGrant, client: OAuthClient | None) -> OAuthGrantView:
+def grant_to_view(
+    grant: OAuthClientGrant, client: OAuthClient | None, *, can_revoke: bool
+) -> OAuthGrantView:
     """Build the enriched view; ``client`` may be None for a deleted row."""
     return OAuthGrantView(
         id=grant.id,
@@ -56,4 +62,5 @@ def grant_to_view(grant: OAuthClientGrant, client: OAuthClient | None) -> OAuthG
         created_at=grant.created_at,
         revoked_at=grant.revoked_at,
         last_used_at=grant.last_used_at,
+        can_revoke=can_revoke,
     )

--- a/src/jentic_one/admin/web/app.py
+++ b/src/jentic_one/admin/web/app.py
@@ -21,6 +21,7 @@ from jentic_one.admin.web.routers import (
     jobs,
     monitoring,
     oauth_clients,
+    oauth_grants,
     permissions,
     users,
 )
@@ -62,6 +63,7 @@ def get_routers() -> list[tuple[APIRouter, str, list[str]]]:
         (monitoring.router, "", []),
         (config.router, "", []),
         (oauth_clients.router, "", []),
+        (oauth_grants.router, "", []),
     ]
 
 

--- a/src/jentic_one/admin/web/deps.py
+++ b/src/jentic_one/admin/web/deps.py
@@ -16,6 +16,7 @@ from jentic_one.admin.services.job_result_service import JobResultService
 from jentic_one.admin.services.job_service import JobService
 from jentic_one.admin.services.monitoring_service import MonitoringService
 from jentic_one.admin.services.oauth_client_service import OAuthClientService
+from jentic_one.admin.services.oauth_grant_admin_service import OAuthGrantAdminService
 from jentic_one.admin.services.permission_service import PermissionService
 from jentic_one.admin.services.provider_config_service import ProviderConfigService
 from jentic_one.admin.services.user_service import UserService
@@ -77,6 +78,10 @@ def get_event_stream_service(ctx: Context = Depends(get_ctx)) -> EventStreamServ
 
 def get_oauth_client_service(ctx: Context = Depends(get_ctx)) -> OAuthClientService:
     return OAuthClientService(ctx)
+
+
+def get_oauth_grant_admin_service(ctx: Context = Depends(get_ctx)) -> OAuthGrantAdminService:
+    return OAuthGrantAdminService(ctx)
 
 
 def get_monitoring_service(request: Request) -> MonitoringService:

--- a/src/jentic_one/admin/web/routers/oauth_clients.py
+++ b/src/jentic_one/admin/web/routers/oauth_clients.py
@@ -38,6 +38,7 @@ def _to_response(view: OAuthClientView) -> OAuthClientResponse:
         registration_source=view.registration_source,
         software_id=view.software_id,
         approval_status=view.approval_status,
+        active_grant_count=view.active_grant_count,
         created_at=view.created_at,
         updated_at=view.updated_at,
         created_by=view.created_by,

--- a/src/jentic_one/admin/web/routers/oauth_grants.py
+++ b/src/jentic_one/admin/web/routers/oauth_grants.py
@@ -32,6 +32,7 @@ def _to_response(view: OAuthGrantView) -> OAuthGrantAdminResponse:
         created_at=view.created_at,
         revoked_at=view.revoked_at,
         last_used_at=view.last_used_at,
+        can_revoke=view.can_revoke,
     )
 
 
@@ -59,6 +60,7 @@ async def list_oauth_grants(
     column is how an admin spots stranded grants.
     """
     page = await svc.list_grants(
+        identity=identity,
         client_id=client_id,
         agent_id=agent_id,
         user_id=user_id,

--- a/src/jentic_one/admin/web/routers/oauth_grants.py
+++ b/src/jentic_one/admin/web/routers/oauth_grants.py
@@ -1,0 +1,73 @@
+"""OAuth grants admin router — the §4.8 cross-view over consent→agent grants."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Query
+
+from jentic_one.admin.services.oauth_grant_admin_service import OAuthGrantAdminService
+from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView
+from jentic_one.admin.web.deps import get_oauth_grant_admin_service
+from jentic_one.admin.web.schemas.oauth_grants import (
+    OAuthGrantAdminListResponse,
+    OAuthGrantAdminResponse,
+)
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.web import get_current_identity
+
+router = APIRouter()
+
+
+def _to_response(view: OAuthGrantView) -> OAuthGrantAdminResponse:
+    return OAuthGrantAdminResponse(
+        id=view.id,
+        oauth_client_id=view.oauth_client_id,
+        client_name=view.client_name,
+        client_origin=view.client_origin,
+        user_id=view.user_id,
+        agent_id=view.agent_id,
+        scopes=view.scopes,
+        status=view.status,
+        created_at=view.created_at,
+        revoked_at=view.revoked_at,
+        last_used_at=view.last_used_at,
+    )
+
+
+@router.get("/admin/oauth-grants", summary="List OAuth grants")
+async def list_oauth_grants(
+    identity: Identity = get_current_identity(required_permissions=["oauth-clients:read"]),
+    svc: OAuthGrantAdminService = Depends(get_oauth_grant_admin_service),
+    client_id: str | None = Query(
+        default=None, description="Filter by the client's public client_id."
+    ),
+    agent_id: str | None = Query(default=None, description="Filter by bound agent."),
+    user_id: str | None = Query(default=None, description="Filter by consenting user."),
+    status: Literal["active", "revoked"] | None = Query(
+        default=None, description="Filter by grant lifecycle state."
+    ),
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = None,
+) -> OAuthGrantAdminListResponse:
+    """List consent→agent grants across all clients and agents (§4.8).
+
+    The admin cross-view over the grant registry: filter by client, agent,
+    consenting user, or status. Each item carries the client's display name
+    and redirect-URI origin plus the consenting ``user_id`` — after an agent
+    ownership transfer the grant stays with the original consenter, so this
+    column is how an admin spots stranded grants.
+    """
+    page = await svc.list_grants(
+        client_id=client_id,
+        agent_id=agent_id,
+        user_id=user_id,
+        status=status,
+        limit=limit,
+        cursor=cursor,
+    )
+    return OAuthGrantAdminListResponse(
+        data=[_to_response(v) for v in page.data],
+        has_more=page.has_more,
+        next_cursor=page.next_cursor,
+    )

--- a/src/jentic_one/admin/web/schemas/oauth_clients.py
+++ b/src/jentic_one/admin/web/schemas/oauth_clients.py
@@ -134,6 +134,12 @@ class OAuthClientResponse(BaseModel):
         "Only approved clients may enter OAuth flows; ``active`` remains the "
         "independent kill switch."
     )
+    active_grant_count: int = Field(
+        default=0,
+        description="Number of active consent→agent grants for this client (§4.8 "
+        "per-client grant count). Computed on the read endpoints (list/get); "
+        "write-path responses report 0.",
+    )
     created_at: datetime
     updated_at: datetime | None
     created_by: str | None

--- a/src/jentic_one/admin/web/schemas/oauth_grants.py
+++ b/src/jentic_one/admin/web/schemas/oauth_grants.py
@@ -1,0 +1,46 @@
+"""OAuth grant response schemas for the admin web layer (phase-3a §4.8)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class OAuthGrantAdminResponse(BaseModel):
+    """One consent→agent grant in the admin cross-view."""
+
+    id: str = Field(description="Grant ID (ksuid, `ocg_` prefix).")
+    oauth_client_id: str = Field(
+        description="The client's public client_id — the same identifier stamped "
+        "on tokens minted under this grant."
+    )
+    client_name: str | None = Field(
+        description="Display name of the registered client, if the row still exists."
+    )
+    client_origin: str | None = Field(
+        description="Origin (scheme://host) of the client's first redirect URI — "
+        "the 'authorized apps' display pattern."
+    )
+    user_id: str = Field(
+        description="The consenting user who approved this grant. Shown even "
+        "after an agent ownership transfer: the grant stays with the original "
+        "consenter (it is their consent, not the agent's)."
+    )
+    agent_id: str = Field(description="The agent this grant binds the client to.")
+    scopes: list[str] = Field(description="Scopes granted at consent (the D2 intersection).")
+    status: str = Field(description="Grant lifecycle state: ``active`` or ``revoked``.")
+    created_at: datetime
+    revoked_at: datetime | None
+    last_used_at: datetime | None = Field(
+        description="Last time the client obtained tokens under this grant "
+        "(stamped at exchange/refresh, not per request)."
+    )
+
+
+class OAuthGrantAdminListResponse(BaseModel):
+    """A paginated list of OAuth grants (admin cross-view)."""
+
+    data: list[OAuthGrantAdminResponse]
+    has_more: bool
+    next_cursor: str | None = None

--- a/src/jentic_one/admin/web/schemas/oauth_grants.py
+++ b/src/jentic_one/admin/web/schemas/oauth_grants.py
@@ -36,6 +36,15 @@ class OAuthGrantAdminResponse(BaseModel):
         description="Last time the client obtained tokens under this grant "
         "(stamped at exchange/refresh, not per request)."
     )
+    # G10: the list gate (`oauth-clients:read`) is wider than the revoke set
+    # (org:admin / oauth-clients:write) — a read-only admin can list but not
+    # revoke. `can_revoke` surfaces the revoke predicate per item so clients
+    # never render a revoke that would 403.
+    can_revoke: bool = Field(
+        description="Whether the CALLER may revoke this grant (the consenting "
+        "user, or an admin holding the revoke permission set). May be false "
+        "even for callers who can list — e.g. a read-only admin."
+    )
 
 
 class OAuthGrantAdminListResponse(BaseModel):

--- a/src/jentic_one/auth/services/errors.py
+++ b/src/jentic_one/auth/services/errors.py
@@ -159,11 +159,15 @@ class OAuthGrantAccessDeniedError(AuthServiceError):
     Grant ``:revoke`` is owner-or-admin (design §4.8): the consenting user
     owns the grant; anyone else needs the admin permission. 403, not 404 —
     the grant id is a ksuid, not a secret.
+
+    ``resource_id`` is the denied resource — a grant id on the ``:revoke``
+    path, an agent id on the per-agent listing path (the listing gate denies
+    before any grant is in hand).
     """
 
-    def __init__(self, grant_id: str, *, message: str | None = None) -> None:
-        super().__init__(message or f"Not permitted to operate on OAuth grant '{grant_id}'")
-        self.grant_id = grant_id
+    def __init__(self, resource_id: str, *, message: str | None = None) -> None:
+        super().__init__(message or f"Not permitted to operate on OAuth grant '{resource_id}'")
+        self.resource_id = resource_id
 
 
 class InvalidClientMetadataError(AuthServiceError):

--- a/src/jentic_one/auth/services/errors.py
+++ b/src/jentic_one/auth/services/errors.py
@@ -161,8 +161,8 @@ class OAuthGrantAccessDeniedError(AuthServiceError):
     the grant id is a ksuid, not a secret.
     """
 
-    def __init__(self, grant_id: str) -> None:
-        super().__init__(f"Not permitted to operate on OAuth grant '{grant_id}'")
+    def __init__(self, grant_id: str, *, message: str | None = None) -> None:
+        super().__init__(message or f"Not permitted to operate on OAuth grant '{grant_id}'")
         self.grant_id = grant_id
 
 

--- a/src/jentic_one/auth/services/oauth_grant_service.py
+++ b/src/jentic_one/auth/services/oauth_grant_service.py
@@ -14,21 +14,30 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from jentic_one.admin.core.schema.oauth_client_grants import OAuthClientGrant
 from jentic_one.admin.repos import (
     AccessTokenRepository,
+    AgentRepository,
     OAuthClientGrantRepository,
     RefreshTokenRepository,
 )
+from jentic_one.admin.services.oauth_grant_admin_service import OAuthGrantAdminService
+from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView
 from jentic_one.auth.services.errors import (
+    ActorNotFoundError,
     OAuthGrantAccessDeniedError,
     OAuthGrantNotFoundError,
 )
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit
 from jentic_one.shared.auth.identity import Identity
-from jentic_one.shared.auth.permission_catalog import OAUTH_CLIENTS_WRITE, ORG_ADMIN
+from jentic_one.shared.auth.permission_catalog import (
+    OAUTH_CLIENTS_READ,
+    OAUTH_CLIENTS_WRITE,
+    ORG_ADMIN,
+)
 from jentic_one.shared.context import Context
 from jentic_one.shared.events import emit_event_best_effort
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.models.oauth_clients import OAuthGrantStatus
+from jentic_one.shared.pagination import Page
 
 logger = structlog.get_logger(__name__)
 
@@ -37,6 +46,12 @@ logger = structlog.get_logger(__name__)
 #: holders administer the client lifecycle (the same permission gating the
 #: admin oauth-clients router), and a grant is part of that lifecycle.
 _ADMIN_PERMISSIONS: frozenset[str] = frozenset({ORG_ADMIN, OAUTH_CLIENTS_WRITE})
+
+#: Read-side admin set (§4.8 listings): everything above plus the read-only
+#: half of the client-lifecycle permission pair — the same permission that
+#: gates ``GET /admin/oauth-clients`` and the ``/admin/oauth-grants``
+#: cross-view, so a caller who can see grants there can see them per-agent.
+_ADMIN_READ_PERMISSIONS: frozenset[str] = _ADMIN_PERMISSIONS | {OAUTH_CLIENTS_READ}
 
 
 class OAuthGrantService:
@@ -182,6 +197,40 @@ class OAuthGrantService:
         revoked = await self._ctx.admin_db.run_in_transaction(_write)
         if revoked:
             logger.info("oauth_grant_revoked", grant_id=grant_id, actor_id=identity.sub)
+
+    async def list_grants_for_agent(
+        self,
+        agent_id: str,
+        *,
+        identity: Identity,
+        status: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> Page[OAuthGrantView]:
+        """The per-agent "Connected clients" listing (§4.8).
+
+        Owner-or-admin, mirroring ``revoke_grant``'s semantics on the read
+        side: the agent's owner sees their agent's grants; anyone else needs
+        an admin permission (403, not 404 — agent ids are ksuids, not
+        secrets). Items carry the §4.8 display fields (client name,
+        redirect-URI origin, scopes, created, last-used, status) plus the
+        consenting ``user_id`` so the G10 ownership-transfer gap is visible.
+        """
+        async with self._ctx.admin_db.session() as session:
+            agent = await AgentRepository.get_by_id(session, agent_id)
+        if agent is None:
+            raise ActorNotFoundError(agent_id)
+        if agent.owner_id != identity.sub and not (
+            _ADMIN_READ_PERMISSIONS & set(identity.permissions)
+        ):
+            raise OAuthGrantAccessDeniedError(
+                agent_id,
+                message=f"Not permitted to list OAuth grants for agent '{agent_id}'",
+            )
+
+        return await OAuthGrantAdminService(self._ctx).list_grants(
+            agent_id=agent_id, status=status, limit=limit, cursor=cursor
+        )
 
     async def get_grant(self, grant_id: str) -> OAuthClientGrant | None:
         """Read one grant row (used by tests and the exchange path)."""

--- a/src/jentic_one/auth/services/oauth_grant_service.py
+++ b/src/jentic_one/auth/services/oauth_grant_service.py
@@ -18,7 +18,11 @@ from jentic_one.admin.repos import (
     OAuthClientGrantRepository,
     RefreshTokenRepository,
 )
-from jentic_one.admin.services.oauth_grant_admin_service import OAuthGrantAdminService
+from jentic_one.admin.services.oauth_grant_admin_service import (
+    GRANT_REVOKE_ADMIN_PERMISSIONS,
+    OAuthGrantAdminService,
+    viewer_can_revoke,
+)
 from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView
 from jentic_one.auth.services.errors import (
     ActorNotFoundError,
@@ -27,11 +31,7 @@ from jentic_one.auth.services.errors import (
 )
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit
 from jentic_one.shared.auth.identity import Identity
-from jentic_one.shared.auth.permission_catalog import (
-    OAUTH_CLIENTS_READ,
-    OAUTH_CLIENTS_WRITE,
-    ORG_ADMIN,
-)
+from jentic_one.shared.auth.permission_catalog import OAUTH_CLIENTS_READ
 from jentic_one.shared.context import Context
 from jentic_one.shared.events import emit_event_best_effort
 from jentic_one.shared.models import ActorType
@@ -41,17 +41,13 @@ from jentic_one.shared.pagination import Page
 
 logger = structlog.get_logger(__name__)
 
-#: Permissions that make a non-owner an admin for grant operations. Broader
-#: than the usual ``ORG_ADMIN``-only idiom on purpose: ``oauth-clients:write``
-#: holders administer the client lifecycle (the same permission gating the
-#: admin oauth-clients router), and a grant is part of that lifecycle.
-_ADMIN_PERMISSIONS: frozenset[str] = frozenset({ORG_ADMIN, OAUTH_CLIENTS_WRITE})
-
-#: Read-side admin set (§4.8 listings): everything above plus the read-only
-#: half of the client-lifecycle permission pair — the same permission that
-#: gates ``GET /admin/oauth-clients`` and the ``/admin/oauth-grants``
-#: cross-view, so a caller who can see grants there can see them per-agent.
-_ADMIN_READ_PERMISSIONS: frozenset[str] = _ADMIN_PERMISSIONS | {OAUTH_CLIENTS_READ}
+#: Read-side admin set (§4.8 listings): the ``:revoke`` write pair
+#: (:data:`GRANT_REVOKE_ADMIN_PERMISSIONS` — the single revoke-predicate
+#: definition, shared with ``viewer_can_revoke``) plus the read-only half of
+#: the client-lifecycle permission pair — the same permission that gates
+#: ``GET /admin/oauth-clients`` and the ``/admin/oauth-grants`` cross-view,
+#: so a caller who can see grants there can see them per-agent.
+_ADMIN_READ_PERMISSIONS: frozenset[str] = GRANT_REVOKE_ADMIN_PERMISSIONS | {OAUTH_CLIENTS_READ}
 
 
 class OAuthGrantService:
@@ -147,9 +143,7 @@ class OAuthGrantService:
             grant = await OAuthClientGrantRepository.get_by_id(session, grant_id)
             if grant is None:
                 raise OAuthGrantNotFoundError(grant_id)
-            if grant.user_id != identity.sub and not (
-                _ADMIN_PERMISSIONS & set(identity.permissions)
-            ):
+            if not viewer_can_revoke(grant.user_id, identity):
                 raise OAuthGrantAccessDeniedError(grant_id)
 
             newly_revoked = grant.status == OAuthGrantStatus.ACTIVE.value and (
@@ -214,7 +208,11 @@ class OAuthGrantService:
         an admin permission (403, not 404 — agent ids are ksuids, not
         secrets). Items carry the §4.8 display fields (client name,
         redirect-URI origin, scopes, created, last-used, status) plus the
-        consenting ``user_id`` so the G10 ownership-transfer gap is visible.
+        consenting ``user_id`` and the viewer's per-item ``can_revoke``
+        capability, so the G10 ownership-transfer gap is visible AND
+        actionable state is honest (list keys on the agent's current owner,
+        revoke on the grant's consenting user — they diverge after a
+        transfer).
         """
         async with self._ctx.admin_db.session() as session:
             agent = await AgentRepository.get_by_id(session, agent_id)
@@ -229,7 +227,7 @@ class OAuthGrantService:
             )
 
         return await OAuthGrantAdminService(self._ctx).list_grants(
-            agent_id=agent_id, status=status, limit=limit, cursor=cursor
+            identity=identity, agent_id=agent_id, status=status, limit=limit, cursor=cursor
         )
 
     async def get_grant(self, grant_id: str) -> OAuthClientGrant | None:

--- a/src/jentic_one/auth/web/app.py
+++ b/src/jentic_one/auth/web/app.py
@@ -10,7 +10,11 @@ from jentic.problem_details import Unauthorized
 
 from jentic_one.auth.services.errors import AuthServiceError
 from jentic_one.auth.services.token_service import ACCESS_TOKEN_PREFIX, TokenService
-from jentic_one.auth.web.errors import database_error_handler, service_error_handler
+from jentic_one.auth.web.errors import (
+    cursor_error_handler,
+    database_error_handler,
+    service_error_handler,
+)
 from jentic_one.auth.web.routers import (
     agents,
     authorize,
@@ -32,6 +36,7 @@ from jentic_one.shared.auth.verify import resolve_permissions_for_actor, verify_
 from jentic_one.shared.context import Context
 from jentic_one.shared.db.errors import DatabaseUnavailableError
 from jentic_one.shared.models import ActorType
+from jentic_one.shared.pagination import InvalidCursorError
 from jentic_one.shared.scopes import OIDC_PASSTHROUGH_SCOPES
 from jentic_one.shared.state import build_state_backend
 from jentic_one.shared.state.factory import BackendKind
@@ -68,6 +73,9 @@ def get_exception_handlers() -> list[tuple[type[Exception], Any]]:
     return [
         (AuthServiceError, service_error_handler),
         (DatabaseUnavailableError, database_error_handler),
+        # A user-supplied `?cursor=` that fails to decode must 400, not 500 —
+        # the per-agent grant listing decodes it (see auth/web/errors.py).
+        (InvalidCursorError, cursor_error_handler),
     ]
 
 

--- a/src/jentic_one/auth/web/errors.py
+++ b/src/jentic_one/auth/web/errors.py
@@ -28,6 +28,7 @@ from jentic_one.auth.services.errors import (
 )
 from jentic_one.shared.db.errors import DatabaseUnavailableError
 from jentic_one.shared.metrics import get_meter
+from jentic_one.shared.pagination import InvalidCursorError
 from jentic_one.shared.web.errors import make_service_error_handler
 
 _logger = structlog.get_logger(__name__)
@@ -93,3 +94,17 @@ _DB_SAFE_DETAILS: dict[type[Exception], str] = {
 }
 
 database_error_handler = make_service_error_handler(_DB_ERROR_MAP, safe_details=_DB_SAFE_DETAILS)
+
+# A tampered/garbage pagination cursor on `GET /agents/{id}/oauth-grants` is a
+# client fault, not a server one: map it to a 400 like the admin surface
+# (`admin/web/errors.py`) and the registry routers do. Registered as its own
+# handler because `InvalidCursorError` lives outside the `AuthServiceError`
+# hierarchy (it's a shared pagination error, ultimately a ValueError). Without
+# this, the standalone auth deployment 500s on `?cursor=garbage` — combined
+# mode was rescued only because the admin surface registers the handler on the
+# shared app.
+_CURSOR_ERROR_MAP: dict[type[Exception], tuple[int, str]] = {
+    InvalidCursorError: (400, "invalid_cursor"),
+}
+
+cursor_error_handler = make_service_error_handler(_CURSOR_ERROR_MAP)

--- a/src/jentic_one/auth/web/routers/oauth_grants.py
+++ b/src/jentic_one/auth/web/routers/oauth_grants.py
@@ -1,14 +1,22 @@
-"""OAuth consent-grant endpoints — the per-grant kill switch (phase-3a §4.6/§4.8).
+"""OAuth consent-grant endpoints — revoke + per-agent listing (phase-3a §4.6/§4.8).
 
-Only the ``:revoke`` verb ships in 3a-3; the grants listing surfaces (per-agent
-"Connected clients", admin cross-view) are 3a-5 UI scope.
+The ``:revoke`` verb shipped in 3a-3; 3a-5 adds the per-agent "Connected
+clients" listing. The admin cross-view lives on the admin router
+(``GET /admin/oauth-grants``).
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Response
+from typing import Literal
 
+from fastapi import APIRouter, Depends, Query, Response
+
+from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView
 from jentic_one.auth.services.oauth_grant_service import OAuthGrantService
+from jentic_one.auth.web.schemas.oauth_grants import (
+    OAuthGrantListResponse,
+    OAuthGrantResponse,
+)
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
 from jentic_one.shared.web import get_current_identity
@@ -20,6 +28,55 @@ router = APIRouter()
 
 def get_oauth_grant_service(ctx: Context = Depends(get_ctx)) -> OAuthGrantService:
     return OAuthGrantService(ctx)
+
+
+def grant_response(view: OAuthGrantView) -> OAuthGrantResponse:
+    return OAuthGrantResponse(
+        id=view.id,
+        oauth_client_id=view.oauth_client_id,
+        client_name=view.client_name,
+        client_origin=view.client_origin,
+        user_id=view.user_id,
+        agent_id=view.agent_id,
+        scopes=view.scopes,
+        status=view.status,
+        created_at=view.created_at,
+        revoked_at=view.revoked_at,
+        last_used_at=view.last_used_at,
+    )
+
+
+@router.get(
+    "/agents/{agent_id}/oauth-grants",
+    summary="List agent OAuth grants",
+    responses=not_found(),
+)
+async def list_agent_oauth_grants(
+    agent_id: str,
+    identity: Identity = get_current_identity(),
+    grant_svc: OAuthGrantService = Depends(get_oauth_grant_service),
+    status: Literal["active", "revoked"] | None = Query(
+        default=None, description="Filter by grant lifecycle state."
+    ),
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = None,
+) -> OAuthGrantListResponse:
+    """List OAuth consent grants binding clients to this agent (§4.8).
+
+    The "Connected clients" surface: every grant carries the client's display
+    name and redirect-URI origin, the granted scopes, the consenting user,
+    and created/last-used timestamps. Allowed for the agent's owner or an
+    admin — authorization is enforced in the service layer, mirroring the
+    ``:revoke`` semantics.
+    """
+    page = await grant_svc.list_grants_for_agent(
+        agent_id, identity=identity, status=status, limit=limit, cursor=cursor
+    )
+    return OAuthGrantListResponse(
+        data=[grant_response(v) for v in page.data],
+        has_more=page.has_more,
+        next_cursor=page.next_cursor,
+    )
 
 
 @router.post(

--- a/src/jentic_one/auth/web/routers/oauth_grants.py
+++ b/src/jentic_one/auth/web/routers/oauth_grants.py
@@ -43,6 +43,7 @@ def grant_response(view: OAuthGrantView) -> OAuthGrantResponse:
         created_at=view.created_at,
         revoked_at=view.revoked_at,
         last_used_at=view.last_used_at,
+        can_revoke=view.can_revoke,
     )
 
 

--- a/src/jentic_one/auth/web/schemas/oauth_grants.py
+++ b/src/jentic_one/auth/web/schemas/oauth_grants.py
@@ -36,6 +36,17 @@ class OAuthGrantResponse(BaseModel):
         description="Last time the client obtained tokens under this grant "
         "(stamped at exchange/refresh, not per request)."
     )
+    # G10: the list predicate (agent's current owner or read-set admin) and the
+    # revoke predicate (grant's consenting user or write-set admin) deliberately
+    # diverge — after an agent ownership transfer the new owner can list but
+    # not revoke. `can_revoke` surfaces the revoke predicate per item so
+    # clients never render a revoke that would 403.
+    can_revoke: bool = Field(
+        description="Whether the CALLER may revoke this grant (the consenting "
+        "user, or an admin holding the revoke permission set). May be false "
+        "even for callers who can list — e.g. the agent's new owner after an "
+        "ownership transfer, or a read-only admin."
+    )
 
 
 class OAuthGrantListResponse(BaseModel):

--- a/src/jentic_one/auth/web/schemas/oauth_grants.py
+++ b/src/jentic_one/auth/web/schemas/oauth_grants.py
@@ -1,0 +1,46 @@
+"""Response schemas for the OAuth grant listing surfaces (phase-3a §4.8)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class OAuthGrantResponse(BaseModel):
+    """One consent→agent grant in API responses."""
+
+    id: str = Field(description="Grant ID (ksuid, `ocg_` prefix).")
+    oauth_client_id: str = Field(
+        description="The client's public client_id — the same identifier stamped "
+        "on tokens minted under this grant."
+    )
+    client_name: str | None = Field(
+        description="Display name of the registered client, if the row still exists."
+    )
+    client_origin: str | None = Field(
+        description="Origin (scheme://host) of the client's first redirect URI — "
+        "the 'authorized apps' display pattern."
+    )
+    user_id: str = Field(
+        description="The consenting user who approved this grant. Shown even "
+        "after an agent ownership transfer: the grant stays with the original "
+        "consenter (it is their consent, not the agent's)."
+    )
+    agent_id: str = Field(description="The agent this grant binds the client to.")
+    scopes: list[str] = Field(description="Scopes granted at consent (the D2 intersection).")
+    status: str = Field(description="Grant lifecycle state: ``active`` or ``revoked``.")
+    created_at: datetime
+    revoked_at: datetime | None
+    last_used_at: datetime | None = Field(
+        description="Last time the client obtained tokens under this grant "
+        "(stamped at exchange/refresh, not per request)."
+    )
+
+
+class OAuthGrantListResponse(BaseModel):
+    """A paginated list of OAuth grants."""
+
+    data: list[OAuthGrantResponse]
+    has_more: bool
+    next_cursor: str | None = None

--- a/src/jentic_one/shared/web/openapi_meta.py
+++ b/src/jentic_one/shared/web/openapi_meta.py
@@ -886,6 +886,8 @@ _TAG_RULES: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^/auth/idp"), "Discovery"),
     (re.compile(r"^/audit"), "Audit"),
     (re.compile(r"^/admin/oauth-clients"), "OAuth Clients"),
+    # Grant listings/revoke share the OAuth tag with the grant kill switch.
+    (re.compile(r"^/admin/oauth-grants"), "OAuth"),
     # Anonymous DCR front door — before the broader ^/oauth rule below.
     (re.compile(r"^/oauth-clients"), "OAuth Clients"),
     # Platform-actor surfaces (superset, not in the original reference).

--- a/tests/integration/auth/test_oauth_grant_listing.py
+++ b/tests/integration/auth/test_oauth_grant_listing.py
@@ -1,0 +1,249 @@
+"""Integration tests for the 3a-5 grant listing surfaces (design §4.8, §9).
+
+Covers the read side of the grant registry end-to-end at the service layer:
+the per-agent "Connected clients" listing with its owner-or-admin
+authorization matrix, the admin cross-view with its filters and keyset
+pagination, the §4.8 display enrichment (client name + redirect-URI origin +
+consenting ``user_id`` — gap G10), and the per-client active-grant counts
+folded into the admin client listing.
+
+    Seed helpers and the ``clean_grants`` fixture are shared with the grant
+channel tests via :mod:`tests.integration.auth.seeds` and this package's
+``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jentic_one.admin.services.errors import InvalidInputError
+from jentic_one.admin.services.oauth_client_service import OAuthClientService
+from jentic_one.admin.services.oauth_grant_admin_service import OAuthGrantAdminService
+from jentic_one.auth.services.errors import (
+    ActorNotFoundError,
+    OAuthGrantAccessDeniedError,
+)
+from jentic_one.auth.services.oauth_grant_service import OAuthGrantService
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.context import Context
+from tests.integration.auth import seeds
+
+pytestmark = pytest.mark.integration
+
+_CLIENT_ID = seeds.CLIENT_ID
+_seed_user = seeds.seed_user
+_seed_agent = seeds.seed_agent
+_seed_client = seeds.seed_client
+
+
+# --- per-agent listing: authorization matrix (§4.8 / §9) ---------------------
+
+
+async def test_list_grants_for_agent_owner_or_admin_matrix(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """Owner OK; stranger 403-mapped; each admin read permission OK; unknown
+    agent 404-mapped — mirroring the ``:revoke`` semantics on the read side."""
+    owner_id = await _seed_user(integration_context, "usr_l_owner")
+    stranger_id = await _seed_user(integration_context, "usr_l_stranger")
+    admin_id = await _seed_user(integration_context, "usr_l_admin")
+    agent_id = await _seed_agent(integration_context, owner_id=owner_id, scopes=["apis:read"])
+    await _seed_client(integration_context, allowed_scopes=["apis:read"])
+    grant_svc = OAuthGrantService(integration_context)
+
+    grant_id = await grant_svc.create_grant(
+        user_id=owner_id, oauth_client_id=_CLIENT_ID, agent_id=agent_id, scopes=["apis:read"]
+    )
+
+    with pytest.raises(ActorNotFoundError):
+        await grant_svc.list_grants_for_agent(
+            "agt_missing", identity=Identity(sub=owner_id, email="")
+        )
+
+    with pytest.raises(OAuthGrantAccessDeniedError):
+        await grant_svc.list_grants_for_agent(
+            agent_id, identity=Identity(sub=stranger_id, email="")
+        )
+
+    page = await grant_svc.list_grants_for_agent(
+        agent_id, identity=Identity(sub=owner_id, email="")
+    )
+    assert [g.id for g in page.data] == [grant_id]
+
+    # Each admin permission unlocks the read: the write pair from :revoke plus
+    # the read half that gates the admin cross-view.
+    for permission in ("org:admin", "oauth-clients:write", "oauth-clients:read"):
+        page = await grant_svc.list_grants_for_agent(
+            agent_id,
+            identity=Identity(sub=admin_id, email="", permissions=[permission]),
+        )
+        assert [g.id for g in page.data] == [grant_id]
+
+
+async def test_list_grants_for_agent_enrichment_and_status_filter(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """Items carry the §4.8 display fields — client name, redirect-URI origin,
+    consenting ``user_id`` (G10) — and the status filter separates the active
+    row from revoked history."""
+    owner_id = await _seed_user(integration_context, "usr_l_enrich")
+    agent_id = await _seed_agent(integration_context, owner_id=owner_id, scopes=["apis:read"])
+    await _seed_client(integration_context, allowed_scopes=["apis:read"])
+    grant_svc = OAuthGrantService(integration_context)
+    owner = Identity(sub=owner_id, email="")
+
+    # Two consents for the same pair: the §4.1 collapse revokes the first.
+    await grant_svc.create_grant(
+        user_id=owner_id, oauth_client_id=_CLIENT_ID, agent_id=agent_id, scopes=["apis:read"]
+    )
+    active_id = await grant_svc.create_grant(
+        user_id=owner_id, oauth_client_id=_CLIENT_ID, agent_id=agent_id, scopes=["apis:read"]
+    )
+
+    active = await grant_svc.list_grants_for_agent(agent_id, identity=owner, status="active")
+    assert [g.id for g in active.data] == [active_id]
+    view = active.data[0]
+    assert view.client_name == "Grant Channel App"
+    assert view.client_origin == "https://mcpapp.example.com"
+    assert view.user_id == owner_id  # the consenting owner, surfaced per G10
+    assert view.agent_id == agent_id
+    assert view.scopes == ["apis:read"]
+    assert view.created_at is not None and view.revoked_at is None
+
+    revoked = await grant_svc.list_grants_for_agent(agent_id, identity=owner, status="revoked")
+    assert len(revoked.data) == 1
+    assert revoked.data[0].revoked_at is not None
+
+    everything = await grant_svc.list_grants_for_agent(agent_id, identity=owner)
+    assert len(everything.data) == 2
+    # Newest first.
+    assert everything.data[0].id == active_id
+
+
+# --- admin cross-view: filters + pagination (§4.8) ---------------------------
+
+
+async def test_admin_cross_view_filters(integration_context: Context, clean_grants: None) -> None:
+    """GET /admin/oauth-grants filters: agent, consenting user, client, status
+    — each narrowing the §4.8 cross-view independently."""
+    user_a = await _seed_user(integration_context, "usr_l_xa")
+    user_b = await _seed_user(integration_context, "usr_l_xb")
+    agent_a = await _seed_agent(
+        integration_context, owner_id=user_a, scopes=["apis:read"], name="xview-agent-a"
+    )
+    agent_b = await _seed_agent(
+        integration_context, owner_id=user_b, scopes=["apis:read"], name="xview-agent-b"
+    )
+    await _seed_client(integration_context, allowed_scopes=["apis:read"])
+    other_client = await _seed_client(
+        integration_context, allowed_scopes=["apis:read"], client_id="oc_grant_listing_other"
+    )
+    grant_svc = OAuthGrantService(integration_context)
+
+    g_a = await grant_svc.create_grant(
+        user_id=user_a, oauth_client_id=_CLIENT_ID, agent_id=agent_a, scopes=["apis:read"]
+    )
+    g_b = await grant_svc.create_grant(
+        user_id=user_b, oauth_client_id=_CLIENT_ID, agent_id=agent_b, scopes=["apis:read"]
+    )
+    g_c = await grant_svc.create_grant(
+        user_id=user_b, oauth_client_id=other_client, agent_id=agent_b, scopes=["apis:read"]
+    )
+    await grant_svc.revoke_grant(g_b, identity=Identity(sub=user_b, email=""))
+
+    admin_svc = OAuthGrantAdminService(integration_context)
+
+    everything = await admin_svc.list_grants()
+    assert {g.id for g in everything.data} == {g_a, g_b, g_c}
+
+    by_agent = await admin_svc.list_grants(agent_id=agent_a)
+    assert [g.id for g in by_agent.data] == [g_a]
+
+    by_user = await admin_svc.list_grants(user_id=user_b)
+    assert {g.id for g in by_user.data} == {g_b, g_c}
+
+    by_client = await admin_svc.list_grants(client_id=other_client)
+    assert [g.id for g in by_client.data] == [g_c]
+
+    active = await admin_svc.list_grants(status="active")
+    assert {g.id for g in active.data} == {g_a, g_c}
+    revoked = await admin_svc.list_grants(status="revoked")
+    assert [g.id for g in revoked.data] == [g_b]
+
+    with pytest.raises(InvalidInputError, match="status"):
+        await admin_svc.list_grants(status="bogus")
+
+
+async def test_admin_cross_view_keyset_pagination(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """limit/cursor walk the full set newest-first without overlap or loss."""
+    user_id = await _seed_user(integration_context, "usr_l_page")
+    await _seed_client(integration_context, allowed_scopes=["apis:read"])
+    grant_svc = OAuthGrantService(integration_context)
+
+    # Distinct (client, agent) pairs so the §4.1 collapse leaves all rows alive.
+    expected: list[str] = []
+    for i in range(3):
+        agent_id = await _seed_agent(
+            integration_context, owner_id=user_id, scopes=["apis:read"], name=f"page-agent-{i}"
+        )
+        expected.append(
+            await grant_svc.create_grant(
+                user_id=user_id,
+                oauth_client_id=_CLIENT_ID,
+                agent_id=agent_id,
+                scopes=["apis:read"],
+            )
+        )
+
+    admin_svc = OAuthGrantAdminService(integration_context)
+    seen: list[str] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        page = await admin_svc.list_grants(limit=1, cursor=cursor)
+        seen.extend(g.id for g in page.data)
+        pages += 1
+        if not page.has_more:
+            assert page.next_cursor is None
+            break
+        assert page.next_cursor is not None
+        cursor = page.next_cursor
+    assert pages == 3
+    assert seen == list(reversed(expected))  # newest first, no overlap/loss
+
+
+# --- per-client active-grant counts (§4.8) -----------------------------------
+
+
+async def test_client_listing_carries_active_grant_count(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """The admin client list/get fold in per-client ACTIVE grant counts;
+    revoked rows do not count."""
+    user_id = await _seed_user(integration_context, "usr_l_count")
+    agent_a = await _seed_agent(
+        integration_context, owner_id=user_id, scopes=["apis:read"], name="count-agent-a"
+    )
+    agent_b = await _seed_agent(
+        integration_context, owner_id=user_id, scopes=["apis:read"], name="count-agent-b"
+    )
+    await _seed_client(integration_context, allowed_scopes=["apis:read"])
+    grant_svc = OAuthGrantService(integration_context)
+
+    await grant_svc.create_grant(
+        user_id=user_id, oauth_client_id=_CLIENT_ID, agent_id=agent_a, scopes=["apis:read"]
+    )
+    revoked_id = await grant_svc.create_grant(
+        user_id=user_id, oauth_client_id=_CLIENT_ID, agent_id=agent_b, scopes=["apis:read"]
+    )
+    await grant_svc.revoke_grant(revoked_id, identity=Identity(sub=user_id, email=""))
+
+    client_svc = OAuthClientService(integration_context)
+    views = [c for c in await client_svc.list_all() if c.client_id == _CLIENT_ID]
+    assert len(views) == 1
+    assert views[0].active_grant_count == 1
+
+    got = await client_svc.get(views[0].id)
+    assert got.active_grant_count == 1

--- a/tests/integration/auth/test_oauth_grant_listing.py
+++ b/tests/integration/auth/test_oauth_grant_listing.py
@@ -3,9 +3,11 @@
 Covers the read side of the grant registry end-to-end at the service layer:
 the per-agent "Connected clients" listing with its owner-or-admin
 authorization matrix, the admin cross-view with its filters and keyset
-pagination, the §4.8 display enrichment (client name + redirect-URI origin +
-consenting ``user_id`` — gap G10), and the per-client active-grant counts
-folded into the admin client listing.
+pagination (including the id tiebreaker on ``created_at`` ties), the §4.8
+display enrichment (client name + redirect-URI origin + consenting
+``user_id`` — gap G10), the per-item ``can_revoke`` capability (the G10
+list/revoke predicate divergence made explicit), and the per-client
+active-grant counts folded into the admin client listing.
 
     Seed helpers and the ``clean_grants`` fixture are shared with the grant
 channel tests via :mod:`tests.integration.auth.seeds` and this package's
@@ -14,8 +16,13 @@ channel tests via :mod:`tests.integration.auth.seeds` and this package's
 
 from __future__ import annotations
 
-import pytest
+from datetime import UTC, datetime
 
+import pytest
+from sqlalchemy import update
+
+from jentic_one.admin.core.schema.oauth_client_grants import OAuthClientGrant
+from jentic_one.admin.repos import AgentRepository
 from jentic_one.admin.services.errors import InvalidInputError
 from jentic_one.admin.services.oauth_client_service import OAuthClientService
 from jentic_one.admin.services.oauth_grant_admin_service import OAuthGrantAdminService
@@ -34,6 +41,25 @@ _CLIENT_ID = seeds.CLIENT_ID
 _seed_user = seeds.seed_user
 _seed_agent = seeds.seed_agent
 _seed_client = seeds.seed_client
+
+#: Cross-view caller for tests where the viewer's revoke capability is not the
+#: subject under test (org:admin holds the revoke set, so can_revoke is True).
+_VIEWER = Identity(sub="usr_l_viewer", email="", permissions=["org:admin"])
+
+
+async def _force_created_at(ctx: Context, grant_ids: list[str], created_at: datetime) -> None:
+    """Pin several grants to one ``created_at`` — a keyset-tie fixture.
+
+    ``create_grant`` stamps distinct timestamps, so boundary ties (burst
+    consents, coarse DB timestamp precision) are manufactured directly.
+    """
+    async with ctx.admin_db.session() as session:
+        await session.execute(
+            update(OAuthClientGrant)
+            .where(OAuthClientGrant.id.in_(grant_ids))
+            .values(created_at=created_at)
+        )
+        await session.commit()
 
 
 # --- per-agent listing: authorization matrix (§4.8 / §9) ---------------------
@@ -153,25 +179,25 @@ async def test_admin_cross_view_filters(integration_context: Context, clean_gran
 
     admin_svc = OAuthGrantAdminService(integration_context)
 
-    everything = await admin_svc.list_grants()
+    everything = await admin_svc.list_grants(identity=_VIEWER)
     assert {g.id for g in everything.data} == {g_a, g_b, g_c}
 
-    by_agent = await admin_svc.list_grants(agent_id=agent_a)
+    by_agent = await admin_svc.list_grants(identity=_VIEWER, agent_id=agent_a)
     assert [g.id for g in by_agent.data] == [g_a]
 
-    by_user = await admin_svc.list_grants(user_id=user_b)
+    by_user = await admin_svc.list_grants(identity=_VIEWER, user_id=user_b)
     assert {g.id for g in by_user.data} == {g_b, g_c}
 
-    by_client = await admin_svc.list_grants(client_id=other_client)
+    by_client = await admin_svc.list_grants(identity=_VIEWER, client_id=other_client)
     assert [g.id for g in by_client.data] == [g_c]
 
-    active = await admin_svc.list_grants(status="active")
+    active = await admin_svc.list_grants(identity=_VIEWER, status="active")
     assert {g.id for g in active.data} == {g_a, g_c}
-    revoked = await admin_svc.list_grants(status="revoked")
+    revoked = await admin_svc.list_grants(identity=_VIEWER, status="revoked")
     assert [g.id for g in revoked.data] == [g_b]
 
     with pytest.raises(InvalidInputError, match="status"):
-        await admin_svc.list_grants(status="bogus")
+        await admin_svc.list_grants(identity=_VIEWER, status="bogus")
 
 
 async def test_admin_cross_view_keyset_pagination(
@@ -202,7 +228,7 @@ async def test_admin_cross_view_keyset_pagination(
     cursor: str | None = None
     pages = 0
     while True:
-        page = await admin_svc.list_grants(limit=1, cursor=cursor)
+        page = await admin_svc.list_grants(identity=_VIEWER, limit=1, cursor=cursor)
         seen.extend(g.id for g in page.data)
         pages += 1
         if not page.has_more:
@@ -214,6 +240,153 @@ async def test_admin_cross_view_keyset_pagination(
     assert seen == list(reversed(expected))  # newest first, no overlap/loss
 
 
+async def test_admin_cross_view_pagination_walks_created_at_ties(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """Rows sharing a page-boundary ``created_at`` are not skipped: the cursor
+    carries ``(created_at, id)`` and the repo applies the compound keyset
+    (``created_at < c OR (created_at = c AND id < cid)``)."""
+    user_id = await _seed_user(integration_context, "usr_l_tie")
+    await _seed_client(integration_context, allowed_scopes=["apis:read"])
+    grant_svc = OAuthGrantService(integration_context)
+
+    grant_ids: list[str] = []
+    for i in range(5):
+        agent_id = await _seed_agent(
+            integration_context, owner_id=user_id, scopes=["apis:read"], name=f"tie-agent-{i}"
+        )
+        grant_ids.append(
+            await grant_svc.create_grant(
+                user_id=user_id,
+                oauth_client_id=_CLIENT_ID,
+                agent_id=agent_id,
+                scopes=["apis:read"],
+            )
+        )
+    # Every row shares one timestamp, so EVERY page boundary is a tie.
+    await _force_created_at(
+        integration_context, grant_ids, datetime(2026, 8, 15, 12, 0, 0, tzinfo=UTC)
+    )
+
+    admin_svc = OAuthGrantAdminService(integration_context)
+    seen: list[str] = []
+    cursor: str | None = None
+    while True:
+        page = await admin_svc.list_grants(identity=_VIEWER, limit=2, cursor=cursor)
+        seen.extend(g.id for g in page.data)
+        if not page.has_more:
+            break
+        cursor = page.next_cursor
+    # All 5 rows walked exactly once (id DESC within the tied timestamp).
+    assert seen == sorted(grant_ids, reverse=True)
+
+
+async def test_list_grants_for_agent_pagination_walks_created_at_ties(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """The per-agent listing walks tied ``created_at`` rows without skips —
+    the same compound keyset via the shared admin read service."""
+    owner_id = await _seed_user(integration_context, "usr_l_tie_agent")
+    agent_id = await _seed_agent(
+        integration_context, owner_id=owner_id, scopes=["apis:read"], name="tie-one-agent"
+    )
+    grant_svc = OAuthGrantService(integration_context)
+
+    # Distinct clients on ONE agent so the §4.1 pair-collapse keeps all rows.
+    grant_ids: list[str] = []
+    for i in range(4):
+        client_id = await _seed_client(
+            integration_context,
+            allowed_scopes=["apis:read"],
+            client_id=f"oc_grant_listing_tie_{i}",
+        )
+        grant_ids.append(
+            await grant_svc.create_grant(
+                user_id=owner_id,
+                oauth_client_id=client_id,
+                agent_id=agent_id,
+                scopes=["apis:read"],
+            )
+        )
+    await _force_created_at(
+        integration_context, grant_ids, datetime(2026, 8, 16, 9, 30, 0, tzinfo=UTC)
+    )
+
+    owner = Identity(sub=owner_id, email="")
+    seen: list[str] = []
+    cursor: str | None = None
+    while True:
+        page = await grant_svc.list_grants_for_agent(
+            agent_id, identity=owner, limit=1, cursor=cursor
+        )
+        seen.extend(g.id for g in page.data)
+        if not page.has_more:
+            break
+        cursor = page.next_cursor
+    assert seen == sorted(grant_ids, reverse=True)
+
+
+# --- per-item can_revoke capability (G10 list/revoke divergence) --------------
+
+
+async def test_can_revoke_matrix_consenter_transfer_and_admin_arms(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """``can_revoke`` mirrors the ``:revoke`` predicate per item — including
+    the two G10 divergence arms: the agent's post-transfer owner can LIST but
+    not revoke, and a read-only admin can LIST but not revoke."""
+    consenter_id = await _seed_user(integration_context, "usr_l_consenter")
+    new_owner_id = await _seed_user(integration_context, "usr_l_new_owner")
+    ro_admin_id = await _seed_user(integration_context, "usr_l_ro_admin")
+    agent_id = await _seed_agent(
+        integration_context, owner_id=consenter_id, scopes=["apis:read"], name="cap-agent"
+    )
+    await _seed_client(integration_context, allowed_scopes=["apis:read"])
+    grant_svc = OAuthGrantService(integration_context)
+    grant_id = await grant_svc.create_grant(
+        user_id=consenter_id, oauth_client_id=_CLIENT_ID, agent_id=agent_id, scopes=["apis:read"]
+    )
+
+    # The consenting owner sees an actionable revoke.
+    consenter = Identity(sub=consenter_id, email="")
+    page = await grant_svc.list_grants_for_agent(agent_id, identity=consenter)
+    assert [(g.id, g.can_revoke) for g in page.data] == [(grant_id, True)]
+
+    # G10 transfer arm: hand the agent to a new owner. The new owner can list
+    # (list keys on the agent's CURRENT owner) but can_revoke is False (revoke
+    # keys on the grant's CONSENTING user) — and the revoke verb agrees.
+    async with integration_context.admin_db.session() as session:
+        await AgentRepository.update_agent(session, agent_id, owner_id=new_owner_id)
+        await session.commit()
+
+    new_owner = Identity(sub=new_owner_id, email="")
+    page = await grant_svc.list_grants_for_agent(agent_id, identity=new_owner)
+    assert [(g.id, g.can_revoke) for g in page.data] == [(grant_id, False)]
+    with pytest.raises(OAuthGrantAccessDeniedError):
+        await grant_svc.revoke_grant(grant_id, identity=new_owner)
+
+    # Read-only-admin arm: `oauth-clients:read` unlocks the LIST but is not in
+    # the revoke write set — can_revoke False, and the revoke verb agrees.
+    ro_admin = Identity(sub=ro_admin_id, email="", permissions=["oauth-clients:read"])
+    page = await grant_svc.list_grants_for_agent(agent_id, identity=ro_admin)
+    assert [(g.id, g.can_revoke) for g in page.data] == [(grant_id, False)]
+    with pytest.raises(OAuthGrantAccessDeniedError):
+        await grant_svc.revoke_grant(grant_id, identity=ro_admin)
+
+    # The write-set admins CAN revoke — capability True on both surfaces.
+    for permission in ("org:admin", "oauth-clients:write"):
+        admin = Identity(sub=ro_admin_id, email="", permissions=[permission])
+        page = await grant_svc.list_grants_for_agent(agent_id, identity=admin)
+        assert [(g.id, g.can_revoke) for g in page.data] == [(grant_id, True)]
+        cross = await OAuthGrantAdminService(integration_context).list_grants(identity=admin)
+        assert [(g.id, g.can_revoke) for g in cross.data] == [(grant_id, True)]
+
+    # The consenting user still holds the revoke on the admin cross-view shape
+    # too (were they ever granted the read permission to reach it).
+    cross = await OAuthGrantAdminService(integration_context).list_grants(identity=consenter)
+    assert [(g.id, g.can_revoke) for g in cross.data] == [(grant_id, True)]
+
+
 # --- per-client active-grant counts (§4.8) -----------------------------------
 
 
@@ -221,7 +394,7 @@ async def test_client_listing_carries_active_grant_count(
     integration_context: Context, clean_grants: None
 ) -> None:
     """The admin client list/get fold in per-client ACTIVE grant counts;
-    revoked rows do not count."""
+    revoked rows do not count and neighbours' grants do not bleed in."""
     user_id = await _seed_user(integration_context, "usr_l_count")
     agent_a = await _seed_agent(
         integration_context, owner_id=user_id, scopes=["apis:read"], name="count-agent-a"
@@ -230,6 +403,9 @@ async def test_client_listing_carries_active_grant_count(
         integration_context, owner_id=user_id, scopes=["apis:read"], name="count-agent-b"
     )
     await _seed_client(integration_context, allowed_scopes=["apis:read"])
+    other_client = await _seed_client(
+        integration_context, allowed_scopes=["apis:read"], client_id="oc_grant_listing_count"
+    )
     grant_svc = OAuthGrantService(integration_context)
 
     await grant_svc.create_grant(
@@ -239,11 +415,16 @@ async def test_client_listing_carries_active_grant_count(
         user_id=user_id, oauth_client_id=_CLIENT_ID, agent_id=agent_b, scopes=["apis:read"]
     )
     await grant_svc.revoke_grant(revoked_id, identity=Identity(sub=user_id, email=""))
+    # A neighbouring client's active grant must not inflate the first's count.
+    await grant_svc.create_grant(
+        user_id=user_id, oauth_client_id=other_client, agent_id=agent_b, scopes=["apis:read"]
+    )
 
     client_svc = OAuthClientService(integration_context)
-    views = [c for c in await client_svc.list_all() if c.client_id == _CLIENT_ID]
-    assert len(views) == 1
-    assert views[0].active_grant_count == 1
+    views = {c.client_id: c for c in await client_svc.list_all()}
+    assert views[_CLIENT_ID].active_grant_count == 1
+    assert views[other_client].active_grant_count == 1
 
-    got = await client_svc.get(views[0].id)
+    # get() scopes its aggregate to the one requested client (review F4).
+    got = await client_svc.get(views[_CLIENT_ID].id)
     assert got.active_grant_count == 1

--- a/tests/unit/admin/services/test_oauth_client_service.py
+++ b/tests/unit/admin/services/test_oauth_client_service.py
@@ -835,12 +835,19 @@ async def test_approve_missing_client_raises(mock_repo: MagicMock) -> None:
 
 
 # ---------- list_all approval_status filter ----------
+#
+# The list/get read paths also fold in the §4.8 active-grant counts, so the
+# grant repo is patched alongside the client repo (returning no counts).
 
 
+@patch("jentic_one.admin.services.oauth_client_service.OAuthClientGrantRepository")
 @patch("jentic_one.admin.services.oauth_client_service.OAuthClientRepository")
-async def test_list_all_passes_approval_status_filter(mock_repo: MagicMock) -> None:
+async def test_list_all_passes_approval_status_filter(
+    mock_repo: MagicMock, mock_grant_repo: MagicMock
+) -> None:
     ctx = _make_ctx()
     mock_repo.list_all = AsyncMock(return_value=[])
+    mock_grant_repo.count_active_by_client = AsyncMock(return_value={})
 
     svc = OAuthClientService(ctx)
     await svc.list_all(include_inactive=True, approval_status="pending")
@@ -851,14 +858,16 @@ async def test_list_all_passes_approval_status_filter(mock_repo: MagicMock) -> N
 
 
 @pytest.mark.parametrize("approval_status", ["pending", "denied"])
+@patch("jentic_one.admin.services.oauth_client_service.OAuthClientGrantRepository")
 @patch("jentic_one.admin.services.oauth_client_service.OAuthClientRepository")
 async def test_list_all_pending_or_denied_filter_implies_include_inactive(
-    mock_repo: MagicMock, approval_status: str
+    mock_repo: MagicMock, mock_grant_repo: MagicMock, approval_status: str
 ) -> None:
     """Pending/denied rows are active=false by construction (D7); the approval
     queue must not need the caller to also pass include_inactive=true."""
     ctx = _make_ctx()
     mock_repo.list_all = AsyncMock(return_value=[])
+    mock_grant_repo.count_active_by_client = AsyncMock(return_value={})
 
     svc = OAuthClientService(ctx)
     await svc.list_all(approval_status=approval_status)
@@ -868,11 +877,15 @@ async def test_list_all_pending_or_denied_filter_implies_include_inactive(
     )
 
 
+@patch("jentic_one.admin.services.oauth_client_service.OAuthClientGrantRepository")
 @patch("jentic_one.admin.services.oauth_client_service.OAuthClientRepository")
-async def test_list_all_approved_filter_keeps_active_default(mock_repo: MagicMock) -> None:
+async def test_list_all_approved_filter_keeps_active_default(
+    mock_repo: MagicMock, mock_grant_repo: MagicMock
+) -> None:
     """Filtering on approved keeps today's active-only default."""
     ctx = _make_ctx()
     mock_repo.list_all = AsyncMock(return_value=[])
+    mock_grant_repo.count_active_by_client = AsyncMock(return_value={})
 
     svc = OAuthClientService(ctx)
     await svc.list_all(approval_status="approved")

--- a/tests/unit/admin/web/test_oauth_grants_router.py
+++ b/tests/unit/admin/web/test_oauth_grants_router.py
@@ -1,9 +1,11 @@
 """Unit tests for the admin grant cross-view (GET /admin/oauth-grants).
 
-The §4.8 admin listing: permission gate (`oauth-clients:read`), filter
-forwarding, and the wire shape — including the consenting ``user_id`` column
-(gap G10: after an agent ownership transfer the grant stays with the original
-consenter, so the cross-view must show who holds it).
+The §4.8 admin listing: permission gate (`oauth-clients:read`), the
+unauthenticated 401 arm, filter forwarding, the tampered-cursor 400 mapping,
+and the wire shape — including the consenting ``user_id`` column (gap G10:
+after an agent ownership transfer the grant stays with the original
+consenter, so the cross-view must show who holds it) and the per-item
+``can_revoke`` capability.
 """
 
 from __future__ import annotations
@@ -17,14 +19,15 @@ from fastapi.testclient import TestClient
 
 from jentic_one.admin.services.oauth_grant_admin_service import OAuthGrantAdminService
 from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView
+from jentic_one.admin.web.app import get_exception_handlers
 from jentic_one.admin.web.deps import get_oauth_grant_admin_service
 from jentic_one.admin.web.routers.oauth_grants import router
 from jentic_one.shared.auth.identity import Identity
-from jentic_one.shared.pagination import Page
+from jentic_one.shared.pagination import InvalidCursorError, Page
 from jentic_one.shared.web.deps import resolve_identity
 
 
-def _view() -> OAuthGrantView:
+def _view(*, can_revoke: bool = True) -> OAuthGrantView:
     return OAuthGrantView(
         id="ocg_1",
         oauth_client_id="oc_app",
@@ -37,6 +40,7 @@ def _view() -> OAuthGrantView:
         created_at=datetime(2026, 8, 1, tzinfo=UTC),
         revoked_at=None,
         last_used_at=None,
+        can_revoke=can_revoke,
     )
 
 
@@ -49,14 +53,32 @@ def mock_svc() -> MagicMock:
     return svc
 
 
-def _client(mock_svc: MagicMock, *, permissions: list[str]) -> TestClient:
+def _make_app(mock_svc: MagicMock) -> FastAPI:
     app = FastAPI()
     app.include_router(router)
-    identity = Identity(sub="usr_admin", email="admin@example.com", permissions=permissions)
-    app.dependency_overrides[resolve_identity] = lambda: identity
+    # The REAL registration list from the admin app factory, so these tests
+    # prove the surface maps InvalidCursorError → 400, not 500.
+    for exc_class, handler in get_exception_handlers():
+        app.add_exception_handler(exc_class, handler)
     app.dependency_overrides[get_oauth_grant_admin_service] = lambda: mock_svc
     app.state.ctx = MagicMock()
+    return app
+
+
+def _client(mock_svc: MagicMock, *, permissions: list[str]) -> TestClient:
+    app = _make_app(mock_svc)
+    identity = Identity(sub="usr_admin", email="admin@example.com", permissions=permissions)
+    app.dependency_overrides[resolve_identity] = lambda: identity
     return TestClient(app)
+
+
+def test_list_unauthenticated_is_401(mock_svc: MagicMock) -> None:
+    """No credential → 401 through the real resolve_identity path (no
+    dependency override), and the service is never consulted."""
+    unauthed = TestClient(_make_app(mock_svc), raise_server_exceptions=False)
+    resp = unauthed.get("/admin/oauth-grants")
+    assert resp.status_code == 401
+    mock_svc.list_grants.assert_not_awaited()
 
 
 def test_list_requires_oauth_clients_read(mock_svc: MagicMock) -> None:
@@ -80,6 +102,19 @@ def test_list_returns_shape_and_pagination(mock_svc: MagicMock) -> None:
     # G10: the consenting user is part of the wire contract.
     assert item["user_id"] == "usr_consenter"
     assert item["status"] == "active"
+    assert item["can_revoke"] is True
+
+
+def test_list_surfaces_can_revoke_false(mock_svc: MagicMock) -> None:
+    """A read-only admin lists but cannot revoke (the G10 divergence) —
+    can_revoke=false travels to the wire."""
+    mock_svc.list_grants = AsyncMock(
+        return_value=Page(data=[_view(can_revoke=False)], has_more=False, next_cursor=None)
+    )
+    client = _client(mock_svc, permissions=["oauth-clients:read"])
+    resp = client.get("/admin/oauth-grants")
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["can_revoke"] is False
 
 
 def test_list_forwards_filters(mock_svc: MagicMock) -> None:
@@ -96,7 +131,9 @@ def test_list_forwards_filters(mock_svc: MagicMock) -> None:
         },
     )
     assert resp.status_code == 200
-    kwargs = mock_svc.list_grants.call_args.kwargs
+    kwargs = dict(mock_svc.list_grants.call_args.kwargs)
+    # The caller's identity rides along for the per-item can_revoke computation.
+    assert kwargs.pop("identity").sub == "usr_admin"
     assert kwargs == {
         "client_id": "oc_app",
         "agent_id": "agt_1",
@@ -105,6 +142,15 @@ def test_list_forwards_filters(mock_svc: MagicMock) -> None:
         "limit": 7,
         "cursor": "cur_prev",
     }
+
+
+def test_list_maps_tampered_cursor_to_400(mock_svc: MagicMock) -> None:
+    """`?cursor=garbage` is a client fault: 400 invalid_cursor, never a 500."""
+    mock_svc.list_grants = AsyncMock(side_effect=InvalidCursorError("Invalid pagination cursor"))
+    client = _client(mock_svc, permissions=["oauth-clients:read"])
+    resp = client.get("/admin/oauth-grants", params={"cursor": "garbage"})
+    assert resp.status_code == 400
+    assert resp.json()["type"] == "invalid_cursor"
 
 
 def test_list_rejects_unknown_status(mock_svc: MagicMock) -> None:

--- a/tests/unit/admin/web/test_oauth_grants_router.py
+++ b/tests/unit/admin/web/test_oauth_grants_router.py
@@ -1,0 +1,114 @@
+"""Unit tests for the admin grant cross-view (GET /admin/oauth-grants).
+
+The §4.8 admin listing: permission gate (`oauth-clients:read`), filter
+forwarding, and the wire shape — including the consenting ``user_id`` column
+(gap G10: after an agent ownership transfer the grant stays with the original
+consenter, so the cross-view must show who holds it).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from jentic_one.admin.services.oauth_grant_admin_service import OAuthGrantAdminService
+from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView
+from jentic_one.admin.web.deps import get_oauth_grant_admin_service
+from jentic_one.admin.web.routers.oauth_grants import router
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.pagination import Page
+from jentic_one.shared.web.deps import resolve_identity
+
+
+def _view() -> OAuthGrantView:
+    return OAuthGrantView(
+        id="ocg_1",
+        oauth_client_id="oc_app",
+        client_name="MCP App",
+        client_origin="https://mcpapp.example.com",
+        user_id="usr_consenter",
+        agent_id="agt_1",
+        scopes=["apis:read"],
+        status="active",
+        created_at=datetime(2026, 8, 1, tzinfo=UTC),
+        revoked_at=None,
+        last_used_at=None,
+    )
+
+
+@pytest.fixture()
+def mock_svc() -> MagicMock:
+    svc = MagicMock(spec=OAuthGrantAdminService)
+    svc.list_grants = AsyncMock(
+        return_value=Page(data=[_view()], has_more=True, next_cursor="cur_next")
+    )
+    return svc
+
+
+def _client(mock_svc: MagicMock, *, permissions: list[str]) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    identity = Identity(sub="usr_admin", email="admin@example.com", permissions=permissions)
+    app.dependency_overrides[resolve_identity] = lambda: identity
+    app.dependency_overrides[get_oauth_grant_admin_service] = lambda: mock_svc
+    app.state.ctx = MagicMock()
+    return TestClient(app)
+
+
+def test_list_requires_oauth_clients_read(mock_svc: MagicMock) -> None:
+    client = _client(mock_svc, permissions=["agents:read"])
+    resp = client.get("/admin/oauth-grants")
+    assert resp.status_code == 403
+    mock_svc.list_grants.assert_not_awaited()
+
+
+def test_list_returns_shape_and_pagination(mock_svc: MagicMock) -> None:
+    client = _client(mock_svc, permissions=["oauth-clients:read"])
+    resp = client.get("/admin/oauth-grants")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["has_more"] is True
+    assert body["next_cursor"] == "cur_next"
+    (item,) = body["data"]
+    assert item["id"] == "ocg_1"
+    assert item["client_name"] == "MCP App"
+    assert item["client_origin"] == "https://mcpapp.example.com"
+    # G10: the consenting user is part of the wire contract.
+    assert item["user_id"] == "usr_consenter"
+    assert item["status"] == "active"
+
+
+def test_list_forwards_filters(mock_svc: MagicMock) -> None:
+    client = _client(mock_svc, permissions=["oauth-clients:read"])
+    resp = client.get(
+        "/admin/oauth-grants",
+        params={
+            "client_id": "oc_app",
+            "agent_id": "agt_1",
+            "user_id": "usr_x",
+            "status": "revoked",
+            "limit": 7,
+            "cursor": "cur_prev",
+        },
+    )
+    assert resp.status_code == 200
+    kwargs = mock_svc.list_grants.call_args.kwargs
+    assert kwargs == {
+        "client_id": "oc_app",
+        "agent_id": "agt_1",
+        "user_id": "usr_x",
+        "status": "revoked",
+        "limit": 7,
+        "cursor": "cur_prev",
+    }
+
+
+def test_list_rejects_unknown_status(mock_svc: MagicMock) -> None:
+    client = _client(mock_svc, permissions=["oauth-clients:read"])
+    resp = client.get("/admin/oauth-grants", params={"status": "bogus"})
+    assert resp.status_code == 422
+    mock_svc.list_grants.assert_not_awaited()

--- a/tests/unit/auth/web/test_agent_oauth_grants_router.py
+++ b/tests/unit/auth/web/test_agent_oauth_grants_router.py
@@ -1,10 +1,11 @@
 """Unit tests for the per-agent grant listing (GET /agents/{id}/oauth-grants).
 
-The §4.8 "Connected clients" endpoint: response shape, query forwarding, and
-the web mapping of the service-layer authorization results (owner-or-admin is
-enforced in :class:`OAuthGrantService`, so here it is mocked as its error
-outcomes: 403 for a non-owner without admin permission, 404 for an unknown
-agent).
+The §4.8 "Connected clients" endpoint: response shape (including the per-item
+``can_revoke`` capability, G10), query forwarding, and the web mapping of the
+service-layer outcomes (owner-or-admin is enforced in
+:class:`OAuthGrantService`, so here it is mocked as its error outcomes: 403
+for a non-owner without admin permission, 404 for an unknown agent, 400 for a
+tampered cursor) plus the unauthenticated 401 arm.
 """
 
 from __future__ import annotations
@@ -19,18 +20,17 @@ from fastapi.testclient import TestClient
 from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView
 from jentic_one.auth.services.errors import (
     ActorNotFoundError,
-    AuthServiceError,
     OAuthGrantAccessDeniedError,
 )
 from jentic_one.auth.services.oauth_grant_service import OAuthGrantService
-from jentic_one.auth.web.errors import service_error_handler
+from jentic_one.auth.web.app import get_exception_handlers
 from jentic_one.auth.web.routers import oauth_grants
 from jentic_one.shared.auth.identity import Identity
-from jentic_one.shared.pagination import Page
+from jentic_one.shared.pagination import InvalidCursorError, Page
 from jentic_one.shared.web.deps import resolve_identity
 
 
-def _view(grant_id: str = "ocg_1") -> OAuthGrantView:
+def _view(grant_id: str = "ocg_1", *, can_revoke: bool = True) -> OAuthGrantView:
     return OAuthGrantView(
         id=grant_id,
         oauth_client_id="oc_app",
@@ -43,6 +43,7 @@ def _view(grant_id: str = "ocg_1") -> OAuthGrantView:
         created_at=datetime(2026, 8, 1, tzinfo=UTC),
         revoked_at=None,
         last_used_at=datetime(2026, 8, 2, tzinfo=UTC),
+        can_revoke=can_revoke,
     )
 
 
@@ -59,13 +60,22 @@ def mock_grant_svc() -> MagicMock:
     return svc
 
 
-@pytest.fixture()
-def client(mock_grant_svc: MagicMock) -> TestClient:
+def _make_app(mock_grant_svc: MagicMock) -> FastAPI:
     app = FastAPI()
     app.include_router(oauth_grants.router)
-    app.add_exception_handler(AuthServiceError, service_error_handler)
+    # The REAL registration list from the auth app factory (standalone and
+    # combined-mode both consume it), so these tests prove the surface maps
+    # every service outcome — notably InvalidCursorError → 400, not 500.
+    for exc_class, handler in get_exception_handlers():
+        app.add_exception_handler(exc_class, handler)
     app.dependency_overrides[oauth_grants.get_oauth_grant_service] = lambda: mock_grant_svc
     app.state.ctx = MagicMock()
+    return app
+
+
+@pytest.fixture()
+def client(mock_grant_svc: MagicMock) -> TestClient:
+    app = _make_app(mock_grant_svc)
     app.dependency_overrides[resolve_identity] = _identity
     return TestClient(app)
 
@@ -87,6 +97,19 @@ def test_list_returns_grant_shape(client: TestClient, mock_grant_svc: MagicMock)
     assert item["scopes"] == ["apis:read"]
     assert item["status"] == "active"
     assert item["last_used_at"] is not None
+    # G10: the revoke capability is part of the wire contract.
+    assert item["can_revoke"] is True
+
+
+def test_list_surfaces_can_revoke_false(client: TestClient, mock_grant_svc: MagicMock) -> None:
+    """A viewer who may list but not revoke (post-transfer owner, read-only
+    admin — the G10 divergence) sees can_revoke=false on the wire."""
+    mock_grant_svc.list_grants_for_agent = AsyncMock(
+        return_value=Page(data=[_view(can_revoke=False)], has_more=False, next_cursor=None)
+    )
+    resp = client.get("/agents/agt_1/oauth-grants")
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["can_revoke"] is False
 
 
 def test_list_forwards_filters_and_identity(client: TestClient, mock_grant_svc: MagicMock) -> None:
@@ -119,3 +142,23 @@ def test_list_maps_unknown_agent_to_404(client: TestClient, mock_grant_svc: Magi
     resp = client.get("/agents/agt_x/oauth-grants")
     assert resp.status_code == 404
     assert resp.json()["type"] == "actor_not_found"
+
+
+def test_list_maps_tampered_cursor_to_400(client: TestClient, mock_grant_svc: MagicMock) -> None:
+    """`?cursor=garbage` is a client fault: the standalone auth surface must
+    map InvalidCursorError to 400, never let it escape as a 500 (review F2)."""
+    mock_grant_svc.list_grants_for_agent = AsyncMock(
+        side_effect=InvalidCursorError("Invalid pagination cursor")
+    )
+    resp = client.get("/agents/agt_1/oauth-grants?cursor=garbage")
+    assert resp.status_code == 400
+    assert resp.json()["type"] == "invalid_cursor"
+
+
+def test_list_unauthenticated_is_401(mock_grant_svc: MagicMock) -> None:
+    """No credential → 401 through the real resolve_identity path (no
+    dependency override), and the service is never consulted."""
+    unauthed = TestClient(_make_app(mock_grant_svc), raise_server_exceptions=False)
+    resp = unauthed.get("/agents/agt_1/oauth-grants")
+    assert resp.status_code == 401
+    mock_grant_svc.list_grants_for_agent.assert_not_awaited()

--- a/tests/unit/auth/web/test_agent_oauth_grants_router.py
+++ b/tests/unit/auth/web/test_agent_oauth_grants_router.py
@@ -1,0 +1,121 @@
+"""Unit tests for the per-agent grant listing (GET /agents/{id}/oauth-grants).
+
+The §4.8 "Connected clients" endpoint: response shape, query forwarding, and
+the web mapping of the service-layer authorization results (owner-or-admin is
+enforced in :class:`OAuthGrantService`, so here it is mocked as its error
+outcomes: 403 for a non-owner without admin permission, 404 for an unknown
+agent).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView
+from jentic_one.auth.services.errors import (
+    ActorNotFoundError,
+    AuthServiceError,
+    OAuthGrantAccessDeniedError,
+)
+from jentic_one.auth.services.oauth_grant_service import OAuthGrantService
+from jentic_one.auth.web.errors import service_error_handler
+from jentic_one.auth.web.routers import oauth_grants
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.pagination import Page
+from jentic_one.shared.web.deps import resolve_identity
+
+
+def _view(grant_id: str = "ocg_1") -> OAuthGrantView:
+    return OAuthGrantView(
+        id=grant_id,
+        oauth_client_id="oc_app",
+        client_name="MCP App",
+        client_origin="https://mcpapp.example.com",
+        user_id="usr_consenter",
+        agent_id="agt_1",
+        scopes=["apis:read"],
+        status="active",
+        created_at=datetime(2026, 8, 1, tzinfo=UTC),
+        revoked_at=None,
+        last_used_at=datetime(2026, 8, 2, tzinfo=UTC),
+    )
+
+
+def _identity() -> Identity:
+    return Identity(sub="usr_owner", email="owner@example.com")
+
+
+@pytest.fixture()
+def mock_grant_svc() -> MagicMock:
+    svc = MagicMock(spec=OAuthGrantService)
+    svc.list_grants_for_agent = AsyncMock(
+        return_value=Page(data=[_view()], has_more=False, next_cursor=None)
+    )
+    return svc
+
+
+@pytest.fixture()
+def client(mock_grant_svc: MagicMock) -> TestClient:
+    app = FastAPI()
+    app.include_router(oauth_grants.router)
+    app.add_exception_handler(AuthServiceError, service_error_handler)
+    app.dependency_overrides[oauth_grants.get_oauth_grant_service] = lambda: mock_grant_svc
+    app.state.ctx = MagicMock()
+    app.dependency_overrides[resolve_identity] = _identity
+    return TestClient(app)
+
+
+def test_list_returns_grant_shape(client: TestClient, mock_grant_svc: MagicMock) -> None:
+    resp = client.get("/agents/agt_1/oauth-grants")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["has_more"] is False
+    assert body["next_cursor"] is None
+    (item,) = body["data"]
+    assert item["id"] == "ocg_1"
+    assert item["oauth_client_id"] == "oc_app"
+    assert item["client_name"] == "MCP App"
+    assert item["client_origin"] == "https://mcpapp.example.com"
+    # G10: the consenting user is part of the wire contract.
+    assert item["user_id"] == "usr_consenter"
+    assert item["agent_id"] == "agt_1"
+    assert item["scopes"] == ["apis:read"]
+    assert item["status"] == "active"
+    assert item["last_used_at"] is not None
+
+
+def test_list_forwards_filters_and_identity(client: TestClient, mock_grant_svc: MagicMock) -> None:
+    resp = client.get("/agents/agt_1/oauth-grants?status=revoked&limit=5&cursor=abc")
+    assert resp.status_code == 200
+    kwargs = mock_grant_svc.list_grants_for_agent.call_args.kwargs
+    assert mock_grant_svc.list_grants_for_agent.call_args.args == ("agt_1",)
+    assert kwargs["status"] == "revoked"
+    assert kwargs["limit"] == 5
+    assert kwargs["cursor"] == "abc"
+    assert kwargs["identity"].sub == "usr_owner"
+
+
+def test_list_rejects_unknown_status(client: TestClient) -> None:
+    resp = client.get("/agents/agt_1/oauth-grants?status=bogus")
+    assert resp.status_code == 422
+
+
+def test_list_maps_access_denied_to_403(client: TestClient, mock_grant_svc: MagicMock) -> None:
+    mock_grant_svc.list_grants_for_agent = AsyncMock(
+        side_effect=OAuthGrantAccessDeniedError("agt_1")
+    )
+    resp = client.get("/agents/agt_1/oauth-grants")
+    assert resp.status_code == 403
+    assert resp.json()["type"] == "oauth_grant_access_denied"
+
+
+def test_list_maps_unknown_agent_to_404(client: TestClient, mock_grant_svc: MagicMock) -> None:
+    mock_grant_svc.list_grants_for_agent = AsyncMock(side_effect=ActorNotFoundError("agt_x"))
+    resp = client.get("/agents/agt_x/oauth-grants")
+    assert resp.status_code == 404
+    assert resp.json()["type"] == "actor_not_found"

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -5945,6 +5945,11 @@
             "title": "Agent Id",
             "type": "string"
           },
+          "can_revoke": {
+            "description": "Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. a read-only admin.",
+            "title": "Can Revoke",
+            "type": "boolean"
+          },
           "client_name": {
             "anyOf": [
               {
@@ -6039,7 +6044,8 @@
           "status",
           "created_at",
           "revoked_at",
-          "last_used_at"
+          "last_used_at",
+          "can_revoke"
         ],
         "title": "OAuthGrantAdminResponse",
         "type": "object"
@@ -6085,6 +6091,11 @@
             "title": "Agent Id",
             "type": "string"
           },
+          "can_revoke": {
+            "description": "Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. the agent's new owner after an ownership transfer, or a read-only admin.",
+            "title": "Can Revoke",
+            "type": "boolean"
+          },
           "client_name": {
             "anyOf": [
               {
@@ -6179,7 +6190,8 @@
           "status",
           "created_at",
           "revoked_at",
-          "last_used_at"
+          "last_used_at",
+          "can_revoke"
         ],
         "title": "OAuthGrantResponse",
         "type": "object"

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -5232,6 +5232,12 @@
             "title": "Active",
             "type": "boolean"
           },
+          "active_grant_count": {
+            "default": 0,
+            "description": "Number of active consent→agent grants for this client (§4.8 per-client grant count). Computed on the read endpoints (list/get); write-path responses report 0.",
+            "title": "Active Grant Count",
+            "type": "integer"
+          },
           "allowed_scopes": {
             "anyOf": [
               {
@@ -5658,6 +5664,12 @@
             "title": "Active",
             "type": "boolean"
           },
+          "active_grant_count": {
+            "default": 0,
+            "description": "Number of active consent→agent grants for this client (§4.8 per-client grant count). Computed on the read endpoints (list/get); write-path responses report 0.",
+            "title": "Active Grant Count",
+            "type": "integer"
+          },
           "allowed_scopes": {
             "anyOf": [
               {
@@ -5890,6 +5902,286 @@
           }
         },
         "title": "OAuthClientUpdateRequest",
+        "type": "object"
+      },
+      "OAuthGrantAdminListResponse": {
+        "description": "A paginated list of OAuth grants (admin cross-view).",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OAuthGrantAdminResponse"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "has_more": {
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "title": "OAuthGrantAdminListResponse",
+        "type": "object"
+      },
+      "OAuthGrantAdminResponse": {
+        "description": "One consent→agent grant in the admin cross-view.",
+        "properties": {
+          "agent_id": {
+            "description": "The agent this grant binds the client to.",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "client_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the registered client, if the row still exists.",
+            "title": "Client Name"
+          },
+          "client_origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Origin (scheme://host) of the client's first redirect URI — the 'authorized apps' display pattern.",
+            "title": "Client Origin"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "description": "Grant ID (ksuid, `ocg_` prefix).",
+            "title": "Id",
+            "type": "string"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last time the client obtained tokens under this grant (stamped at exchange/refresh, not per request).",
+            "title": "Last Used At"
+          },
+          "oauth_client_id": {
+            "description": "The client's public client_id — the same identifier stamped on tokens minted under this grant.",
+            "title": "Oauth Client Id",
+            "type": "string"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          },
+          "scopes": {
+            "description": "Scopes granted at consent (the D2 intersection).",
+            "items": {
+              "type": "string"
+            },
+            "title": "Scopes",
+            "type": "array"
+          },
+          "status": {
+            "description": "Grant lifecycle state: ``active`` or ``revoked``.",
+            "title": "Status",
+            "type": "string"
+          },
+          "user_id": {
+            "description": "The consenting user who approved this grant. Shown even after an agent ownership transfer: the grant stays with the original consenter (it is their consent, not the agent's).",
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "oauth_client_id",
+          "client_name",
+          "client_origin",
+          "user_id",
+          "agent_id",
+          "scopes",
+          "status",
+          "created_at",
+          "revoked_at",
+          "last_used_at"
+        ],
+        "title": "OAuthGrantAdminResponse",
+        "type": "object"
+      },
+      "OAuthGrantListResponse": {
+        "description": "A paginated list of OAuth grants.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OAuthGrantResponse"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "has_more": {
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "title": "OAuthGrantListResponse",
+        "type": "object"
+      },
+      "OAuthGrantResponse": {
+        "description": "One consent→agent grant in API responses.",
+        "properties": {
+          "agent_id": {
+            "description": "The agent this grant binds the client to.",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "client_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the registered client, if the row still exists.",
+            "title": "Client Name"
+          },
+          "client_origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Origin (scheme://host) of the client's first redirect URI — the 'authorized apps' display pattern.",
+            "title": "Client Origin"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "description": "Grant ID (ksuid, `ocg_` prefix).",
+            "title": "Id",
+            "type": "string"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last time the client obtained tokens under this grant (stamped at exchange/refresh, not per request).",
+            "title": "Last Used At"
+          },
+          "oauth_client_id": {
+            "description": "The client's public client_id — the same identifier stamped on tokens minted under this grant.",
+            "title": "Oauth Client Id",
+            "type": "string"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          },
+          "scopes": {
+            "description": "Scopes granted at consent (the D2 intersection).",
+            "items": {
+              "type": "string"
+            },
+            "title": "Scopes",
+            "type": "array"
+          },
+          "status": {
+            "description": "Grant lifecycle state: ``active`` or ``revoked``.",
+            "title": "Status",
+            "type": "string"
+          },
+          "user_id": {
+            "description": "The consenting user who approved this grant. Shown even after an agent ownership transfer: the grant stays with the original consenter (it is their consent, not the agent's).",
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "oauth_client_id",
+          "client_name",
+          "client_origin",
+          "user_id",
+          "agent_id",
+          "scopes",
+          "status",
+          "created_at",
+          "revoked_at",
+          "last_used_at"
+        ],
+        "title": "OAuthGrantResponse",
         "type": "object"
       },
       "OperationPreviewListResponse": {
@@ -13308,6 +13600,247 @@
         ]
       }
     },
+    "/admin/oauth-grants": {
+      "get": {
+        "description": "List consent→agent grants across all clients and agents (§4.8).\n\nThe admin cross-view over the grant registry: filter by client, agent,\nconsenting user, or status. Each item carries the client's display name\nand redirect-URI origin plus the consenting ``user_id`` — after an agent\nownership transfer the grant stays with the original consenter, so this\ncolumn is how an admin spots stranded grants.",
+        "operationId": "listOauthGrants",
+        "parameters": [
+          {
+            "description": "Filter by the client's public client_id.",
+            "in": "query",
+            "name": "client_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by the client's public client_id.",
+              "title": "Client Id"
+            }
+          },
+          {
+            "description": "Filter by bound agent.",
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by bound agent.",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "description": "Filter by consenting user.",
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by consenting user.",
+              "title": "User Id"
+            }
+          },
+          {
+            "description": "Filter by grant lifecycle state.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "active",
+                    "revoked"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by grant lifecycle state.",
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthGrantAdminListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request was malformed or failed a precondition.",
+                  "instance": "/example/path",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "bad_request"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Authentication is required or the bearer token is invalid.",
+                  "instance": "/example/path",
+                  "status": 401,
+                  "title": "Unauthorized",
+                  "type": "unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The authenticated principal lacks the required permission.",
+                  "instance": "/example/path",
+                  "status": 403,
+                  "title": "Forbidden",
+                  "type": "forbidden"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Request validation failed; see errors[] for details.",
+                  "errors": [
+                    {
+                      "detail": "Field 'name' must not be blank.",
+                      "pointer": "#/name"
+                    }
+                  ],
+                  "instance": "/example/path",
+                  "status": 422,
+                  "title": "Unprocessable Entity",
+                  "type": "validation_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "An unexpected error occurred.",
+                  "instance": "/example/path",
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "type": "server_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The database is temporarily unavailable; please retry.",
+                  "instance": "/example/path",
+                  "status": 503,
+                  "title": "Service Unavailable",
+                  "type": "database_unavailable"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List OAuth grants",
+        "tags": [
+          "OAuth"
+        ]
+      }
+    },
     "/agents": {
       "get": {
         "description": "List agents — scoped by identity via dynamic query scoping.",
@@ -14520,6 +15053,219 @@
           }
         ],
         "summary": "Update Agent Jwks",
+        "tags": [
+          "Agents"
+        ]
+      }
+    },
+    "/agents/{agent_id}/oauth-grants": {
+      "get": {
+        "description": "List OAuth consent grants binding clients to this agent (§4.8).\n\nThe \"Connected clients\" surface: every grant carries the client's display\nname and redirect-URI origin, the granted scopes, the consenting user,\nand created/last-used timestamps. Allowed for the agent's owner or an\nadmin — authorization is enforced in the service layer, mirroring the\n``:revoke`` semantics.",
+        "operationId": "listAgentOauthGrants",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by grant lifecycle state.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "active",
+                    "revoked"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by grant lifecycle state.",
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthGrantListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request was malformed or failed a precondition.",
+                  "instance": "/example/path",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "bad_request"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Authentication is required or the bearer token is invalid.",
+                  "instance": "/example/path",
+                  "status": 401,
+                  "title": "Unauthorized",
+                  "type": "unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The authenticated principal lacks the required permission.",
+                  "instance": "/example/path",
+                  "status": 403,
+                  "title": "Forbidden",
+                  "type": "forbidden"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The requested resource does not exist or is not visible to you.",
+                  "instance": "/example/path",
+                  "status": 404,
+                  "title": "Not Found",
+                  "type": "not_found"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Request validation failed; see errors[] for details.",
+                  "errors": [
+                    {
+                      "detail": "Field 'name' must not be blank.",
+                      "pointer": "#/name"
+                    }
+                  ],
+                  "instance": "/example/path",
+                  "status": 422,
+                  "title": "Unprocessable Entity",
+                  "type": "validation_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "An unexpected error occurred.",
+                  "instance": "/example/path",
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "type": "server_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The database is temporarily unavailable; please retry.",
+                  "instance": "/example/path",
+                  "status": 503,
+                  "title": "Service Unavailable",
+                  "type": "database_unavailable"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List agent OAuth grants",
         "tags": [
           "Agents"
         ]

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -7,6 +7,7 @@ import { workspaceHandlers } from '@/modules/workspace/mocks/handlers';
 import { credentialsHandlers, credentialsE2eHooks } from '@/shared/credentials/mocks/handlers';
 import { railEventsHandlers } from '@/shared/app/rail/mocks/handlers';
 import { monitorHandlers } from '@/modules/monitor/mocks/handlers';
+import { settingsHandlers } from '@/modules/settings/mocks/handlers';
 
 /**
  * Root MSW handler table.
@@ -167,6 +168,9 @@ export const handlers = [
 	...dashboardHandlers,
 	...workspaceHandlers,
 	...railEventsHandlers,
+	// Settings owns the admin OAuth-client registry (/admin/oauth-clients),
+	// including the phase-3a approval queue.
+	...settingsHandlers,
 	// Monitor owns the full observability surface (/executions, /jobs, /events
 	// + SSE, /audit). Several of these paths are ALSO mocked by the dashboard
 	// and the ambient Agent Rail for their own shell widgets; those modules

--- a/ui/src/modules/agents/__tests__/ConnectedClientsCard.test.tsx
+++ b/ui/src/modules/agents/__tests__/ConnectedClientsCard.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/__tests__/test-utils';
 import { setToken } from '@/shared/api';
 import { Toaster } from '@/shared/ui';
-import { resetAgentsStore } from '@/modules/agents/mocks/handlers';
+import { resetAgentsStore, seedOauthGrants } from '@/modules/agents/mocks/handlers';
 import { ConnectedClientsCard } from '@/modules/agents/components/detail/ConnectedClientsCard';
 
 function renderCard(props: { agentId: string; agentName: string }) {
@@ -82,6 +82,78 @@ describe('ConnectedClientsCard', () => {
 		// The grant leaves the active slice → empty state takes over.
 		expect(await screen.findByText('No connected clients')).toBeInTheDocument();
 		expect(await screen.findByText('Grant revoked')).toBeInTheDocument();
+	});
+
+	it('disables Revoke with an explanatory tooltip when the caller cannot revoke (G10)', async () => {
+		// Post-transfer shape: the current owner LISTS the grant but the server
+		// says they cannot revoke it (consenting user ≠ viewer, no write set).
+		seedOauthGrants([
+			{
+				id: 'ocg_stranded_1',
+				client_name: 'Stranded Client',
+				user_id: 'usr_departed_owner',
+				can_revoke: false,
+			},
+		]);
+		renderCard({ agentId: 'agnt_active_1', agentName: 'support-agent' });
+		await screen.findByText('Stranded Client');
+
+		// The consenter's own grant keeps its live Revoke button…
+		expect(screen.getByRole('button', { name: 'Revoke grant for Cursor' })).toBeEnabled();
+		// …while the stranded grant's button is disabled, not a 403 trap.
+		const disabled = screen.getByRole('button', {
+			name: 'Revoke grant for Stranded Client (not permitted)',
+		});
+		expect(disabled).toBeDisabled();
+		// The tooltip explains WHY (rendered visually hidden until hover/focus).
+		expect(screen.getByText(/Only the user who consented to this grant/)).toBeInTheDocument();
+	});
+
+	it('shows the server reason in the toast when a revoke 403s under the button', async () => {
+		// Belt-and-braces arm: `canRevoke` went stale between render and click
+		// (e.g. an ownership change mid-session) — the 403 toast must carry the
+		// server's problem-details reason, not a generic "failed".
+		const user = userEvent.setup();
+		const reason = 'Access denied to OAuth grant ocg_active_1.';
+		worker.use(
+			createErrorHandler('post', '/oauth-grants/:id\\:revoke', {
+				status: 403,
+				body: { detail: reason },
+			}),
+		);
+		renderCard({ agentId: 'agnt_active_1', agentName: 'support-agent' });
+		await screen.findByText('Cursor');
+
+		await user.click(screen.getByRole('button', { name: 'Revoke grant for Cursor' }));
+		const dialog = await screen.findByRole('dialog');
+		await user.click(within(dialog).getByRole('button', { name: 'Revoke' }));
+
+		expect(await screen.findByText('Not permitted to revoke this grant')).toBeInTheDocument();
+		expect(screen.getByText(reason)).toBeInTheDocument();
+	});
+
+	it('pages through Load more and marks the count badge open-ended until the tail loads', async () => {
+		// 51 extra actives + the seeded Cursor grant = 52 > one page (50).
+		seedOauthGrants(
+			Array.from({ length: 51 }, (_, i) => ({
+				id: `ocg_bulk_${i}`,
+				client_name: `Bulk Client ${i}`,
+			})),
+		);
+		const user = userEvent.setup();
+		renderCard({ agentId: 'agnt_active_1', agentName: 'support-agent' });
+		await screen.findByText('Cursor');
+
+		// First page: 50 rows loaded, more behind the cursor → "50+" badge.
+		expect(screen.getByText('50+')).toBeInTheDocument();
+		const loadMore = screen.getByRole('button', { name: 'Load more' });
+		await user.click(loadMore);
+
+		// Tail loaded: exact count, no "+", and the button withdraws.
+		expect(await screen.findByText('52')).toBeInTheDocument();
+		expect(screen.queryByText('50+')).not.toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
+		expect(screen.getByText('Bulk Client 50')).toBeInTheDocument();
 	});
 
 	it('shows an honest empty state when no client is connected', async () => {

--- a/ui/src/modules/agents/__tests__/ConnectedClientsCard.test.tsx
+++ b/ui/src/modules/agents/__tests__/ConnectedClientsCard.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { worker } from '@/mocks/browser';
+import {
+	renderWithProviders,
+	screen,
+	within,
+	userEvent,
+	checkA11y,
+	createErrorHandler,
+} from '@/__tests__/test-utils';
+import { setToken } from '@/shared/api';
+import { Toaster } from '@/shared/ui';
+import { resetAgentsStore } from '@/modules/agents/mocks/handlers';
+import { ConnectedClientsCard } from '@/modules/agents/components/detail/ConnectedClientsCard';
+
+function renderCard(props: { agentId: string; agentName: string }) {
+	return renderWithProviders(
+		<>
+			<ConnectedClientsCard {...props} />
+			<Toaster />
+		</>,
+	);
+}
+
+describe('ConnectedClientsCard', () => {
+	beforeEach(() => {
+		setToken('test-token');
+		resetAgentsStore();
+	});
+
+	it('lists active grants with client, scopes, consenting user, and timestamps', async () => {
+		// `ocg_active_1` (Cursor → agnt_active_1) is seeded active.
+		renderCard({ agentId: 'agnt_active_1', agentName: 'support-agent' });
+
+		expect(
+			await screen.findByRole('heading', { name: 'Connected clients' }),
+		).toBeInTheDocument();
+		expect(await screen.findByText('Cursor')).toBeInTheDocument();
+		// Redirect-URI origin (the "authorized apps" display pattern).
+		expect(screen.getByText('http://localhost:33418')).toBeInTheDocument();
+		// Granted scopes render as chips.
+		expect(screen.getByText('apis:read')).toBeInTheDocument();
+		expect(screen.getByText('capabilities:execute')).toBeInTheDocument();
+		// G10: WHO consented is shown (usr_admin_1 resolves via the actor directory).
+		expect(await screen.findByText('Admin User')).toBeInTheDocument();
+		expect(screen.getByText(/last used/)).toBeInTheDocument();
+		// The revoked history row is not in the default (active) view.
+		expect(screen.queryByText('Old Integration')).not.toBeInTheDocument();
+	});
+
+	it('reveals revoked history via the status filter, with a status badge', async () => {
+		const user = userEvent.setup();
+		renderCard({ agentId: 'agnt_active_1', agentName: 'support-agent' });
+		await screen.findByText('Cursor');
+
+		await user.click(screen.getByRole('button', { name: 'Revoked' }));
+		const row = (await screen.findByText('Old Integration')).closest('li');
+		expect(row).not.toBeNull();
+		// The status badge on the row (distinct from the "Revoked" filter button).
+		expect(within(row as HTMLElement).getByText('Revoked')).toBeInTheDocument();
+		// G10 made visible: the revoked grant belonged to a since-departed owner,
+		// whose raw id renders because the directory cannot resolve it.
+		expect(screen.getByText('usr_departed_owner')).toBeInTheDocument();
+		// Revoked rows offer no revoke button.
+		expect(screen.queryByRole('button', { name: /Revoke grant/ })).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: 'All' }));
+		expect(await screen.findByText('Cursor')).toBeInTheDocument();
+		expect(screen.getByText('Old Integration')).toBeInTheDocument();
+	});
+
+	it('revokes a grant through the confirm dialog and drops the row', async () => {
+		const user = userEvent.setup();
+		renderCard({ agentId: 'agnt_active_1', agentName: 'support-agent' });
+		await screen.findByText('Cursor');
+
+		await user.click(screen.getByRole('button', { name: 'Revoke grant for Cursor' }));
+		const dialog = await screen.findByRole('dialog');
+		expect(within(dialog).getByText(/every token issued under this grant/)).toBeInTheDocument();
+		await user.click(within(dialog).getByRole('button', { name: 'Revoke' }));
+
+		// The grant leaves the active slice → empty state takes over.
+		expect(await screen.findByText('No connected clients')).toBeInTheDocument();
+		expect(await screen.findByText('Grant revoked')).toBeInTheDocument();
+	});
+
+	it('shows an honest empty state when no client is connected', async () => {
+		// `agnt_disabled_1` has no seeded grants.
+		renderCard({ agentId: 'agnt_disabled_1', agentName: 'legacy-scraper' });
+		expect(await screen.findByText('No connected clients')).toBeInTheDocument();
+		expect(
+			screen.getByText(/No OAuth client currently holds a grant on legacy-scraper/),
+		).toBeInTheDocument();
+	});
+
+	it('renders a quiet owner-or-admin note on 403 instead of a hard error', async () => {
+		worker.use(
+			createErrorHandler('get', '/agents/:id/oauth-grants', {
+				status: 403,
+				body: { detail: 'Not permitted' },
+			}),
+		);
+		renderCard({ agentId: 'agnt_active_1', agentName: 'support-agent' });
+		expect(
+			await screen.findByText(
+				"Only the agent's owner or an admin can view its connected clients.",
+			),
+		).toBeInTheDocument();
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+
+	it('surfaces an error alert when the list fails to load', async () => {
+		worker.use(createErrorHandler('get', '/agents/:id/oauth-grants', { status: 500 }));
+		renderCard({ agentId: 'agnt_active_1', agentName: 'support-agent' });
+		expect(await screen.findByRole('alert')).toBeInTheDocument();
+	});
+
+	it('has no critical a11y violations', async () => {
+		const { container } = renderCard({
+			agentId: 'agnt_active_1',
+			agentName: 'support-agent',
+		});
+		await screen.findByText('Cursor');
+		await checkA11y(container);
+	});
+});

--- a/ui/src/modules/agents/api/client.ts
+++ b/ui/src/modules/agents/api/client.ts
@@ -19,6 +19,7 @@ import {
 	ExecutionsService,
 	GroupBy,
 	MonitoringService,
+	OAuthService,
 	PermissionsService,
 	ServiceAccountsService,
 	SystemService,
@@ -26,6 +27,7 @@ import {
 	type AgentResponse,
 	type AuditResponse,
 	type EventResponse,
+	type OAuthGrantResponse,
 	type ServiceAccountResponse,
 } from '@/shared/api';
 import {
@@ -39,6 +41,7 @@ import {
 	type LinkableToolkit,
 	type McpLastSeen,
 	type McpSessionEntity,
+	type OAuthGrantEntity,
 	type PermissionCatalogEntry,
 	type ServiceAccountEntity,
 	type ToolkitBindingEntity,
@@ -925,5 +928,62 @@ export async function fetchInstanceIdentity(): Promise<InstanceIdentityEntity> {
 		};
 	} catch (error) {
 		throw toAgentsError(error, 'Failed to load the instance identity.');
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OAuth consent grants (phase-3a §4.8) — the "Connected clients" panel.
+// ---------------------------------------------------------------------------
+
+function grantToEntity(r: OAuthGrantResponse): OAuthGrantEntity {
+	return {
+		id: r.id,
+		oauthClientId: r.oauth_client_id,
+		clientName: r.client_name ?? null,
+		clientOrigin: r.client_origin ?? null,
+		userId: r.user_id,
+		agentId: r.agent_id,
+		scopes: r.scopes,
+		status: r.status,
+		createdAt: r.created_at,
+		revokedAt: r.revoked_at ?? null,
+		lastUsedAt: r.last_used_at ?? null,
+	};
+}
+
+/**
+ * The OAuth clients holding a consent→agent grant on this agent
+ * (`GET /agents/{id}/oauth-grants`, owner-or-admin). `status` narrows to
+ * active/revoked; null returns the full history.
+ */
+export async function listAgentOauthGrants(
+	agentId: string,
+	status: 'active' | 'revoked' | null = 'active',
+): Promise<ListResult<OAuthGrantEntity>> {
+	try {
+		const res = await AgentsService.listAgentOauthGrants({
+			agentId,
+			status,
+		});
+		return {
+			entities: res.data.map(grantToEntity),
+			hasMore: res.has_more,
+			nextCursor: res.next_cursor ?? null,
+		};
+	} catch (error) {
+		throw toAgentsError(error, "Failed to load the agent's connected clients.");
+	}
+}
+
+/**
+ * Revoke one consent→agent grant (`POST /oauth-grants/{id}:revoke`) — the
+ * per-grant kill switch (§4.6). The backend also revokes every access/refresh
+ * token minted under the grant; the client's next token use fails closed.
+ */
+export async function revokeOauthGrant(grantId: string): Promise<void> {
+	try {
+		await OAuthService.revokeOauthGrant({ grantId });
+	} catch (error) {
+		throw toAgentsError(error, 'Failed to revoke the grant.');
 	}
 }

--- a/ui/src/modules/agents/api/client.ts
+++ b/ui/src/modules/agents/api/client.ts
@@ -948,22 +948,27 @@ function grantToEntity(r: OAuthGrantResponse): OAuthGrantEntity {
 		createdAt: r.created_at,
 		revokedAt: r.revoked_at ?? null,
 		lastUsedAt: r.last_used_at ?? null,
+		canRevoke: r.can_revoke,
 	};
 }
 
 /**
  * The OAuth clients holding a consent→agent grant on this agent
  * (`GET /agents/{id}/oauth-grants`, owner-or-admin). `status` narrows to
- * active/revoked; null returns the full history.
+ * active/revoked; null returns the full history. Cursor-paginated like the
+ * other list reads (`listAgents`): callers page through `nextCursor`.
  */
 export async function listAgentOauthGrants(
 	agentId: string,
 	status: 'active' | 'revoked' | null = 'active',
+	params: { cursor?: string | null; limit?: number } = {},
 ): Promise<ListResult<OAuthGrantEntity>> {
 	try {
 		const res = await AgentsService.listAgentOauthGrants({
 			agentId,
 			status,
+			cursor: params.cursor ?? null,
+			limit: params.limit ?? 50,
 		});
 		return {
 			entities: res.data.map(grantToEntity),

--- a/ui/src/modules/agents/api/hooks.ts
+++ b/ui/src/modules/agents/api/hooks.ts
@@ -62,6 +62,8 @@ import {
 	fetchMcpLastSeenByActor,
 	fetchMcpSessions,
 	listActorAudit,
+	listAgentOauthGrants,
+	revokeOauthGrant,
 	type ActorAuditEntry,
 	type ActorUsage,
 	type ActorUsageDetail,
@@ -77,6 +79,7 @@ import type {
 	LinkableToolkit,
 	McpLastSeen,
 	McpSessionEntity,
+	OAuthGrantEntity,
 	PermissionCatalogEntry,
 	ServiceAccountEntity,
 	ToolkitBindingEntity,
@@ -167,6 +170,20 @@ export const actorAccessRequestsKey = (actorId: string, status: string) =>
  */
 export const actorAccessRequestsRootKey = (actorId: string) =>
 	['access-requests', 'by-actor', actorId] as const;
+
+/**
+ * OAuth consent grants binding clients to one agent (phase-3a §4.8), keyed by
+ * agent + status slice under the shared `oauthGrantsRoot`: grant creation
+ * happens out-of-band (a consent screen in another tab) and lands as an
+ * `oauth_grant.created` SSE event, which the shared agent-stream provider
+ * bridges into an invalidation of that root — so the slice must live under it.
+ */
+export const agentOauthGrantsKey = (agentId: string, status: string) =>
+	[...sharedQueryKeys.oauthGrantsRoot, 'by-agent', agentId, status] as const;
+
+/** Prefix key covering every status slice of one agent's grants. */
+export const agentOauthGrantsRootKey = (agentId: string) =>
+	[...sharedQueryKeys.oauthGrantsRoot, 'by-agent', agentId] as const;
 
 function notifyError(error: unknown, fallback: string): void {
 	toast({
@@ -752,6 +769,42 @@ export function useActorAccessRequests(actorId: string | null, status: string | 
 		queryKey: actorAccessRequestsKey(actorId ?? '', status ?? 'all'),
 		queryFn: () => fetchActorAccessRequests(actorId as string, status),
 		enabled: actorId != null,
+	});
+}
+
+/**
+ * The OAuth clients holding a consent→agent grant on this agent — the detail
+ * console's "Connected clients" panel (phase-3a §4.8). Owner-or-admin on the
+ * backend; a 403 surfaces as an error the card renders honestly.
+ */
+export function useAgentOauthGrants(
+	agentId: string | null,
+	status: 'active' | 'revoked' | null = 'active',
+) {
+	return useQuery<ListResult<OAuthGrantEntity>>({
+		queryKey: agentOauthGrantsKey(agentId ?? '', status ?? 'all'),
+		queryFn: () => listAgentOauthGrants(agentId as string, status),
+		enabled: agentId != null,
+	});
+}
+
+/**
+ * Revoke a consent→agent grant (§4.6 kill switch). Invalidates every status
+ * slice of the agent's grants (the row moves active→revoked) plus the shared
+ * oauth-clients root, whose rows carry a per-client active-grant count.
+ */
+export function useRevokeOauthGrant(agentId: string | null) {
+	const qc = useQueryClient();
+	return useMutation<void, Error, string>({
+		mutationFn: (grantId: string) => revokeOauthGrant(grantId),
+		onSuccess: () => {
+			if (agentId) {
+				void qc.invalidateQueries({ queryKey: agentOauthGrantsRootKey(agentId) });
+			}
+			void qc.invalidateQueries({ queryKey: sharedQueryKeys.oauthClientsRoot });
+			toast({ title: 'Grant revoked', variant: 'success' });
+		},
+		onError: (e) => notifyError(e, 'Failed to revoke the grant.'),
 	});
 }
 

--- a/ui/src/modules/agents/api/hooks.ts
+++ b/ui/src/modules/agents/api/hooks.ts
@@ -64,6 +64,7 @@ import {
 	listActorAudit,
 	listAgentOauthGrants,
 	revokeOauthGrant,
+	AgentsApiError,
 	type ActorAuditEntry,
 	type ActorUsage,
 	type ActorUsageDetail,
@@ -776,14 +777,23 @@ export function useActorAccessRequests(actorId: string | null, status: string | 
  * The OAuth clients holding a consent→agent grant on this agent — the detail
  * console's "Connected clients" panel (phase-3a §4.8). Owner-or-admin on the
  * backend; a 403 surfaces as an error the card renders honestly.
+ *
+ * Cursor-paginated like {@link useAgents}: the first page renders
+ * immediately and the card offers "Load more" through `next_cursor`, so an
+ * agent with more than one page of grants (default 50) is fully reachable.
  */
 export function useAgentOauthGrants(
 	agentId: string | null,
 	status: 'active' | 'revoked' | null = 'active',
 ) {
-	return useQuery<ListResult<OAuthGrantEntity>>({
+	return useInfiniteQuery<ListResult<OAuthGrantEntity>>({
 		queryKey: agentOauthGrantsKey(agentId ?? '', status ?? 'all'),
-		queryFn: () => listAgentOauthGrants(agentId as string, status),
+		queryFn: ({ pageParam }) =>
+			listAgentOauthGrants(agentId as string, status, {
+				cursor: (pageParam as string | null) ?? null,
+			}),
+		initialPageParam: null,
+		getNextPageParam: (last) => (last.hasMore ? last.nextCursor : null),
 		enabled: agentId != null,
 	});
 }
@@ -792,6 +802,12 @@ export function useAgentOauthGrants(
  * Revoke a consent→agent grant (§4.6 kill switch). Invalidates every status
  * slice of the agent's grants (the row moves active→revoked) plus the shared
  * oauth-clients root, whose rows carry a per-client active-grant count.
+ *
+ * A 403 gets an HONEST toast: the server's reason (the revoke predicate is
+ * the grant's consenting user or a write-set admin — narrower than the list
+ * predicate, G10) rather than a generic "failed". The card already disables
+ * the button on `canRevoke=false`, so this is the belt-and-braces arm for a
+ * capability that went stale between render and click.
  */
 export function useRevokeOauthGrant(agentId: string | null) {
 	const qc = useQueryClient();
@@ -804,7 +820,19 @@ export function useRevokeOauthGrant(agentId: string | null) {
 			void qc.invalidateQueries({ queryKey: sharedQueryKeys.oauthClientsRoot });
 			toast({ title: 'Grant revoked', variant: 'success' });
 		},
-		onError: (e) => notifyError(e, 'Failed to revoke the grant.'),
+		onError: (e) => {
+			if (e instanceof AgentsApiError && e.status === 403) {
+				toast({
+					title: 'Not permitted to revoke this grant',
+					// The server's problem-details reason, carried through the
+					// repository's error normalisation.
+					description: e.message,
+					variant: 'error',
+				});
+				return;
+			}
+			notifyError(e, 'Failed to revoke the grant.');
+		},
 	});
 }
 

--- a/ui/src/modules/agents/api/index.ts
+++ b/ui/src/modules/agents/api/index.ts
@@ -37,6 +37,8 @@ export {
 	useServiceAccountScopes,
 	useReplaceServiceAccountScopes,
 	useActorAccessRequests,
+	useAgentOauthGrants,
+	useRevokeOauthGrant,
 	useActorsUsage,
 	useActorUsageDetail,
 	useActorExecutions,
@@ -48,6 +50,8 @@ export {
 	useInstanceIdentity,
 	actorAccessRequestsKey,
 	actorAccessRequestsRootKey,
+	agentOauthGrantsKey,
+	agentOauthGrantsRootKey,
 } from '@/modules/agents/api/hooks';
 
 export { AgentsApiError } from '@/modules/agents/api/client';
@@ -83,6 +87,7 @@ export type {
 	LinkableToolkit,
 	McpLastSeen,
 	McpSessionEntity,
+	OAuthGrantEntity,
 	PermissionCatalogEntry,
 	ServiceAccountEntity,
 	ToolkitBindingEntity,

--- a/ui/src/modules/agents/api/types.ts
+++ b/ui/src/modules/agents/api/types.ts
@@ -261,7 +261,12 @@ export interface InstanceIdentityEntity {
  * One consent→agent grant (`GET /agents/{id}/oauth-grants`). `userId` is the
  * CONSENTING user, surfaced deliberately: after an agent ownership transfer
  * the grant stays with the original consenter (gap G10), so the panel must
- * show who holds it, not assume the current owner does.
+ * show who holds it, not assume the current owner does. `canRevoke` is the
+ * server-computed revoke capability for the CALLER — the revoke predicate
+ * (consenting user or write-set admin) deliberately diverges from the list
+ * predicate (agent's current owner or read-set admin), so a viewer may see a
+ * grant they cannot revoke; the card disables the button instead of offering
+ * an action that would 403.
  */
 export interface OAuthGrantEntity {
 	id: string;
@@ -275,4 +280,5 @@ export interface OAuthGrantEntity {
 	createdAt: string;
 	revokedAt: string | null;
 	lastUsedAt: string | null;
+	canRevoke: boolean;
 }

--- a/ui/src/modules/agents/api/types.ts
+++ b/ui/src/modules/agents/api/types.ts
@@ -251,3 +251,28 @@ export interface InstanceIdentityEntity {
 	baseUrl: string;
 	host: string;
 }
+
+// ---------------------------------------------------------------------------
+// OAuth consent grants (phase-3a §4.8) — the detail console's "Connected
+// clients" panel: which OAuth clients hold a live consent→agent grant.
+// ---------------------------------------------------------------------------
+
+/**
+ * One consent→agent grant (`GET /agents/{id}/oauth-grants`). `userId` is the
+ * CONSENTING user, surfaced deliberately: after an agent ownership transfer
+ * the grant stays with the original consenter (gap G10), so the panel must
+ * show who holds it, not assume the current owner does.
+ */
+export interface OAuthGrantEntity {
+	id: string;
+	oauthClientId: string;
+	clientName: string | null;
+	clientOrigin: string | null;
+	userId: string;
+	agentId: string;
+	scopes: string[];
+	status: string;
+	createdAt: string;
+	revokedAt: string | null;
+	lastUsedAt: string | null;
+}

--- a/ui/src/modules/agents/components/detail/ConnectedClientsCard.tsx
+++ b/ui/src/modules/agents/components/detail/ConnectedClientsCard.tsx
@@ -1,0 +1,195 @@
+/**
+ * ConnectedClientsCard — the OAuth clients holding a live consent→agent grant
+ * on THIS agent (phase-3a §4.8): the loud-attachment counter made visible
+ * per-agent, in the GitHub/Google "authorized apps" grammar.
+ *
+ * Each row shows the client (name + redirect-URI origin), the granted scopes,
+ * WHO consented (`userId` via `ActorLabel` — deliberately surfaced: after an
+ * agent ownership transfer the grant stays with the original consenter, gap
+ * G10, so admins can spot stranded grants), created / last-used timestamps,
+ * and the per-grant Revoke kill switch (§4.6). A status filter mirrors the
+ * access-requests card so revoked history is reachable on demand.
+ *
+ * Listing is owner-or-admin on the backend; a 403 renders as an honest quiet
+ * note (a non-owner operator can see the agent but not its grants), never a
+ * hard error surface.
+ */
+import { useState } from 'react';
+import { Plug2, ShieldOff } from 'lucide-react';
+import {
+	ActorLabel,
+	Badge,
+	Button,
+	DetailSection,
+	Dialog,
+	EmptyState,
+	ErrorAlert,
+	LoadingState,
+	SegmentedToggle,
+	type SegmentedToggleOption,
+} from '@/shared/ui';
+import { timeAgo } from '@/shared/lib/utils';
+import {
+	useAgentOauthGrants,
+	useRevokeOauthGrant,
+	AgentsApiError,
+	type OAuthGrantEntity,
+} from '@/modules/agents/api';
+
+type StatusFilter = 'active' | 'revoked' | 'all';
+
+const STATUS_OPTIONS: SegmentedToggleOption<StatusFilter>[] = [
+	{ value: 'active', label: 'Active' },
+	{ value: 'revoked', label: 'Revoked' },
+	{ value: 'all', label: 'All' },
+];
+
+/** "clientName (origin)" with honest fallbacks for a since-deleted client row. */
+function clientLabel(grant: OAuthGrantEntity): string {
+	return grant.clientName ?? grant.oauthClientId;
+}
+
+export function ConnectedClientsCard({
+	agentId,
+	agentName,
+}: {
+	agentId: string;
+	agentName: string;
+}) {
+	const [status, setStatus] = useState<StatusFilter>('active');
+	const queryStatus = status === 'all' ? null : status;
+	const { data, isPending, isError, error } = useAgentOauthGrants(agentId, queryStatus);
+	const revoke = useRevokeOauthGrant(agentId);
+	const [revokeTarget, setRevokeTarget] = useState<OAuthGrantEntity | null>(null);
+
+	const grants = data?.entities;
+	const forbidden = error instanceof AgentsApiError && error.status === 403;
+
+	return (
+		<>
+			<DetailSection
+				title="Connected clients"
+				icon={<Plug2 className="h-4 w-4" />}
+				titleExtra={
+					grants && grants.length > 0 ? (
+						<Badge variant="default">{grants.length}</Badge>
+					) : null
+				}
+				bodyClassName="space-y-3"
+			>
+				<SegmentedToggle options={STATUS_OPTIONS} value={status} onChange={setStatus} />
+
+				{isPending ? (
+					<LoadingState size="sm" />
+				) : forbidden ? (
+					<p className="text-muted-foreground text-sm">
+						Only the agent's owner or an admin can view its connected clients.
+					</p>
+				) : isError ? (
+					<ErrorAlert
+						message={
+							error instanceof Error
+								? error.message
+								: "Failed to load this agent's connected clients."
+						}
+					/>
+				) : !grants || grants.length === 0 ? (
+					<EmptyState
+						icon={<Plug2 className="h-8 w-8" aria-hidden="true" />}
+						title={status === 'active' ? 'No connected clients' : 'No matching grants'}
+						description={
+							status === 'active'
+								? `No OAuth client currently holds a grant on ${agentName}. Clients appear here after a user consents to connect one.`
+								: `${agentName} has no grants matching this filter.`
+						}
+					/>
+				) : (
+					<ul className="divide-border divide-y">
+						{grants.map((grant) => (
+							<li
+								key={grant.id}
+								className="flex flex-wrap items-start justify-between gap-3 py-3"
+							>
+								<div className="min-w-0 flex-1">
+									<p className="text-foreground flex flex-wrap items-center gap-2 font-medium">
+										<span className="truncate">{clientLabel(grant)}</span>
+										{grant.status === 'revoked' && (
+											<Badge variant="danger">Revoked</Badge>
+										)}
+									</p>
+									{grant.clientOrigin && (
+										<p className="text-muted-foreground truncate font-mono text-xs">
+											{grant.clientOrigin}
+										</p>
+									)}
+									<div className="mt-1.5 flex flex-wrap gap-1">
+										{grant.scopes.length > 0 ? (
+											grant.scopes.map((scope) => (
+												<Badge key={scope} variant="default">
+													{scope}
+												</Badge>
+											))
+										) : (
+											<span className="text-muted-foreground text-xs">
+												No scopes granted
+											</span>
+										)}
+									</div>
+									<p className="text-muted-foreground mt-1.5 text-xs">
+										Consented by <ActorLabel actorId={grant.userId} /> · granted{' '}
+										{timeAgo(grant.createdAt)} · last used{' '}
+										{grant.lastUsedAt ? timeAgo(grant.lastUsedAt) : 'never'}
+									</p>
+								</div>
+								{grant.status === 'active' && (
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={(): void => setRevokeTarget(grant)}
+										disabled={revoke.isPending}
+										aria-label={`Revoke grant for ${clientLabel(grant)}`}
+									>
+										<ShieldOff className="h-4 w-4" />
+										Revoke
+									</Button>
+								)}
+							</li>
+						))}
+					</ul>
+				)}
+			</DetailSection>
+
+			{revokeTarget != null && (
+				<Dialog
+					open
+					onClose={(): void => setRevokeTarget(null)}
+					title="Revoke this grant?"
+					footer={
+						<>
+							<Button variant="outline" onClick={(): void => setRevokeTarget(null)}>
+								Cancel
+							</Button>
+							<Button
+								variant="danger"
+								disabled={revoke.isPending}
+								onClick={(): void => {
+									revoke.mutate(revokeTarget.id, {
+										onSuccess: () => setRevokeTarget(null),
+									});
+								}}
+							>
+								{revoke.isPending ? 'Revoking...' : 'Revoke'}
+							</Button>
+						</>
+					}
+				>
+					<p className="text-muted-foreground">
+						<strong>{clientLabel(revokeTarget)}</strong> will immediately lose access to{' '}
+						<strong>{agentName}</strong>: every token issued under this grant is
+						revoked. The client must go through consent again to reconnect.
+					</p>
+				</Dialog>
+			)}
+		</>
+	);
+}

--- a/ui/src/modules/agents/components/detail/ConnectedClientsCard.tsx
+++ b/ui/src/modules/agents/components/detail/ConnectedClientsCard.tsx
@@ -7,8 +7,14 @@
  * WHO consented (`userId` via `ActorLabel` — deliberately surfaced: after an
  * agent ownership transfer the grant stays with the original consenter, gap
  * G10, so admins can spot stranded grants), created / last-used timestamps,
- * and the per-grant Revoke kill switch (§4.6). A status filter mirrors the
- * access-requests card so revoked history is reachable on demand.
+ * and the per-grant Revoke kill switch (§4.6). Revoke honours the server's
+ * per-item `canRevoke` capability: the revoke predicate (consenting user or
+ * write-set admin) is deliberately NARROWER than the list predicate (agent's
+ * current owner or read-set admin — the G10 divergence), so a viewer who can
+ * see a grant may not be able to revoke it; the button disables with an
+ * explanatory tooltip instead of offering a 403. A status filter mirrors the
+ * access-requests card so revoked history is reachable on demand, and the
+ * list pages through `next_cursor` behind "Load more" like the roster.
  *
  * Listing is owner-or-admin on the backend; a 403 renders as an honest quiet
  * note (a non-owner operator can see the agent but not its grants), never a
@@ -26,6 +32,7 @@ import {
 	ErrorAlert,
 	LoadingState,
 	SegmentedToggle,
+	Tooltip,
 	type SegmentedToggleOption,
 } from '@/shared/ui';
 import { timeAgo } from '@/shared/lib/utils';
@@ -49,6 +56,10 @@ function clientLabel(grant: OAuthGrantEntity): string {
 	return grant.clientName ?? grant.oauthClientId;
 }
 
+/** Why the Revoke button is disabled — the G10 list/revoke divergence, in words. */
+const CANNOT_REVOKE_REASON =
+	'Only the user who consented to this grant, or an admin with the OAuth-clients write permission, can revoke it.';
+
 export function ConnectedClientsCard({
 	agentId,
 	agentName,
@@ -58,11 +69,12 @@ export function ConnectedClientsCard({
 }) {
 	const [status, setStatus] = useState<StatusFilter>('active');
 	const queryStatus = status === 'all' ? null : status;
-	const { data, isPending, isError, error } = useAgentOauthGrants(agentId, queryStatus);
+	const query = useAgentOauthGrants(agentId, queryStatus);
+	const { isPending, isError, error, hasNextPage, isFetchingNextPage } = query;
 	const revoke = useRevokeOauthGrant(agentId);
 	const [revokeTarget, setRevokeTarget] = useState<OAuthGrantEntity | null>(null);
 
-	const grants = data?.entities;
+	const grants = query.data?.pages.flatMap((p) => p.entities);
 	const forbidden = error instanceof AgentsApiError && error.status === 403;
 
 	return (
@@ -72,7 +84,12 @@ export function ConnectedClientsCard({
 				icon={<Plug2 className="h-4 w-4" />}
 				titleExtra={
 					grants && grants.length > 0 ? (
-						<Badge variant="default">{grants.length}</Badge>
+						// No cheap server-side total exists, so the badge counts
+						// the LOADED rows and marks an unloaded tail "50+"-style.
+						<Badge variant="default">
+							{grants.length}
+							{hasNextPage ? '+' : ''}
+						</Badge>
 					) : null
 				}
 				bodyClassName="space-y-3"
@@ -104,58 +121,88 @@ export function ConnectedClientsCard({
 						}
 					/>
 				) : (
-					<ul className="divide-border divide-y">
-						{grants.map((grant) => (
-							<li
-								key={grant.id}
-								className="flex flex-wrap items-start justify-between gap-3 py-3"
-							>
-								<div className="min-w-0 flex-1">
-									<p className="text-foreground flex flex-wrap items-center gap-2 font-medium">
-										<span className="truncate">{clientLabel(grant)}</span>
-										{grant.status === 'revoked' && (
-											<Badge variant="danger">Revoked</Badge>
-										)}
-									</p>
-									{grant.clientOrigin && (
-										<p className="text-muted-foreground truncate font-mono text-xs">
-											{grant.clientOrigin}
+					<>
+						<ul className="divide-border divide-y">
+							{grants.map((grant) => (
+								<li
+									key={grant.id}
+									className="flex flex-wrap items-start justify-between gap-3 py-3"
+								>
+									<div className="min-w-0 flex-1">
+										<p className="text-foreground flex flex-wrap items-center gap-2 font-medium">
+											<span className="truncate">{clientLabel(grant)}</span>
+											{grant.status === 'revoked' && (
+												<Badge variant="danger">Revoked</Badge>
+											)}
 										</p>
-									)}
-									<div className="mt-1.5 flex flex-wrap gap-1">
-										{grant.scopes.length > 0 ? (
-											grant.scopes.map((scope) => (
-												<Badge key={scope} variant="default">
-													{scope}
-												</Badge>
-											))
-										) : (
-											<span className="text-muted-foreground text-xs">
-												No scopes granted
-											</span>
+										{grant.clientOrigin && (
+											<p className="text-muted-foreground truncate font-mono text-xs">
+												{grant.clientOrigin}
+											</p>
 										)}
+										<div className="mt-1.5 flex flex-wrap gap-1">
+											{grant.scopes.length > 0 ? (
+												grant.scopes.map((scope) => (
+													<Badge key={scope} variant="default">
+														{scope}
+													</Badge>
+												))
+											) : (
+												<span className="text-muted-foreground text-xs">
+													No scopes granted
+												</span>
+											)}
+										</div>
+										<p className="text-muted-foreground mt-1.5 text-xs">
+											Consented by <ActorLabel actorId={grant.userId} /> ·
+											granted {timeAgo(grant.createdAt)} · last used{' '}
+											{grant.lastUsedAt ? timeAgo(grant.lastUsedAt) : 'never'}
+										</p>
 									</div>
-									<p className="text-muted-foreground mt-1.5 text-xs">
-										Consented by <ActorLabel actorId={grant.userId} /> · granted{' '}
-										{timeAgo(grant.createdAt)} · last used{' '}
-										{grant.lastUsedAt ? timeAgo(grant.lastUsedAt) : 'never'}
-									</p>
-								</div>
-								{grant.status === 'active' && (
-									<Button
-										variant="outline"
-										size="sm"
-										onClick={(): void => setRevokeTarget(grant)}
-										disabled={revoke.isPending}
-										aria-label={`Revoke grant for ${clientLabel(grant)}`}
-									>
-										<ShieldOff className="h-4 w-4" />
-										Revoke
-									</Button>
-								)}
-							</li>
-						))}
-					</ul>
+									{grant.status === 'active' &&
+										(grant.canRevoke ? (
+											<Button
+												variant="outline"
+												size="sm"
+												onClick={(): void => setRevokeTarget(grant)}
+												disabled={revoke.isPending}
+												aria-label={`Revoke grant for ${clientLabel(grant)}`}
+											>
+												<ShieldOff className="h-4 w-4" />
+												Revoke
+											</Button>
+										) : (
+											// The server says the CALLER can't revoke this
+											// grant (G10: not the consenter, not a write-set
+											// admin) — disable rather than offer a 403.
+											<Tooltip content={CANNOT_REVOKE_REASON}>
+												<Button
+													variant="outline"
+													size="sm"
+													disabled
+													aria-label={`Revoke grant for ${clientLabel(grant)} (not permitted)`}
+												>
+													<ShieldOff className="h-4 w-4" />
+													Revoke
+												</Button>
+											</Tooltip>
+										))}
+								</li>
+							))}
+						</ul>
+						{hasNextPage && (
+							<div className="flex justify-center">
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={(): void => void query.fetchNextPage()}
+									disabled={isFetchingNextPage}
+								>
+									{isFetchingNextPage ? 'Loading…' : 'Load more'}
+								</Button>
+							</div>
+						)}
+					</>
 				)}
 			</DetailSection>
 

--- a/ui/src/modules/agents/mocks/handlers.ts
+++ b/ui/src/modules/agents/mocks/handlers.ts
@@ -97,6 +97,24 @@ let serviceAccounts: ServiceAccountRow[] = [];
 /** Per-actor granted scopes, keyed by actor id (agents + service accounts). */
 let actorScopes: Record<string, string[]> = {};
 
+/** One consent→agent OAuth grant (`GET /agents/{id}/oauth-grants`, §4.8). */
+interface OAuthGrantRow {
+	id: string;
+	oauth_client_id: string;
+	client_name: string | null;
+	client_origin: string | null;
+	user_id: string;
+	agent_id: string;
+	scopes: string[];
+	status: 'active' | 'revoked';
+	created_at: string;
+	revoked_at: string | null;
+	last_used_at: string | null;
+}
+
+/** Consent→agent grants, mutated by the `:revoke` kill switch. */
+let oauthGrants: OAuthGrantRow[] = [];
+
 /**
  * The platform permission catalogue (`GET /permissions`).
  *
@@ -350,6 +368,38 @@ export function resetAgentsStore(): void {
 		],
 		sva_active_1: ['credentials:read'],
 	};
+	// OAuth consent grants (§4.8): `agnt_active_1` has one live connected
+	// client plus revoked history; the consenting user_id deliberately differs
+	// from ADMIN on the revoked row so the G10 "who consented" column is
+	// observable. Other actors have none (exercises the empty state).
+	oauthGrants = [
+		{
+			id: 'ocg_active_1',
+			oauth_client_id: 'oc_cursor_ide',
+			client_name: 'Cursor',
+			client_origin: 'http://localhost:33418',
+			user_id: 'usr_admin_1',
+			agent_id: 'agnt_active_1',
+			scopes: ['apis:read', 'capabilities:execute'],
+			status: 'active',
+			created_at: now(-45),
+			revoked_at: null,
+			last_used_at: now(-5),
+		},
+		{
+			id: 'ocg_revoked_1',
+			oauth_client_id: 'oc_old_tool',
+			client_name: 'Old Integration',
+			client_origin: 'https://old.example.com',
+			user_id: 'usr_departed_owner',
+			agent_id: 'agnt_active_1',
+			scopes: ['apis:read'],
+			status: 'revoked',
+			created_at: now(-600),
+			revoked_at: now(-300),
+			last_used_at: null,
+		},
+	];
 }
 
 resetAgentsStore();
@@ -1181,5 +1231,25 @@ export const agentsHandlers = [
 		}
 		actorScopes[row.id] = [...new Set(requested)];
 		return HttpResponse.json({ scopes: actorScopes[row.id] });
+	}),
+	// ---- OAuth consent grants (§4.8): the Connected-clients panel ----
+	http.get('/agents/:id/oauth-grants', ({ params, request }) => {
+		const agent = agents.find((a) => a.id === params.id);
+		if (!agent) return new HttpResponse(null, { status: 404 });
+		const status = new URL(request.url).searchParams.get('status');
+		const rows = oauthGrants.filter(
+			(g) => g.agent_id === params.id && (!status || g.status === status),
+		);
+		return HttpResponse.json({ data: rows, has_more: false, next_cursor: null });
+	}),
+	http.post('/oauth-grants/:id\\:revoke', ({ params }) => {
+		const grant = oauthGrants.find((g) => g.id === params.id);
+		if (!grant) return new HttpResponse(null, { status: 404 });
+		// Idempotent, like the backend: re-revoking is a 204 no-op.
+		if (grant.status === 'active') {
+			grant.status = 'revoked';
+			grant.revoked_at = now();
+		}
+		return new HttpResponse(null, { status: 204 });
 	}),
 ];

--- a/ui/src/modules/agents/mocks/handlers.ts
+++ b/ui/src/modules/agents/mocks/handlers.ts
@@ -110,6 +110,8 @@ interface OAuthGrantRow {
 	created_at: string;
 	revoked_at: string | null;
 	last_used_at: string | null;
+	/** Per-item revoke capability for the CALLER (G10 list/revoke divergence). */
+	can_revoke: boolean;
 }
 
 /** Consent→agent grants, mutated by the `:revoke` kill switch. */
@@ -385,6 +387,7 @@ export function resetAgentsStore(): void {
 			created_at: now(-45),
 			revoked_at: null,
 			last_used_at: now(-5),
+			can_revoke: true,
 		},
 		{
 			id: 'ocg_revoked_1',
@@ -398,8 +401,33 @@ export function resetAgentsStore(): void {
 			created_at: now(-600),
 			revoked_at: now(-300),
 			last_used_at: null,
+			can_revoke: false,
 		},
 	];
+}
+
+/**
+ * Test-only: append extra grant rows (e.g. to exercise the connected-clients
+ * pagination or a `can_revoke=false` disabled Revoke button). Resets with
+ * `resetAgentsStore()`.
+ */
+export function seedOauthGrants(rows: Array<Partial<OAuthGrantRow> & { id: string }>): void {
+	for (const over of rows) {
+		oauthGrants.push({
+			oauth_client_id: 'oc_seeded',
+			client_name: 'Seeded Client',
+			client_origin: 'https://seeded.example.com',
+			user_id: 'usr_admin_1',
+			agent_id: 'agnt_active_1',
+			scopes: ['apis:read'],
+			status: 'active',
+			created_at: now(-45),
+			revoked_at: null,
+			last_used_at: null,
+			can_revoke: true,
+			...over,
+		});
+	}
 }
 
 resetAgentsStore();
@@ -1236,11 +1264,22 @@ export const agentsHandlers = [
 	http.get('/agents/:id/oauth-grants', ({ params, request }) => {
 		const agent = agents.find((a) => a.id === params.id);
 		if (!agent) return new HttpResponse(null, { status: 404 });
-		const status = new URL(request.url).searchParams.get('status');
+		const url = new URL(request.url);
+		const status = url.searchParams.get('status');
 		const rows = oauthGrants.filter(
 			(g) => g.agent_id === params.id && (!status || g.status === status),
 		);
-		return HttpResponse.json({ data: rows, has_more: false, next_cursor: null });
+		// Index-based cursor pagination, like the sibling mock stores: the card
+		// pages through `next_cursor` behind "Load more".
+		const limit = Number(url.searchParams.get('limit') ?? 50);
+		const start = Number(url.searchParams.get('cursor') ?? 0);
+		const pageRows = rows.slice(start, start + limit);
+		const hasMore = start + limit < rows.length;
+		return HttpResponse.json({
+			data: pageRows,
+			has_more: hasMore,
+			next_cursor: hasMore ? String(start + limit) : null,
+		});
 	}),
 	http.post('/oauth-grants/:id\\:revoke', ({ params }) => {
 		const grant = oauthGrants.find((g) => g.id === params.id);

--- a/ui/src/modules/agents/pages/AgentDetailPage.tsx
+++ b/ui/src/modules/agents/pages/AgentDetailPage.tsx
@@ -69,6 +69,7 @@ import {
 import { ActorStatusBadge } from '@/modules/agents/components/ActorStatusBadge';
 import { ScopesCard } from '@/modules/agents/components/ScopesCard';
 import { ActorAccessRequestsCard } from '@/modules/agents/components/ActorAccessRequestsCard';
+import { ConnectedClientsCard } from '@/modules/agents/components/detail/ConnectedClientsCard';
 import {
 	LifecycleDialogs,
 	type PendingConfirm,
@@ -406,6 +407,8 @@ export default function AgentDetailPage() {
 						<ScopesCard actorKind="agent" actorId={agent.id} actorName={agent.name} />
 						{/* Pending access requests this agent has filed (#619). */}
 						<ActorAccessRequestsCard actorId={agent.id} actorName={agent.name} />
+						{/* OAuth clients holding a consent→agent grant (phase-3a §4.8). */}
+						<ConnectedClientsCard agentId={agent.id} agentName={agent.name} />
 					</>
 				)}
 

--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderWithProviders, screen, within, userEvent, checkA11y } from '@/__tests__/test-utils';
+import { setToken } from '@/shared/api';
+import { Toaster } from '@/shared/ui';
+import { resetSettingsStore } from '@/modules/settings/mocks/handlers';
+import { OAuthClientsSection } from '@/modules/settings/pages/OAuthClientsSection';
+
+function renderSection(route = '/settings') {
+	return renderWithProviders(
+		<>
+			<OAuthClientsSection />
+			<Toaster />
+		</>,
+		{ route },
+	);
+}
+
+describe('OAuthClientsSection', () => {
+	beforeEach(() => {
+		setToken('test-token');
+		resetSettingsStore();
+	});
+
+	it('lists clients with badges and the per-client active-grant count', async () => {
+		renderSection();
+
+		// The admin-registered confidential client, with its §4.8 grant count.
+		expect(await screen.findByText('Internal Dashboard')).toBeInTheDocument();
+		expect(screen.getByText('Active grants:')).toBeInTheDocument();
+		expect(screen.getByText('2')).toBeInTheDocument();
+		// Pending/denied rows are inactive → hidden from the default clients list.
+		expect(screen.queryByText('Sketchy Tool')).not.toBeInTheDocument();
+	});
+
+	it('carries the pending count on the Approval queue tab label', async () => {
+		renderSection();
+		// One seeded pending registration → the tab badge shows 1.
+		const tab = await screen.findByRole('tab', { name: /Approval queue/ });
+		expect(await within(tab).findByText('1')).toBeInTheDocument();
+	});
+
+	it('deep-links to the queue via ?tab=queue (the rail Review action)', async () => {
+		renderSection('/settings?tab=queue');
+		// The pending DCR registration renders with its badges (scoped to the
+		// row heading — "Pending" also names the queue's filter button).
+		const heading = await screen.findByText('Cursor');
+		const row = heading.closest('h3');
+		expect(row).not.toBeNull();
+		expect(within(row as HTMLElement).getByText('Public')).toBeInTheDocument();
+		expect(within(row as HTMLElement).getByText('DCR')).toBeInTheDocument();
+		expect(within(row as HTMLElement).getByText('Pending')).toBeInTheDocument();
+		expect(screen.getByText('com.cursor.ide')).toBeInTheDocument();
+	});
+
+	it('approves a pending registration and empties the queue (D7 pending→approved)', async () => {
+		const user = userEvent.setup();
+		renderSection('/settings?tab=queue');
+		await screen.findByText('Cursor');
+
+		await user.click(screen.getByRole('button', { name: 'Approve' }));
+
+		expect(await screen.findByText('Cursor approved')).toBeInTheDocument();
+		expect(await screen.findByText('No pending registrations')).toBeInTheDocument();
+
+		// The approved client now shows on the Clients tab, active.
+		await user.click(screen.getByRole('tab', { name: /Clients/ }));
+		expect(await screen.findByText('Cursor')).toBeInTheDocument();
+	});
+
+	it('denies a pending registration via the reason dialog (D7 pending→denied)', async () => {
+		const user = userEvent.setup();
+		renderSection('/settings?tab=queue');
+		await screen.findByText('Cursor');
+
+		await user.click(screen.getByRole('button', { name: 'Deny' }));
+		const dialog = await screen.findByRole('dialog');
+		await user.type(
+			within(dialog).getByLabelText('Reason (optional)'),
+			'unknown redirect URIs',
+		);
+		await user.click(within(dialog).getByRole('button', { name: 'Deny' }));
+
+		expect(await screen.findByText('Cursor denied')).toBeInTheDocument();
+		expect(await screen.findByText('No pending registrations')).toBeInTheDocument();
+	});
+
+	it('recovers a denied client: the Denied filter re-offers Approve (D7 denied→approved)', async () => {
+		const user = userEvent.setup();
+		renderSection('/settings?tab=queue');
+		await screen.findByText('Cursor');
+
+		// The seeded denied row lives under the Denied filter, without a Deny verb.
+		await user.click(screen.getByRole('button', { name: 'Denied' }));
+		expect(await screen.findByText('Sketchy Tool')).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Deny' })).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: 'Approve' }));
+		expect(await screen.findByText('Sketchy Tool approved')).toBeInTheDocument();
+		expect(await screen.findByText('No denied clients')).toBeInTheDocument();
+	});
+
+	it('has no critical a11y violations on the queue tab', async () => {
+		const { container } = renderSection('/settings?tab=queue');
+		await screen.findByText('Cursor');
+		await checkA11y(container);
+	});
+});

--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen, within, userEvent, checkA11y } from '@/__tests__/test-utils';
-import { setToken } from '@/shared/api';
+import { worker } from '@/mocks/browser';
+import { setToken, type EventResponse } from '@/shared/api';
 import { Toaster } from '@/shared/ui';
+import { AgentStreamProvider, useAgentStream } from '@/shared/lib/agentStream';
 import { resetSettingsStore } from '@/modules/settings/mocks/handlers';
 import { OAuthClientsSection } from '@/modules/settings/pages/OAuthClientsSection';
 
@@ -82,6 +85,73 @@ describe('OAuthClientsSection', () => {
 
 		expect(await screen.findByText('Cursor denied')).toBeInTheDocument();
 		expect(await screen.findByText('No pending registrations')).toBeInTheDocument();
+	});
+
+	it('settles the actionable rail row on deny success (the deny-arm settle mirror)', async () => {
+		// A deny emits no `oauth_client.*` SSE event (§4.8/D7) — the approve arm
+		// gets its rail settle from the `oauth_client.approved` event, so the
+		// deny mutation must mirror it locally via the stream context. Mount the
+		// section INSIDE the provider with the actionable registration in the
+		// backlog and watch the row acknowledge on deny success.
+		const registered: EventResponse = {
+			_links: { self: '/events/evt_oauth_registered' },
+			event_id: 'evt_oauth_registered',
+			type: 'oauth_client.registered',
+			severity: 'info' as EventResponse['severity'],
+			summary: 'OAuth client registered: Cursor',
+			requires_action: true,
+			acknowledged: false,
+			created_at: new Date().toISOString(),
+			// The internal admin-row id — the deny mutation's settle key.
+			data: { oauth_client_id: 'oac_pending_1' },
+		};
+		worker.use(
+			http.get('/events', () =>
+				HttpResponse.json({ data: [registered], has_more: false, next_cursor: null }),
+			),
+		);
+		function SettleProbe() {
+			const { events } = useAgentStream();
+			const row = events.find((e) => e.type === 'oauth_client.registered');
+			return <div data-testid="registered-acked">{row ? String(row.acknowledged) : ''}</div>;
+		}
+		const user = userEvent.setup();
+		renderWithProviders(
+			<AgentStreamProvider live={false}>
+				<OAuthClientsSection />
+				<Toaster />
+				<SettleProbe />
+			</AgentStreamProvider>,
+			{ route: '/settings?tab=queue' },
+		);
+		await screen.findByText('Cursor');
+		await expect.poll(() => screen.getByTestId('registered-acked').textContent).toBe('false');
+
+		await user.click(screen.getByRole('button', { name: 'Deny' }));
+		const dialog = await screen.findByRole('dialog');
+		await user.click(within(dialog).getByRole('button', { name: 'Deny' }));
+
+		expect(await screen.findByText('Cursor denied')).toBeInTheDocument();
+		// The mutation's onSuccess settled the stream row locally.
+		await expect.poll(() => screen.getByTestId('registered-acked').textContent).toBe('true');
+	});
+
+	it('keeps the deny reason draft across a casual dismiss (dialog-state rule)', async () => {
+		const user = userEvent.setup();
+		renderSection('/settings?tab=queue');
+		await screen.findByText('Cursor');
+
+		await user.click(screen.getByRole('button', { name: 'Deny' }));
+		let dialog = await screen.findByRole('dialog');
+		await user.type(within(dialog).getByLabelText('Reason (optional)'), 'half-typed thought');
+		await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+		// Reopen for the SAME client: the half-typed draft survived the dismiss.
+		await user.click(screen.getByRole('button', { name: 'Deny' }));
+		dialog = await screen.findByRole('dialog');
+		expect(within(dialog).getByLabelText('Reason (optional)')).toHaveValue(
+			'half-typed thought',
+		);
 	});
 
 	it('recovers a denied client: the Denied filter re-offers Approve (D7 denied→approved)', async () => {

--- a/ui/src/modules/settings/api/hooks.ts
+++ b/ui/src/modules/settings/api/hooks.ts
@@ -13,6 +13,7 @@ import {
 	type OAuthClientUpdateRequest,
 	type PermissionResponse,
 } from '@/shared/api';
+import { useAgentStreamOptional } from '@/shared/lib';
 
 export type OAuthClient = OAuthClientResponse;
 
@@ -21,7 +22,11 @@ export type OAuthClient = OAuthClientResponse;
 // `oauth_grant.*` event lands (phase-3a §4.8), which must hit these slices.
 const QUERY_KEY = sharedQueryKeys.oauthClientsRoot;
 const QUEUE_KEY = [...QUERY_KEY, 'queue'] as const;
-const PERMISSIONS_KEY = [...QUERY_KEY, 'permissions'] as const;
+// The permission catalogue is NOT client data — it gets its own root (like the
+// agents module's `permissionsKey`) so the oauth-clients invalidation fan-out
+// (every client mutation + every live `oauth_client.*`/`oauth_grant.*` event
+// sweeps `oauthClientsRoot`) doesn't pointlessly refetch `GET /permissions`.
+const PERMISSIONS_KEY = ['settings-oauth-permissions'] as const;
 
 export function usePermissionCatalogue() {
 	return useQuery<PermissionResponse[]>({
@@ -66,14 +71,21 @@ export function useApproveOAuthClient() {
 /** Deny a client (D7: the row is kept, so approve can reverse the decision). */
 export function useDenyOAuthClient() {
 	const qc = useQueryClient();
+	// A deny emits no SSE event (unlike approve, whose `oauth_client.approved`
+	// event settles the rail's actionable row via the stream mirror), so this
+	// mutation settles the `oauth_client.registered` row itself — it knows the
+	// client id. Provider-optional: tests and embedded surfaces without the
+	// rail's stream still work.
+	const stream = useAgentStreamOptional();
 	return useMutation({
 		mutationFn: ({ id, reason }: { id: string; reason?: string }) =>
 			OAuthClientsService.denyOauthClient({
 				id,
 				requestBody: reason ? { reason } : undefined,
 			}),
-		onSuccess: () => {
+		onSuccess: (_data, { id }) => {
 			void qc.invalidateQueries({ queryKey: QUERY_KEY });
+			stream?.settleOAuthClientRegistration(id);
 		},
 	});
 }

--- a/ui/src/modules/settings/api/hooks.ts
+++ b/ui/src/modules/settings/api/hooks.ts
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
 	OAuthClientsService,
 	PermissionsService,
+	sharedQueryKeys,
 	type OAuthClientCreateRequest,
 	type OAuthClientCreateResponse,
 	type OAuthClientResponse,
@@ -15,8 +16,12 @@ import {
 
 export type OAuthClient = OAuthClientResponse;
 
-const QUERY_KEY = ['oauth-clients'] as const;
-const PERMISSIONS_KEY = ['oauth-clients', 'permissions'] as const;
+// Derived from the shared cross-module root: the agent-stream provider
+// invalidates `sharedQueryKeys.oauthClientsRoot` when a live `oauth_client.*` /
+// `oauth_grant.*` event lands (phase-3a §4.8), which must hit these slices.
+const QUERY_KEY = sharedQueryKeys.oauthClientsRoot;
+const QUEUE_KEY = [...QUERY_KEY, 'queue'] as const;
+const PERMISSIONS_KEY = [...QUERY_KEY, 'permissions'] as const;
 
 export function usePermissionCatalogue() {
 	return useQuery<PermissionResponse[]>({
@@ -31,6 +36,45 @@ export function useOAuthClients(includeInactive = false) {
 		queryKey: [...QUERY_KEY, { includeInactive }],
 		queryFn: () =>
 			OAuthClientsService.listOauthClients({ includeInactive }).then((r) => r.data),
+	});
+}
+
+/**
+ * The D7 approval queue (phase-3a §4.8): DCR registrations awaiting a
+ * decision, or previously denied rows (deny is reversible — a later approve
+ * un-bricks the client). `approval_status=pending|denied` implies
+ * `include_inactive` server-side, so no flag is needed here.
+ */
+export function useOAuthClientQueue(approvalStatus: 'pending' | 'denied' = 'pending') {
+	return useQuery({
+		queryKey: [...QUEUE_KEY, approvalStatus],
+		queryFn: () => OAuthClientsService.listOauthClients({ approvalStatus }).then((r) => r.data),
+	});
+}
+
+/** Approve a client (D7: pending→approved, or the denied→approved recovery). */
+export function useApproveOAuthClient() {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (id: string) => OAuthClientsService.approveOauthClient({ id }),
+		onSuccess: () => {
+			void qc.invalidateQueries({ queryKey: QUERY_KEY });
+		},
+	});
+}
+
+/** Deny a client (D7: the row is kept, so approve can reverse the decision). */
+export function useDenyOAuthClient() {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: ({ id, reason }: { id: string; reason?: string }) =>
+			OAuthClientsService.denyOauthClient({
+				id,
+				requestBody: reason ? { reason } : undefined,
+			}),
+		onSuccess: () => {
+			void qc.invalidateQueries({ queryKey: QUERY_KEY });
+		},
 	});
 }
 

--- a/ui/src/modules/settings/mocks/handlers.ts
+++ b/ui/src/modules/settings/mocks/handlers.ts
@@ -1,0 +1,190 @@
+/**
+ * Settings MSW handlers + in-memory store — the admin OAuth-client registry
+ * (`/admin/oauth-clients`), including the phase-3a D7 approval lifecycle the
+ * approval-queue tab drives (pending→approved/denied, denied→approved
+ * recovery) and the §4.8 per-client active-grant count.
+ *
+ * Shapes match the generated `OAuthClientResponse`; the state machine mirrors
+ * the backend: approve activates the row, deny keeps it (inactive) so a later
+ * approve can reverse the decision. Registered additively in
+ * src/mocks/handlers.ts.
+ */
+import { http, HttpResponse } from 'msw';
+
+interface OAuthClientRow {
+	id: string;
+	client_id: string;
+	name: string;
+	description: string | null;
+	redirect_uris: string[];
+	allowed_scopes: string[] | null;
+	token_endpoint_auth_method: string;
+	consent_model: string;
+	require_consent: boolean;
+	active: boolean;
+	registration_source: string;
+	software_id: string | null;
+	approval_status: 'pending' | 'approved' | 'denied';
+	active_grant_count: number;
+	created_at: string;
+	created_by: string | null;
+	updated_at: string | null;
+}
+
+const now = (offsetMin = 0) => new Date(Date.now() + offsetMin * 60_000).toISOString();
+
+function seedClient(
+	over: Partial<OAuthClientRow> & Pick<OAuthClientRow, 'id' | 'client_id' | 'name'>,
+): OAuthClientRow {
+	return {
+		description: null,
+		redirect_uris: ['https://app.example.com/callback'],
+		allowed_scopes: ['apis:read'],
+		token_endpoint_auth_method: 'client_secret_basic',
+		consent_model: 'user',
+		require_consent: true,
+		active: true,
+		registration_source: 'admin',
+		software_id: null,
+		approval_status: 'approved',
+		active_grant_count: 0,
+		created_at: now(-120),
+		created_by: 'usr_admin_1',
+		updated_at: null,
+		...over,
+	};
+}
+
+/** Mutable per-session store. Reset between tests via `resetSettingsStore()`. */
+let oauthClients: OAuthClientRow[] = [];
+
+export function resetSettingsStore(): void {
+	oauthClients = [
+		// An admin-registered confidential client, live, with grants attached.
+		seedClient({
+			id: 'oac_admin_1',
+			client_id: 'oc_dashboard',
+			name: 'Internal Dashboard',
+			description: 'Company metrics dashboard.',
+			active_grant_count: 2,
+		}),
+		// A DCR-registered PUBLIC client awaiting the D7 approval decision:
+		// inactive by construction until approved, no secret (PKCE-only).
+		seedClient({
+			id: 'oac_pending_1',
+			client_id: 'oc_cursor_ide',
+			name: 'Cursor',
+			redirect_uris: ['http://localhost:33418/callback'],
+			token_endpoint_auth_method: 'none',
+			consent_model: 'agent',
+			registration_source: 'dcr',
+			software_id: 'com.cursor.ide',
+			approval_status: 'pending',
+			active: false,
+			created_at: now(-10),
+			created_by: null,
+		}),
+		// A previously denied DCR client — the denied→approved recovery path.
+		seedClient({
+			id: 'oac_denied_1',
+			client_id: 'oc_sketchy_tool',
+			name: 'Sketchy Tool',
+			token_endpoint_auth_method: 'none',
+			registration_source: 'dcr',
+			approval_status: 'denied',
+			active: false,
+			created_at: now(-30),
+			created_by: null,
+		}),
+	];
+}
+
+resetSettingsStore();
+
+function genId(prefix: string): string {
+	return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export const settingsHandlers = [
+	http.get('/admin/oauth-clients', ({ request }) => {
+		const url = new URL(request.url);
+		const approvalStatus = url.searchParams.get('approval_status');
+		const includeInactive =
+			url.searchParams.get('include_inactive') === 'true' ||
+			// Mirrors the backend: a pending/denied filter implies include_inactive
+			// (those rows are inactive by construction — D7).
+			approvalStatus === 'pending' ||
+			approvalStatus === 'denied';
+		const rows = oauthClients.filter(
+			(c) =>
+				(includeInactive || c.active) &&
+				(!approvalStatus || c.approval_status === approvalStatus),
+		);
+		return HttpResponse.json({ data: rows, has_more: false, next_cursor: null });
+	}),
+	http.post('/admin/oauth-clients', async ({ request }) => {
+		const body = (await request.json()) as Partial<OAuthClientRow> & { name: string };
+		const row = seedClient({
+			id: genId('oac'),
+			client_id: genId('oc'),
+			name: body.name,
+			description: body.description ?? null,
+			redirect_uris: body.redirect_uris ?? [],
+			allowed_scopes: body.allowed_scopes ?? null,
+			token_endpoint_auth_method: body.token_endpoint_auth_method ?? 'client_secret_basic',
+			require_consent: body.require_consent ?? true,
+			created_at: now(),
+		});
+		oauthClients.push(row);
+		return HttpResponse.json(
+			{ ...row, client_secret: 'ocs_mock_secret_once' },
+			{ status: 201 },
+		);
+	}),
+	http.get('/admin/oauth-clients/:id', ({ params }) => {
+		const row = oauthClients.find((c) => c.id === params.id);
+		return row ? HttpResponse.json(row) : new HttpResponse(null, { status: 404 });
+	}),
+	http.patch('/admin/oauth-clients/:id', async ({ params, request }) => {
+		const row = oauthClients.find((c) => c.id === params.id);
+		if (!row) return new HttpResponse(null, { status: 404 });
+		const body = (await request.json()) as Partial<OAuthClientRow>;
+		// Mirrors the backend gate: only approved clients may be (re)activated.
+		if (body.active === true && row.approval_status !== 'approved') {
+			return new HttpResponse(null, { status: 409 });
+		}
+		Object.assign(row, body, { updated_at: now() });
+		return HttpResponse.json(row);
+	}),
+	http.delete('/admin/oauth-clients/:id', ({ params }) => {
+		const row = oauthClients.find((c) => c.id === params.id);
+		if (!row) return new HttpResponse(null, { status: 404 });
+		row.active = false;
+		return new HttpResponse(null, { status: 204 });
+	}),
+	http.post('/admin/oauth-clients/:id/rotate-secret', ({ params }) => {
+		const row = oauthClients.find((c) => c.id === params.id);
+		if (!row) return new HttpResponse(null, { status: 404 });
+		if (row.token_endpoint_auth_method === 'none') {
+			return new HttpResponse(null, { status: 409 });
+		}
+		return HttpResponse.json({ client_secret: 'ocs_mock_rotated_once' });
+	}),
+	// D7 approval verbs: approve activates; deny keeps the row for recovery.
+	http.post('/admin/oauth-clients/:id\\:approve', ({ params }) => {
+		const row = oauthClients.find((c) => c.id === params.id);
+		if (!row) return new HttpResponse(null, { status: 404 });
+		row.approval_status = 'approved';
+		row.active = true;
+		row.updated_at = now();
+		return HttpResponse.json(row);
+	}),
+	http.post('/admin/oauth-clients/:id\\:deny', ({ params }) => {
+		const row = oauthClients.find((c) => c.id === params.id);
+		if (!row) return new HttpResponse(null, { status: 404 });
+		row.approval_status = 'denied';
+		row.active = false;
+		row.updated_at = now();
+		return HttpResponse.json(row);
+	}),
+];

--- a/ui/src/modules/settings/pages/OAuthClientsSection.tsx
+++ b/ui/src/modules/settings/pages/OAuthClientsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import {
 	Plus,
@@ -425,17 +425,34 @@ function ClientBadges({ client }: { client: OAuthClient }) {
 }
 
 interface DenyClientDialogProps {
-	client: OAuthClient;
+	/** The client under decision; null only before the first Deny click. */
+	client: OAuthClient | null;
+	open: boolean;
 	onClose: () => void;
 	onConfirm: (reason: string) => void;
 	isPending: boolean;
 }
 
-function DenyClientDialog({ client, onClose, onConfirm, isPending }: DenyClientDialogProps) {
+/**
+ * Deny confirmation with an optional reason draft. Mounted once and toggled
+ * via `open` (dialog-state rule: persist between dismissals, reset on
+ * successful commit) — a casual Esc/backdrop dismiss keeps the half-typed
+ * reason. The draft resets when the TARGET changes (a different client's
+ * denial is a different draft), which also covers the success path: the
+ * parent clears the target after a committed deny.
+ */
+function DenyClientDialog({ client, open, onClose, onConfirm, isPending }: DenyClientDialogProps) {
 	const [reason, setReason] = useState('');
+	const lastIdRef = useRef(client?.id);
+	useEffect(() => {
+		if (lastIdRef.current !== client?.id) {
+			lastIdRef.current = client?.id;
+			setReason('');
+		}
+	}, [client?.id]);
 	return (
 		<Dialog
-			open
+			open={open && client != null}
 			onClose={onClose}
 			title="Deny OAuth Client?"
 			footer={
@@ -455,7 +472,7 @@ function DenyClientDialog({ client, onClose, onConfirm, isPending }: DenyClientD
 		>
 			<div className="space-y-3">
 				<p className="text-muted-foreground">
-					<strong>{client.name}</strong> will not be able to start authorization flows.
+					<strong>{client?.name}</strong> will not be able to start authorization flows.
 					The registration is kept, so you can approve it later to reverse this.
 				</p>
 				<div>
@@ -491,7 +508,10 @@ function ApprovalQueueTab() {
 	const { data: clients, isLoading, error } = useOAuthClientQueue(filter);
 	const approveMutation = useApproveOAuthClient();
 	const denyMutation = useDenyOAuthClient();
+	// Target + open are separate so a casual dismiss keeps the target (and the
+	// dialog's reason draft — dialog-state rule); only a committed deny clears it.
 	const [denyTarget, setDenyTarget] = useState<OAuthClient | null>(null);
+	const [denyOpen, setDenyOpen] = useState(false);
 
 	const handleApprove = async (client: OAuthClient): Promise<void> => {
 		try {
@@ -514,6 +534,8 @@ function ApprovalQueueTab() {
 				reason: reason || undefined,
 			});
 			toast({ title: `${denyTarget.name} denied`, variant: 'success' });
+			setDenyOpen(false);
+			// Clearing the target resets the dialog's reason draft (commit path).
 			setDenyTarget(null);
 		} catch (err) {
 			toast({
@@ -570,7 +592,10 @@ function ApprovalQueueTab() {
 										<Button
 											size="sm"
 											variant="outline"
-											onClick={(): void => setDenyTarget(client)}
+											onClick={(): void => {
+												setDenyTarget(client);
+												setDenyOpen(true);
+											}}
 											disabled={denyMutation.isPending}
 										>
 											Deny
@@ -609,14 +634,15 @@ function ApprovalQueueTab() {
 				</div>
 			)}
 
-			{denyTarget != null && (
-				<DenyClientDialog
-					client={denyTarget}
-					onClose={(): void => setDenyTarget(null)}
-					onConfirm={(reason): void => void handleDeny(reason)}
-					isPending={denyMutation.isPending}
-				/>
-			)}
+			{/* Mounted persistently (not `{target && …}`) so a casual dismiss
+			    keeps the reason draft — see DenyClientDialog. */}
+			<DenyClientDialog
+				client={denyTarget}
+				open={denyOpen}
+				onClose={(): void => setDenyOpen(false)}
+				onConfirm={(reason): void => void handleDeny(reason)}
+				isPending={denyMutation.isPending}
+			/>
 		</div>
 	);
 }

--- a/ui/src/modules/settings/pages/OAuthClientsSection.tsx
+++ b/ui/src/modules/settings/pages/OAuthClientsSection.tsx
@@ -1,6 +1,18 @@
 import { useState } from 'react';
-import { Plus, Trash2, Pencil, KeyRound, RotateCcw, ShieldAlert, X } from 'lucide-react';
+import { useSearchParams } from 'react-router';
 import {
+	Plus,
+	Trash2,
+	Pencil,
+	KeyRound,
+	RotateCcw,
+	ShieldAlert,
+	ShieldQuestion,
+	CheckCircle2,
+	X,
+} from 'lucide-react';
+import {
+	Badge,
 	Button,
 	CopyButton,
 	Dialog,
@@ -9,10 +21,17 @@ import {
 	Label,
 	LoadingState,
 	PageHelp,
+	SegmentedToggle,
+	TabNav,
 	toast,
+	type SegmentedToggleOption,
+	type TabNavOption,
 } from '@/shared/ui';
 import {
 	useOAuthClients,
+	useOAuthClientQueue,
+	useApproveOAuthClient,
+	useDenyOAuthClient,
 	useCreateOAuthClient,
 	useUpdateOAuthClient,
 	useDeactivateOAuthClient,
@@ -387,7 +406,260 @@ function RotateConfirmDialog({
 	);
 }
 
+/**
+ * Row badges shared by the clients list and the approval queue: `Public`
+ * (secret-less PKCE client, D5), `DCR` (front-door registration, D8), and the
+ * approval state when it isn't plain `approved` (D7).
+ */
+function ClientBadges({ client }: { client: OAuthClient }) {
+	return (
+		<>
+			{client.token_endpoint_auth_method === 'none' && (
+				<Badge variant="default">Public</Badge>
+			)}
+			{client.registration_source === 'dcr' && <Badge variant="default">DCR</Badge>}
+			{client.approval_status === 'pending' && <Badge variant="pending">Pending</Badge>}
+			{client.approval_status === 'denied' && <Badge variant="danger">Denied</Badge>}
+		</>
+	);
+}
+
+interface DenyClientDialogProps {
+	client: OAuthClient;
+	onClose: () => void;
+	onConfirm: (reason: string) => void;
+	isPending: boolean;
+}
+
+function DenyClientDialog({ client, onClose, onConfirm, isPending }: DenyClientDialogProps) {
+	const [reason, setReason] = useState('');
+	return (
+		<Dialog
+			open
+			onClose={onClose}
+			title="Deny OAuth Client?"
+			footer={
+				<>
+					<Button variant="outline" onClick={onClose}>
+						Cancel
+					</Button>
+					<Button
+						variant="danger"
+						onClick={(): void => onConfirm(reason.trim())}
+						disabled={isPending}
+					>
+						{isPending ? 'Denying...' : 'Deny'}
+					</Button>
+				</>
+			}
+		>
+			<div className="space-y-3">
+				<p className="text-muted-foreground">
+					<strong>{client.name}</strong> will not be able to start authorization flows.
+					The registration is kept, so you can approve it later to reverse this.
+				</p>
+				<div>
+					<Label htmlFor="deny-reason">Reason (optional)</Label>
+					<Input
+						id="deny-reason"
+						value={reason}
+						onChange={(e): void => setReason(e.target.value)}
+						placeholder="e.g., unknown redirect URIs"
+					/>
+				</div>
+			</div>
+		</Dialog>
+	);
+}
+
+type QueueFilter = 'pending' | 'denied';
+
+const QUEUE_FILTER_OPTIONS: SegmentedToggleOption<QueueFilter>[] = [
+	{ value: 'pending', label: 'Pending' },
+	{ value: 'denied', label: 'Denied' },
+];
+
+/**
+ * The DCR approval queue (phase-3a §4.8, D7): registrations land `pending` +
+ * inactive; Approve activates them, Deny keeps the row (reversible — the
+ * Denied filter re-offers Approve as the recovery path). With auto-approve on
+ * (D9, the OSS default) the queue is normally empty — it is chiefly a manual
+ * / enterprise-mode surface.
+ */
+function ApprovalQueueTab() {
+	const [filter, setFilter] = useState<QueueFilter>('pending');
+	const { data: clients, isLoading, error } = useOAuthClientQueue(filter);
+	const approveMutation = useApproveOAuthClient();
+	const denyMutation = useDenyOAuthClient();
+	const [denyTarget, setDenyTarget] = useState<OAuthClient | null>(null);
+
+	const handleApprove = async (client: OAuthClient): Promise<void> => {
+		try {
+			await approveMutation.mutateAsync(client.id);
+			toast({ title: `${client.name} approved`, variant: 'success' });
+		} catch (err) {
+			toast({
+				title: 'Failed to approve client',
+				description: err instanceof Error ? err.message : undefined,
+				variant: 'error',
+			});
+		}
+	};
+
+	const handleDeny = async (reason: string): Promise<void> => {
+		if (!denyTarget) return;
+		try {
+			await denyMutation.mutateAsync({
+				id: denyTarget.id,
+				reason: reason || undefined,
+			});
+			toast({ title: `${denyTarget.name} denied`, variant: 'success' });
+			setDenyTarget(null);
+		} catch (err) {
+			toast({
+				title: 'Failed to deny client',
+				description: err instanceof Error ? err.message : undefined,
+				variant: 'error',
+			});
+		}
+	};
+
+	return (
+		<div className="space-y-4">
+			<SegmentedToggle options={QUEUE_FILTER_OPTIONS} value={filter} onChange={setFilter} />
+
+			{isLoading ? (
+				<LoadingState message="Loading approval queue..." />
+			) : error ? (
+				<p className="text-destructive">Failed to load the approval queue</p>
+			) : !clients?.length ? (
+				<EmptyState
+					icon={<CheckCircle2 className="h-6 w-6" />}
+					title={filter === 'pending' ? 'No pending registrations' : 'No denied clients'}
+					description={
+						filter === 'pending'
+							? 'Client registrations awaiting approval will appear here.'
+							: 'Denied registrations are kept here — approving one reverses the decision.'
+					}
+				/>
+			) : (
+				<div className="space-y-4">
+					{clients.map((client) => (
+						<div key={client.id} className="border-border rounded-lg border p-4">
+							<div className="flex items-start justify-between gap-3">
+								<div className="min-w-0">
+									<h3 className="text-foreground flex flex-wrap items-center gap-2 font-medium">
+										{client.name}
+										<ClientBadges client={client} />
+									</h3>
+									{client.description && (
+										<p className="text-muted-foreground text-sm">
+											{client.description}
+										</p>
+									)}
+								</div>
+								<div className="flex shrink-0 gap-2">
+									<Button
+										size="sm"
+										onClick={(): void => void handleApprove(client)}
+										disabled={approveMutation.isPending}
+									>
+										Approve
+									</Button>
+									{client.approval_status !== 'denied' && (
+										<Button
+											size="sm"
+											variant="outline"
+											onClick={(): void => setDenyTarget(client)}
+											disabled={denyMutation.isPending}
+										>
+											Deny
+										</Button>
+									)}
+								</div>
+							</div>
+							<div className="mt-3 space-y-2 text-sm">
+								<div>
+									<span className="text-muted-foreground">Client ID: </span>
+									<code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
+										{client.client_id}
+									</code>
+								</div>
+								{client.software_id && (
+									<div>
+										<span className="text-muted-foreground">Software ID: </span>
+										<code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
+											{client.software_id}
+										</code>
+									</div>
+								)}
+								<div>
+									<span className="text-muted-foreground">Redirect URIs: </span>
+									<ul className="text-foreground mt-1 list-inside list-disc pl-1">
+										{client.redirect_uris.map((uri) => (
+											<li key={uri} className="truncate font-mono text-xs">
+												{uri}
+											</li>
+										))}
+									</ul>
+								</div>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+
+			{denyTarget != null && (
+				<DenyClientDialog
+					client={denyTarget}
+					onClose={(): void => setDenyTarget(null)}
+					onConfirm={(reason): void => void handleDeny(reason)}
+					isPending={denyMutation.isPending}
+				/>
+			)}
+		</div>
+	);
+}
+
+const SECTION_TABS = ['clients', 'queue'] as const;
+type SectionTab = (typeof SECTION_TABS)[number];
+
+function isSectionTab(value: string | null): value is SectionTab {
+	return SECTION_TABS.includes(value as SectionTab);
+}
+
 export function OAuthClientsSection() {
+	// Tab lives in `?tab=` so the rail's "Review" action on an
+	// `oauth_client.registered` alert can deep-link straight to the queue.
+	const [searchParams, setSearchParams] = useSearchParams();
+	const tabParam = searchParams.get('tab');
+	const activeTab: SectionTab = isSectionTab(tabParam) ? tabParam : 'clients';
+	// Fetched at section level so the queue tab label can carry the pending
+	// count even while the clients tab is active.
+	const { data: pendingClients } = useOAuthClientQueue('pending');
+
+	const setTab = (tab: SectionTab): void => {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				if (tab === 'clients') next.delete('tab');
+				else next.set('tab', tab);
+				return next;
+			},
+			{ replace: false },
+		);
+	};
+
+	const tabOptions: TabNavOption<SectionTab>[] = [
+		{ value: 'clients', label: 'Clients', icon: <KeyRound className="h-4 w-4" /> },
+		{
+			value: 'queue',
+			label: 'Approval queue',
+			icon: <ShieldQuestion className="h-4 w-4" />,
+			count: pendingClients?.length || undefined,
+		},
+	];
+
 	const [createOpen, setCreateOpen] = useState(false);
 	const [editClient, setEditClient] = useState<OAuthClient | null>(null);
 	const [deleteTarget, setDeleteTarget] = useState<OAuthClient | null>(null);
@@ -491,147 +763,182 @@ export function OAuthClientsSection() {
 				</div>
 			</div>
 
-			<div className="mb-4 flex items-center justify-between">
-				<div className="flex items-center gap-2">
-					<input
-						type="checkbox"
-						id="show-inactive"
-						checked={showInactive}
-						onChange={(e): void => setShowInactive(e.target.checked)}
-						className="h-4 w-4"
-					/>
-					<Label htmlFor="show-inactive" className="text-sm">
-						Show inactive
-					</Label>
-				</div>
-				<Button variant="ghost" size="sm" onClick={(): void => void refetch()}>
-					Refresh
-				</Button>
-			</div>
+			<TabNav<SectionTab>
+				options={tabOptions}
+				value={activeTab}
+				onChange={setTab}
+				ariaLabel="OAuth client sections"
+				className="mb-4"
+			/>
 
-			{isLoading ? (
-				<LoadingState message="Loading OAuth clients..." />
-			) : error ? (
-				<p className="text-destructive">Failed to load OAuth clients</p>
-			) : !clients?.length ? (
-				<EmptyState
-					icon={<KeyRound className="h-6 w-6" />}
-					title="No OAuth clients"
-					description="Register an OAuth client to allow third-party applications to authenticate with Jentic One."
-					action={
-						<Button onClick={(): void => setCreateOpen(true)}>
-							<Plus className="mr-2 h-4 w-4" />
-							Create your first client
-						</Button>
-					}
-				/>
-			) : (
-				<div className="space-y-4">
-					{clients.map((client) => (
-						<div
-							key={client.id}
-							className={`border-border rounded-lg border p-4 ${!client.active ? 'opacity-50' : ''}`}
-						>
-							<div className="flex items-start justify-between">
-								<div>
-									<h3 className="text-foreground font-medium">
-										{client.name}
-										{!client.active && (
-											<span className="bg-muted text-muted-foreground ml-2 rounded px-1.5 py-0.5 text-xs">
-												Inactive
-											</span>
-										)}
-									</h3>
-									{client.description && (
-										<p className="text-muted-foreground text-sm">
-											{client.description}
-										</p>
-									)}
-								</div>
-								<div className="flex gap-1">
-									{client.active && (
-										<Button
-											variant="ghost"
-											size="sm"
-											onClick={(): void => setRotateTarget(client)}
-											title="Rotate secret"
-										>
-											<ShieldAlert className="h-4 w-4" />
-										</Button>
-									)}
-									<Button
-										variant="ghost"
-										size="sm"
-										onClick={(): void => setEditClient(client)}
-									>
-										<Pencil className="h-4 w-4" />
-									</Button>
-									{client.active ? (
-										<Button
-											variant="ghost"
-											size="sm"
-											onClick={(): void => setDeleteTarget(client)}
-										>
-											<Trash2 className="h-4 w-4" />
-										</Button>
-									) : (
-										<Button
-											variant="ghost"
-											size="sm"
-											onClick={(): void => void handleReactivate(client)}
-											disabled={reactivateMutation.isPending}
-										>
-											<RotateCcw className="h-4 w-4" />
-										</Button>
-									)}
-								</div>
-							</div>
-							<div className="mt-3 space-y-2 text-sm">
-								<div>
-									<span className="text-muted-foreground">Client ID: </span>
-									<code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
-										{client.client_id}
-									</code>
-									<CopyButton
-										value={client.client_id}
-										variant="ghost"
-										size="icon"
-									/>
-								</div>
-								<div>
-									<span className="text-muted-foreground">Redirect URIs: </span>
-									<ul className="text-foreground mt-1 list-inside list-disc pl-1">
-										{client.redirect_uris.map((uri) => (
-											<li key={uri} className="truncate font-mono text-xs">
-												{uri}
-											</li>
-										))}
-									</ul>
-								</div>
-								<div>
-									<span className="text-muted-foreground">
-										Consent required:{' '}
-									</span>
-									<span className="text-foreground">
-										{client.require_consent ? 'Yes' : 'No'}
-									</span>
-								</div>
-								{client.allowed_scopes != null && (
-									<div>
-										<span className="text-muted-foreground">
-											Allowed scopes:{' '}
-										</span>
-										<span className="text-foreground">
-											{client.allowed_scopes.length > 0
-												? client.allowed_scopes.join(', ')
-												: 'OIDC only'}
-										</span>
-									</div>
-								)}
-							</div>
+			{activeTab === 'queue' && <ApprovalQueueTab />}
+
+			{activeTab === 'clients' && (
+				<>
+					<div className="mb-4 flex items-center justify-between">
+						<div className="flex items-center gap-2">
+							<input
+								type="checkbox"
+								id="show-inactive"
+								checked={showInactive}
+								onChange={(e): void => setShowInactive(e.target.checked)}
+								className="h-4 w-4"
+							/>
+							<Label htmlFor="show-inactive" className="text-sm">
+								Show inactive
+							</Label>
 						</div>
-					))}
-				</div>
+						<Button variant="ghost" size="sm" onClick={(): void => void refetch()}>
+							Refresh
+						</Button>
+					</div>
+
+					{isLoading ? (
+						<LoadingState message="Loading OAuth clients..." />
+					) : error ? (
+						<p className="text-destructive">Failed to load OAuth clients</p>
+					) : !clients?.length ? (
+						<EmptyState
+							icon={<KeyRound className="h-6 w-6" />}
+							title="No OAuth clients"
+							description="Register an OAuth client to allow third-party applications to authenticate with Jentic One."
+							action={
+								<Button onClick={(): void => setCreateOpen(true)}>
+									<Plus className="mr-2 h-4 w-4" />
+									Create your first client
+								</Button>
+							}
+						/>
+					) : (
+						<div className="space-y-4">
+							{clients.map((client) => (
+								<div
+									key={client.id}
+									className={`border-border rounded-lg border p-4 ${!client.active ? 'opacity-50' : ''}`}
+								>
+									<div className="flex items-start justify-between">
+										<div>
+											<h3 className="text-foreground flex flex-wrap items-center gap-2 font-medium">
+												{client.name}
+												<ClientBadges client={client} />
+												{!client.active && (
+													<span className="bg-muted text-muted-foreground rounded px-1.5 py-0.5 text-xs">
+														Inactive
+													</span>
+												)}
+											</h3>
+											{client.description && (
+												<p className="text-muted-foreground text-sm">
+													{client.description}
+												</p>
+											)}
+										</div>
+										<div className="flex gap-1">
+											{client.active &&
+												client.token_endpoint_auth_method !== 'none' && (
+													<Button
+														variant="ghost"
+														size="sm"
+														onClick={(): void =>
+															setRotateTarget(client)
+														}
+														title="Rotate secret"
+													>
+														<ShieldAlert className="h-4 w-4" />
+													</Button>
+												)}
+											<Button
+												variant="ghost"
+												size="sm"
+												onClick={(): void => setEditClient(client)}
+											>
+												<Pencil className="h-4 w-4" />
+											</Button>
+											{client.active ? (
+												<Button
+													variant="ghost"
+													size="sm"
+													onClick={(): void => setDeleteTarget(client)}
+												>
+													<Trash2 className="h-4 w-4" />
+												</Button>
+											) : (
+												<Button
+													variant="ghost"
+													size="sm"
+													onClick={(): void =>
+														void handleReactivate(client)
+													}
+													disabled={reactivateMutation.isPending}
+												>
+													<RotateCcw className="h-4 w-4" />
+												</Button>
+											)}
+										</div>
+									</div>
+									<div className="mt-3 space-y-2 text-sm">
+										<div>
+											<span className="text-muted-foreground">
+												Client ID:{' '}
+											</span>
+											<code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
+												{client.client_id}
+											</code>
+											<CopyButton
+												value={client.client_id}
+												variant="ghost"
+												size="icon"
+											/>
+										</div>
+										<div>
+											<span className="text-muted-foreground">
+												Redirect URIs:{' '}
+											</span>
+											<ul className="text-foreground mt-1 list-inside list-disc pl-1">
+												{client.redirect_uris.map((uri) => (
+													<li
+														key={uri}
+														className="truncate font-mono text-xs"
+													>
+														{uri}
+													</li>
+												))}
+											</ul>
+										</div>
+										<div>
+											<span className="text-muted-foreground">
+												Consent required:{' '}
+											</span>
+											<span className="text-foreground">
+												{client.require_consent ? 'Yes' : 'No'}
+											</span>
+										</div>
+										<div>
+											<span className="text-muted-foreground">
+												Active grants:{' '}
+											</span>
+											<span className="text-foreground">
+												{client.active_grant_count}
+											</span>
+										</div>
+										{client.allowed_scopes != null && (
+											<div>
+												<span className="text-muted-foreground">
+													Allowed scopes:{' '}
+												</span>
+												<span className="text-foreground">
+													{client.allowed_scopes.length > 0
+														? client.allowed_scopes.join(', ')
+														: 'OIDC only'}
+												</span>
+											</div>
+										)}
+									</div>
+								</div>
+							))}
+						</div>
+					)}
+				</>
 			)}
 
 			{createOpen && (

--- a/ui/src/shared/api/generated/index.ts
+++ b/ui/src/shared/api/generated/index.ts
@@ -129,6 +129,10 @@ export type { OAuthClientRegistrationResponse } from './models/OAuthClientRegist
 export type { OAuthClientResponse } from './models/OAuthClientResponse';
 export type { OAuthClientRotateSecretResponse } from './models/OAuthClientRotateSecretResponse';
 export type { OAuthClientUpdateRequest } from './models/OAuthClientUpdateRequest';
+export type { OAuthGrantAdminListResponse } from './models/OAuthGrantAdminListResponse';
+export type { OAuthGrantAdminResponse } from './models/OAuthGrantAdminResponse';
+export type { OAuthGrantListResponse } from './models/OAuthGrantListResponse';
+export type { OAuthGrantResponse } from './models/OAuthGrantResponse';
 export type { OperationPreviewListResponse } from './models/OperationPreviewListResponse';
 export type { OperationResultResponse } from './models/OperationResultResponse';
 export type { OperationSummaryLinksResponse } from './models/OperationSummaryLinksResponse';

--- a/ui/src/shared/api/generated/models/OAuthClientCreateResponse.ts
+++ b/ui/src/shared/api/generated/models/OAuthClientCreateResponse.ts
@@ -8,6 +8,10 @@
 export type OAuthClientCreateResponse = {
     active: boolean;
     /**
+     * Number of active consent→agent grants for this client (§4.8 per-client grant count). Computed on the read endpoints (list/get); write-path responses report 0.
+     */
+    active_grant_count?: number;
+    /**
      * Scopes this client may request. Null means unrestricted.
      */
     allowed_scopes: (Array<string> | null);

--- a/ui/src/shared/api/generated/models/OAuthClientResponse.ts
+++ b/ui/src/shared/api/generated/models/OAuthClientResponse.ts
@@ -8,6 +8,10 @@
 export type OAuthClientResponse = {
     active: boolean;
     /**
+     * Number of active consent→agent grants for this client (§4.8 per-client grant count). Computed on the read endpoints (list/get); write-path responses report 0.
+     */
+    active_grant_count?: number;
+    /**
      * Scopes this client may request. Null means unrestricted.
      */
     allowed_scopes: (Array<string> | null);

--- a/ui/src/shared/api/generated/models/OAuthGrantAdminListResponse.ts
+++ b/ui/src/shared/api/generated/models/OAuthGrantAdminListResponse.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { OAuthGrantAdminResponse } from './OAuthGrantAdminResponse';
+/**
+ * A paginated list of OAuth grants (admin cross-view).
+ */
+export type OAuthGrantAdminListResponse = {
+    data: Array<OAuthGrantAdminResponse>;
+    has_more: boolean;
+    next_cursor?: (string | null);
+};
+

--- a/ui/src/shared/api/generated/models/OAuthGrantAdminResponse.ts
+++ b/ui/src/shared/api/generated/models/OAuthGrantAdminResponse.ts
@@ -1,0 +1,48 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * One consent→agent grant in the admin cross-view.
+ */
+export type OAuthGrantAdminResponse = {
+    /**
+     * The agent this grant binds the client to.
+     */
+    agent_id: string;
+    /**
+     * Display name of the registered client, if the row still exists.
+     */
+    client_name: (string | null);
+    /**
+     * Origin (scheme://host) of the client's first redirect URI — the 'authorized apps' display pattern.
+     */
+    client_origin: (string | null);
+    created_at: string;
+    /**
+     * Grant ID (ksuid, `ocg_` prefix).
+     */
+    id: string;
+    /**
+     * Last time the client obtained tokens under this grant (stamped at exchange/refresh, not per request).
+     */
+    last_used_at: (string | null);
+    /**
+     * The client's public client_id — the same identifier stamped on tokens minted under this grant.
+     */
+    oauth_client_id: string;
+    revoked_at: (string | null);
+    /**
+     * Scopes granted at consent (the D2 intersection).
+     */
+    scopes: Array<string>;
+    /**
+     * Grant lifecycle state: ``active`` or ``revoked``.
+     */
+    status: string;
+    /**
+     * The consenting user who approved this grant. Shown even after an agent ownership transfer: the grant stays with the original consenter (it is their consent, not the agent's).
+     */
+    user_id: string;
+};
+

--- a/ui/src/shared/api/generated/models/OAuthGrantAdminResponse.ts
+++ b/ui/src/shared/api/generated/models/OAuthGrantAdminResponse.ts
@@ -11,6 +11,10 @@ export type OAuthGrantAdminResponse = {
      */
     agent_id: string;
     /**
+     * Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. a read-only admin.
+     */
+    can_revoke: boolean;
+    /**
      * Display name of the registered client, if the row still exists.
      */
     client_name: (string | null);

--- a/ui/src/shared/api/generated/models/OAuthGrantListResponse.ts
+++ b/ui/src/shared/api/generated/models/OAuthGrantListResponse.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { OAuthGrantResponse } from './OAuthGrantResponse';
+/**
+ * A paginated list of OAuth grants.
+ */
+export type OAuthGrantListResponse = {
+    data: Array<OAuthGrantResponse>;
+    has_more: boolean;
+    next_cursor?: (string | null);
+};
+

--- a/ui/src/shared/api/generated/models/OAuthGrantResponse.ts
+++ b/ui/src/shared/api/generated/models/OAuthGrantResponse.ts
@@ -11,6 +11,10 @@ export type OAuthGrantResponse = {
      */
     agent_id: string;
     /**
+     * Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. the agent's new owner after an ownership transfer, or a read-only admin.
+     */
+    can_revoke: boolean;
+    /**
      * Display name of the registered client, if the row still exists.
      */
     client_name: (string | null);

--- a/ui/src/shared/api/generated/models/OAuthGrantResponse.ts
+++ b/ui/src/shared/api/generated/models/OAuthGrantResponse.ts
@@ -1,0 +1,48 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * One consent→agent grant in API responses.
+ */
+export type OAuthGrantResponse = {
+    /**
+     * The agent this grant binds the client to.
+     */
+    agent_id: string;
+    /**
+     * Display name of the registered client, if the row still exists.
+     */
+    client_name: (string | null);
+    /**
+     * Origin (scheme://host) of the client's first redirect URI — the 'authorized apps' display pattern.
+     */
+    client_origin: (string | null);
+    created_at: string;
+    /**
+     * Grant ID (ksuid, `ocg_` prefix).
+     */
+    id: string;
+    /**
+     * Last time the client obtained tokens under this grant (stamped at exchange/refresh, not per request).
+     */
+    last_used_at: (string | null);
+    /**
+     * The client's public client_id — the same identifier stamped on tokens minted under this grant.
+     */
+    oauth_client_id: string;
+    revoked_at: (string | null);
+    /**
+     * Scopes granted at consent (the D2 intersection).
+     */
+    scopes: Array<string>;
+    /**
+     * Grant lifecycle state: ``active`` or ``revoked``.
+     */
+    status: string;
+    /**
+     * The consenting user who approved this grant. Shown even after an agent ownership transfer: the grant stays with the original consenter (it is their consent, not the agent's).
+     */
+    user_id: string;
+};
+

--- a/ui/src/shared/api/generated/services/AgentsService.ts
+++ b/ui/src/shared/api/generated/services/AgentsService.ts
@@ -14,6 +14,7 @@ import type { ApiKeyResponse } from '../models/ApiKeyResponse';
 import type { ClaimRequest } from '../models/ClaimRequest';
 import type { jentic_one__auth__web__schemas__agents__DenyRequest } from '../models/jentic_one__auth__web__schemas__agents__DenyRequest';
 import type { JwksUpdateRequest } from '../models/JwksUpdateRequest';
+import type { OAuthGrantListResponse } from '../models/OAuthGrantListResponse';
 import type { ToolkitBindingListResponse } from '../models/ToolkitBindingListResponse';
 import type { ToolkitBindingResponse } from '../models/ToolkitBindingResponse';
 import type { ToolkitBindRequest } from '../models/ToolkitBindRequest';
@@ -248,6 +249,54 @@ export class AgentsService {
                 400: `Bad Request`,
                 401: `Unauthorized`,
                 403: `Forbidden`,
+                422: `Unprocessable Entity`,
+                500: `Internal Server Error`,
+                503: `Service Unavailable`,
+            },
+        });
+    }
+    /**
+     * List agent OAuth grants
+     * List OAuth consent grants binding clients to this agent (§4.8).
+     *
+     * The "Connected clients" surface: every grant carries the client's display
+     * name and redirect-URI origin, the granted scopes, the consenting user,
+     * and created/last-used timestamps. Allowed for the agent's owner or an
+     * admin — authorization is enforced in the service layer, mirroring the
+     * ``:revoke`` semantics.
+     * @returns OAuthGrantListResponse Successful Response
+     * @throws ApiError
+     */
+    public static listAgentOauthGrants({
+        agentId,
+        status,
+        limit = 50,
+        cursor,
+    }: {
+        agentId: string,
+        /**
+         * Filter by grant lifecycle state.
+         */
+        status?: ('active' | 'revoked' | null),
+        limit?: number,
+        cursor?: (string | null),
+    }): CancelablePromise<OAuthGrantListResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/agents/{agent_id}/oauth-grants',
+            path: {
+                'agent_id': agentId,
+            },
+            query: {
+                'status': status,
+                'limit': limit,
+                'cursor': cursor,
+            },
+            errors: {
+                400: `Bad Request`,
+                401: `Unauthorized`,
+                403: `Forbidden`,
+                404: `Not Found`,
                 422: `Unprocessable Entity`,
                 500: `Internal Server Error`,
                 503: `Service Unavailable`,

--- a/ui/src/shared/api/generated/services/OAuthService.ts
+++ b/ui/src/shared/api/generated/services/OAuthService.ts
@@ -7,12 +7,73 @@ import type { IntrospectRequest } from '../models/IntrospectRequest';
 import type { IntrospectResponse } from '../models/IntrospectResponse';
 import type { MintRequest } from '../models/MintRequest';
 import type { MintResponse } from '../models/MintResponse';
+import type { OAuthGrantAdminListResponse } from '../models/OAuthGrantAdminListResponse';
 import type { RevokeRequest } from '../models/RevokeRequest';
 import type { TokenResponse } from '../models/TokenResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 export class OAuthService {
+    /**
+     * List OAuth grants
+     * List consent→agent grants across all clients and agents (§4.8).
+     *
+     * The admin cross-view over the grant registry: filter by client, agent,
+     * consenting user, or status. Each item carries the client's display name
+     * and redirect-URI origin plus the consenting ``user_id`` — after an agent
+     * ownership transfer the grant stays with the original consenter, so this
+     * column is how an admin spots stranded grants.
+     * @returns OAuthGrantAdminListResponse Successful Response
+     * @throws ApiError
+     */
+    public static listOauthGrants({
+        clientId,
+        agentId,
+        userId,
+        status,
+        limit = 50,
+        cursor,
+    }: {
+        /**
+         * Filter by the client's public client_id.
+         */
+        clientId?: (string | null),
+        /**
+         * Filter by bound agent.
+         */
+        agentId?: (string | null),
+        /**
+         * Filter by consenting user.
+         */
+        userId?: (string | null),
+        /**
+         * Filter by grant lifecycle state.
+         */
+        status?: ('active' | 'revoked' | null),
+        limit?: number,
+        cursor?: (string | null),
+    }): CancelablePromise<OAuthGrantAdminListResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/admin/oauth-grants',
+            query: {
+                'client_id': clientId,
+                'agent_id': agentId,
+                'user_id': userId,
+                'status': status,
+                'limit': limit,
+                'cursor': cursor,
+            },
+            errors: {
+                400: `Bad Request`,
+                401: `Unauthorized`,
+                403: `Forbidden`,
+                422: `Unprocessable Entity`,
+                500: `Internal Server Error`,
+                503: `Service Unavailable`,
+            },
+        });
+    }
     /**
      * Authorize Endpoint
      * RFC 6749 Authorization endpoint with PKCE (S256 only).

--- a/ui/src/shared/api/index.ts
+++ b/ui/src/shared/api/index.ts
@@ -278,3 +278,12 @@ export type { InstanceIdentityResponse } from '@/shared/api/generated/models/Ins
 // session bundle as password login. Append-only, like the rest.
 export { getIdpDescriptor, exchangeAuthCode } from '@/shared/api/idp';
 export type { IdpDescriptor } from '@/shared/api/idp';
+
+// OAuth consent grants (phase-3a §4.8, local-MCP 3a-5). The per-agent
+// "Connected clients" listing lives on `AgentsService.listAgentOauthGrants`
+// (already exported above); the grant kill switch (`POST
+// /oauth-grants/{id}:revoke`) and the admin cross-view (`GET
+// /admin/oauth-grants`) live on `OAuthService`. Append-only, like the rest.
+export { OAuthService } from '@/shared/api/generated/services/OAuthService';
+export type { OAuthGrantResponse } from '@/shared/api/generated/models/OAuthGrantResponse';
+export type { OAuthGrantListResponse } from '@/shared/api/generated/models/OAuthGrantListResponse';

--- a/ui/src/shared/api/queryKeys.ts
+++ b/ui/src/shared/api/queryKeys.ts
@@ -121,4 +121,23 @@ export const sharedQueryKeys = {
 	 * acked from the rail until its staleTime lapses (#671 follow-through).
 	 */
 	monitorEventsRoot: ['monitor', 'events'] as const,
+	/**
+	 * The OAuth-clients root (`GET /admin/oauth-clients`). Owned by the Settings
+	 * module (its client + approval-queue slices derive from this), but the
+	 * shared agent-stream provider must invalidate it when an `oauth_client.*`
+	 * event (DCR registration, approval) or an `oauth_grant.*` event (the rows
+	 * carry a per-client active-grant count) lands on the live stream —
+	 * otherwise the approval queue sits on its staleTime right after a client
+	 * registers (phase-3a §4.8).
+	 */
+	oauthClientsRoot: ['oauth-clients'] as const,
+	/**
+	 * The OAuth-grants root (per-agent "Connected clients" slices,
+	 * `GET /agents/{id}/oauth-grants`, derive from this — phase-3a §4.8). The
+	 * Agents module owns the panel, but grant creation happens out-of-band (a
+	 * consent screen in another tab) and revocation can happen from an admin
+	 * surface, so the shared agent-stream provider invalidates this root when
+	 * an `oauth_grant.*` event arrives.
+	 */
+	oauthGrantsRoot: ['oauth-grants'] as const,
 };

--- a/ui/src/shared/app/rail/RailHeader.tsx
+++ b/ui/src/shared/app/rail/RailHeader.tsx
@@ -45,6 +45,7 @@ const KIND_LABEL: Record<StreamEvent['kind'], string> = {
 	credential: 'creds',
 	agent: 'agents',
 	catalog: 'catalog',
+	oauth: 'oauth',
 	other: 'other',
 };
 const ALL_KINDS = Object.keys(KIND_LABEL) as Array<StreamEvent['kind']>;

--- a/ui/src/shared/app/rail/StreamEventIcon.tsx
+++ b/ui/src/shared/app/rail/StreamEventIcon.tsx
@@ -42,6 +42,12 @@ const TYPE_ICON_MAP: Record<string, { Icon: LucideIcon; tone: string }> = {
 	'catalog.update_available': { Icon: PackageCheck, tone: 'text-warning' },
 	'catalog.update_conflicts_overlay': { Icon: AlertTriangle, tone: 'text-warning' },
 	'overlay.deprecated': { Icon: Layers, tone: 'text-muted-foreground' },
+	// Interactive OAuth (phase-3a §4.8): client registration awaits an approval
+	// decision (warning), the rest are lifecycle notifications.
+	'oauth_client.registered': { Icon: ShieldQuestion, tone: 'text-warning' },
+	'oauth_client.approved': { Icon: CheckCircle2, tone: 'text-success' },
+	'oauth_grant.created': { Icon: KeyRound, tone: 'text-success' },
+	'oauth_grant.revoked': { Icon: XCircle, tone: 'text-muted-foreground' },
 };
 
 const KIND_ICON_MAP: Record<StreamKind, { Icon: LucideIcon; tone: string }> = {
@@ -51,6 +57,7 @@ const KIND_ICON_MAP: Record<StreamKind, { Icon: LucideIcon; tone: string }> = {
 	access_request: { Icon: ShieldQuestion, tone: 'text-muted-foreground' },
 	agent: { Icon: Bot, tone: 'text-muted-foreground' },
 	catalog: { Icon: Layers, tone: 'text-muted-foreground' },
+	oauth: { Icon: KeyRound, tone: 'text-muted-foreground' },
 	other: { Icon: AlertTriangle, tone: 'text-muted-foreground' },
 };
 

--- a/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { page, cdp } from '@vitest/browser/context';
-import type { ReactElement } from 'react';
+import { act, type ReactElement } from 'react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -23,6 +23,7 @@ import {
 	severityForWire,
 	streamDayKey,
 	unacknowledgedFailureCount,
+	useAgentStream,
 	RAIL_COLLAPSED_STORAGE_KEY,
 	TOAST_SCOPE_STORAGE_KEY,
 	type StreamEvent,
@@ -1132,6 +1133,164 @@ describe('AgentRail — shell-mounted live surface', () => {
 		await screen.findByText(/Execution failed: slack\.postMessage/i);
 		// The heartbeat must NOT have produced a "Platform" row.
 		expect(screen.queryByText('Platform')).not.toBeInTheDocument();
+	});
+});
+
+describe('rail — oauth additions (3a-5, phase-3a §4.8)', () => {
+	const OAUTH_CLIENT_ID = 'oc_dcr_app';
+
+	function registeredWire(over: Partial<EventResponse> = {}): EventResponse {
+		return wireEvent({
+			event_id: 'evt_oauth_registered',
+			type: 'oauth_client.registered',
+			severity: 'info' as EventResponse['severity'],
+			summary: 'OAuth client registered: MCP App',
+			requires_action: true,
+			data: { oauth_client_id: OAUTH_CLIENT_ID },
+			...over,
+		});
+	}
+
+	it('kindForType buckets the oauth_client.* / oauth_grant.* namespaces into oauth', () => {
+		expect(kindForType('oauth_client.registered')).toBe('oauth');
+		expect(kindForType('oauth_client.approved')).toBe('oauth');
+		expect(kindForType('oauth_grant.created')).toBe('oauth');
+		expect(kindForType('oauth_grant.revoked')).toBe('oauth');
+	});
+
+	it('inlineActionsFor offers Review (→ Settings queue) + Acknowledge for a DCR registration', () => {
+		const ev = makeEvent({
+			type: 'oauth_client.registered',
+			kind: 'oauth',
+			requiresAction: true,
+			tokens: { oauth_client_id: OAUTH_CLIENT_ID },
+			groupKey: `oauth:oauth_client.registered:${OAUTH_CLIENT_ID}`,
+		});
+		const actions = inlineActionsFor(ev);
+		const review = actions.find((a) => a.kind === 'view_oauth_queue');
+		expect(review?.label).toBe('Review');
+		// The D7 approve/deny verbs live on the Settings approval queue tab.
+		expect(review?.href?.(ev)).toBe('/settings?tab=queue');
+		expect(actions.map((a) => a.kind)).toContain('acknowledge');
+		// Once settled the actionable slot goes passive.
+		expect(inlineActionsFor({ ...ev, acknowledged: true }).map((a) => a.kind)).not.toContain(
+			'view_oauth_queue',
+		);
+	});
+
+	it('primaryDestinationFor deep-links grant events to the agent, client events to the queue', () => {
+		// A grant row names the bound agent — its Connected-clients panel is the
+		// §4.8 surface that lists (and can revoke) the grant.
+		const grant = makeEvent({
+			type: 'oauth_grant.created',
+			kind: 'oauth',
+			tokens: { grant_id: 'ocg_1', agent_id: 'agt_42' },
+		});
+		expect(primaryDestinationFor(grant)).toBe('/agents/agt_42');
+		// A client lifecycle row has no agent — it goes to the approval queue.
+		const registered = makeEvent({
+			type: 'oauth_client.registered',
+			kind: 'oauth',
+			tokens: { oauth_client_id: OAUTH_CLIENT_ID },
+		});
+		expect(primaryDestinationFor(registered)).toBe('/settings?tab=queue');
+	});
+
+	it('settles the actionable registration row when the APPROVE event arrives over SSE', async () => {
+		// Backlog: the actionable registration alone. SSE then delivers the
+		// approve decision — the live mirror must settle the registered row
+		// (drop its Review prompt) without waiting for a backlog refetch.
+		const registered = registeredWire();
+		const approved = wireEvent({
+			event_id: 'evt_oauth_approved',
+			type: 'oauth_client.approved',
+			summary: 'OAuth client approved: MCP App',
+			data: { oauth_client_id: OAUTH_CLIENT_ID },
+		});
+		worker.use(
+			http.get('/events', () =>
+				HttpResponse.json({ data: [registered], has_more: false, next_cursor: null }),
+			),
+			http.get('/events/stream', () => {
+				const frames = [registered, approved]
+					.map(
+						(e) =>
+							`event: ${e.type}\nid: ${e.event_id}\ndata: ${JSON.stringify(e)}\n\n`,
+					)
+					.join('');
+				const encoder = new TextEncoder();
+				const stream = new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(encoder.encode(frames));
+					},
+				});
+				return new HttpResponse(stream, {
+					headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+				});
+			}),
+		);
+		render(
+			<QueryClientProvider
+				client={
+					new QueryClient({
+						defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+					})
+				}
+			>
+				<MemoryRouter initialEntries={['/dashboard']}>
+					<AgentStreamProvider live={true}>
+						<Routes>
+							<Route path="/*" element={<AgentRail />} />
+						</Routes>
+					</AgentStreamProvider>
+				</MemoryRouter>
+			</QueryClientProvider>,
+		);
+		// Both rows land in the feed…
+		await screen.findByText(/OAuth client registered: MCP App/i);
+		await screen.findByText(/OAuth client approved: MCP App/i);
+		// …and the registration's actionable Review prompt is gone (settled).
+		await waitFor(() =>
+			expect(screen.queryByRole('button', { name: 'Review' })).not.toBeInTheDocument(),
+		);
+	});
+
+	it('settles the actionable registration row on DENY via the context (no SSE event exists)', async () => {
+		// A deny emits no oauth_client.* event (§4.8/D7) — the deny mutation
+		// calls `settleOAuthClientRegistration` itself. Drive the context handle
+		// exactly like `useDenyOAuthClient` does and watch the row settle.
+		worker.use(
+			http.get('/events', () =>
+				HttpResponse.json({
+					data: [registeredWire()],
+					has_more: false,
+					next_cursor: null,
+				}),
+			),
+		);
+		let settle: ((oauthClientId: string) => void) | undefined;
+		function SettleProbe() {
+			settle = useAgentStream().settleOAuthClientRegistration;
+			return null;
+		}
+		renderRail(
+			<>
+				<AgentRail />
+				<SettleProbe />
+			</>,
+		);
+		await screen.findByRole('button', { name: 'Review' });
+
+		// A settle for a DIFFERENT client must not touch the row.
+		act(() => settle?.('oc_other_client'));
+		expect(screen.getByRole('button', { name: 'Review' })).toBeInTheDocument();
+
+		act(() => settle?.(OAUTH_CLIENT_ID));
+		await waitFor(() =>
+			expect(screen.queryByRole('button', { name: 'Review' })).not.toBeInTheDocument(),
+		);
+		// The row itself stays in the feed — only its actionable slot settled.
+		expect(screen.getByText(/OAuth client registered: MCP App/i)).toBeInTheDocument();
 	});
 });
 

--- a/ui/src/shared/lib/agentStream.tsx
+++ b/ui/src/shared/lib/agentStream.tsx
@@ -397,6 +397,17 @@ type AgentStreamValue = {
 	 * stream and supersedes this optimistic flip.
 	 */
 	resolveEvent: (eventId: string) => void;
+	/**
+	 * Settle every unacknowledged actionable `oauth_client.registered` row for
+	 * one client (matched on the internal `oauth_client_id` token). The approve
+	 * arm gets this mirror for free from the `oauth_client.approved` SSE event;
+	 * a DENY emits no event (§4.8 / D7), so the deny mutation — which knows the
+	 * client id — calls this on success. The backend settles the row inside the
+	 * decision transaction either way; this only syncs the live session's local
+	 * copy so a stale "Review" prompt doesn't linger until the next backlog
+	 * fetch.
+	 */
+	settleOAuthClientRegistration: (oauthClientId: string) => void;
 	/** Fetch one older page from `GET /events?cursor=…` and append it. */
 	loadOlderEvents: () => Promise<void>;
 	canLoadOlder: boolean;
@@ -546,6 +557,24 @@ export function AgentStreamProvider({
 		});
 	}, []);
 
+	// One definition for both `oauth_client.registered` settle arms (approve
+	// via its SSE event in the live subscription below, deny via the deny
+	// mutation through the context) so the matching predicate can't drift.
+	const settleOAuthClientRegistration = useCallback(
+		(oauthClientId: string) => {
+			setEvents((prev) =>
+				prev.map((row) =>
+					row.type === 'oauth_client.registered' &&
+					row.tokens.oauth_client_id === oauthClientId &&
+					!row.acknowledged
+						? markResolved(row)
+						: row,
+				),
+			);
+		},
+		[markResolved],
+	);
+
 	// 1. Backlog seed.
 	useEffect(() => {
 		let cancelled = false;
@@ -650,16 +679,9 @@ export function AgentStreamProvider({
 						// alert inside the approve/deny transaction (§4.8 / D7);
 						// mirror on local rows so the live session drops the stale
 						// "Review" prompt immediately. (A deny emits no event, so
-						// its settle lands on the next backlog fetch instead.)
-						setEvents((prev) =>
-							prev.map((row) =>
-								row.type === 'oauth_client.registered' &&
-								row.tokens.oauth_client_id === ev.tokens.oauth_client_id &&
-								!row.acknowledged
-									? markResolved(row)
-									: row,
-							),
-						);
+						// the deny mutation calls this same settle directly —
+						// see settleOAuthClientRegistration.)
+						settleOAuthClientRegistration(ev.tokens.oauth_client_id);
 					}
 					if (!firstDelivery) return;
 					setLatest(ev);
@@ -689,6 +711,7 @@ export function AgentStreamProvider({
 		invalidateAgentSurfaces,
 		invalidateOAuthSurfaces,
 		markResolved,
+		settleOAuthClientRegistration,
 	]);
 
 	const acknowledge = useCallback(
@@ -781,6 +804,7 @@ export function AgentStreamProvider({
 			acknowledge,
 			decide,
 			resolveEvent,
+			settleOAuthClientRegistration,
 			loadOlderEvents,
 			canLoadOlder: hasMore && cursor != null,
 			loadingOlder,
@@ -792,6 +816,7 @@ export function AgentStreamProvider({
 			acknowledge,
 			decide,
 			resolveEvent,
+			settleOAuthClientRegistration,
 			loadOlderEvents,
 			hasMore,
 			cursor,

--- a/ui/src/shared/lib/agentStream.tsx
+++ b/ui/src/shared/lib/agentStream.tsx
@@ -62,7 +62,14 @@ export type StreamSeverity = 'critical' | 'error' | 'warning' | 'info';
  * the backend adds later so the rail never crashes on an unknown type.
  */
 export type StreamKind =
-	'import' | 'execution' | 'access_request' | 'credential' | 'agent' | 'catalog' | 'other';
+	| 'import'
+	| 'execution'
+	| 'access_request'
+	| 'credential'
+	| 'agent'
+	| 'catalog'
+	| 'oauth'
+	| 'other';
 
 /** Tokens lifted from `EventResponse` (`trace_id` + the free-form `data` map). */
 export type StreamTokens = {
@@ -82,6 +89,12 @@ export type StreamTokens = {
 	name?: string;
 	version?: string;
 	overlay_id?: string;
+	// OAuth surface (phase-3a §4.8): DCR/approval events carry the client's
+	// INTERNAL id (`oauth_client_id` = the admin row's ksuid); grant events
+	// carry the grant id plus the client's PUBLIC client_id under the same
+	// `oauth_client_id` data key (the token-lineage join key).
+	oauth_client_id?: string;
+	grant_id?: string;
 };
 
 /** Conflict digests from a `catalog.update_conflicts_overlay` event's `data.conflict`. */
@@ -151,10 +164,15 @@ const KNOWN_KINDS = new Set<StreamKind>([
  * loop (an upstream spec change, an overlay conflict, an overlay deprecation),
  * so they collapse into a single `catalog` kind — one filter chip, one label,
  * one deep-link target (the affected API's Workspace detail page).
+ *
+ * `oauth_client.*` and `oauth_grant.*` likewise collapse into one `oauth` kind
+ * (phase-3a §4.8): client registration/approval and consent-grant lifecycle
+ * are two halves of the same interactive-OAuth surface.
  */
 export function kindForType(type: string): StreamKind {
 	const ns = type.split('.', 1)[0];
 	if (ns === 'overlay') return 'catalog';
+	if (ns === 'oauth_client' || ns === 'oauth_grant') return 'oauth';
 	return KNOWN_KINDS.has(ns as StreamKind) ? (ns as StreamKind) : 'other';
 }
 
@@ -170,6 +188,7 @@ export const STREAM_KIND_LABEL: Record<StreamKind, string> = {
 	access_request: 'Access request',
 	agent: 'Agent',
 	catalog: 'Catalog',
+	oauth: 'OAuth',
 	other: 'Platform',
 };
 
@@ -223,6 +242,10 @@ function buildGroupKey(t: Pick<StreamEvent, 'kind' | 'type' | 'tokens'>): string
 		// keying on the agent would collapse two requests filed by the same
 		// agent in one burst — the normal CLI provisioning case — into one row.
 		t.tokens.access_request_id ??
+		// A grant id keys the grant-lifecycle pair; the client id keys the
+		// registration/approval pair (distinct clients → distinct rows).
+		t.tokens.grant_id ??
+		t.tokens.oauth_client_id ??
 		// Distinct registering agents still get distinct rows.
 		t.tokens.agent_id ??
 		t.tokens.trace_id ??
@@ -290,6 +313,11 @@ export function adaptEvent(e: EventResponse): StreamEvent {
 		name: stringField(data, 'name'),
 		version: stringField(data, 'version'),
 		overlay_id: stringField(data, 'overlay_id'),
+		// OAuth events (phase-3a §4.8): both halves stamp `oauth_client_id`;
+		// grant lifecycle events also carry the grant id (and an `agent_id`,
+		// picked up by the shared field above).
+		oauth_client_id: stringField(data, 'oauth_client_id'),
+		grant_id: stringField(data, 'grant_id'),
 	};
 	const kind = kindForType(e.type);
 	const parsedTs = e.created_at ? Date.parse(e.created_at) : NaN;
@@ -436,6 +464,19 @@ export function AgentStreamProvider({
 		// setup wizard's badge and agent-named toolkit suggestion) misses and
 		// falls back to the raw `agnt_…` id until the cache expires.
 		void queryClient.invalidateQueries({ queryKey: sharedQueryKeys.actorDirectoryRoot });
+	}, [queryClient]);
+
+	/**
+	 * Refresh the interactive-OAuth surfaces (Settings approval queue + client
+	 * rows with their grant counts, per-agent "Connected clients" panels). A
+	 * DCR registration, an approval decision, or a consent grant all land as
+	 * `oauth_client.*` / `oauth_grant.*` SSE events (phase-3a §4.8); without
+	 * this bridge those surfaces sat on their staleTime right after the change.
+	 */
+	const invalidateOAuthSurfaces = useCallback(() => {
+		void queryClient.invalidateQueries({ queryKey: sharedQueryKeys.oauthClientsRoot });
+		void queryClient.invalidateQueries({ queryKey: sharedQueryKeys.oauthGrantsRoot });
+		void queryClient.invalidateQueries({ queryKey: DASHBOARD_ROOT_KEY });
 	}, [queryClient]);
 
 	// Fresh mirror of `events` for callbacks that need the current list WITHOUT
@@ -600,6 +641,26 @@ export function AgentStreamProvider({
 							),
 						);
 					}
+					if (
+						ev.kind === 'oauth' &&
+						ev.type === 'oauth_client.approved' &&
+						ev.tokens.oauth_client_id
+					) {
+						// The backend settles the actionable oauth_client.registered
+						// alert inside the approve/deny transaction (§4.8 / D7);
+						// mirror on local rows so the live session drops the stale
+						// "Review" prompt immediately. (A deny emits no event, so
+						// its settle lands on the next backlog fetch instead.)
+						setEvents((prev) =>
+							prev.map((row) =>
+								row.type === 'oauth_client.registered' &&
+								row.tokens.oauth_client_id === ev.tokens.oauth_client_id &&
+								!row.acknowledged
+									? markResolved(row)
+									: row,
+							),
+						);
+					}
 					if (!firstDelivery) return;
 					setLatest(ev);
 					// Bridge: a filed/decided access request changes the durable
@@ -612,6 +673,8 @@ export function AgentStreamProvider({
 						invalidateApprovalSurfaces();
 					} else if (ev.kind === 'agent') {
 						invalidateAgentSurfaces();
+					} else if (ev.kind === 'oauth') {
+						invalidateOAuthSurfaces();
 					}
 				},
 				onError: () => setStatus('error'),
@@ -619,7 +682,14 @@ export function AgentStreamProvider({
 			},
 		);
 		return unsubscribe;
-	}, [live, upsert, invalidateApprovalSurfaces, invalidateAgentSurfaces, markResolved]);
+	}, [
+		live,
+		upsert,
+		invalidateApprovalSurfaces,
+		invalidateAgentSurfaces,
+		invalidateOAuthSurfaces,
+		markResolved,
+	]);
 
 	const acknowledge = useCallback(
 		async (eventId: string) => {
@@ -925,7 +995,8 @@ export type InlineActionKind =
 	| 'view_api'
 	| 'view_execution'
 	| 'view_job'
-	| 'view_trace';
+	| 'view_trace'
+	| 'view_oauth_queue';
 
 export type InlineActionSpec = {
 	kind: InlineActionKind;
@@ -989,6 +1060,10 @@ const NAV = {
 		if (!vendor || !name || !version) return null;
 		return `/workspace/${[vendor, name, version].map(encodeURIComponent).join('/')}`;
 	},
+	// The Settings OAuth approval queue (phase-3a §4.8/D7) — where the
+	// approve/deny verbs for a pending DCR registration live. Static target:
+	// the queue tab lists every pending client.
+	oauthQueue: () => '/settings?tab=queue',
 };
 
 export function inlineActionsFor(ev: StreamEvent): InlineActionSpec[] {
@@ -1011,6 +1086,12 @@ export function inlineActionsFor(ev: StreamEvent): InlineActionSpec[] {
 			// A self-registered agent awaits approval — route the operator to the
 			// agent's page (where approve/deny lives) instead of a bare Acknowledge.
 			actions.push({ kind: 'view_agent', label: 'Review', href: NAV.agent });
+			actions.push({ kind: 'acknowledge', label: 'Acknowledge', acknowledges: true });
+		} else if (ev.type === 'oauth_client.registered') {
+			// A DCR client registration awaiting approval (phase-3a §4.8) — route
+			// the operator to the Settings approval queue, where the D7
+			// approve/deny verbs live, alongside Acknowledge.
+			actions.push({ kind: 'view_oauth_queue', label: 'Review', href: NAV.oauthQueue });
 			actions.push({ kind: 'acknowledge', label: 'Acknowledge', acknowledges: true });
 		} else if (
 			(ev.type === 'catalog.update_available' ||
@@ -1041,6 +1122,10 @@ export function inlineActionsFor(ev: StreamEvent): InlineActionSpec[] {
 		if (!actions.some((a) => a.kind === 'view_api')) {
 			actions.push({ kind: 'view_api', label: 'View API', href: NAV.workspaceApi });
 		}
+	} else if (ev.kind === 'oauth' && ev.tokens.agent_id) {
+		// Grant lifecycle rows deep-link to the bound agent, whose "Connected
+		// clients" panel lists (and can revoke) the grant (§4.8).
+		actions.push({ kind: 'view_agent', label: 'View agent', href: NAV.agent });
 	} else if (ev.tokens.trace_id) {
 		actions.push({ kind: 'view_trace', label: 'View trace', href: NAV.trace });
 	}
@@ -1110,6 +1195,10 @@ export function primaryDestinationFor(ev: StreamEvent): string | null {
 			return NAV.agent(ev) ?? NAV.trace(ev);
 		case 'catalog':
 			return NAV.workspaceApi(ev) ?? NAV.trace(ev);
+		case 'oauth':
+			// Grant rows go to the bound agent's console (its Connected-clients
+			// panel); client registration/approval rows go to the Settings queue.
+			return ev.tokens.grant_id && ev.tokens.agent_id ? NAV.agent(ev) : NAV.oauthQueue();
 		default:
 			return NAV.trace(ev);
 	}


### PR DESCRIPTION
## Summary

Fifth and final OSS slice of the phase-3a interactive-OAuth work (design: plans `themes/local-mcp/phase-3a-design.md` §4.8/D7/D9, signed off on plans PR #25). Builds on #1218/#1219/#1220/#1221, all merged.

**Backend**
- `GET /agents/{agent_id}/oauth-grants` (owner-or-admin) and `GET /admin/oauth-grants` (cross-view, `oauth-clients:read`) — compound-keyset pagination, status/client/agent/user filters, per-item `can_revoke` capability computed from the real revoke predicate (shared helper with 3a-3's `:revoke`, not duplicated).
- Per-client `active_grant_count` on the oauth-clients read paths (§4.8 loud-attachment counter).
- No schema changes; `:revoke` from 3a-3 wired, not duplicated.

**UI**
- Settings → approval queue tab: pending DCR registrations with approve/deny (D7 state machine incl. denied→approved recovery), public-client badges, deep-linkable via `?tab=`.
- Agent detail → "Connected clients" panel: client + origin, scope chips, consenting user (gap G10 surfaced), created/last-used, revoke behind confirm — disabled with tooltip when `can_revoke=false`.
- Rail notifications: `oauth_client.registered` actionable alert with Review deep-link, settled on approve (SSE) and deny (local mirror); grant events deep-link to the agent.

Adversarial review + fix wave ran pre-push (same discipline as the whole stack): 3 MAJORs fixed (compound keyset tiebreaker per repo precedent, `InvalidCursorError→400` on the standalone auth surface, honest revoke capability instead of 403-ing buttons) plus all minors and three of four nits.

G10 note: list/revoke predicate divergence under agent ownership transfer is a known design gap, decided and tracked in #1222 (revoke-on-transfer follow-up); this PR keeps the UI honest meanwhile via `can_revoke`.

## Test plan

- [x] ruff + mypy clean
- [x] Unit + arch: 3232 passed (authz matrices incl. 401 arms on both endpoints, D7 queue verbs incl. recovery, tie + tamper pagination arms)
- [x] SQLite integration: 703 passed (real-data authz matrix, pagination walks, scoped counts)
- [x] UI: eslint + tsc clean, vitest 1184 passed (queue, connected-clients, rail arms)
- [x] Go client build
- [ ] Postgres integration on CI (no local Docker)

Made with [Cursor](https://cursor.com)