### PR TITLE
chore(install.sh): update the default install to include both CLIs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -81,12 +81,12 @@ The cask installs both `jentic` and `jenticctl`.
 ### 2. One-line download (verified binary, no compiler)
 
 ```bash
-# jentic only (default) — for talking to a remote jentic server:
+# both binaries (default) — jentic (discover/run) + jenticctl (run the stack locally):
 JENTIC_INSTALL_METHOD=binary \
   curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
 
-# both binaries (also install jenticctl to run the stack locally):
-JENTIC_INSTALL_METHOD=binary JENTIC_INSTALL_BINARIES=both \
+# jentic only — for talking to a remote jentic server without the stack tooling:
+JENTIC_INSTALL_METHOD=binary JENTIC_INSTALL_BINARIES=jentic \
   curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
 ```
 
@@ -104,7 +104,7 @@ Environment knobs:
 
 - `JENTIC_INSTALL_METHOD` — `auto` (default) · `binary` (force download; errors
   if no asset) · `source` (force the from-source build).
-- `JENTIC_INSTALL_BINARIES` — `jentic` (default for downloads) · `both`.
+- `JENTIC_INSTALL_BINARIES` — `both` (default) · `jentic` (agent CLI only).
 - `JENTIC_NO_INSTALL=1` — install the binaries only; **skip** the
   `jenticctl install` stack wizard (useful in CI or when you only want the CLI).
 - `GITHUB_TOKEN=ghp_xxx` — download/clone from a **private** fork (token needs

--- a/tests/tools/install_test.sh
+++ b/tests/tools/install_test.sh
@@ -366,11 +366,15 @@ assert_eq "asset_name: jentic linux/amd64 strips the v" "jentic_0.31.0_linux_amd
 out="$(OS=darwin ARCH=arm64 JENTIC_REF=0.31.0 asset_name jenticctl)"
 assert_eq "asset_name: jenticctl darwin/arm64 (no v prefix)" "jenticctl_0.31.0_darwin_arm64.tar.gz" "$out"
 
-# --- download mode: selected binaries (jentic-only default, both opt-in) -----
-out="$(JENTIC_INSTALL_BINARIES=jentic download_selected_binaries | tr '\n' ' ')"
-assert_eq "download_selected_binaries: default is jentic-only" "jentic " "$out"
+# --- download mode: selected binaries (both default, jentic-only opt-in) -----
+# The sourced installer already resolved JENTIC_INSTALL_BINARIES to its default,
+# so calling the helper with no override exercises the shipped default (both).
+out="$(download_selected_binaries | tr '\n' ' ')"
+assert_eq "download_selected_binaries: default is both" "jentic jenticctl " "$out"
 out="$(JENTIC_INSTALL_BINARIES=both download_selected_binaries | tr '\n' ' ')"
-assert_eq "download_selected_binaries: both adds jenticctl" "jentic jenticctl " "$out"
+assert_eq "download_selected_binaries: both fetches jentic + jenticctl" "jentic jenticctl " "$out"
+out="$(JENTIC_INSTALL_BINARIES=jentic download_selected_binaries | tr '\n' ' ')"
+assert_eq "download_selected_binaries: jentic narrows to the agent CLI" "jentic " "$out"
 
 # --- download mode: verify_checksum is FAIL-CLOSED (P1) ----------------------
 # The whole download phase is sold as fail-closed. A checksums.txt with no row

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -170,10 +170,11 @@ GITHUB_TOKEN="${GITHUB_TOKEN:-}"
 JENTIC_INSTALL_METHOD="${JENTIC_INSTALL_METHOD:-auto}"
 
 # JENTIC_INSTALL_BINARIES selects which binaries the download path fetches:
-#   jentic (default for downloads) the agent CLI only — most users need only this.
-#   both   also fetch jenticctl (installer/lifecycle). The from-source path always
-#          builds both regardless of this knob.
-JENTIC_INSTALL_BINARIES="${JENTIC_INSTALL_BINARIES:-jentic}"
+#   both   (default) fetch jentic (API-spec) and jenticctl (installer/lifecycle).
+#   jentic the agent CLI only — for talking to a remote jentic server without the
+#          local stack lifecycle tooling. The from-source path always builds both
+#          regardless of this knob.
+JENTIC_INSTALL_BINARIES="${JENTIC_INSTALL_BINARIES:-both}"
 
 # cosign keyless-signing identity, mirrored from docs/releasing.md and the Go
 # updater (cli/internal/update/download.go). Used to verify checksums.txt.sig.
@@ -568,12 +569,12 @@ fetch_source() {
 # only the "produce the binaries in $WORKDIR" step differs.
 
 # download_selected_binaries prints the binary names the download path should
-# fetch, honouring JENTIC_INSTALL_BINARIES (jentic-only default; `both` adds
-# jenticctl). Kept a function so main() and the manifest logic agree.
+# fetch, honouring JENTIC_INSTALL_BINARIES (both by default; `jentic` narrows to
+# the agent CLI only). Kept a function so main() and the manifest logic agree.
 download_selected_binaries() {
   case "$JENTIC_INSTALL_BINARIES" in
-    both) printf '%s\n%s\n' "$API_BINARY" "$CTL_BINARY" ;;
-    *)    printf '%s\n' "$API_BINARY" ;;
+    jentic) printf '%s\n' "$API_BINARY" ;;
+    *)      printf '%s\n%s\n' "$API_BINARY" "$CTL_BINARY" ;;
   esac
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Jentic One!
Keep PRs focused and reviewable. Do not include secrets or credentials.
Match the depth to the change: a typo fix needs one Summary sentence;
a structural change needs every section (and ideally a diagram).
-->

## Summary

<!-- 1-3 sentences: the problem and why this change is the fix. Written for
     a reader who has NOT seen the diff — lead with the impact, not the
     mechanics. -->
The one-line install included only the `jentic` agent CLI by default, which left local self-hosted installs with no `jenticctl` cli to manage or even start the Jentic One instance. Swap the default to `both` with `JENTIC_INSTALL_BINARIES=jentic` as the path for agent CLI only for remote-server use. The from-source path is unchanged (it always builds both).

## Changes

<!-- One bullet per meaningful change, most important first. Name the surface
     (`control`, `ui`, `cli`, `deploy`, …). Say what is deliberately OUT of
     scope. For topology/flow changes, a ```mermaid``` block renders here. -->

- Inverted the default install logic so that both CLIs are installed by default (`JENTIC_INSTALL_BINARIES=jentic` to exclude the `jenticctl` cli).

## Risk & rollback

<!-- Required when the change warrants it: breaking changes, migrations,
     auth/credential/permission surface, new config/env vars — each on its
     own line. How to revert. If genuinely low-risk: "Low risk: <reason>". -->

## Test plan

<!-- How this was verified: commands run (`make check`, e2e), or manual steps
     a reviewer can reproduce. UI changes: screenshot or short recording.
     If no automated tests: "No automated tests; manual verification: …" -->

## Review guide

<!-- Optional, for larger PRs: where to start reading, in what order, what to
     scrutinize. Delete if not needed. -->

## Related issue

<!-- e.g. Closes #123 -->

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [ ] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [x] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included
