### PR TITLE
feat(cli): official CLI container image + MCP registry entry (2-E4 PR A+B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       openapi-client: ${{ steps.filter.outputs.openapi-client }}
       installer: ${{ steps.filter.outputs.installer }}
       e2e-install: ${{ steps.filter.outputs.e2e-install }}
+      mcp-registry: ${{ steps.filter.outputs.mcp-registry }}
     steps:
       - uses: actions/checkout@v7
 
@@ -101,6 +102,12 @@ jobs:
             installer:
               - 'tools/install.sh'
               - 'tests/tools/**'
+            mcp-registry:
+              # Drift gate for the official MCP registry entry: release.yml's
+              # publish-registry job stamps the tag version into this file and
+              # publishes it, so a schema break must be caught in-PR, not at
+              # release time.
+              - 'cli/server.json'
             e2e-install:
               # CLI-V2 Phase 9 (impl/9.0 §9.4): the cross-OS install + smoke
               # matrix. The Linux leg does a real Docker install; macOS/Windows
@@ -878,6 +885,30 @@ jobs:
       - name: Run installer tests
         run: bash tests/tools/install_test.sh
 
+  # Official-MCP-registry drift gate: cli/server.json is published (version-
+  # stamped) by release.yml's publish-registry job on every stable tag, so a
+  # schema/semantic break in the committed file must fail the PR that
+  # introduces it rather than the release DAG's last job. Same validator
+  # (`mcp-publisher validate`) and pinned version as the release job.
+  mcp-registry-validate:
+    name: MCP registry manifest valid
+    needs: [changes]
+    if: needs.changes.outputs.mcp-registry == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Validate cli/server.json
+        run: ./mcp-publisher validate cli/server.json
+
   # CLI-V2 Phase 9 (impl/9.0 §9.4): cross-platform install + smoke matrix.
   #   - ubuntu-24.04:  full headless Docker install + live-stack smoke (deep).
   #   - macos-latest:  build via install.sh (no chain-install) + offline smoke.
@@ -1011,7 +1042,7 @@ jobs:
   ci-status:
     name: CI status
     if: always()
-    needs: [lint, openapi-client-drift, security, test-unit, test-integration, ui, ui-e2e, ui-e2e-realbackend, smoke-packaging, cli, cli-artifact-smoke, installer, e2e-install]
+    needs: [lint, openapi-client-drift, security, test-unit, test-integration, ui, ui-e2e, ui-e2e-realbackend, smoke-packaging, cli, cli-artifact-smoke, installer, mcp-registry-validate, e2e-install]
     runs-on: ubuntu-latest
     steps:
       - name: Check job results
@@ -1029,6 +1060,7 @@ jobs:
             ${{ needs.cli.result }}
             ${{ needs.cli-artifact-smoke.result }}
             ${{ needs.installer.result }}
+            ${{ needs.mcp-registry-validate.result }}
             ${{ needs.e2e-install.result }}
         run: |
           for r in $RESULTS; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       installer: ${{ steps.filter.outputs.installer }}
       e2e-install: ${{ steps.filter.outputs.e2e-install }}
       mcp-registry: ${{ steps.filter.outputs.mcp-registry }}
+      cli-image: ${{ steps.filter.outputs.cli-image }}
     steps:
       - uses: actions/checkout@v7
 
@@ -108,6 +109,15 @@ jobs:
               # publishes it, so a schema break must be caught in-PR, not at
               # release time.
               - 'cli/server.json'
+            cli-image:
+              # Branch-CI build + scan of the CLI image (cli-image-scan job):
+              # release.yml's publish-cli-image builds this Dockerfile on every
+              # tag and GATES the `release` job, so a build break (e.g. a
+              # cli/go.mod `go` directive outpacing the pinned golang digest)
+              # or a new base-image CVE must fail the PR that introduces it,
+              # not the release run.
+              - 'deploy/docker/cli.Dockerfile'
+              - 'cli/**'
             e2e-install:
               # CLI-V2 Phase 9 (impl/9.0 §9.4): the cross-OS install + smoke
               # matrix. The Linux leg does a real Docker install; macOS/Windows
@@ -313,6 +323,43 @@ jobs:
         with:
           scan-type: 'image'
           image-ref: jentic-one/app:scan
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '1'
+          trivyignores: .trivyignore
+
+  # Branch-CI build + scan of the CLI image — the same "fail here before a
+  # registry does" posture the security job applies to the app image, but
+  # path-gated: it only matters when cli/** or its Dockerfile change.
+  # Without it, the FIRST-EVER build of deploy/docker/cli.Dockerfile would
+  # happen inside release.yml's publish-cli-image on a real tag — a job that
+  # gates `release` — so silent breakage (cli/go.mod's `go` directive
+  # outpacing the pinned golang digest, source-layout drift breaking
+  # `COPY cli/ ./`, new fixable base-image CVEs) would surface only as a red
+  # release run. amd64-only and never pushed: release.yml owns multi-arch
+  # and publishing.
+  cli-image-scan:
+    name: CLI image build & scan
+    needs: [changes]
+    if: needs.changes.outputs.cli-image == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build the CLI image (amd64, not pushed)
+        run: |
+          docker build -f deploy/docker/cli.Dockerfile \
+            --build-arg VERSION=0.0.0-ci \
+            -t jentic-one/cli:scan .
+
+      # Same policy as the security job's app-image scan above: fixable
+      # HIGH/CRITICAL fail, overrides live in .trivyignore (CVE id +
+      # justification + expiry).
+      - name: Trivy image scan (fixable HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: jentic-one/cli:scan
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           exit-code: '1'
@@ -900,12 +947,28 @@ jobs:
 
       - name: Install mcp-publisher
         env:
+          # MUST move in lockstep with release.yml publish-registry's copy of
+          # these two literals — a bump touching one file silently splits this
+          # gate from the publisher (the checksum pin at least forces both
+          # bumps to be deliberate: a new version fails loudly here until its
+          # hash is looked up and updated).
           MCP_PUBLISHER_VERSION: v1.8.1
+          # sha256 of mcp-publisher_linux_amd64.tar.gz from upstream's
+          # registry_1.8.1_checksums.txt — release-tag assets are mutable, so
+          # verify the download instead of trusting the tag.
+          MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
         run: |
           set -euo pipefail
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
-            | tar xz mcp-publisher
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
 
+      # NOTE: `mcp-publisher validate` is NOT an offline schema check — v1.8.1
+      # POSTs the file to the live registry's /v0/validate endpoint (no offline
+      # mode exists), so this step depends on registry.modelcontextprotocol.io
+      # being up. Accepted trade-off: it validates against the semantics the
+      # publish will actually hit.
       - name: Validate cli/server.json
         run: ./mcp-publisher validate cli/server.json
 
@@ -1042,7 +1105,7 @@ jobs:
   ci-status:
     name: CI status
     if: always()
-    needs: [lint, openapi-client-drift, security, test-unit, test-integration, ui, ui-e2e, ui-e2e-realbackend, smoke-packaging, cli, cli-artifact-smoke, installer, mcp-registry-validate, e2e-install]
+    needs: [lint, openapi-client-drift, security, cli-image-scan, test-unit, test-integration, ui, ui-e2e, ui-e2e-realbackend, smoke-packaging, cli, cli-artifact-smoke, installer, mcp-registry-validate, e2e-install]
     runs-on: ubuntu-latest
     steps:
       - name: Check job results
@@ -1051,6 +1114,7 @@ jobs:
             ${{ needs.lint.result }}
             ${{ needs.openapi-client-drift.result }}
             ${{ needs.security.result }}
+            ${{ needs.cli-image-scan.result }}
             ${{ needs.test-unit.result }}
             ${{ needs.test-integration.result }}
             ${{ needs.ui.result }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,8 +531,11 @@ jobs:
           VERSION: ${{ steps.build.outputs.version }}
         run: |
           set -euo pipefail
+          # Prerelease-aware: extract the FULL semver (incl. -rc.N / +meta)
+          # so a v1.2.3-rc.1 tag compares against 1.2.3-rc.1, not a stripped
+          # 1.2.3 that could never match.
           got="$(docker run --rm "${IMAGE}:${VERSION}-amd64" jentic --version 2>/dev/null \
-            | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)"
+            | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?' | head -n1 || true)"
           echo "tag=${VERSION} image binary=${got}"
           test "${got}" = "${VERSION}" || { echo "::error::jentic --version (${got}) != tag (${VERSION})"; exit 1; }
           want_name="$(jq -r .name cli/server.json)"
@@ -661,7 +664,9 @@ jobs:
           want="${GITHUB_REF_NAME#v}"
           bin="$(find dist -type f -name jentic -path '*linux_amd64*' | head -n1)"
           test -n "${bin}" || { echo "::error::could not locate built jentic binary under cli/dist"; ls -R dist || true; exit 1; }
-          got="$("${bin}" --version 2>/dev/null | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)"
+          # Prerelease-aware (same extraction as publish-cli-image's gate): a
+          # v1.2.3-rc.1 tag must compare against the full 1.2.3-rc.1 stamp.
+          got="$("${bin}" --version 2>/dev/null | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?' | head -n1 || true)"
           echo "tag=${want} binary=${got}"
           test "${got}" = "${want}" || { echo "::error::jentic --version (${got}) != tag (${want})"; exit 1; }
         working-directory: cli
@@ -710,8 +715,15 @@ jobs:
     #   - DNS TXT record on jentic.one: "v=MCPv1; k=ed25519; p=<base64 pubkey>",
     #   - the GHCR jentic-one-cli package made PUBLIC after its first push
     #     (ownership verification pulls it anonymously).
-    # Until the secret exists this job fails at login; the release artifacts
-    # are unaffected (this job gates nothing).
+    # DORMANT until the secret is provisioned — in kind with the ECR tail's
+    # vars-gating: secrets aren't readable in job-level `if:`, so the
+    # "Publisher key provisioned?" step below checks the env-injected secret
+    # and every publish step gates on its output. Unprovisioned (forks,
+    # pre-provisioning releases) = clean green skip; provisioned + broken =
+    # loud red. The release artifacts are unaffected either way (this job
+    # gates nothing).
+    # `publish-cli-image` is transitively implied via `release`; kept
+    # explicitly as self-documentation of what this job consumes.
     needs: [publish-cli-image, release]
     runs-on: ubuntu-latest
     permissions:
@@ -733,23 +745,52 @@ jobs:
             echo "Prerelease tag — skipping the MCP registry publish"
           fi
 
+      # Dormant gate (see the job comment): GitHub can't evaluate `secrets.*`
+      # in job-level `if:`, so check the env-injected secret in a step and
+      # gate everything below on the output. Empty/absent secret = green
+      # skip; once provisioned, any publish failure is a loud red.
+      - name: Publisher key provisioned?
+        id: key
+        env:
+          MCP_REGISTRY_ED25519_KEY: ${{ secrets.MCP_REGISTRY_ED25519_KEY }}
+        run: |
+          if [ -n "${MCP_REGISTRY_ED25519_KEY}" ]; then
+            echo "provisioned=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "provisioned=false" >> "$GITHUB_OUTPUT"
+            echo "MCP_REGISTRY_ED25519_KEY not provisioned — skipping the MCP registry publish (dormant)"
+          fi
+
       # Pinned release download (never `latest/download`) — same
       # reproducibility posture as every other pinned tool in this pipeline.
       - name: Install mcp-publisher
-        if: steps.guard.outputs.stable == 'true'
+        if: steps.guard.outputs.stable == 'true' && steps.key.outputs.provisioned == 'true'
         env:
+          # MUST move in lockstep with ci.yml mcp-registry-validate's copy of
+          # these two literals — a bump touching one file silently splits the
+          # PR gate from the publisher (the checksum pin at least forces both
+          # bumps to be deliberate: a new version fails loudly here until its
+          # hash is looked up and updated).
           MCP_PUBLISHER_VERSION: v1.8.1
+          # sha256 of mcp-publisher_linux_amd64.tar.gz from upstream's
+          # registry_1.8.1_checksums.txt — release-tag assets are mutable, so
+          # verify the download instead of trusting the tag.
+          MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
         run: |
           set -euo pipefail
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
-            | tar xz mcp-publisher
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
 
       # cli/server.json is committed with a 0.0.0 placeholder (drift-gated by
       # ci.yml's mcp-registry-validate job); the tag version is stamped into
       # `version` and the OCI package identifier here so the entry always
       # tracks the binary/image version — no manual step per release.
+      # (`validate` here, as in ci.yml, POSTs to the live registry's
+      # /v0/validate — v1.8.1 has no offline mode.)
       - name: Stamp the release version into server.json and validate
-        if: steps.guard.outputs.stable == 'true'
+        if: steps.guard.outputs.stable == 'true' && steps.key.outputs.provisioned == 'true'
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
@@ -762,10 +803,15 @@ jobs:
 
       # DNS login is the non-interactive, CI-friendly method that grants
       # publish rights on one.jentic/* (github-oidc would only grant
-      # io.github.jentic/*, the old namespace). The secret goes through env,
-      # never argv interpolation into the script text.
+      # io.github.jentic/*, the old namespace). The secret is injected via
+      # env — never ${{ }}-interpolated into the script text — but v1.8.1's
+      # `login dns` accepts the key ONLY as a --private-key flag, so it does
+      # land on mcp-publisher's argv for the login's duration (visible in
+      # /proc/*/cmdline). Acceptable on an ephemeral single-tenant runner;
+      # the argv-free alternative upstream offers is KMS-backed signing,
+      # which needs cloud infra we don't have here.
       - name: Publish to the official MCP registry
-        if: steps.guard.outputs.stable == 'true'
+        if: steps.guard.outputs.stable == 'true' && steps.key.outputs.provisioned == 'true'
         env:
           MCP_REGISTRY_ED25519_KEY: ${{ secrets.MCP_REGISTRY_ED25519_KEY }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,24 @@
 #                      smoke: the image is part of the release, so it must not
 #                      publish (nor move :latest) while any deployment mode is
 #                      red.
+#   3b. publish-cli-image — (parallel to publish-image, same gate+smoke bar)
+#                      build the `jentic` CLI image FROM SOURCE
+#                      (deploy/docker/cli.Dockerfile) and push it to GHCR
+#                      (ghcr.io/<owner>/jentic-one-cli). This is the container
+#                      the MCP container-isolation rung spawns
+#                      (docs/security/mcp-same-host-hardening.md, Recipe 3) and
+#                      the OCI package behind the official MCP registry entry.
 #   4. release       — GoReleaser builds the signed, checksummed jenticctl +
 #                      jentic binaries (cosign keyless via OIDC + syft SBOMs) and
 #                      pushes the Homebrew cask. This is the install (see
-#                      docs/releasing.md). Needs gate + smoke + publish-image so
-#                      a release never half-ships (binaries without the image).
+#                      docs/releasing.md). Needs gate + smoke + both publish
+#                      jobs so a release never half-ships (binaries without the
+#                      images, or vice versa).
+#   5. publish-registry — refresh the official MCP registry entry
+#                      (one.jentic/jentic, cli/server.json) at the released
+#                      version via mcp-publisher. Runs LAST: the entry
+#                      references the CLI image and the release, and a registry
+#                      failure must never strand either.
 #
 # Only tags trigger this; branch CI stays in ci.yml. GITHUB_TOKEN can create the
 # release assets here because we're already ON the tag (no downstream trigger
@@ -395,13 +408,214 @@ jobs:
           cosign sign "${ECR_IMAGE}@${DIGEST}"
           cosign attest --type spdxjson --predicate sbom.spdx.json "${ECR_IMAGE}@${DIGEST}"
 
+  publish-cli-image:
+    name: Publish CLI image to GHCR
+    # Mirrors publish-image step-for-step (same gate+smoke bar, same
+    # credential-ordering posture, per-arch Trivy before any push, cosign +
+    # SBOM by digest, :latest last) — diff-review against that job. Built
+    # FROM SOURCE (deploy/docker/cli.Dockerfile), NOT from GoReleaser
+    # artifacts: GoReleaser's `dockers:` was considered and rejected — it
+    # cannot interpose the per-arch Trivy scan between build and push, and it
+    # would move image publishing AFTER the binaries, breaking the
+    # never-half-ships gating (the image must be able to gate the `release`
+    # job). Version-stamp parity with the binaries is enforced by the
+    # `jentic --version` == tag gate below.
+    needs: [gate, smoke]
+    runs-on: ubuntu-latest
+    # Serialize CLI-image publishes across concurrently pushed tags — same
+    # rationale as publish-image's group, separate group because the two
+    # jobs touch different GHCR packages and may run in parallel.
+    concurrency:
+      group: release-publish-cli-image
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: write # push the CLI image to GHCR (ghcr.io/<owner>/jentic-one-cli)
+      id-token: write # cosign keyless signing (fulcio/OIDC), mirroring the CLI binaries
+    steps:
+      - uses: actions/checkout@v7
+
+      # Install the third-party tooling BEFORE `docker login` writes the
+      # packages:write-scoped token to ~/.docker/config.json — see the
+      # credential-ordering comment on publish-image; the same posture
+      # applies verbatim here.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Install syft (SBOM)
+        uses: anchore/sbom-action/download-syft@v0
+
+      # The Go build cross-compiles on the BUILDPLATFORM (no emulated
+      # compile), but the runtime stage's apt-get still executes per-arch, so
+      # the arm64 leg needs QEMU. Set up BEFORE `docker login` (same ordering
+      # rationale as above).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # DATE is resolved ONCE here (not per buildx invocation): it feeds the
+      # version-stamp ldflags as a build arg, and a differing value between
+      # the scan builds and the final --push build would invalidate the layer
+      # cache and rebuild (or worse, re-stamp) the pushed image.
+      - name: Resolve image name/version
+        id: build
+        run: |
+          set -euo pipefail
+          OWNER="$(tr '[:upper:]' '[:lower:]' <<<"${GITHUB_REPOSITORY_OWNER}")"
+          IMAGE="ghcr.io/${OWNER}/jentic-one-cli"
+          VERSION="${GITHUB_REF_NAME#v}"
+          SHA="$(git rev-parse --short HEAD)"
+          DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
+
+      # Trivy gates BEFORE any push (an index can't be `--load`ed, so build
+      # each arch single-platform, load it, scan it) — same recipe and
+      # rationale as publish-image. buildx caches the layers, so the final
+      # multi-arch `--push` build below is nearly free.
+      - name: Build per-arch images for scanning (loaded locally)
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+          VERSION: ${{ steps.build.outputs.version }}
+          SHA: ${{ steps.build.outputs.sha }}
+          DATE: ${{ steps.build.outputs.date }}
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            docker buildx build -f deploy/docker/cli.Dockerfile \
+              --platform "linux/${arch}" \
+              --build-arg VERSION="${VERSION}" \
+              --build-arg COMMIT="${SHA}" \
+              --build-arg DATE="${DATE}" \
+              -t "${IMAGE}:${VERSION}-${arch}" \
+              --load .
+          done
+
+      # CVE gate before anything is pushed — for EVERY shipped arch. Same
+      # policy as publish-image: fixable HIGH/CRITICAL fail, overrides live
+      # in .trivyignore (CVE id + justification + expiry).
+      - name: Trivy image scan — amd64 (release gate)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: ${{ steps.build.outputs.image }}:${{ steps.build.outputs.version }}-amd64
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '1'
+          trivyignores: .trivyignore
+      - name: Trivy image scan — arm64 (release gate)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: ${{ steps.build.outputs.image }}:${{ steps.build.outputs.version }}-arm64
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '1'
+          trivyignores: .trivyignore
+
+      # CLI-specific release gates, still before any push:
+      #   1. `jentic --version` == tag — mirrors the `release` job's binary
+      #      check, so a bad ldflag stamp can't ship an image whose CLI
+      #      disagrees with the tag (the image version must always equal the
+      #      binary version it contains).
+      #   2. The io.modelcontextprotocol.server.name label == server.json's
+      #      `name` — the official MCP registry's OCI ownership verification
+      #      pulls the image and checks exactly this, so a drift here would
+      #      surface as a publish-registry failure at the end of the DAG.
+      - name: Image version matches tag + MCP registry ownership label
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+          VERSION: ${{ steps.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          got="$(docker run --rm "${IMAGE}:${VERSION}-amd64" jentic --version 2>/dev/null \
+            | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)"
+          echo "tag=${VERSION} image binary=${got}"
+          test "${got}" = "${VERSION}" || { echo "::error::jentic --version (${got}) != tag (${VERSION})"; exit 1; }
+          want_name="$(jq -r .name cli/server.json)"
+          got_name="$(docker inspect --format '{{ index .Config.Labels "io.modelcontextprotocol.server.name" }}' "${IMAGE}:${VERSION}-amd64")"
+          echo "server.json name=${want_name} image label=${got_name}"
+          test "${got_name}" = "${want_name}" || { echo "::error::io.modelcontextprotocol.server.name label (${got_name}) != cli/server.json name (${want_name})"; exit 1; }
+
+      # Login deliberately AFTER build + scan (see the installer-ordering
+      # comment on publish-image): no third-party tool runs with the registry
+      # credential on disk.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build+push the MULTI-ARCH index in one step — a cache hit on the
+      # layers the scan builds populated (same build args, same DATE). The
+      # pushed INDEX digest is the immutable pin cosign signs below.
+      - name: Build + push multi-arch index (version + SHA tags)
+        id: push
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+          VERSION: ${{ steps.build.outputs.version }}
+          SHA: ${{ steps.build.outputs.sha }}
+          DATE: ${{ steps.build.outputs.date }}
+        run: |
+          set -euo pipefail
+          docker buildx build -f deploy/docker/cli.Dockerfile \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg VERSION="${VERSION}" \
+            --build-arg COMMIT="${SHA}" \
+            --build-arg DATE="${DATE}" \
+            -t "${IMAGE}:${VERSION}" \
+            -t "${IMAGE}:${SHA}" \
+            --metadata-file /tmp/bake-metadata.json \
+            --push .
+          DIGEST="$(jq -r '."containerimage.digest"' /tmp/bake-metadata.json)"
+          test -n "${DIGEST}" && [ "${DIGEST}" != "null" ]
+          echo "Image index digest: ${DIGEST}"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      # Sign the image and attach an SBOM attestation — identical recipe to
+      # publish-image: cosign keyless via the job's OIDC identity + syft
+      # SBOM, both targeting the immutable INDEX digest (covers every arch),
+      # never a floating tag.
+      - name: Sign the image and attest its SBOM (cosign keyless + syft)
+        env:
+          COSIGN_YES: "true"
+          IMAGE: ${{ steps.push.outputs.image }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign "${IMAGE}@${DIGEST}"
+          syft "${IMAGE}@${DIGEST}" -o spdx-json > sbom.spdx.json
+          cosign attest --type spdxjson --predicate sbom.spdx.json "${IMAGE}@${DIGEST}"
+
+      # :latest moves LAST, only on stable releases, only after signing —
+      # same guard and mechanism (registry-side manifest copy) as
+      # publish-image.
+      - name: Move :latest (stable releases only, after signing)
+        env:
+          IMAGE: ${{ steps.push.outputs.image }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            docker buildx imagetools create -t "${IMAGE}:latest" "${IMAGE}@${DIGEST}"
+            echo "Moved ${IMAGE}:latest to ${IMAGE}@${DIGEST}"
+          else
+            echo "Prerelease tag — not moving :latest"
+          fi
+
   release:
     name: GoReleaser (signed CLI binaries)
-    # publish-image gates the binaries too: a release must not exist in a state
-    # where the CLI shipped but the container image it documents did not (or
-    # vice versa). If either publish half fails, the whole release run is red
-    # and gets re-run from the tag.
-    needs: [gate, smoke, publish-image]
+    # The publish jobs gate the binaries too: a release must not exist in a
+    # state where the CLI shipped but the container images it documents did
+    # not (or vice versa). If any publish half fails, the whole release run is
+    # red and gets re-run from the tag.
+    needs: [gate, smoke, publish-image, publish-cli-image]
     runs-on: ubuntu-latest
     permissions:
       contents: write # attach artifacts to the GitHub Release
@@ -479,3 +693,82 @@ jobs:
             gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
               -f ref="refs/tags/${CLI_TAG}" -f sha="${GITHUB_SHA}"
           fi
+
+  publish-registry:
+    name: Publish MCP registry entry (one.jentic/jentic)
+    # Runs LAST in the DAG: the entry references the CLI image (the
+    # registry's OCI ownership verification PULLS ghcr.io/jentic/jentic-one-cli
+    # and checks its io.modelcontextprotocol.server.name label) and describes
+    # the released version, and a registry failure must never strand the
+    # image/binaries — same posture as publish-image's Marketplace-ECR tail.
+    # A red run here is retried by re-running the workflow from the tag; the
+    # earlier jobs re-push the same digest-addressed content.
+    #
+    # PREREQUISITES (one-time admin setup, see #1214's lead-time asks):
+    #   - Ed25519 publisher keypair minted; the PRIVATE key (64 hex chars)
+    #     stored as the MCP_REGISTRY_ED25519_KEY Actions secret,
+    #   - DNS TXT record on jentic.one: "v=MCPv1; k=ed25519; p=<base64 pubkey>",
+    #   - the GHCR jentic-one-cli package made PUBLIC after its first push
+    #     (ownership verification pulls it anonymously).
+    # Until the secret exists this job fails at login; the release artifacts
+    # are unaffected (this job gates nothing).
+    needs: [publish-cli-image, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      # Stable tags only — mirror the publish jobs' :latest regex guard, so a
+      # prerelease (e.g. v1.2.3-rc.1) never touches the public registry
+      # entry. Steps below are gated on this output rather than failing,
+      # keeping prerelease runs green.
+      - name: Stable tag guard
+        id: guard
+        run: |
+          if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stable=false" >> "$GITHUB_OUTPUT"
+            echo "Prerelease tag — skipping the MCP registry publish"
+          fi
+
+      # Pinned release download (never `latest/download`) — same
+      # reproducibility posture as every other pinned tool in this pipeline.
+      - name: Install mcp-publisher
+        if: steps.guard.outputs.stable == 'true'
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+
+      # cli/server.json is committed with a 0.0.0 placeholder (drift-gated by
+      # ci.yml's mcp-registry-validate job); the tag version is stamped into
+      # `version` and the OCI package identifier here so the entry always
+      # tracks the binary/image version — no manual step per release.
+      - name: Stamp the release version into server.json and validate
+        if: steps.guard.outputs.stable == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "${VERSION}" \
+            '.version = $v
+             | .packages[0].identifier = "ghcr.io/jentic/jentic-one-cli:" + $v' \
+            cli/server.json > /tmp/server.json
+          mv /tmp/server.json cli/server.json
+          ./mcp-publisher validate cli/server.json
+
+      # DNS login is the non-interactive, CI-friendly method that grants
+      # publish rights on one.jentic/* (github-oidc would only grant
+      # io.github.jentic/*, the old namespace). The secret goes through env,
+      # never argv interpolation into the script text.
+      - name: Publish to the official MCP registry
+        if: steps.guard.outputs.stable == 'true'
+        env:
+          MCP_REGISTRY_ED25519_KEY: ${{ secrets.MCP_REGISTRY_ED25519_KEY }}
+        run: |
+          set -euo pipefail
+          ./mcp-publisher login dns --domain=jentic.one --private-key="${MCP_REGISTRY_ED25519_KEY}"
+          ./mcp-publisher publish cli/server.json

--- a/cli/server.json
+++ b/cli/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "one.jentic/jentic",
+  "title": "Jentic",
+  "description": "Search APIs and workflows by intent and execute them: send messages, fetch data, automate tasks.",
+  "repository": {
+    "url": "https://github.com/jentic/jentic-one",
+    "source": "github"
+  },
+  "websiteUrl": "https://jentic.com",
+  "version": "0.0.0",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/jentic/jentic-one-cli:0.0.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/deploy/docker/cli.Dockerfile
+++ b/deploy/docker/cli.Dockerfile
@@ -1,0 +1,97 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-arch image for the `jentic` agent CLI, built FROM SOURCE (not from
+# GoReleaser artifacts) so the release pipeline can publish it BEFORE the
+# binaries ship — the image gates the `release` job, preserving release.yml's
+# "a release never half-ships" invariant with no circular dependency.
+# Version-stamp parity with the binaries is enforced by the publish job's
+# `jentic --version` == tag gate.
+#
+# The runtime stage implements the container-isolation contract stated in
+# docs/security/mcp-same-host-hardening.md (Recipe 3):
+#   - `jentic` on PATH,
+#   - non-root uid 10001 (`jentic` user) with writable HOME=/home/jentic,
+#   - $HOME/.config/jentic pre-created and OWNED by that user, so a named
+#     volume mounted there seeds with the right ownership on first mount
+#     (Docker copies the image's content at the mount path into an empty
+#     named volume),
+#   - ca-certificates for TLS to remote instances.
+#
+# No ENTRYPOINT: Recipe 3's entries (and its registration step) pass the
+# binary name explicitly (`… <image> jentic mcp --context <name>` /
+# `… <image> jentic register …`), so the argv must start the process
+# directly. CMD gives a bare `docker run -i <image>` a useful default —
+# the stdio MCP server — which is what official-MCP-registry clients spawn
+# for an `oci` package (cli/server.json).
+#
+# The io.modelcontextprotocol.server.name label is the registry's OCI
+# OWNERSHIP VERIFICATION: publishing to registry.modelcontextprotocol.io
+# pulls the image and requires this label to equal server.json's `name`.
+# Keep the two in lockstep (cli/server.json).
+
+# Pinned to specific digests for reproducible builds (same policy as the
+# sibling service Dockerfiles). To bump: `docker pull golang:1.25` /
+# `ubuntu:24.04`, then update the digests (`docker buildx imagetools
+# inspect <image>` prints them). The BUILDER never ships; the RUNTIME is
+# Ubuntu, matching the app images' base (Ubuntu backports NVD-critical
+# glibc fixes Debian stable marks won't-fix, keeping the Trivy gate green).
+ARG GOLANG_IMAGE=golang:1.25@sha256:699337d620559a59b4a2bb298ad59611e535d2ee755a34cf2d2a98f37578dc80
+ARG UBUNTU_IMAGE=ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+
+# Go cross-compiles natively, so build on the BUILDPLATFORM and target
+# TARGETOS/TARGETARCH — no QEMU-emulated compile on the arm64 leg (same
+# rationale as app.multiarch.Dockerfile's ui-builder stage).
+FROM --platform=$BUILDPLATFORM ${GOLANG_IMAGE} AS builder
+ARG TARGETOS
+ARG TARGETARCH
+# Version stamp, injected by the publish job (release.yml publish-cli-image)
+# as the tag's X.Y.Z / short SHA / build date — the same
+# -X …cmdcore.{version,commit,date} trio as cli/Makefile and
+# cli/.goreleaser.yaml, so `jentic --version` inside the image equals the
+# released binaries' output. `.git/` is dockerignored, so COMMIT cannot be
+# derived in-build and must be passed in.
+ARG VERSION=dev
+ARG COMMIT=none
+ARG DATE=unknown
+
+WORKDIR /src
+# Dependency layer first so source edits don't re-download modules.
+COPY cli/go.mod cli/go.sum ./
+RUN go mod download
+COPY cli/ ./
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath \
+      -ldflags "-s -w \
+        -X github.com/jentic/jentic-one/cli/internal/cli/cmdcore.version=${VERSION} \
+        -X github.com/jentic/jentic-one/cli/internal/cli/cmdcore.commit=${COMMIT} \
+        -X github.com/jentic/jentic-one/cli/internal/cli/cmdcore.date=${DATE}" \
+      -o /out/jentic ./cmd/jentic
+
+FROM ${UBUNTU_IMAGE} AS runtime
+
+# MUST match cli/server.json's `name` — see the ownership-verification note
+# in the header. Standard OCI source label alongside it so GHCR links the
+# package to this repo.
+LABEL io.modelcontextprotocol.server.name="one.jentic/jentic" \
+      org.opencontainers.image.source="https://github.com/jentic/jentic-one" \
+      org.opencontainers.image.description="Jentic One agent CLI (jentic) — local MCP stdio server" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# The upgrade picks up security fixes published since the pinned digest's
+# last upstream rebuild (same posture as app.multiarch.Dockerfile).
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Recipe 3's uid/HOME/config-dir contract — see the header comment.
+RUN useradd --uid 10001 --create-home jentic \
+    && mkdir -p /home/jentic/.config/jentic \
+    && chown -R jentic:jentic /home/jentic
+
+COPY --from=builder /out/jentic /usr/local/bin/jentic
+
+USER 10001:10001
+ENV HOME=/home/jentic
+CMD ["jentic", "mcp"]

--- a/docs/security/mcp-same-host-hardening.md
+++ b/docs/security/mcp-same-host-hardening.md
@@ -127,14 +127,24 @@ The keys live in a named volume rather than in the desktop user's home, so
 ordinary file reads by desktop-user processes cannot reach them (but see the
 residual risk below — Docker daemon access can).
 
-**Bring your own image.** No official CLI image is published today — build
-one from the released `jentic` binary. The steps below assume an image that
-provides: the `jentic` binary on `PATH`; a non-root user (uid 10001 here)
-with a writable `HOME` (`/home/jentic`); and the config directory
+**Official image.** The CLI image is published with every release as
+`ghcr.io/jentic/jentic-one-cli:<X.Y.Z>` (multi-arch amd64+arm64, built from
+`deploy/docker/cli.Dockerfile`, cosign-signed with an SBOM attestation — the
+same verification recipe as the app image, see deploy/README.md "Verify the
+image signature"). Pin a version tag matching your instance's release rather
+than floating on `:latest`. The image provides the contract the steps below
+assume: the `jentic` binary on `PATH`; a non-root user (uid 10001) with a
+writable `HOME` (`/home/jentic`); and the config directory
 `$HOME/.config/jentic` pre-created and **owned by that user**, so the named
 volume initializes with the right ownership on first mount (Docker seeds an
-empty named volume from the image's content at the mount path). A minimal
-example:
+empty named volume from the image's content at the mount path). This is a
+manual recipe today — with the image published, a later release re-enables
+the automated container rung in `jentic setup`'s isolation step, the only
+automatable isolated rung on Windows.
+
+**Bring your own image (fallback).** If you cannot pull from `ghcr.io`, any
+image satisfying the same contract works in the steps below — build one from
+the released `jentic` binary. A minimal example:
 
 ```dockerfile
 FROM debian:bookworm-slim
@@ -161,7 +171,7 @@ ENV HOME=/home/jentic
    docker run -i --rm \
      --add-host=host.docker.internal:host-gateway \
      -v jentic-mcp-claude:/home/jentic/.config/jentic \
-     your-jentic-cli-image \
+     ghcr.io/jentic/jentic-one-cli:<version> \
      jentic register --url http://host.docker.internal:8000 \
        --broker-url http://host.docker.internal:8100 \
        --env local --name claude
@@ -175,7 +185,7 @@ ENV HOME=/home/jentic
 
    ```
    docker run --rm -v jentic-mcp-claude:/home/jentic/.config/jentic \
-     your-jentic-cli-image jentic context rename local-claude claude
+     ghcr.io/jentic/jentic-one-cli:<version> jentic context rename local-claude claude
    ```
 
 3. **Point the MCP entry at the container.** `--read-only` makes the rootfs
@@ -194,7 +204,7 @@ ENV HOME=/home/jentic
               "--add-host=host.docker.internal:host-gateway",
               "--tmpfs", "/tmp",
               "-v", "jentic-mcp-claude:/home/jentic/.config/jentic",
-              "your-jentic-cli-image",
+              "ghcr.io/jentic/jentic-one-cli:<version>",
               "jentic", "mcp", "--context", "claude",
               "--log-file", "/tmp/mcp.log"]
    }


### PR DESCRIPTION
Re-proposal of #1224 (merged prematurely, backed out by #1227) — identical content, held for manual review. **Do not merge until Manuel signs off.**

## What this ships (issue #1214, PR A + B)

| Item | Where |
|---|---|
| CLI container image, built from source, Recipe-3 contract (uid 10001, `HOME=/home/jentic`, pre-owned `~/.config/jentic`), `CMD ["jentic","mcp"]` | `deploy/docker/cli.Dockerfile` |
| MCP ownership label `io.modelcontextprotocol.server.name=one.jentic/jentic` + OCI labels | `deploy/docker/cli.Dockerfile` |
| `publish-cli-image` job — step-for-step mirror of `publish-image` (per-arch Trivy pre-push, cosign keyless, syft SBOM, `:latest` on stable tags only) + `jentic --version`==tag gate + label==server.json assertion | `.github/workflows/release.yml` |
| `release` widened to need the CLI image; `publish-registry` strictly last in the DAG | `.github/workflows/release.yml` |
| MCP registry entry (2025-12-11 schema, `one.jentic/jentic`, OCI package, version stamped at release) | `cli/server.json` |
| `publish-registry` — pinned `mcp-publisher` v1.8.1 (sha256-verified), validate → `login dns` → publish, **dormant-gated**: skips green until the publisher secret is provisioned | `.github/workflows/release.yml` |
| Branch-CI drift gate: `mcp-registry-validate` (path-filtered) + `cli-image-scan` (amd64 build + Trivy of the CLI Dockerfile) | `.github/workflows/ci.yml` |
| Recipe 3 docs flipped to the official image; G6 flip-back note | `docs/security/mcp-same-host-hardening.md` |

## PR A+B coupling

#1214 sliced this as two PRs; they are landed together deliberately — the image gate reads `cli/server.json`, and one commit guarantees the label↔registry-name lockstep lands atomically. Reviewer verdict: coupling safe.

## Adversarial review (all findings addressed)

- **F1 (MAJOR)** Dockerfile never built in branch CI → added the path-gated `cli-image-scan` job (green on this branch, 1m35s).
- **F2 (MAJOR)** `publish-registry` went red when unprovisioned → dormant-gated on the secret's presence; loud red only when configured-and-broken.
- **F3** `--version` gates were not prerelease-aware (incl. the pre-existing `release` twin) → full-semver comparison, verified against `0.0.0-ci` and `1.2.3-rc.1`.
- **F4** `mcp-publisher` download now sha256-pinned in both workflows (checksum independently verified against upstream's `registry_1.8.1_checksums.txt`).
- **F5** validate step calls the live registry API (no offline mode in v1.8.1) — commented; known trade-off.
- **F6** secret lands on `login dns` argv (no env/stdin alternative in v1.8.1; KMS noted) — comment reworded.
- **F7** redundant `needs` kept, self-documenting.

## Human prerequisites (due Fri 5 Sep)

1. Actions secret **`MCP_REGISTRY_ED25519_KEY`** — 64-hex-char Ed25519 private key of the publisher keypair.
2. DNS TXT on `jentic.one`: `v=MCPv1; k=ed25519; p=<base64 pubkey>` (verify: `dig TXT jentic.one`).
3. GHCR **`jentic-one-cli`** package set public after first push (registry ownership verification pulls anonymously).

Until (1) exists, `publish-registry` skips green; images and binaries ship regardless.

## Why

The hosted MCP server sunsets 20 Sep. After that, MCP support means running `jentic mcp` locally — a thin shim that speaks MCP on stdio and proxies everything real to your Jentic One instance (default `127.0.0.1:8000`). The CLI alone does nothing: with no instance, `get_started` returns `no_config` and tells the operator to deploy one. That's by design.

**Why an image:** two reasons, neither of which is "people want to run a CLI in Docker".
1. The MCP registry only accepts npm/pypi/nuget/mcpb/OCI packages — OCI is the only fit for a Go binary. The registry verifies ownership by pulling the image anonymously and checking the `server.name` label (hence the label↔`server.json` lockstep gate, and why A+B land in one commit).
2. The Recipe-3 container-isolation rung needs an official image to exist — it was demoted in #1191 precisely because none did. This PR unblocks re-enabling it (PR C).

**Why a registry entry:** succession, not acquisition. The existing `io.github.jentic/mcp-server` entry points at the hosted server and gets deprecated at sunset; without a replacement, Jentic shows up dead in every MCP client catalog. For people already running Jentic One it's a verified install path instead of copy-pasting JSON from docs. Marginal cost on top of the image: ~20 lines of JSON and one dormant CI job.

**DNS verification** is namespace-ownership proof, nothing is hosted: public key in a TXT record on `jentic.one`, CI signs with the private key, the registry checks the signature.

Made with [Cursor](https://cursor.com)

