### PR TITLE
feat(credentials): pluggable encryption-key sources (env, macOS Keychain)

### DIFF
--- a/cli/internal/cli/ctl/assets/config-schema.json
+++ b/cli/internal/cli/ctl/assets/config-schema.json
@@ -607,22 +607,53 @@
       "type": "object"
     },
     "EncryptionKey": {
-      "description": "A single named encryption key.",
+      "description": "A single named encryption key.\n\nThe key material comes from exactly one source:\n\n- ``material``: inline base64 in the config file (the default layout\n  written by ``jenticctl install``).\n- ``material_env``: the NAME of an environment variable holding the\n  base64 material (container/orchestrator secret injection).\n- ``material_keychain``: the service name of a macOS Keychain\n  generic-password item holding the base64 material (local installs;\n  written by ``jenticctl install --keychain``).\n\nResolution happens lazily when the EncryptionService is first built —\nnot at config load — so commands that never touch encryption can't\ntrigger a Keychain prompt. See ``shared/crypto/key_material.py``.",
       "properties": {
         "id": {
           "title": "Id",
           "type": "string"
         },
         "material": {
-          "format": "password",
-          "title": "Material",
-          "type": "string",
-          "writeOnly": true
+          "anyOf": [
+            {
+              "format": "password",
+              "type": "string",
+              "writeOnly": true
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Material"
+        },
+        "material_env": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Material Env"
+        },
+        "material_keychain": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Material Keychain"
         }
       },
       "required": [
-        "id",
-        "material"
+        "id"
       ],
       "title": "EncryptionKey",
       "type": "object"

--- a/cli/internal/cli/ctl/generated/config.go
+++ b/cli/internal/cli/ctl/generated/config.go
@@ -937,13 +937,39 @@ func (j *EncryptionConfig) UnmarshalJSON(value []byte) error {
 }
 
 // A single named encryption key.
+//
+// The key material comes from exactly one source:
+//
+//   - “material“: inline base64 in the config file (the default layout
+//     written by “jenticctl install“).
+//   - “material_env“: the NAME of an environment variable holding the
+//     base64 material (container/orchestrator secret injection).
+//   - “material_keychain“: the service name of a macOS Keychain
+//     generic-password item holding the base64 material (local installs;
+//     written by “jenticctl install --keychain“).
+//
+// Resolution happens lazily when the EncryptionService is first built —
+// not at config load — so commands that never touch encryption can't
+// trigger a Keychain prompt. See “shared/crypto/key_material.py“.
 type EncryptionKey struct {
 	// Id corresponds to the JSON schema field "id".
 	Id string `json:"id" yaml:"id" mapstructure:"id"`
 
 	// Material corresponds to the JSON schema field "material".
-	Material string `json:"material" yaml:"material" mapstructure:"material"`
+	Material interface{} `json:"material,omitempty,omitzero" yaml:"material,omitempty" mapstructure:"material,omitempty"`
+
+	// MaterialEnv corresponds to the JSON schema field "material_env".
+	MaterialEnv interface{} `json:"material_env,omitempty,omitzero" yaml:"material_env,omitempty" mapstructure:"material_env,omitempty"`
+
+	// MaterialKeychain corresponds to the JSON schema field "material_keychain".
+	MaterialKeychain interface{} `json:"material_keychain,omitempty,omitzero" yaml:"material_keychain,omitempty" mapstructure:"material_keychain,omitempty"`
 }
+
+type EncryptionKeyMaterialEnv_0 *string
+
+type EncryptionKeyMaterialKeychain_0 *string
+
+type EncryptionKeyMaterial_0 *string
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *EncryptionKey) UnmarshalJSON(value []byte) error {
@@ -953,9 +979,6 @@ func (j *EncryptionKey) UnmarshalJSON(value []byte) error {
 	}
 	if _, ok := raw["id"]; raw != nil && !ok {
 		return fmt.Errorf("field id in EncryptionKey: required")
-	}
-	if _, ok := raw["material"]; raw != nil && !ok {
-		return fmt.Errorf("field material in EncryptionKey: required")
 	}
 	type Plain EncryptionKey
 	var plain Plain

--- a/cli/internal/cli/ctlcmd/install.go
+++ b/cli/internal/cli/ctlcmd/install.go
@@ -30,6 +30,11 @@ type installOptions struct {
 	noWizard     bool
 	freshSecrets bool
 	freshVenv    bool
+	// keychain moves the credentials encryption key into the macOS Keychain
+	// instead of writing it inline into jentic-one.yaml (local source path on
+	// darwin only — a container cannot reach the host keychain). On a
+	// reinstall it also migrates a reused inline keyset into the keychain.
+	keychain bool
 	// preset selects an embedded config preset (impl/6.0 §3.5); empty means none
 	// (schema defaults + the wizard/flags stand). The schema-driven --section-field
 	// flags are bound onto the command from the generated BackendConfig and, together
@@ -108,6 +113,10 @@ func newInstallCmd(app *app) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.freshVenv, "fresh-venv", false,
 		"wipe any existing local venv before building (recovers a wedged/half-populated "+
 			"~/.jentic/venv from a prior failed install; local path only)")
+	cmd.Flags().BoolVar(&opts.keychain, "keychain", false,
+		"store the credentials encryption key in the macOS Keychain instead of "+
+			"jentic-one.yaml (macOS + source runtime only; a reinstall migrates an "+
+			"existing inline key; uninstall leaves the keychain item in place)")
 	cmd.Flags().StringVar(&opts.preset, "preset", "",
 		"apply an embedded config preset over schema defaults ("+strings.Join(ctl.Presets(), ", ")+"); empty means none")
 	cmd.Flags().BoolVar(&opts.configForm, "config-form", false,
@@ -223,6 +232,21 @@ func (a *app) finishInstall(cmd *cobra.Command, opts *installOptions, draft *ins
 
 	if err := draft.FillSecrets(); err != nil {
 		return err
+	}
+
+	// --keychain: move the (fresh or reused) key material into the macOS
+	// Keychain and leave only a material_keychain reference for Render.
+	// Validated inside ApplyKeychain (darwin + non-Docker); failing here,
+	// before the consent gate and any disk writes, keeps a refused flag from
+	// leaving a half-done install behind.
+	if opts.keychain {
+		if err := draft.ApplyKeychain(); err != nil {
+			return err
+		}
+		fmt.Fprintln(a.Out, theme.Dimf(
+			"Stored the credentials encryption key in the macOS Keychain "+
+				"(service prefix %q); jentic-one.yaml carries only a reference.",
+			install.KeychainServiceName("")))
 	}
 
 	// Telemetry consent gate: asked once, after the user has confirmed their

--- a/cli/internal/install/draft.go
+++ b/cli/internal/install/draft.go
@@ -126,6 +126,13 @@ type Draft struct {
 	// layout from EncryptionKey in that case.
 	EncryptionKeyset *encryptionOut
 
+	// EncryptionKeychain is the Keychain service name the encryption key was
+	// stored under when the operator passed --keychain (set by ApplyKeychain
+	// after it moves the material out of the draft). When non-empty (and no
+	// keyset carry-over is present) render.go emits a `material_keychain`
+	// reference instead of an inline `material` value.
+	EncryptionKeychain string
+
 	// Telemetry consent decision, stamped onto the draft by the install command
 	// (from the consent prompt) before rendering. When TelemetryEnabled is true
 	// a stable opaque TelemetryInstanceID is generated and both are written into

--- a/cli/internal/install/keychain.go
+++ b/cli/internal/install/keychain.go
@@ -1,0 +1,113 @@
+// keychain.go — macOS Keychain storage for the credentials encryption key.
+//
+// `jenticctl install --keychain` moves the AES key OUT of the generated
+// jentic-one.yaml: the material is stored as a Keychain generic-password item
+// and the config carries only a `material_keychain: <service>` reference,
+// resolved at runtime by the backend (shared/crypto/key_material.py). The
+// point is the local threat model — any process running as the operator's
+// user can read a 0600 config file, but a Keychain item read from a
+// non-approved binary triggers a user-visible authorization prompt.
+
+package install
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// securityBin is the absolute path to the macOS security(1) tool. Absolute on
+// purpose: a PATH lookup would let a same-user process interpose a fake
+// binary — exactly the adversary this feature exists for.
+const securityBin = "/usr/bin/security"
+
+// keychainServicePrefix names the generic-password items this installer
+// manages. The full service name is the prefix + the keyset entry id, so a
+// rotated multi-key keyset maps to one item per key.
+const keychainServicePrefix = "jentic-one-credentials-encryption-"
+
+// keychainAccount is the fixed account attribute for our items; lookups (here
+// and backend-side) match on the service name alone.
+const keychainAccount = "jentic-one"
+
+// runSecurity executes the security(1) invocation. Package-level seam so
+// tests can capture arguments without touching a real keychain.
+var runSecurity = func(args ...string) error {
+	cmd := exec.Command(securityBin, args...) //nolint:gosec // fixed absolute binary
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s %s: %w (%s)", securityBin, args[0], err, string(out))
+	}
+	return nil
+}
+
+// goos is runtime.GOOS behind a seam so tests can exercise the darwin-only
+// paths from any CI platform.
+var goos = runtime.GOOS
+
+// KeychainSupported reports whether the host can store the encryption key in
+// a keychain. Darwin-only: the item must live in the operator's login
+// keychain, which neither Linux nor the Docker path can reach.
+func KeychainSupported() bool { return goos == "darwin" }
+
+// KeychainServiceName returns the generic-password service name for a keyset
+// entry id (the value written to `material_keychain` in the config).
+func KeychainServiceName(keyID string) string { return keychainServicePrefix + keyID }
+
+// storeKeychainSecret upserts (-U) a generic-password item holding the base64
+// key material. Known trade-off, documented in the plan: the secret transits
+// the argv of one short-lived local process at install time.
+func storeKeychainSecret(service, secret string) error {
+	return runSecurity(
+		"add-generic-password", "-U",
+		"-s", service,
+		"-a", keychainAccount,
+		"-w", secret,
+	)
+}
+
+// ApplyKeychain moves the draft's encryption key material into the macOS
+// Keychain and rewrites the draft so render.go emits `material_keychain`
+// references instead of inline `material` values. Call after FillSecrets /
+// ReuseSecrets and before Render.
+//
+// Two cases:
+//   - Fresh install: the generated EncryptionKey is stored under the v1
+//     service name and cleared from the draft.
+//   - Reinstall reusing an existing keyset: every inline entry is migrated
+//     (same material, new home — ciphertexts stay decryptable); entries that
+//     are already keychain references are left alone, so the flag is
+//     idempotent across reinstalls.
+func (d *Draft) ApplyKeychain() error {
+	if !KeychainSupported() {
+		return fmt.Errorf("--keychain requires macOS (GOOS=%s)", goos)
+	}
+	if d.IsDocker() {
+		return fmt.Errorf("--keychain is not supported on the Docker path: " +
+			"the app container cannot reach the host keychain; use the source " +
+			"runtime path, or inject the key via material_env instead")
+	}
+
+	if d.EncryptionKeyset != nil {
+		for i := range d.EncryptionKeyset.Entries {
+			e := &d.EncryptionKeyset.Entries[i]
+			if e.Material == "" {
+				continue // already a keychain reference (or malformed; render as-is)
+			}
+			service := KeychainServiceName(e.ID)
+			if err := storeKeychainSecret(service, e.Material); err != nil {
+				return fmt.Errorf("store key %q in keychain: %w", e.ID, err)
+			}
+			e.Material = ""
+			e.MaterialKeychain = service
+		}
+		return nil
+	}
+
+	service := KeychainServiceName("v1")
+	if err := storeKeychainSecret(service, d.EncryptionKey); err != nil {
+		return fmt.Errorf("store key in keychain: %w", err)
+	}
+	d.EncryptionKey = ""
+	d.EncryptionKeychain = service
+	return nil
+}

--- a/cli/internal/install/keychain_test.go
+++ b/cli/internal/install/keychain_test.go
@@ -1,0 +1,157 @@
+package install
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// withKeychainStubs points the GOOS seam at darwin and captures security(1)
+// invocations instead of touching a real keychain.
+func withKeychainStubs(t *testing.T) *[][]string {
+	t.Helper()
+	var calls [][]string
+	prevGoos, prevRun := goos, runSecurity
+	goos = "darwin"
+	runSecurity = func(args ...string) error {
+		calls = append(calls, args)
+		return nil
+	}
+	t.Cleanup(func() { goos, runSecurity = prevGoos, prevRun })
+	return &calls
+}
+
+func TestApplyKeychainFreshInstall(t *testing.T) {
+	calls := withKeychainStubs(t)
+
+	d := NewDraft()
+	d.RuntimePath = RuntimeSource
+	d.EncryptionKey = "b64-material"
+
+	if err := d.ApplyKeychain(); err != nil {
+		t.Fatalf("ApplyKeychain: %v", err)
+	}
+	if d.EncryptionKey != "" {
+		t.Errorf("EncryptionKey not cleared from the draft: %q", d.EncryptionKey)
+	}
+	if want := "jentic-one-credentials-encryption-v1"; d.EncryptionKeychain != want {
+		t.Errorf("EncryptionKeychain = %q, want %q", d.EncryptionKeychain, want)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("security called %d times, want 1", len(*calls))
+	}
+	got := strings.Join((*calls)[0], " ")
+	want := "add-generic-password -U -s jentic-one-credentials-encryption-v1 -a jentic-one -w b64-material"
+	if got != want {
+		t.Errorf("security args = %q, want %q", got, want)
+	}
+}
+
+func TestApplyKeychainRefusesDocker(t *testing.T) {
+	withKeychainStubs(t)
+
+	d := NewDraft() // NewDraft defaults to the Docker runtime path
+	if err := d.ApplyKeychain(); err == nil || !strings.Contains(err.Error(), "Docker") {
+		t.Errorf("expected Docker refusal, got %v", err)
+	}
+}
+
+func TestApplyKeychainRefusesNonDarwin(t *testing.T) {
+	calls := withKeychainStubs(t)
+	goos = "linux"
+
+	d := NewDraft()
+	d.RuntimePath = RuntimeSource
+	d.EncryptionKey = "b64-material"
+	if err := d.ApplyKeychain(); err == nil || !strings.Contains(err.Error(), "macOS") {
+		t.Errorf("expected macOS refusal, got %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("security must not be called on non-darwin, got %d calls", len(*calls))
+	}
+}
+
+func TestApplyKeychainMigratesReusedKeyset(t *testing.T) {
+	calls := withKeychainStubs(t)
+
+	d := NewDraft()
+	d.RuntimePath = RuntimeSource
+	d.EncryptionKeyset = &encryptionOut{
+		ActiveID: "v2",
+		Entries: []encryptionEntryOut{
+			{ID: "v1", MaterialKeychain: "jentic-one-credentials-encryption-v1"}, // already migrated
+			{ID: "v2", Material: "inline-v2"},
+		},
+	}
+
+	if err := d.ApplyKeychain(); err != nil {
+		t.Fatalf("ApplyKeychain: %v", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("security called %d times, want 1 (only the inline entry)", len(*calls))
+	}
+	e := d.EncryptionKeyset.Entries[1]
+	if e.Material != "" || e.MaterialKeychain != "jentic-one-credentials-encryption-v2" {
+		t.Errorf("v2 entry not migrated: %+v", e)
+	}
+}
+
+func TestRenderEmitsKeychainReference(t *testing.T) {
+	d := NewDraft()
+	d.RuntimePath = RuntimeSource
+	d.EncryptionKeychain = "jentic-one-credentials-encryption-v1"
+
+	data, err := d.Render()
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var cfg struct {
+		Credentials struct {
+			Encryption encryptionOut `yaml:"encryption"`
+		} `yaml:"credentials"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal rendered config: %v", err)
+	}
+	entries := cfg.Credentials.Encryption.Entries
+	if len(entries) != 1 {
+		t.Fatalf("keyset entries = %d, want 1", len(entries))
+	}
+	if entries[0].MaterialKeychain != d.EncryptionKeychain {
+		t.Errorf("material_keychain = %q, want %q", entries[0].MaterialKeychain, d.EncryptionKeychain)
+	}
+	if entries[0].Material != "" {
+		t.Errorf("inline material leaked into the rendered config: %q", entries[0].Material)
+	}
+}
+
+func TestReuseSecretsCarriesKeychainKeyset(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/jentic-one.yaml"
+	prior := `
+credentials:
+  encryption:
+    active_id: v1
+    entries:
+      - id: v1
+        material_keychain: jentic-one-credentials-encryption-v1
+`
+	if err := os.WriteFile(path, []byte(prior), 0o600); err != nil {
+		t.Fatalf("write prior config: %v", err)
+	}
+
+	d := NewDraft()
+	reused, err := ReuseSecrets(d, path)
+	if err != nil {
+		t.Fatalf("ReuseSecrets: %v", err)
+	}
+	if !reused {
+		t.Fatal("keychain-reference keyset was not treated as reusable")
+	}
+	if d.EncryptionKeyset == nil ||
+		d.EncryptionKeyset.Entries[0].MaterialKeychain != "jentic-one-credentials-encryption-v1" {
+		t.Errorf("keyset not carried over verbatim: %+v", d.EncryptionKeyset)
+	}
+}

--- a/cli/internal/install/render.go
+++ b/cli/internal/install/render.go
@@ -84,8 +84,9 @@ type adminOut struct {
 }
 
 type encryptionEntryOut struct {
-	ID       string `yaml:"id"`
-	Material string `yaml:"material"`
+	ID               string `yaml:"id"`
+	Material         string `yaml:"material,omitempty"`
+	MaterialKeychain string `yaml:"material_keychain,omitempty"`
 }
 
 type encryptionOut struct {
@@ -171,10 +172,17 @@ type configOut struct {
 // encryptionOut builds the credentials.encryption block. When ReuseSecrets
 // carried a keyset over from an existing config, render it verbatim so a
 // hand-rotated multi-key keyset survives the rewrite; otherwise emit the
-// default single-v1 layout populated by FillSecrets.
+// default single-v1 layout — a keychain reference when ApplyKeychain moved
+// the material out of the config, else the inline key from FillSecrets.
 func (d *Draft) encryptionOut() encryptionOut {
 	if d.EncryptionKeyset != nil {
 		return *d.EncryptionKeyset
+	}
+	if d.EncryptionKeychain != "" {
+		return encryptionOut{
+			ActiveID: "v1",
+			Entries:  []encryptionEntryOut{{ID: "v1", MaterialKeychain: d.EncryptionKeychain}},
+		}
 	}
 	return encryptionOut{
 		ActiveID: "v1",

--- a/cli/internal/install/reuse.go
+++ b/cli/internal/install/reuse.go
@@ -105,12 +105,13 @@ func ReuseSecrets(d *Draft, path string) (bool, error) {
 
 	// Encryption keyset: preserve the whole block verbatim. A hand-rotated
 	// multi-key keyset (active_id: v2 + v1/v2 entries) must survive; only
-	// carry it over when it looks real (has at least one non-empty entry) so
-	// an empty/malformed prior config doesn't wipe the fresh default.
+	// carry it over when it looks real (has at least one entry with inline
+	// material OR a keychain reference — see keychain.go) so an
+	// empty/malformed prior config doesn't wipe the fresh default.
 	if len(view.Credentials.Encryption.Entries) > 0 {
 		nonEmpty := false
 		for _, e := range view.Credentials.Encryption.Entries {
-			if e.ID != "" && e.Material != "" {
+			if e.ID != "" && (e.Material != "" || e.MaterialKeychain != "") {
 				nonEmpty = true
 				break
 			}

--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -607,22 +607,53 @@
       "type": "object"
     },
     "EncryptionKey": {
-      "description": "A single named encryption key.",
+      "description": "A single named encryption key.\n\nThe key material comes from exactly one source:\n\n- ``material``: inline base64 in the config file (the default layout\n  written by ``jenticctl install``).\n- ``material_env``: the NAME of an environment variable holding the\n  base64 material (container/orchestrator secret injection).\n- ``material_keychain``: the service name of a macOS Keychain\n  generic-password item holding the base64 material (local installs;\n  written by ``jenticctl install --keychain``).\n\nResolution happens lazily when the EncryptionService is first built —\nnot at config load — so commands that never touch encryption can't\ntrigger a Keychain prompt. See ``shared/crypto/key_material.py``.",
       "properties": {
         "id": {
           "title": "Id",
           "type": "string"
         },
         "material": {
-          "format": "password",
-          "title": "Material",
-          "type": "string",
-          "writeOnly": true
+          "anyOf": [
+            {
+              "format": "password",
+              "type": "string",
+              "writeOnly": true
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Material"
+        },
+        "material_env": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Material Env"
+        },
+        "material_keychain": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Material Keychain"
         }
       },
       "required": [
-        "id",
-        "material"
+        "id"
       ],
       "title": "EncryptionKey",
       "type": "object"

--- a/docs/context-and-config.md
+++ b/docs/context-and-config.md
@@ -31,6 +31,25 @@ All other fields have sensible defaults (localhost:5432, pool sizes, etc.).
 
 Database passwords use `pydantic.SecretStr` — they are automatically redacted in logs, repr, and serialization. Access the raw value only via `.get_secret_value()`.
 
+### Encryption key sources
+
+The AES-256-GCM keyset that encrypts stored credentials (`credentials.encryption.entries`) supports one material source per entry — set exactly one:
+
+```yaml
+credentials:
+  encryption:
+    active_id: v1
+    entries:
+      - id: v1
+        material: "<base64>"           # inline (default; written by jenticctl install)
+      # - id: v1
+      #   material_env: MY_KEK_VAR     # name of an env var holding the base64 key
+      # - id: v1
+      #   material_keychain: jentic-one-credentials-encryption-v1  # macOS Keychain service name
+```
+
+`material_env` suits containerized deployments (compose/K8s secret injection). `material_keychain` reads a macOS Keychain generic-password item via `/usr/bin/security` and is written by `jenticctl install --keychain` (macOS, source runtime only) — it keeps the key off disk so a same-user process cannot silently read it. Resolution happens when the encryption service is first used, not at config load, so a locked keychain never blocks unrelated commands.
+
 ## Context
 
 `Context` is the central object that holds the resolved config and manages database engines/sessions.

--- a/src/jentic_one/shared/config.py
+++ b/src/jentic_one/shared/config.py
@@ -369,10 +369,27 @@ _KEY_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class EncryptionKey(BaseModel):
-    """A single named encryption key."""
+    """A single named encryption key.
+
+    The key material comes from exactly one source:
+
+    - ``material``: inline base64 in the config file (the default layout
+      written by ``jenticctl install``).
+    - ``material_env``: the NAME of an environment variable holding the
+      base64 material (container/orchestrator secret injection).
+    - ``material_keychain``: the service name of a macOS Keychain
+      generic-password item holding the base64 material (local installs;
+      written by ``jenticctl install --keychain``).
+
+    Resolution happens lazily when the EncryptionService is first built —
+    not at config load — so commands that never touch encryption can't
+    trigger a Keychain prompt. See ``shared/crypto/key_material.py``.
+    """
 
     id: str
-    material: SecretStr
+    material: SecretStr | None = None
+    material_env: str | None = None
+    material_keychain: str | None = None
 
     @field_validator("id")
     @classmethod
@@ -380,6 +397,24 @@ class EncryptionKey(BaseModel):
         if not _KEY_ID_RE.match(v):
             raise ValueError("key id must match [a-zA-Z0-9_-]+")
         return v
+
+    @model_validator(mode="after")
+    def _exactly_one_source(self) -> EncryptionKey:
+        sources = [
+            s
+            for s, present in (
+                ("material", self.material is not None),
+                ("material_env", bool(self.material_env)),
+                ("material_keychain", bool(self.material_keychain)),
+            )
+            if present
+        ]
+        if len(sources) != 1:
+            raise ValueError(
+                "exactly one of material, material_env, material_keychain must be set"
+                + (f" (got: {', '.join(sources)})" if sources else "")
+            )
+        return self
 
 
 class EncryptionConfig(BaseModel):

--- a/src/jentic_one/shared/crypto/encryption.py
+++ b/src/jentic_one/shared/crypto/encryption.py
@@ -12,6 +12,7 @@ import os
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 from jentic_one.shared.config import ConfigError, EncryptionConfig
+from jentic_one.shared.crypto.key_material import resolve_key_material
 
 _NONCE_BYTES = 12
 _KEY_BYTES = 32
@@ -34,7 +35,7 @@ class EncryptionService:
         for entry in cfg.entries:
             if entry.id in self._ciphers:
                 raise ConfigError(f"Duplicate encryption key id: '{entry.id}'")
-            raw = base64.b64decode(entry.material.get_secret_value())
+            raw = resolve_key_material(entry)
             if len(raw) != _KEY_BYTES:
                 raise ConfigError(
                     f"Encryption key '{entry.id}' must be {_KEY_BYTES} bytes, got {len(raw)}"

--- a/src/jentic_one/shared/crypto/key_material.py
+++ b/src/jentic_one/shared/crypto/key_material.py
@@ -1,0 +1,87 @@
+"""Resolve encryption-key material from its configured source.
+
+An :class:`~jentic_one.shared.config.EncryptionKey` entry carries exactly one
+source: inline base64 (``material``), an environment-variable name
+(``material_env``), or a macOS Keychain generic-password service name
+(``material_keychain``). This module turns an entry into raw key bytes.
+
+Resolution is invoked from ``EncryptionService.__init__`` — lazily, at first
+use of ``Context.encryption`` — so config loading alone never touches the
+environment or the Keychain (a Keychain read can block on a user prompt).
+
+The Keychain path shells out to ``/usr/bin/security`` by ABSOLUTE path on
+purpose: local installs treat same-user agent processes as the adversary, and
+a ``PATH`` lookup would let any of them interpose a fake ``security`` binary.
+No timeout is applied to the call — a locked keychain legitimately blocks on
+a user-facing unlock/allow prompt.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+import sys
+
+from jentic_one.shared.config import ConfigError, EncryptionKey
+
+_SECURITY_BIN = "/usr/bin/security"
+
+
+def _run_security(service: str) -> subprocess.CompletedProcess[str]:
+    """Execute the Keychain lookup. Module-level seam so tests can stub it."""
+    # Fixed absolute binary, no shell — see the module docstring on PATH hijacking.
+    return subprocess.run(
+        [_SECURITY_BIN, "find-generic-password", "-s", service, "-w"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _from_keychain(key_id: str, service: str) -> str:
+    if sys.platform != "darwin":
+        raise ConfigError(
+            f"Encryption key '{key_id}' uses material_keychain, which is only "
+            f"supported on macOS (platform: {sys.platform})"
+        )
+    result = _run_security(service)
+    if result.returncode != 0:
+        raise ConfigError(
+            f"Encryption key '{key_id}': Keychain item '{service}' could not be "
+            f"read (security exited {result.returncode}). Create it with "
+            f"'jenticctl install --keychain' or check its access control."
+        )
+    return result.stdout.strip()
+
+
+def _from_env(key_id: str, var: str) -> str:
+    value = os.environ.get(var, "")
+    if not value:
+        raise ConfigError(
+            f"Encryption key '{key_id}': environment variable '{var}' "
+            "(material_env) is not set or empty"
+        )
+    return value
+
+
+def resolve_key_material(entry: EncryptionKey) -> bytes:
+    """Return the raw key bytes for a keyset entry.
+
+    Raises :exc:`ConfigError` when the source is unavailable or the material
+    is not valid base64. Length validation stays with the caller
+    (``EncryptionService``), which owns the cipher requirements.
+    """
+    if entry.material is not None:
+        encoded = entry.material.get_secret_value()
+    elif entry.material_env:
+        encoded = _from_env(entry.id, entry.material_env)
+    elif entry.material_keychain:
+        encoded = _from_keychain(entry.id, entry.material_keychain)
+    else:  # pragma: no cover — the EncryptionKey validator forbids this
+        raise ConfigError(f"Encryption key '{entry.id}' has no material source")
+
+    try:
+        return base64.b64decode(encoded, validate=True)
+    except Exception as exc:
+        raise ConfigError(f"Encryption key '{entry.id}': material is not valid base64") from exc

--- a/tests/arch/test_secrets_are_secretstr.py
+++ b/tests/arch/test_secrets_are_secretstr.py
@@ -18,9 +18,17 @@ CONFIG_FILE = SRC_ROOT / "shared" / "config.py"
 
 SECRET_NAME_PARTS = ("secret", "password", "pepper", "token", "key")
 
+# Fields that match the name heuristic but hold a REFERENCE to a secret's
+# location, not the secret itself. `material_keychain` is the macOS Keychain
+# service NAME the key material lives under (shared/crypto/key_material.py);
+# the material never enters the config object.
+NON_SECRET_FIELDS = frozenset({"material_keychain"})
+
 
 def _is_secret_field(name: str) -> bool:
     """Return True if a field name looks like it holds a secret value."""
+    if name in NON_SECRET_FIELDS:
+        return False
     lowered = name.lower()
     return any(part in lowered for part in SECRET_NAME_PARTS)
 

--- a/tests/unit/shared/crypto/test_encryption.py
+++ b/tests/unit/shared/crypto/test_encryption.py
@@ -44,6 +44,14 @@ def test_roundtrip_empty_string():
     assert svc.decrypt(svc.encrypt("")) == ""
 
 
+def test_roundtrip_with_env_sourced_key(monkeypatch):
+    material = base64.b64encode(os.urandom(32)).decode()
+    monkeypatch.setenv("JENTIC_TEST_ENC_KEY", material)
+    entry = EncryptionKey(id="v1", material_env="JENTIC_TEST_ENC_KEY")
+    svc = EncryptionService(EncryptionConfig(active_id="v1", entries=[entry]))
+    assert svc.decrypt(svc.encrypt("secret")) == "secret"
+
+
 # --- Blob format ---
 
 

--- a/tests/unit/shared/crypto/test_key_material.py
+++ b/tests/unit/shared/crypto/test_key_material.py
@@ -1,0 +1,113 @@
+"""Unit tests for encryption-key material resolution (inline / env / keychain)."""
+
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from jentic_one.shared.config import ConfigError, EncryptionKey
+from jentic_one.shared.crypto import key_material
+from jentic_one.shared.crypto.key_material import resolve_key_material
+
+
+def _material() -> str:
+    return base64.b64encode(os.urandom(32)).decode()
+
+
+# --- Source validation (exactly one) ---
+
+
+def test_no_source_rejected():
+    with pytest.raises(ValidationError, match="exactly one of"):
+        EncryptionKey(id="v1")
+
+
+def test_two_sources_rejected():
+    with pytest.raises(ValidationError, match="exactly one of"):
+        EncryptionKey(id="v1", material=SecretStr(_material()), material_env="SOME_VAR")
+
+
+def test_inline_and_keychain_rejected():
+    with pytest.raises(ValidationError, match="exactly one of"):
+        EncryptionKey(id="v1", material=SecretStr(_material()), material_keychain="svc")
+
+
+# --- Inline source ---
+
+
+def test_inline_material_resolves():
+    encoded = _material()
+    entry = EncryptionKey(id="v1", material=SecretStr(encoded))
+    assert resolve_key_material(entry) == base64.b64decode(encoded)
+
+
+def test_inline_invalid_base64_raises_config_error():
+    entry = EncryptionKey(id="v1", material=SecretStr("not-base64!!"))
+    with pytest.raises(ConfigError, match="not valid base64"):
+        resolve_key_material(entry)
+
+
+# --- Env source ---
+
+
+def test_env_material_resolves(monkeypatch):
+    encoded = _material()
+    monkeypatch.setenv("JENTIC_TEST_KEK", encoded)
+    entry = EncryptionKey(id="v1", material_env="JENTIC_TEST_KEK")
+    assert resolve_key_material(entry) == base64.b64decode(encoded)
+
+
+def test_env_missing_raises_config_error(monkeypatch):
+    monkeypatch.delenv("JENTIC_TEST_KEK", raising=False)
+    entry = EncryptionKey(id="v1", material_env="JENTIC_TEST_KEK")
+    with pytest.raises(ConfigError, match="JENTIC_TEST_KEK"):
+        resolve_key_material(entry)
+
+
+def test_env_empty_raises_config_error(monkeypatch):
+    monkeypatch.setenv("JENTIC_TEST_KEK", "")
+    entry = EncryptionKey(id="v1", material_env="JENTIC_TEST_KEK")
+    with pytest.raises(ConfigError, match="not set or empty"):
+        resolve_key_material(entry)
+
+
+# --- Keychain source ---
+
+
+def _fake_security(stdout: str = "", returncode: int = 0):
+    def run(service: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["/usr/bin/security", "find-generic-password", "-s", service, "-w"],
+            returncode=returncode,
+            stdout=stdout,
+            stderr="",
+        )
+
+    return run
+
+
+def test_keychain_material_resolves(monkeypatch):
+    encoded = _material()
+    monkeypatch.setattr("jentic_one.shared.crypto.key_material.sys.platform", "darwin")
+    monkeypatch.setattr(key_material, "_run_security", _fake_security(stdout=encoded + "\n"))
+    entry = EncryptionKey(id="v1", material_keychain="jentic-one-credentials-encryption-v1")
+    assert resolve_key_material(entry) == base64.b64decode(encoded)
+
+
+def test_keychain_lookup_failure_raises_config_error(monkeypatch):
+    monkeypatch.setattr("jentic_one.shared.crypto.key_material.sys.platform", "darwin")
+    monkeypatch.setattr(key_material, "_run_security", _fake_security(returncode=44))
+    entry = EncryptionKey(id="v1", material_keychain="missing-item")
+    with pytest.raises(ConfigError, match="missing-item"):
+        resolve_key_material(entry)
+
+
+def test_keychain_on_non_darwin_raises_config_error(monkeypatch):
+    monkeypatch.setattr("jentic_one.shared.crypto.key_material.sys.platform", "linux")
+    entry = EncryptionKey(id="v1", material_keychain="svc")
+    with pytest.raises(ConfigError, match=r"only\s+supported on macOS"):
+        resolve_key_material(entry)

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -3089,6 +3089,12 @@
               "usage": "Docker path: pull this app image tag or @sha256: digest (or a full ghcr.io/…@sha256 ref) instead of the version-matched tag; ignored with --build-local"
             },
             {
+              "name": "keychain",
+              "type": "bool",
+              "default": "false",
+              "usage": "store the credentials encryption key in the macOS Keychain instead of jentic-one.yaml (macOS + source runtime only; a reinstall migrates an existing inline key; uninstall leaves the keychain item in place)"
+            },
+            {
               "name": "no-start",
               "type": "bool",
               "default": "false",


### PR DESCRIPTION
## Summary

The AES-256-GCM key that encrypts every stored third-party credential lives as inline base64 in `jentic-one.yaml` — and in the local-install threat model (AI agents running as the operator's own user), a 0600 file is readable by any same-user process, undoing the broker-injection design in one file read. This PR makes the key **source** pluggable per keyset entry: inline `material` (unchanged default), `material_env` (env-var name, for container secret injection), or `material_keychain` (macOS Keychain item — encrypted at rest, ACL/prompt-gated per binary). Plan: `jentic-one-plans/prs/pr-1225-kek-key-sources.md` ([jentic-one-plans#38](https://github.com/jentic/jentic-one-plans/pull/38)).

## Changes

- **shared/config** — `EncryptionKey` grows `material_env` / `material_keychain`; `material` becomes optional; model validator enforces exactly one source. Existing configs parse unchanged.
- **shared/crypto/key_material.py** (new) — resolves an entry to raw key bytes. Keychain reads go through `/usr/bin/security` by **absolute path** (a PATH lookup would let a same-user agent interpose a fake binary). Resolution is lazy (at `EncryptionService` construction, which `Context.encryption` already defers), so config loading never triggers a Keychain prompt.
- **shared/crypto/encryption.py** — reads material via the resolver; cipher/length validation unchanged.
- **cli: `jenticctl install --keychain`** — stores the generated key as a Keychain generic-password item and renders only a `material_keychain` reference; on reinstall, migrates a reused inline keyset entry-by-entry (same material, new home — ciphertexts stay decryptable); idempotent. Refused on the Docker path (a container cannot reach the host keychain) and on non-darwin, before any disk writes.
- **generated artifacts** — `config/config-schema.json`, Go config mirror, `ui/public/cli-reference.json` regenerated (CI drift checks).
- Out of scope, deliberately: CLI profile tokens → keychain (owned by CLI V2), a `kms:` source (config shape leaves room), GCM AAD binding (separate follow-up), keychain-item removal on uninstall (mirrors the reuse-keeps-data-readable contract; stated in `--help`).

## Risk & rollback

- **Credential/config surface**: `EncryptionKey.material` is now optional — invalid configs (no source / two sources) fail at pydantic validation with an explicit message. Default install path is byte-identical without `--keychain`.
- `tests/arch/test_secrets_are_secretstr.py` gains a documented exemption for `material_keychain` (it names a Keychain *service*, not a secret).
- Known trade-off: `--keychain` passes the secret through argv of one short-lived local `security` process at install time.
- Revert: revert the squash commit; configs already migrated to `material_keychain` need the key copied back inline (`security find-generic-password -s jentic-one-credentials-encryption-v1 -w`).

## Test plan

- `make test-unit` (2992 passed) and `make test-arch` (152 passed) — includes new `tests/unit/shared/crypto/test_key_material.py` (inline/env/keychain happy paths, missing/empty env, `security` failure, non-darwin refusal, invalid base64, exactly-one-source validation) and an env-sourced round-trip in `test_encryption.py`.
- `cd cli && go test ./...` — includes `keychain_test.go` (fresh-install store + reference render, Docker/non-darwin refusal, inline-keyset migration idempotence, keychain-keyset reuse round-trip).
- `make check` lint/format/mypy green (`score` step skipped: requires `JENTIC_API_KEY`, unavailable locally).
- No automated macOS-Keychain integration test; manual verification: `jenticctl install --keychain` on macOS (source path), then boot and confirm credential encrypt/decrypt round-trips.

## Review guide

- Start with `src/jentic_one/shared/crypto/key_material.py` (the security-sensitive seam), then the `EncryptionKey` validator in `shared/config.py`; the CLI half pivots on `cli/internal/install/keychain.go` (`ApplyKeychain`), with render/reuse/install.go changes mechanical around it.
- Design context (threat model, FDE-vs-keyring rationale, service-mode follow-up, library roles) lives in the plan and its PR: [jentic-one-plans#38](https://github.com/jentic/jentic-one-plans/pull/38).

Made with [Cursor](https://cursor.com)

