### PR TITLE
fix(auth): revoke OAuth client grants on agent ownership transfer (G10, #1222)

### DIFF
--- a/src/jentic_one/admin/repos/oauth_client_grant_repo.py
+++ b/src/jentic_one/admin/repos/oauth_client_grant_repo.py
@@ -62,6 +62,25 @@ class OAuthClientGrantRepository:
         return list(result.scalars().all())
 
     @staticmethod
+    async def list_active_for_agent(session: AsyncSession, agent_id: str) -> list[OAuthClientGrant]:
+        """Every active grant bound to ONE agent — the transfer sweep set (G10, #1222).
+
+        An agent ownership transfer revokes all of these in the transfer's own
+        transaction, so unlike :meth:`list_grants` this is deliberately
+        unpaginated: the sweep must see the complete set or fail the transfer.
+        """
+        stmt = (
+            select(OAuthClientGrant)
+            .where(
+                OAuthClientGrant.agent_id == agent_id,
+                OAuthClientGrant.status == OAuthGrantStatus.ACTIVE.value,
+            )
+            .order_by(OAuthClientGrant.created_at.asc(), OAuthClientGrant.id.asc())
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
     async def list_grants(
         session: AsyncSession,
         *,

--- a/src/jentic_one/admin/services/oauth_grant_admin_service.py
+++ b/src/jentic_one/admin/services/oauth_grant_admin_service.py
@@ -33,12 +33,12 @@ def viewer_can_revoke(grant_user_id: str, identity: Identity) -> bool:
 
     THE single definition — ``OAuthGrantService.revoke_grant`` enforces it and
     the listing surfaces surface it per item as ``can_revoke``, so the two can
-    never drift. Note the deliberate divergence from the LIST predicate (gap
-    G10): listing keys on the agent's CURRENT owner, revoke on the grant's
-    consenting user — after an agent ownership transfer the new owner can see
-    the grant but not revoke it. That policy decision is still pending; until
-    it lands, ``can_revoke`` makes the divergence explicit instead of letting
-    the UI advertise a revoke that would 403.
+    never drift. Note the deliberate divergence from the LIST predicate:
+    listing keys on the agent's CURRENT owner, revoke on the grant's
+    consenting user. Since G10 (#1222) an agent ownership transfer revokes
+    all active grants in the transfer transaction, so the divergence can no
+    longer strand a LIVE grant with an unrevokable consenter — it persists
+    only on revoked history rows, where ``can_revoke`` keeps the UI honest.
     """
     return grant_user_id == identity.sub or bool(
         GRANT_REVOKE_ADMIN_PERMISSIONS & set(identity.permissions)

--- a/src/jentic_one/admin/services/oauth_grant_admin_service.py
+++ b/src/jentic_one/admin/services/oauth_grant_admin_service.py
@@ -35,10 +35,12 @@ def viewer_can_revoke(grant_user_id: str, identity: Identity) -> bool:
     the listing surfaces surface it per item as ``can_revoke``, so the two can
     never drift. Note the deliberate divergence from the LIST predicate:
     listing keys on the agent's CURRENT owner, revoke on the grant's
-    consenting user. Since G10 (#1222) an agent ownership transfer revokes
-    all active grants in the transfer transaction, so the divergence can no
-    longer strand a LIVE grant with an unrevokable consenter — it persists
-    only on revoked history rows, where ``can_revoke`` keeps the UI honest.
+    consenting user. Since G10 (#1222) the divergence can no longer strand a
+    LIVE grant with an unrevokable consenter — an agent ownership transfer
+    revokes all active grants in the transfer transaction, and the mint path
+    locks + re-checks ownership inside the grant transaction, so the
+    invariant holds by construction, not by timing. It persists only on
+    revoked history rows, where ``can_revoke`` keeps the UI honest.
     """
     return grant_user_id == identity.sub or bool(
         GRANT_REVOKE_ADMIN_PERMISSIONS & set(identity.permissions)

--- a/src/jentic_one/auth/services/agent_service.py
+++ b/src/jentic_one/auth/services/agent_service.py
@@ -29,6 +29,7 @@ from jentic_one.auth.services.errors import (
     ToolkitBindingConflictError,
     ToolkitBindingNotFoundError,
 )
+from jentic_one.auth.services.oauth_grant_service import revoke_active_grants_for_agent
 from jentic_one.auth.services.registration_service import validate_jwks
 from jentic_one.auth.services.schemas.agents import (
     AgentCreatePayload,
@@ -529,6 +530,17 @@ class AgentService:
         update_data: dict[str, str | None],
         identity: Identity,
     ) -> AgentView:
+        """Partially update an agent; an ``owner_id`` change is a transfer.
+
+        Ownership transfer revokes every active OAuth client grant bound to
+        the agent in the SAME transaction (G10, #1222): a grant keys its
+        ``:revoke`` predicate on the consenting user, so leaving the old
+        owner's consent live would strand a grant the new owner cannot revoke
+        self-serve. Fail-safe posture — if the sweep fails, the transfer rolls
+        back; the new owner re-consents through the normal flow if the
+        connection is still wanted. The agent's key channel (API key, scopes,
+        toolkit bindings) is deliberately untouched.
+        """
         try:
             async with self._ctx.admin_db.transaction() as session:
                 agent = await AgentRepository.get_by_id_for_update(session, agent_id)
@@ -537,8 +549,13 @@ class AgentService:
                 if agent.status == ActorStatus.ARCHIVED:
                     raise InvalidTransitionError(agent_id, ActorStatus.ARCHIVED, "update")
                 before = {k: getattr(agent, k) for k in update_data}
+                owner_transferred = (
+                    "owner_id" in update_data and update_data["owner_id"] != agent.owner_id
+                )
                 agent = await AgentRepository.update_agent(session, agent_id, **update_data)
                 after = {k: getattr(agent, k) for k in update_data}
+                if owner_transferred:
+                    await revoke_active_grants_for_agent(session, agent_id, identity=identity)
                 await record_audit(
                     session,
                     action=AuditAction.UPDATE,

--- a/src/jentic_one/auth/services/errors.py
+++ b/src/jentic_one/auth/services/errors.py
@@ -145,6 +145,23 @@ class RateLimitExceededError(AuthServiceError):
         self.retry_after = retry_after
 
 
+class ConsentAgentNotEligibleError(AuthServiceError):
+    """Raised when the mint-time re-check refuses a consent→agent grant.
+
+    ``OAuthGrantService.create_grant`` locks the agent row (``FOR UPDATE``)
+    and re-checks the consent predicate — exists, ``active``, owned by the
+    consenting user — INSIDE the mint transaction, closing the TOCTOU where
+    an ownership transfer commits between the consent screen's unlocked
+    validation read and the grant write. The consent flow maps this to the
+    same human error page as a failed picker validation (never an OAuth
+    redirect carrying a code, never a 500).
+    """
+
+    def __init__(self, agent_id: str) -> None:
+        super().__init__(f"Agent '{agent_id}' is not eligible for a consent grant")
+        self.agent_id = agent_id
+
+
 class OAuthGrantNotFoundError(AuthServiceError):
     """Raised when an oauth_client_grants row does not exist."""
 

--- a/src/jentic_one/auth/services/oauth_grant_service.py
+++ b/src/jentic_one/auth/services/oauth_grant_service.py
@@ -26,6 +26,7 @@ from jentic_one.admin.services.oauth_grant_admin_service import (
 from jentic_one.admin.services.schemas.oauth_grants import OAuthGrantView
 from jentic_one.auth.services.errors import (
     ActorNotFoundError,
+    ConsentAgentNotEligibleError,
     OAuthGrantAccessDeniedError,
     OAuthGrantNotFoundError,
 )
@@ -34,7 +35,7 @@ from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.auth.permission_catalog import OAUTH_CLIENTS_READ
 from jentic_one.shared.context import Context
 from jentic_one.shared.events import emit_event_best_effort
-from jentic_one.shared.models import ActorType
+from jentic_one.shared.models import ActorStatus, ActorType
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.models.oauth_clients import OAuthGrantStatus
 from jentic_one.shared.pagination import Page
@@ -185,15 +186,37 @@ class OAuthGrantService:
     ) -> str:
         """Mint an ``oauth_client_grants`` row at consent-approve (§4.4 step 3).
 
-        Collapses any prior active row for the (client, agent) pair (§4.1:
-        re-consent revokes the old row and inserts the new one — history
-        stays, exactly one active row per pair). Writes the consent audit row
-        (the pre-3a ``record_consent_decision`` shape, extended with
-        ``agent_id``/``grant_id``) and emits ``oauth_grant.created`` — grant
-        creation is deliberately loud (§4.8). Returns the new grant id.
+        Locks the agent row and re-checks the consent predicate (exists +
+        ``active`` + owned by ``user_id``) inside the mint transaction —
+        raising :class:`ConsentAgentNotEligibleError` on failure — so a
+        concurrent ownership transfer serializes against the mint instead of
+        racing it. Collapses any prior active row for the (client, agent)
+        pair (§4.1: re-consent revokes the old row and inserts the new one —
+        history stays, exactly one active row per pair). Writes the consent
+        audit row (the pre-3a ``record_consent_decision`` shape, extended
+        with ``agent_id``/``grant_id``) and emits ``oauth_grant.created`` —
+        grant creation is deliberately loud (§4.8). Returns the new grant id.
         """
 
         async def _write(session: AsyncSession) -> str:
+            # Consent-vs-transfer TOCTOU closure: the consent screen's
+            # ownership check ran in an earlier, unlocked read, so a transfer
+            # can commit in between (the consent handle stays valid for
+            # 300 s). Take the SAME row lock the transfer transaction takes
+            # (FOR UPDATE in AgentService.update_agent) and re-run the
+            # list_consentable_agents predicate here, inside the mint
+            # transaction: either the mint commits first (the transfer's
+            # sweep then revokes it) or the transfer commits first (this
+            # re-check sees the new owner/status and refuses). This lock +
+            # re-check is what makes "a LIVE grant's consenter is the
+            # agent's current owner" hold.
+            agent = await AgentRepository.get_by_id_for_update(session, agent_id)
+            if (
+                agent is None
+                or agent.status != ActorStatus.ACTIVE.value
+                or agent.owner_id != user_id
+            ):
+                raise ConsentAgentNotEligibleError(agent_id)
             prior = await OAuthClientGrantRepository.list_active_for_pair(
                 session, oauth_client_id=oauth_client_id, agent_id=agent_id
             )
@@ -298,10 +321,13 @@ class OAuthGrantService:
         redirect-URI origin, scopes, created, last-used, status) plus the
         consenting ``user_id`` and the viewer's per-item ``can_revoke``
         capability. The two predicates still differ (list keys on the agent's
-        current owner, revoke on the grant's consenting user), but since G10
-        (#1222) an ownership transfer revokes all active grants, so a LIVE
-        grant's consenter is always the current owner — the divergence only
-        shows on revoked history rows.
+        current owner, revoke on the grant's consenting user), but a LIVE
+        grant's consenter is always the current owner — an invariant that
+        holds BECAUSE G10 (#1222) makes an ownership transfer revoke all
+        active grants in the transfer transaction AND ``create_grant`` locks
+        the agent row and re-checks ownership inside the mint transaction
+        (closing the consent-vs-transfer race). The divergence only shows on
+        revoked history rows.
         """
         async with self._ctx.admin_db.session() as session:
             agent = await AgentRepository.get_by_id(session, agent_id)

--- a/src/jentic_one/auth/services/oauth_grant_service.py
+++ b/src/jentic_one/auth/services/oauth_grant_service.py
@@ -49,6 +49,124 @@ logger = structlog.get_logger(__name__)
 #: so a caller who can see grants there can see them per-agent.
 _ADMIN_READ_PERMISSIONS: frozenset[str] = GRANT_REVOKE_ADMIN_PERMISSIONS | {OAUTH_CLIENTS_READ}
 
+#: The revocation cause stamped (audit ``reason`` + event ``data.reason``) on
+#: grants swept by an agent ownership transfer (G10, #1222) — distinguishes a
+#: transfer-revocation from the manual ``:revoke`` (whose audit reason stays
+#: ``"oauth grant revoked"`` and whose event data carries no ``reason`` key,
+#: following the ``OVERLAY_DEPRECATED`` cause-in-data pattern).
+AGENT_TRANSFER_REVOCATION_REASON = "agent_ownership_transferred"
+
+
+async def _revoke_grant_and_sweep_tokens(
+    session: AsyncSession,
+    grant: OAuthClientGrant,
+    *,
+    actor_type: ActorType,
+    actor_id: str,
+    origin: str | None,
+    audit_reason: str,
+    summary: str,
+    event_reason: str | None = None,
+) -> bool:
+    """Flip one grant row + sweep its tokens + audit + event, in the caller's session.
+
+    THE single revocation body — the manual ``:revoke`` kill switch and the
+    ownership-transfer sweep both run through here, so the token kill switch
+    and the emitted ``oauth_grant.revoked`` event can never drift between the
+    two causes. Flush-only: it joins whatever transaction the caller owns.
+    Returns False (writing no audit/event) when the grant was already revoked;
+    the token sweep re-runs regardless (idempotent belt).
+    """
+    newly_revoked = grant.status == OAuthGrantStatus.ACTIVE.value and (
+        await OAuthClientGrantRepository.revoke(session, grant.id)
+    )
+    swept_access = await AccessTokenRepository.revoke_by_grant(session, grant.id)
+    swept_refresh = await RefreshTokenRepository.revoke_by_grant(session, grant.id)
+    if not newly_revoked:
+        return False
+
+    await record_audit(
+        session,
+        action=AuditAction.REVOKE,
+        target_type=AuditTargetType.OAUTH_GRANT,
+        target_id=grant.id,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        after={
+            "oauth_client_id": grant.oauth_client_id,
+            "agent_id": grant.agent_id,
+            "swept_access_tokens": swept_access,
+            "swept_refresh_tokens": swept_refresh,
+        },
+        reason=audit_reason,
+        origin=origin,
+    )
+    data: dict[str, object] = {
+        "grant_id": grant.id,
+        "oauth_client_id": grant.oauth_client_id,
+        "agent_id": grant.agent_id,
+        "user_id": grant.user_id,
+    }
+    if event_reason is not None:
+        data["reason"] = event_reason
+    await emit_event_best_effort(
+        session,
+        type=EventType.OAUTH_GRANT_REVOKED,
+        severity=EventSeverity.INFO,
+        summary=summary,
+        requires_action=False,
+        data=data,
+        created_by=actor_id,
+    )
+    return True
+
+
+async def revoke_active_grants_for_agent(
+    session: AsyncSession,
+    agent_id: str,
+    *,
+    identity: Identity,
+) -> int:
+    """Revoke EVERY active grant bound to ``agent_id`` — the transfer sweep (G10, #1222).
+
+    Called by ``AgentService.update_agent`` inside the ownership-transfer
+    transaction: a transferred agent must not keep grants consented by its
+    previous owner (the new owner could not revoke them self-serve — the
+    ``:revoke`` predicate keys on the consenting user). Runs the same
+    per-grant revocation body as the manual kill switch, stamped with
+    :data:`AGENT_TRANSFER_REVOCATION_REASON` and attributed to the actor
+    performing the transfer.
+
+    Deliberately NO ``viewer_can_revoke`` check: authority comes from the
+    ``agents:write`` gate on the transfer itself. Flush-only and NOT
+    best-effort — an exception propagates so a failed sweep rolls the whole
+    transfer back rather than leaving a transferred agent with live grants.
+    Returns the number of grants revoked.
+    """
+    grants = await OAuthClientGrantRepository.list_active_for_agent(session, agent_id)
+    for grant in grants:
+        await _revoke_grant_and_sweep_tokens(
+            session,
+            grant,
+            actor_type=identity.actor_type,
+            actor_id=identity.sub,
+            origin=identity.origin.value,
+            audit_reason="oauth grant revoked: agent ownership transferred",
+            summary=(
+                f"OAuth grant {grant.id} for client '{grant.oauth_client_id}' was "
+                f"revoked because agent {agent_id} changed owner"
+            ),
+            event_reason=AGENT_TRANSFER_REVOCATION_REASON,
+        )
+    if grants:
+        logger.info(
+            "oauth_grants_revoked_on_agent_transfer",
+            agent_id=agent_id,
+            count=len(grants),
+            actor_id=identity.sub,
+        )
+    return len(grants)
+
 
 class OAuthGrantService:
     """Mint and revoke consent→agent grants."""
@@ -146,47 +264,17 @@ class OAuthGrantService:
             if not viewer_can_revoke(grant.user_id, identity):
                 raise OAuthGrantAccessDeniedError(grant_id)
 
-            newly_revoked = grant.status == OAuthGrantStatus.ACTIVE.value and (
-                await OAuthClientGrantRepository.revoke(session, grant_id)
-            )
-            swept_access = await AccessTokenRepository.revoke_by_grant(session, grant_id)
-            swept_refresh = await RefreshTokenRepository.revoke_by_grant(session, grant_id)
-            if not newly_revoked:
-                return False
-
-            await record_audit(
+            return await _revoke_grant_and_sweep_tokens(
                 session,
-                action=AuditAction.REVOKE,
-                target_type=AuditTargetType.OAUTH_GRANT,
-                target_id=grant_id,
+                grant,
                 actor_type=identity.actor_type,
                 actor_id=identity.sub,
-                after={
-                    "oauth_client_id": grant.oauth_client_id,
-                    "agent_id": grant.agent_id,
-                    "swept_access_tokens": swept_access,
-                    "swept_refresh_tokens": swept_refresh,
-                },
-                reason="oauth grant revoked",
                 origin=identity.origin.value,
-            )
-            await emit_event_best_effort(
-                session,
-                type=EventType.OAUTH_GRANT_REVOKED,
-                severity=EventSeverity.INFO,
+                audit_reason="oauth grant revoked",
                 summary=(
                     f"OAuth grant {grant_id} for client '{grant.oauth_client_id}' was revoked"
                 ),
-                requires_action=False,
-                data={
-                    "grant_id": grant_id,
-                    "oauth_client_id": grant.oauth_client_id,
-                    "agent_id": grant.agent_id,
-                    "user_id": grant.user_id,
-                },
-                created_by=identity.sub,
             )
-            return True
 
         revoked = await self._ctx.admin_db.run_in_transaction(_write)
         if revoked:
@@ -209,10 +297,11 @@ class OAuthGrantService:
         secrets). Items carry the §4.8 display fields (client name,
         redirect-URI origin, scopes, created, last-used, status) plus the
         consenting ``user_id`` and the viewer's per-item ``can_revoke``
-        capability, so the G10 ownership-transfer gap is visible AND
-        actionable state is honest (list keys on the agent's current owner,
-        revoke on the grant's consenting user — they diverge after a
-        transfer).
+        capability. The two predicates still differ (list keys on the agent's
+        current owner, revoke on the grant's consenting user), but since G10
+        (#1222) an ownership transfer revokes all active grants, so a LIVE
+        grant's consenter is always the current owner — the divergence only
+        shows on revoked history rows.
         """
         async with self._ctx.admin_db.session() as session:
             agent = await AgentRepository.get_by_id(session, agent_id)

--- a/src/jentic_one/auth/web/routers/authorize.py
+++ b/src/jentic_one/auth/web/routers/authorize.py
@@ -28,6 +28,7 @@ from jentic_one.admin.services.schemas.oauth_clients import OAuthClientView
 from jentic_one.auth.core.idp import IdpClaims
 from jentic_one.auth.services.authorize_service import AgentConsentOption, AuthorizeService
 from jentic_one.auth.services.errors import (
+    ConsentAgentNotEligibleError,
     InvalidGrantError,
     RateLimitExceededError,
     UserNotAdmittedError,
@@ -1477,13 +1478,23 @@ async def _approve_agent_consent(
         logger.warning("oauth_consent_no_grantable_scopes", client_id=client_id, agent_id=agent_id)
         return RedirectResponse(url="/error?error=no_grantable_scopes", status_code=302)
 
-    grant_id_value = await grant_svc.create_grant(
-        user_id=user_id,
-        oauth_client_id=client_id,
-        agent_id=selected.id,
-        scopes=effective,
-        client_name=oauth_client.name,
-    )
+    try:
+        grant_id_value = await grant_svc.create_grant(
+            user_id=user_id,
+            oauth_client_id=client_id,
+            agent_id=selected.id,
+            scopes=effective,
+            client_name=oauth_client.name,
+        )
+    except ConsentAgentNotEligibleError:
+        # The mint-time lock + re-check refused: the agent was transferred,
+        # archived, or disabled between the picker validation above and the
+        # grant write. Same user-facing posture as a failed picker
+        # validation — the human error page, never a code redirect or a 500.
+        logger.warning(
+            "oauth_consent_agent_invalid_at_mint", client_id=client_id, agent_id=agent_id
+        )
+        return RedirectResponse(url="/error?error=invalid_agent_selection", status_code=302)
     return grant_id_value, effective
 
 

--- a/tests/integration/auth/seeds.py
+++ b/tests/integration/auth/seeds.py
@@ -17,6 +17,8 @@ from jentic_one.admin.repos import (
     OAuthClientRepository,
     UserRepository,
 )
+from jentic_one.auth.services.authorize_service import AuthorizeService
+from jentic_one.auth.services.oauth_grant_service import OAuthGrantService
 from jentic_one.shared.context import Context
 from jentic_one.shared.models import ActorStatus, ActorType
 
@@ -97,3 +99,44 @@ async def seed_client(
         )
         await session.commit()
         return client.client_id
+
+
+async def mint_grant_channel_tokens(
+    ctx: Context,
+    *,
+    user_id: str,
+    agent_id: str,
+    grant_scopes: list[str],
+    client_id: str = CLIENT_ID,
+) -> tuple[str, str, str, str | None]:
+    """Consent-approve + code issue + exchange. Returns (grant_id, at, rt, id_token).
+
+    Shared by the grant-channel and ownership-transfer suites so both mint
+    through the real consent→code→exchange path rather than seeding token
+    rows by hand.
+    """
+    grant_svc = OAuthGrantService(ctx)
+    authorize_svc = AuthorizeService(ctx)
+    grant_id = await grant_svc.create_grant(
+        user_id=user_id,
+        oauth_client_id=client_id,
+        agent_id=agent_id,
+        scopes=grant_scopes,
+        client_name="Grant Channel App",
+    )
+    code = await authorize_svc.issue_authorization_code(
+        user_id=user_id,
+        client_id=client_id,
+        redirect_uri=REDIRECT_URI,
+        code_challenge=code_challenge(CODE_VERIFIER),
+        scopes=" ".join(grant_scopes),
+        grant_id=grant_id,
+    )
+    access, refresh, id_token = await authorize_svc.exchange_code(
+        code=code,
+        code_verifier=CODE_VERIFIER,
+        redirect_uri=REDIRECT_URI,
+        client_id=client_id,
+        oauth_client_id=client_id,
+    )
+    return grant_id, access, refresh, id_token

--- a/tests/integration/auth/test_oauth_grant_channel.py
+++ b/tests/integration/auth/test_oauth_grant_channel.py
@@ -53,41 +53,7 @@ _code_challenge = seeds.code_challenge
 _seed_user = seeds.seed_user
 _seed_agent = seeds.seed_agent
 _seed_client = seeds.seed_client
-
-
-async def _mint_grant_channel_tokens(
-    ctx: Context,
-    *,
-    user_id: str,
-    agent_id: str,
-    grant_scopes: list[str],
-) -> tuple[str, str, str, str | None]:
-    """Consent-approve + code issue + exchange. Returns (grant_id, at, rt, id_token)."""
-    grant_svc = OAuthGrantService(ctx)
-    authorize_svc = AuthorizeService(ctx)
-    grant_id = await grant_svc.create_grant(
-        user_id=user_id,
-        oauth_client_id=_CLIENT_ID,
-        agent_id=agent_id,
-        scopes=grant_scopes,
-        client_name="Grant Channel App",
-    )
-    code = await authorize_svc.issue_authorization_code(
-        user_id=user_id,
-        client_id=_CLIENT_ID,
-        redirect_uri=_REDIRECT_URI,
-        code_challenge=_code_challenge(_CODE_VERIFIER),
-        scopes=" ".join(grant_scopes),
-        grant_id=grant_id,
-    )
-    access, refresh, id_token = await authorize_svc.exchange_code(
-        code=code,
-        code_verifier=_CODE_VERIFIER,
-        redirect_uri=_REDIRECT_URI,
-        client_id=_CLIENT_ID,
-        oauth_client_id=_CLIENT_ID,
-    )
-    return grant_id, access, refresh, id_token
+_mint_grant_channel_tokens = seeds.mint_grant_channel_tokens
 
 
 # --- grant table + minting -------------------------------------------------

--- a/tests/integration/auth/test_oauth_grant_transfer.py
+++ b/tests/integration/auth/test_oauth_grant_transfer.py
@@ -10,7 +10,10 @@ the manual ``:revoke`` body (row flip + token sweep + audit + event).
 
 Covers the service seam (``AgentService.update_agent``) and the full REST
 path (``PATCH /agents/{id}``), plus the fail-safe posture: a failed sweep
-rolls the whole transfer back.
+rolls the whole transfer back. The consent-vs-transfer race half (review F1)
+is covered too: ``create_grant`` locks the agent row and re-checks ownership
+inside the mint transaction, so a consent approval racing a transfer is
+refused instead of committing a live grant consented by the old owner.
 """
 
 from __future__ import annotations
@@ -24,10 +27,16 @@ from sqlalchemy import select
 
 from jentic_one.admin.core.schema.audit import AuditEntry
 from jentic_one.admin.core.schema.events import Event
+from jentic_one.admin.core.schema.oauth_client_grants import OAuthClientGrant
 from jentic_one.admin.repos import AgentRepository
 from jentic_one.auth.services.agent_auth_service import AgentAuthService
 from jentic_one.auth.services.agent_service import AgentService
-from jentic_one.auth.services.errors import AuthServiceError, InvalidGrantError
+from jentic_one.auth.services.authorize_service import AuthorizeService
+from jentic_one.auth.services.errors import (
+    AuthServiceError,
+    ConsentAgentNotEligibleError,
+    InvalidGrantError,
+)
 from jentic_one.auth.services.oauth_grant_service import (
     AGENT_TRANSFER_REVOCATION_REASON,
     OAuthGrantService,
@@ -264,3 +273,116 @@ async def test_rest_patch_owner_transfer_revokes_grants(
     grant = await OAuthGrantService(ctx).get_grant(grant_id)
     assert grant is not None and grant.status == "revoked"
     assert await TokenService(ctx).resolve_access_token(access) is None
+
+
+async def test_consent_mint_racing_transfer_is_refused(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """Two-session race simulation (review F1): the consent screen's ownership
+    validation passes, a transfer commits in between, and the mint is refused
+    by the lock + re-check inside ``create_grant``'s transaction — no live
+    grant consented by the old owner ever commits.
+
+    NOTE: SQLite ignores FOR UPDATE, so on this backend the test proves the
+    in-transaction ownership re-check; the row lock's serialization against a
+    concurrent transfer transaction is proven by CI's Postgres leg.
+    """
+    ctx = integration_context
+    old_owner = await seeds.seed_user(ctx, "usr_t_race_old")
+    new_owner = await seeds.seed_user(ctx, "usr_t_race_new")
+    admin_id = await seeds.seed_user(ctx, "usr_t_race_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=old_owner, scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+
+    # t0 — the consent screen's server-side validation: the agent IS a valid
+    # pick for the old owner (this is the unlocked read the race exploits).
+    options = await AuthorizeService(ctx).list_consentable_agents(old_owner)
+    assert any(o.id == agent_id for o in options)
+
+    # t1 — the transfer commits between validation and mint (the departing
+    # owner can hold the consent handle for up to 300 s).
+    await AgentService(ctx).update_agent(
+        agent_id, update_data={"owner_id": new_owner}, identity=_admin_identity(admin_id)
+    )
+
+    # t2 — the mint re-checks ownership inside its own transaction and refuses.
+    with pytest.raises(ConsentAgentNotEligibleError):
+        await OAuthGrantService(ctx).create_grant(
+            user_id=old_owner,
+            oauth_client_id=seeds.CLIENT_ID,
+            agent_id=agent_id,
+            scopes=["apis:read"],
+            client_name="Grant Channel App",
+        )
+
+    # Nothing committed: no grant row (any status) exists for the agent.
+    async with ctx.admin_db.session() as session:
+        result = await session.execute(
+            select(OAuthClientGrant).where(OAuthClientGrant.agent_id == agent_id)
+        )
+        assert list(result.scalars().all()) == []
+
+
+async def test_transfer_rolls_back_when_post_sweep_step_fails(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """Same-transaction pin (review F2): fail the step AFTER the sweep — the
+    transfer's own ``record_audit`` — and assert from a fresh session that
+    BOTH the owner change and the grant revocations rolled back. This test
+    fails if the sweep ever moves to its own (committed) transaction, which
+    the sweep-failure rollback test alone cannot distinguish."""
+    ctx = integration_context
+    old_owner = await seeds.seed_user(ctx, "usr_t_pin_old")
+    new_owner = await seeds.seed_user(ctx, "usr_t_pin_new")
+    admin_id = await seeds.seed_user(ctx, "usr_t_pin_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=old_owner, scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    grant_id, access, _refresh, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=old_owner, agent_id=agent_id, grant_scopes=["apis:read"]
+    )
+
+    # Patch ONLY the transfer transaction's own audit call (the sweep's
+    # per-grant audits go through oauth_grant_service's import and stay real).
+    with (
+        patch(
+            "jentic_one.auth.services.agent_service.record_audit",
+            new=AsyncMock(side_effect=RuntimeError("audit exploded")),
+        ),
+        pytest.raises(RuntimeError, match="audit exploded"),
+    ):
+        await AgentService(ctx).update_agent(
+            agent_id, update_data={"owner_id": new_owner}, identity=_admin_identity(admin_id)
+        )
+
+    # Fresh session: owner unchanged AND the sweep's writes rolled back with it.
+    async with ctx.admin_db.session() as session:
+        agent = await AgentRepository.get_by_id(session, agent_id)
+    assert agent is not None and agent.owner_id == old_owner
+    grant = await OAuthGrantService(ctx).get_grant(grant_id)
+    assert grant is not None and grant.status == "active"
+    assert await TokenService(ctx).resolve_access_token(access) is not None
+
+
+async def test_transfer_from_unowned_agent_runs_empty_sweep(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """The NULL→owner PATCH arm (review F5): assigning an owner to an unowned
+    agent counts as a transfer (``None != new_owner``) and runs the sweep —
+    an unowned agent can hold no grants, so it is an empty no-op: no crash,
+    no grant audit/events, owner set."""
+    ctx = integration_context
+    old_owner = await seeds.seed_user(ctx, "usr_t_null_old")
+    new_owner = await seeds.seed_user(ctx, "usr_t_null_new")
+    admin_id = await seeds.seed_user(ctx, "usr_t_null_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=old_owner, scopes=["apis:read"])
+    admin = _admin_identity(admin_id)
+    svc = AgentService(ctx)
+
+    # Detach the owner first (owner→NULL is itself a transfer; with no grants
+    # it sweeps nothing) so the PATCH under test genuinely starts from NULL.
+    view = await svc.update_agent(agent_id, update_data={"owner_id": None}, identity=admin)
+    assert view.owner_id is None
+
+    view = await svc.update_agent(agent_id, update_data={"owner_id": new_owner}, identity=admin)
+    assert view.owner_id == new_owner
+    assert await _transfer_revoked_events(ctx, agent_id) == []

--- a/tests/integration/auth/test_oauth_grant_transfer.py
+++ b/tests/integration/auth/test_oauth_grant_transfer.py
@@ -1,0 +1,266 @@
+"""Integration tests for grant revocation on agent ownership transfer (G10, #1222).
+
+An ``oauth_client_grants`` row keys its ``:revoke`` predicate on the grant's
+consenting ``user_id``, but agent ownership is transferable — without the
+transfer sweep, the OLD owner's consent would keep authorizing an MCP client
+to act as an agent that now belongs to someone else, and the NEW owner could
+not revoke it self-serve. Decided policy (2026-09-02): the transfer revokes
+every active grant on the agent in the transfer's own transaction, reusing
+the manual ``:revoke`` body (row flip + token sweep + audit + event).
+
+Covers the service seam (``AgentService.update_agent``) and the full REST
+path (``PATCH /agents/{id}``), plus the fail-safe posture: a failed sweep
+rolls the whole transfer back.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from jentic_one.admin.core.schema.audit import AuditEntry
+from jentic_one.admin.core.schema.events import Event
+from jentic_one.admin.repos import AgentRepository
+from jentic_one.auth.services.agent_auth_service import AgentAuthService
+from jentic_one.auth.services.agent_service import AgentService
+from jentic_one.auth.services.errors import AuthServiceError, InvalidGrantError
+from jentic_one.auth.services.oauth_grant_service import (
+    AGENT_TRANSFER_REVOCATION_REASON,
+    OAuthGrantService,
+)
+from jentic_one.auth.services.token_service import TokenService
+from jentic_one.auth.web.errors import service_error_handler
+from jentic_one.auth.web.routers import agents
+from jentic_one.broker.repos.token_resolver import InProcessTokenResolver
+from jentic_one.shared.auth.api_key_resolver import ApiKeyResolver
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.context import Context
+from jentic_one.shared.models.events import EventType
+from jentic_one.shared.web.deps import resolve_identity
+from tests.integration.auth import seeds
+
+pytestmark = pytest.mark.integration
+
+_CLIENT_ID_2 = "oc_grant_transfer_second"
+
+
+def _admin_identity(admin_id: str) -> Identity:
+    return Identity(
+        sub=admin_id,
+        email="admin@grants.test",
+        permissions=["agents:write", "agents:read", "org:admin"],
+    )
+
+
+async def _transfer_revoked_events(ctx: Context, agent_id: str) -> list[Event]:
+    """``oauth_grant.revoked`` events for one agent (events survive clean_grants)."""
+    async with ctx.admin_db.session() as session:
+        result = await session.execute(
+            select(Event).where(Event.type == EventType.OAUTH_GRANT_REVOKED)
+        )
+        return [e for e in result.scalars().all() if (e.data or {}).get("agent_id") == agent_id]
+
+
+async def _revoke_audit_rows(ctx: Context, grant_ids: set[str]) -> list[AuditEntry]:
+    async with ctx.admin_db.session() as session:
+        result = await session.execute(
+            select(AuditEntry).where(
+                AuditEntry.target_type == "oauth_grant",
+                AuditEntry.target_id.in_(grant_ids),
+                AuditEntry.action == "revoke",
+            )
+        )
+        return list(result.scalars().all())
+
+
+async def test_transfer_revokes_all_grants_sweeps_tokens_and_spares_siblings(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """Transfer → ALL active grants on the agent revoked (multiple clients),
+    their tokens dead on BOTH resolvers, transfer-stamped audit + events
+    written — while a grant on ANOTHER agent of the same owner stays live and
+    the transferred agent's key channel keeps working."""
+    ctx = integration_context
+    old_owner = await seeds.seed_user(ctx, "usr_t_old")
+    new_owner = await seeds.seed_user(ctx, "usr_t_new")
+    admin_id = await seeds.seed_user(ctx, "usr_t_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=old_owner, scopes=["apis:read"])
+    sibling_id = await seeds.seed_agent(
+        ctx, owner_id=old_owner, scopes=["apis:read"], name="sibling-agent"
+    )
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"], client_id=_CLIENT_ID_2)
+
+    # Two grants (two clients) on the transferring agent, one on the sibling.
+    grant_1, access_1, refresh_1, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=old_owner, agent_id=agent_id, grant_scopes=["apis:read"]
+    )
+    grant_2, access_2, _refresh_2, _ = await seeds.mint_grant_channel_tokens(
+        ctx,
+        user_id=old_owner,
+        agent_id=agent_id,
+        grant_scopes=["apis:read"],
+        client_id=_CLIENT_ID_2,
+    )
+    sibling_grant, sibling_access, _sibling_refresh, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=old_owner, agent_id=sibling_id, grant_scopes=["apis:read"]
+    )
+    admin = _admin_identity(admin_id)
+    api_key = await AgentAuthService(ctx).register_api_key(agent_id, identity=admin)
+
+    view = await AgentService(ctx).update_agent(
+        agent_id, update_data={"owner_id": new_owner}, identity=admin
+    )
+    assert view.owner_id == new_owner
+
+    grant_svc = OAuthGrantService(ctx)
+    for grant_id in (grant_1, grant_2):
+        grant = await grant_svc.get_grant(grant_id)
+        assert grant is not None and grant.status == "revoked"
+        assert grant.revoked_at is not None
+    sibling = await grant_svc.get_grant(sibling_grant)
+    assert sibling is not None and sibling.status == "active"
+
+    # Tokens dead on both resolvers; refresh fails closed; sibling stays live.
+    token_svc = TokenService(ctx)
+    broker = InProcessTokenResolver(ctx.admin_db)
+    for access in (access_1, access_2):
+        assert await token_svc.resolve_access_token(access) is None
+        broker_resolved = await broker.resolve_access_token(access)
+        assert broker_resolved is not None and broker_resolved.active is False
+    with pytest.raises(InvalidGrantError):
+        await token_svc.refresh(refresh_1, client_id=seeds.CLIENT_ID)
+    sibling_resolved = await token_svc.resolve_access_token(sibling_access)
+    assert sibling_resolved is not None and sibling_resolved.active is True
+
+    # The key channel is untouched by the sweep — only consent grants die.
+    key_identity = await ApiKeyResolver(ctx.admin_db).resolve(api_key)
+    assert key_identity is not None and key_identity.sub == agent_id
+
+    # Audit rows: one REVOKE per grant, stamped with the transfer reason and
+    # attributed to the transferring admin.
+    audits = await _revoke_audit_rows(ctx, {grant_1, grant_2})
+    assert len(audits) == 2
+    assert all(a.reason == "oauth grant revoked: agent ownership transferred" for a in audits)
+    assert all(a.actor_id == admin_id for a in audits)
+
+    # Events: oauth_grant.revoked per grant, data.reason distinguishing the
+    # transfer cause from a manual :revoke.
+    events = await _transfer_revoked_events(ctx, agent_id)
+    revoked_grant_ids = {(e.data or {}).get("grant_id") for e in events}
+    assert {grant_1, grant_2} <= revoked_grant_ids
+    for event in events:
+        if (event.data or {}).get("grant_id") in (grant_1, grant_2):
+            assert (event.data or {}).get("reason") == AGENT_TRANSFER_REVOCATION_REASON
+            assert event.created_by == admin_id
+
+
+async def test_transfer_with_no_grants_is_a_noop_and_name_patch_spares_grants(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """A transfer with no active grants writes no grant audit/events; a
+    non-owner PATCH (name) on an agent WITH grants leaves them live."""
+    ctx = integration_context
+    old_owner = await seeds.seed_user(ctx, "usr_t_noop_old")
+    new_owner = await seeds.seed_user(ctx, "usr_t_noop_new")
+    admin_id = await seeds.seed_user(ctx, "usr_t_noop_admin")
+    bare_agent = await seeds.seed_agent(ctx, owner_id=old_owner, scopes=["apis:read"])
+    granted_agent = await seeds.seed_agent(
+        ctx, owner_id=old_owner, scopes=["apis:read"], name="granted-agent"
+    )
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    grant_id, access, _refresh, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=old_owner, agent_id=granted_agent, grant_scopes=["apis:read"]
+    )
+    admin = _admin_identity(admin_id)
+    svc = AgentService(ctx)
+
+    view = await svc.update_agent(bare_agent, update_data={"owner_id": new_owner}, identity=admin)
+    assert view.owner_id == new_owner
+    assert await _transfer_revoked_events(ctx, bare_agent) == []
+
+    view = await svc.update_agent(
+        granted_agent, update_data={"name": "renamed-agent"}, identity=admin
+    )
+    assert view.name == "renamed-agent"
+    grant = await OAuthGrantService(ctx).get_grant(grant_id)
+    assert grant is not None and grant.status == "active"
+    assert await TokenService(ctx).resolve_access_token(access) is not None
+
+
+async def test_transfer_rolls_back_when_grant_revocation_fails(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """Fail-safe posture: if the sweep fails mid-transfer, the WHOLE transfer
+    rolls back — no transferred agent is ever left with live grants, and no
+    ownerless half-state is committed."""
+    ctx = integration_context
+    old_owner = await seeds.seed_user(ctx, "usr_t_rb_old")
+    new_owner = await seeds.seed_user(ctx, "usr_t_rb_new")
+    admin_id = await seeds.seed_user(ctx, "usr_t_rb_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=old_owner, scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    grant_id, access, _refresh, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=old_owner, agent_id=agent_id, grant_scopes=["apis:read"]
+    )
+
+    # Inject a failure INSIDE the sweep (the token kill-switch step) — the
+    # repository itself is real; only this one call blows up.
+    with (
+        patch(
+            "jentic_one.auth.services.oauth_grant_service.AccessTokenRepository.revoke_by_grant",
+            new=AsyncMock(side_effect=RuntimeError("sweep exploded")),
+        ),
+        pytest.raises(RuntimeError, match="sweep exploded"),
+    ):
+        await AgentService(ctx).update_agent(
+            agent_id, update_data={"owner_id": new_owner}, identity=_admin_identity(admin_id)
+        )
+
+    # Owner write rolled back with the failed sweep; the grant + token live on.
+    async with ctx.admin_db.session() as session:
+        agent = await AgentRepository.get_by_id(session, agent_id)
+    assert agent is not None and agent.owner_id == old_owner
+    grant = await OAuthGrantService(ctx).get_grant(grant_id)
+    assert grant is not None and grant.status == "active"
+    assert await TokenService(ctx).resolve_access_token(access) is not None
+
+
+async def test_rest_patch_owner_transfer_revokes_grants(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """The full REST path: PATCH /agents/{id} with a new owner_id runs the
+    sweep — the only identity shim is the auth dependency override; router,
+    service, repos, and DB are all real."""
+    ctx = integration_context
+    old_owner = await seeds.seed_user(ctx, "usr_t_rest_old")
+    new_owner = await seeds.seed_user(ctx, "usr_t_rest_new")
+    admin_id = await seeds.seed_user(ctx, "usr_t_rest_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=old_owner, scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    grant_id, access, _refresh, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=old_owner, agent_id=agent_id, grant_scopes=["apis:read"]
+    )
+
+    app = FastAPI()
+    app.include_router(agents.router)
+    app.add_exception_handler(AuthServiceError, service_error_handler)
+    app.state.ctx = ctx
+    app.dependency_overrides[resolve_identity] = lambda: _admin_identity(admin_id)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="https://testserver"
+        ) as client:
+            resp = await client.patch(f"/agents/{agent_id}", json={"owner_id": new_owner})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    assert resp.json()["owner_id"] == new_owner
+    grant = await OAuthGrantService(ctx).get_grant(grant_id)
+    assert grant is not None and grant.status == "revoked"
+    assert await TokenService(ctx).resolve_access_token(access) is None

--- a/tests/unit/auth/test_agent_update_service.py
+++ b/tests/unit/auth/test_agent_update_service.py
@@ -58,11 +58,16 @@ def _make_agent_row(
 
 
 @pytest.mark.asyncio
+@patch(
+    "jentic_one.auth.services.agent_service.revoke_active_grants_for_agent",
+    new_callable=AsyncMock,
+)
 @patch("jentic_one.auth.services.agent_service.record_audit", new_callable=AsyncMock)
 @patch("jentic_one.auth.services.agent_service.AgentRepository")
 async def test_update_agent_sets_owner(
     mock_repo: MagicMock,
     mock_audit: AsyncMock,
+    mock_revoke: AsyncMock,
 ) -> None:
     ctx = _make_ctx()
     svc = AgentService(ctx)
@@ -72,23 +77,95 @@ async def test_update_agent_sets_owner(
     mock_repo.get_by_id_for_update = AsyncMock(return_value=agent_before)
     mock_repo.update_agent = AsyncMock(return_value=agent_after)
 
+    identity = _admin_identity()
     view = await svc.update_agent(
         "agnt_test123",
         update_data={"owner_id": "usr_new_owner"},
-        identity=_admin_identity(),
+        identity=identity,
     )
 
     assert view.owner_id == "usr_new_owner"
     mock_repo.update_agent.assert_called_once()
     mock_audit.assert_called_once()
+    # An owner change is a transfer — the G10 (#1222) grant sweep runs in the
+    # same transaction, attributed to the transferring actor.
+    mock_revoke.assert_awaited_once()
+    assert mock_revoke.await_args is not None
+    assert mock_revoke.await_args.args[1] == "agnt_test123"
+    assert mock_revoke.await_args.kwargs["identity"] is identity
 
 
 @pytest.mark.asyncio
+@patch(
+    "jentic_one.auth.services.agent_service.revoke_active_grants_for_agent",
+    new_callable=AsyncMock,
+)
+@patch("jentic_one.auth.services.agent_service.record_audit", new_callable=AsyncMock)
+@patch("jentic_one.auth.services.agent_service.AgentRepository")
+async def test_update_agent_unchanged_owner_skips_grant_sweep(
+    mock_repo: MagicMock,
+    mock_audit: AsyncMock,
+    mock_revoke: AsyncMock,
+) -> None:
+    """A PATCH carrying the CURRENT owner_id is not a transfer — no sweep."""
+    ctx = _make_ctx()
+    svc = AgentService(ctx)
+
+    same_owner = _make_agent_row(owner_id="usr_owner")
+    mock_repo.get_by_id_for_update = AsyncMock(return_value=same_owner)
+    mock_repo.update_agent = AsyncMock(return_value=same_owner)
+
+    await svc.update_agent(
+        "agnt_test123",
+        update_data={"owner_id": "usr_owner"},
+        identity=_admin_identity(),
+    )
+
+    mock_revoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch(
+    "jentic_one.auth.services.agent_service.revoke_active_grants_for_agent",
+    new_callable=AsyncMock,
+)
+@patch("jentic_one.auth.services.agent_service.record_audit", new_callable=AsyncMock)
+@patch("jentic_one.auth.services.agent_service.AgentRepository")
+async def test_update_agent_grant_sweep_failure_fails_transfer(
+    mock_repo: MagicMock,
+    mock_audit: AsyncMock,
+    mock_revoke: AsyncMock,
+) -> None:
+    """The sweep is NOT best-effort: its failure propagates (and, in the real
+    transaction context manager, rolls the owner write back) rather than
+    leaving a transferred agent with live grants."""
+    ctx = _make_ctx()
+    svc = AgentService(ctx)
+
+    mock_repo.get_by_id_for_update = AsyncMock(return_value=_make_agent_row(owner_id="usr_old"))
+    mock_repo.update_agent = AsyncMock(return_value=_make_agent_row(owner_id="usr_new"))
+    mock_revoke.side_effect = RuntimeError("sweep failed")
+
+    with pytest.raises(RuntimeError, match="sweep failed"):
+        await svc.update_agent(
+            "agnt_test123",
+            update_data={"owner_id": "usr_new"},
+            identity=_admin_identity(),
+        )
+    mock_audit.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch(
+    "jentic_one.auth.services.agent_service.revoke_active_grants_for_agent",
+    new_callable=AsyncMock,
+)
 @patch("jentic_one.auth.services.agent_service.record_audit", new_callable=AsyncMock)
 @patch("jentic_one.auth.services.agent_service.AgentRepository")
 async def test_update_agent_sets_name_and_description(
     mock_repo: MagicMock,
     mock_audit: AsyncMock,
+    mock_revoke: AsyncMock,
 ) -> None:
     ctx = _make_ctx()
     svc = AgentService(ctx)
@@ -106,6 +183,8 @@ async def test_update_agent_sets_name_and_description(
 
     assert view.name == "new-name"
     assert view.description == "new desc"
+    # No owner change — the grant sweep must not run.
+    mock_revoke.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -139,11 +218,16 @@ async def test_update_agent_archived_raises(mock_repo: MagicMock) -> None:
 
 
 @pytest.mark.asyncio
+@patch(
+    "jentic_one.auth.services.agent_service.revoke_active_grants_for_agent",
+    new_callable=AsyncMock,
+)
 @patch("jentic_one.auth.services.agent_service.record_audit", new_callable=AsyncMock)
 @patch("jentic_one.auth.services.agent_service.AgentRepository")
 async def test_update_agent_invalid_owner_raises(
     mock_repo: MagicMock,
     mock_audit: AsyncMock,
+    mock_revoke: AsyncMock,
 ) -> None:
     ctx = _make_ctx()
     ctx.admin_db.transaction.return_value.__aexit__ = AsyncMock(

--- a/tests/unit/auth/web/test_consent_agent_picker.py
+++ b/tests/unit/auth/web/test_consent_agent_picker.py
@@ -20,6 +20,7 @@ from fastapi.testclient import TestClient
 
 from jentic_one.admin.services.schemas.oauth_clients import OAuthClientView
 from jentic_one.auth.services.authorize_service import AgentConsentOption
+from jentic_one.auth.services.errors import ConsentAgentNotEligibleError
 from jentic_one.auth.web.routers import authorize
 from jentic_one.shared.config import AuthConfig
 from jentic_one.shared.state.backend import MemoryStateBackend
@@ -345,6 +346,39 @@ def test_agent_model_invalid_agent_selection_rejected(
     assert resp.status_code == 302
     assert resp.headers["location"] == "/error?error=invalid_agent_selection"
     grant_svc.create_grant.assert_not_awaited()
+    svc.issue_authorization_code.assert_not_awaited()
+
+
+@patch("jentic_one.auth.web.routers.authorize.OAuthGrantService")
+@patch("jentic_one.auth.web.routers.authorize.AuthorizeService")
+@patch("jentic_one.auth.web.routers.authorize.OAuthClientService")
+def test_agent_model_mint_time_refusal_renders_error_page(
+    mock_client_svc_cls: MagicMock,
+    mock_authorize_cls: MagicMock,
+    mock_grant_cls: MagicMock,
+) -> None:
+    """The picker validation passes but the mint-time lock + re-check inside
+    ``create_grant`` refuses (agent transferred/archived in between, review
+    F1) → the same human error page as an invalid selection, no code, never
+    a 500."""
+    client, backend = _make_app()
+    _seed_consent_handle(backend)
+    mock_client_svc_cls.return_value.get_by_client_id = AsyncMock(return_value=_client_view())
+    svc = _mock_authorize_svc(agents=[_agent_option()])
+    mock_authorize_cls.return_value = svc
+    grant_svc = MagicMock()
+    grant_svc.create_grant = AsyncMock(side_effect=ConsentAgentNotEligibleError("agnt_1"))
+    mock_grant_cls.return_value = grant_svc
+
+    resp = client.post(
+        "/oauth/consent",
+        data={"consent_token": _HANDLE, "action": "approve", "agent_id": "agnt_1"},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/error?error=invalid_agent_selection"
+    grant_svc.create_grant.assert_awaited_once()
     svc.issue_authorization_code.assert_not_awaited()
 
 

--- a/ui/src/modules/agents/components/detail/ConnectedClientsCard.tsx
+++ b/ui/src/modules/agents/components/detail/ConnectedClientsCard.tsx
@@ -6,8 +6,9 @@
  * Each row shows the client (name + redirect-URI origin), the granted scopes,
  * WHO consented (`userId` via `ActorLabel` — deliberately surfaced: revoked
  * history rows keep the original consenter, and since G10/#1222 an agent
- * ownership transfer auto-revokes all active grants, so a stale consenter
- * only ever appears on revoked rows), created / last-used timestamps,
+ * ownership transfer auto-revokes all active grants while grant minting
+ * locks + re-checks agent ownership in the same transaction, so a stale
+ * consenter only ever appears on revoked rows), created / last-used timestamps,
  * and the per-grant Revoke kill switch (§4.6). Revoke honours the server's
  * per-item `canRevoke` capability: the revoke predicate (consenting user or
  * write-set admin) is deliberately NARROWER than the list predicate (agent's

--- a/ui/src/modules/agents/components/detail/ConnectedClientsCard.tsx
+++ b/ui/src/modules/agents/components/detail/ConnectedClientsCard.tsx
@@ -4,13 +4,14 @@
  * per-agent, in the GitHub/Google "authorized apps" grammar.
  *
  * Each row shows the client (name + redirect-URI origin), the granted scopes,
- * WHO consented (`userId` via `ActorLabel` — deliberately surfaced: after an
- * agent ownership transfer the grant stays with the original consenter, gap
- * G10, so admins can spot stranded grants), created / last-used timestamps,
+ * WHO consented (`userId` via `ActorLabel` — deliberately surfaced: revoked
+ * history rows keep the original consenter, and since G10/#1222 an agent
+ * ownership transfer auto-revokes all active grants, so a stale consenter
+ * only ever appears on revoked rows), created / last-used timestamps,
  * and the per-grant Revoke kill switch (§4.6). Revoke honours the server's
  * per-item `canRevoke` capability: the revoke predicate (consenting user or
  * write-set admin) is deliberately NARROWER than the list predicate (agent's
- * current owner or read-set admin — the G10 divergence), so a viewer who can
+ * current owner or read-set admin), so a viewer who can
  * see a grant may not be able to revoke it; the button disables with an
  * explanatory tooltip instead of offering a 403. A status filter mirrors the
  * access-requests card so revoked history is reachable on demand, and the


### PR DESCRIPTION
**HOLD: do not merge — pending Manuel's review.**

## Summary

`oauth_client_grants` keys owner-or-admin revocation on the grant's consenting `user_id`, but agent ownership is transferable — after a transfer the old owner's consent kept authorizing an MCP client to act as an agent that now belongs to someone else, and the new owner could not revoke it self-serve (their only lever was disabling the agent, which also kills the key channel). Per the decided G10 policy (revoke-on-transfer, Manuel 2026-09-02), an ownership transfer now revokes every active grant on the agent automatically; the new owner re-consents through the normal flow if the connection is still wanted.

## Changes

- `auth`: extracted the manual `:revoke` body (grant row flip + access/refresh token sweep + audit + `oauth_grant.revoked` event) from `OAuthGrantService.revoke_grant` into a shared session-level helper, so the manual kill switch and the transfer sweep run the identical revocation and can never drift. New `revoke_active_grants_for_agent(session, …)` runs that body over every active grant on the agent, inside the caller's transaction.
- `auth`: `AgentService.update_agent` detects an actual `owner_id` change and runs the sweep in the **same transaction** as the owner write — a failed revocation rolls the whole transfer back (fail-safe: a transferred agent can never be committed with live grants). No `viewer_can_revoke` check: authority comes from the `agents:write` gate on the transfer.
- `auth` (review wave): `OAuthGrantService.create_grant` now locks the agent row and re-checks the consent predicate (exists + active + owned by the consenting user) **inside the mint transaction**, closing the consent-vs-transfer TOCTOU (F1 below). Refusal raises the new `ConsentAgentNotEligibleError`, which the consent flow maps to the same human error page as a failed picker validation — never a code redirect, never a 500.
- Events/audit: transfer revocations emit the established `oauth_grant.revoked` event per grant, attributed to the transferring actor, with `data.reason = "agent_ownership_transferred"` (the `OVERLAY_DEPRECATED` cause-in-data pattern — the event schema has no dedicated reason field); the audit row reason is `"oauth grant revoked: agent ownership transferred"`. The manual `:revoke` path stays byte-identical.
- `admin/repos`: new `OAuthClientGrantRepository.list_active_for_agent` (unpaginated on purpose — the sweep must see the complete set or fail the transfer).
- Comments only: refreshed the now-stale G10 "policy pending" notes in `viewer_can_revoke`, `list_grants_for_agent`, and the UI `ConnectedClientsCard` header; the review wave then softened the "a LIVE grant's consenter is always the current owner" language in all three to state that the invariant holds **because of** the transfer sweep plus the mint-time lock+re-check — by construction, not by timing. (No UI behavior change — the connected-clients list just shrinks; no REST surface changed, no codegen needed.)
- Out of scope: `:claim` and `:approve` set `owner_id` only when it is `NULL`, so `update_agent` is the only path that can move a non-null owner, and grant minting now re-verifies ownership under the row lock. No CLI command patches `owner_id`. Archive/disable grant sweeping is deliberately NOT addressed here — filed as #1233.

## Adversarial review — findings & dispositions

| # | Finding | Severity | Disposition |
|---|---------|----------|-------------|
| F1 | Consent-approve racing a transfer could commit a live grant consented by the old owner (mint path validated ownership in an unlocked read, never re-checked in the write transaction) | HIGH | **Fixed** — `create_grant` takes the agent row lock (`get_by_id_for_update`, the same `FOR UPDATE` the transfer transaction takes) and re-checks exists+active+owner inside the mint transaction: either the mint commits first (the transfer's sweep then revokes it) or the transfer commits first (the re-check refuses). Regression test simulates the two-session race (validate → transfer commits → mint refused); SQLite proves the re-check, CI's Postgres leg proves the lock serialization. |
| F2 | No test would fail if the sweep left the transfer's transaction (rollback test couldn't distinguish same-transaction from separate-propagating-transaction) | MEDIUM | **Test pinned** — new test fails the transfer's own `record_audit` (the step *after* the sweep) and asserts from a fresh session that BOTH the owner change and the grant revocations rolled back. Fails iff the sweep ever commits in its own transaction. |
| F3 | Revocation reaches the broker only after its in-process positive-verdict cache expires | LOW | **Accepted residual** — a grant-channel access token can keep authorizing broker traffic for up to **30 s** after the transfer commits (`DEFAULT_CACHE_TTL_SECONDS`); identical window to the manual `:revoke` (shared helper guarantees parity), documented in the resolver comments. |
| F4 | Archive/disable never sweep grants — rows stay `active` on dead agents (listings/counts; pre-existing, adjacent) | LOW | **Follow-up filed** — #1233 (no live credential: both resolvers gate on `agent.status == 'active'`, and mint now re-checks active). |
| F5 | Coverage nits (NULL→owner PATCH arm untested; SQLite-only local verification) | INFO | **Covered** — new NULL→owner PATCH test (empty sweep, no crash, owner set) plus a router test pinning the mint-time-refusal → error-page mapping; Postgres semantics ride on CI as before. |

## Risk & rollback

- Touches the auth surface (OAuth grant lifecycle + agent transfer + consent mint). Behavior changes: `PATCH /agents/{id}` with a new `owner_id` also revokes that agent's active grants and their tokens; a consent approval whose agent was transferred/archived mid-flow is refused with the standard consent error page. Both are intended and fail-safe (over-revocation recovers via re-consent; under-revocation was the security gap).
- No migration, no config, no API-shape change. Revert = revert the squash commit.

## Test plan

- New unit tests (`tests/unit/auth/test_agent_update_service.py`): transfer calls the sweep with the transferring identity; same-owner PATCH and name/description PATCH skip it; sweep failure propagates and skips the audit write. (`tests/unit/auth/web/test_consent_agent_picker.py`): mint-time refusal renders the invalid-selection error page, no code issued.
- Integration suite (`tests/integration/auth/test_oauth_grant_transfer.py`): transfer with grants from two clients → both revoked, tokens dead on both resolvers (auth `TokenService` + broker raw-SQL) with refresh failing closed, transfer-stamped audit rows + events, sibling agent's grant of the same owner stays live, and the agent's API-key channel keeps resolving; transfer with no grants → no-op; injected sweep failure → owner write rolls back and grant/tokens stay live; full REST path through `PATCH /agents/{id}`; **review wave:** consent-mint racing a transfer is refused with no grant row committed; post-sweep audit failure rolls back owner AND revocations (same-transaction pin); NULL→owner PATCH runs an empty sweep without crashing.
- Gates (review-wave commit `00f90c4a`): `ruff check` + `ruff format --check` clean; `mypy src/` clean (635 files); full unit suite 2983 passed; arch suite 296 passed; `JENTIC_TEST_BACKEND=sqlite … tests/integration/ -m integration` 710 passed, 13 skipped.

## Review guide

- Start with the shared revocation body + transfer sweep in `src/jentic_one/auth/services/oauth_grant_service.py` (including the new lock+re-check at the top of `create_grant._write`), then the `update_agent` hook in `agent_service.py` and the consent-flow error mapping in `auth/web/routers/authorize.py`; the rest is the repo helper, tests, and comment refreshes.

Closes #1222

Made with [Cursor](https://cursor.com)