### PR TITLE
feat(mcp): HTTP-transport session telemetry + docs/advertisement (phase-3 items 6+8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,11 @@ allow. See `docs/security/hardening.md` before using real credentials.
 
 - One governed upstream call per execution. Compose multi-step work yourself; the Broker does
   not orchestrate.
-- A self-hosted deployment serves no HTTP MCP endpoint. Integrate through the `jentic` CLI, the
-  skill it generates, the CLI's local MCP stdio server (an `mcp` subcommand shipping in the
-  next `jentic` release), or plain HTTP against the deployment's own API.
+- A self-hosted deployment serves an HTTP MCP endpoint (`/mcp`) only when its operator enabled
+  it (`server.mcp.enabled`, off by default — see
+  [docs/mcp-http-endpoint.md](docs/mcp-http-endpoint.md)). Otherwise integrate through the
+  `jentic` CLI, the skill it generates, the CLI's local MCP stdio server (an `mcp` subcommand
+  shipping in the next `jentic` release), or plain HTTP against the deployment's own API.
 - A running instance serves `/llms.txt` and `/.well-known/llms.txt` with that deployment's base
   URL. Once an instance exists, prefer those over this file for anything at runtime.
 - Never print, log or echo a stored credential. The Broker does not return them.

--- a/docs/cloud-vs-self-hosted.md
+++ b/docs/cloud-vs-self-hosted.md
@@ -6,7 +6,7 @@ especially for an AI agent (or its operator) that has used both:
 |  | Jentic cloud platform | Jentic One (this repo) |
 | --- | --- | --- |
 | Where it runs | Hosted by Jentic — dashboard at `app.jentic.com`, API at `api.jentic.com` | Your infrastructure (laptop, VM, Kubernetes) |
-| How agents connect | Remote **MCP server** (`https://api.jentic.com/mcp`) configured in the agent runtime with a workspace API key | **`jentic` CLI + generated skill**, the local **`jentic mcp`** stdio server (available in the `jentic` CLI from the next release), or the raw HTTP flow — see below |
+| How agents connect | Remote **MCP server** (`https://api.jentic.com/mcp`) configured in the agent runtime with a workspace API key | **`jentic` CLI + generated skill**, the local **`jentic mcp`** stdio server (available in the `jentic` CLI from the next release), an optional hosted **`/mcp`** endpoint (off by default), or the raw HTTP flow — see below |
 | Agent identity | Workspace API key | Per-agent Ed25519 keypair via dynamic client registration (`jentic register` / `jentic setup`) |
 | Dashboard | `app.jentic.com` | The bundled UI on your deployment (`/app`) |
 | Data | Jentic-hosted workspace | Stays on your infrastructure; stored secrets are decrypted only inside your Broker at execution time |
@@ -14,25 +14,31 @@ especially for an AI agent (or its operator) that has used both:
 They do not share state: an API imported or a credential stored in one is
 invisible to the other.
 
-## MCP against a self-hosted install: the local `jentic mcp` server
+## MCP against a self-hosted install: `jentic mcp` and the `/mcp` endpoint
 
-MCP access to a Jentic One deployment runs through the **local `jentic mcp`
-stdio server** — available in the `jentic` CLI from the next release; check
-`jentic mcp --help`. Your agent runtime (Claude Desktop/Code, Cursor, …)
-spawns it as an ordinary stdio MCP entry; it authenticates with the agent's
-registered identity and exposes the same discover → execute loop the CLI
-drives (`search_apis`, `inspect_operation`, `execute`, …). Every tool result
-carries an identity stamp (`backend`, `host`, `instance_id`, `fetched_at`)
-so an agent can always tell which instance answered.
+MCP access to a Jentic One deployment comes in two shapes. The default is
+the **local `jentic mcp` stdio server** — available in the `jentic` CLI from
+the next release; check `jentic mcp --help`. Your agent runtime (Claude
+Desktop/Code, Cursor, …) spawns it as an ordinary stdio MCP entry; it
+authenticates with the agent's registered identity and exposes the same
+discover → execute loop the CLI drives (`search_apis`, `inspect_operation`,
+`execute`, …). Every tool result carries an identity stamp (`backend`,
+`host`, `instance_id`, `fetched_at`) so an agent can always tell which
+instance answered.
 
-There is still **no hosted `/mcp` HTTP endpoint** on the deployment itself.
-Probing the control plane (`:8000/mcp`, `/v1/mcp`, `/api/mcp`, `/sse`) returns
-404. The broker (`:8100`) answers 401 to an unauthenticated `/mcp` probe —
-that is **not** a hidden MCP server behind auth; it is the broker's
-credential-injecting forward proxy rejecting the request, like it would any
-other unauthenticated path. Do not configure a *URL-based* MCP entry pointing
-at your self-hosted host; MCP entries for a self-hosted install spawn
-`jentic mcp` as a command.
+A deployment can additionally serve a **hosted Streamable HTTP endpoint at
+`/mcp`** on the control plane — the same tool surface, per-request bearer
+auth, no CLI on the agent machine. It is **off by default**
+(`server.mcp.enabled`): on a default install, probing the control plane
+(`:8000/mcp`, `/v1/mcp`, `/api/mcp`, `/sse`) still returns 404 (or, on
+deployments preparing interactive OAuth, a 401 discovery challenge). The
+broker (`:8100`) answers 401 to an unauthenticated `/mcp` probe in every
+configuration — that is **not** a hidden MCP server behind auth; it is the
+broker's credential-injecting forward proxy rejecting the request, like it
+would any other unauthenticated path. Only configure a *URL-based* MCP entry
+against a deployment whose operator has enabled the endpoint — see
+[mcp-http-endpoint.md](mcp-http-endpoint.md) for enabling it, client
+snippets, and stdio-bridge recipes for runtimes that cannot use URL entries.
 
 The supported integration paths for agents are:
 
@@ -47,7 +53,9 @@ The supported integration paths for agents are:
    the execute loop is MCP-preferred. If a session has both surfaces, prefer
    the MCP tools and use the CLI for `setup`/`access` recovery and anything
    not exposed over MCP — both talk to the same instance (check
-   `backend`/`host` in the identity stamp).
+   `backend`/`host` in the identity stamp). Where the operator has enabled
+   the hosted `/mcp` endpoint, a URL-based entry with the agent's API key is
+   the CLI-less alternative ([mcp-http-endpoint.md](mcp-http-endpoint.md)).
 3. **Raw HTTP.** For runtimes without the CLI, every deployment self-describes
    at `GET /llms.txt`: dynamic client registration, token exchange, discovery,
    access requests, and brokered execution.

--- a/docs/mcp-http-endpoint.md
+++ b/docs/mcp-http-endpoint.md
@@ -1,0 +1,148 @@
+# The `/mcp` Streamable HTTP endpoint
+
+Jentic One deployments can serve MCP directly over HTTP: a **stateless
+Streamable HTTP endpoint at `/mcp`** on the control plane (MCP spec revision
+2026-07-28). It exposes the same tool surface as the local `jentic mcp` stdio
+server — `whoami`, `search_apis`, `inspect_operation`, `search_catalog`,
+`execute`, `execute_read`, `get_execution_result` — and the two transports
+are contract-tested against each other, so an agent gets identical envelopes
+whichever one its runtime speaks.
+
+When to use which:
+
+- **Stdio (`jentic mcp`) stays the default for a runtime that can spawn a
+  process** — the agent's key never leaves its machine, and registration
+  (`jentic setup`) is unchanged. See
+  [cloud-vs-self-hosted.md](cloud-vs-self-hosted.md) for the integration
+  paths and [security/mcp-same-host-hardening.md](security/mcp-same-host-hardening.md)
+  for same-host recipes.
+- **The HTTP endpoint is the daemon-native shape**: headless agents, other
+  machines, runtimes that cannot spawn processes, and the many-users-one-URL
+  deployment. No CLI or context on the agent machine — each request carries
+  a bearer.
+
+## Enabling it
+
+The endpoint is config-gated and **off by default** — a default install
+answers the framework's plain 404 on `/mcp` (or, with `server.mcp.oauth.enabled`,
+the OAuth discovery challenge), exactly as before. Enable it in the backend
+config:
+
+```yaml
+server:
+  mcp:
+    enabled: true
+```
+
+Flipping the flag needs no rebuild; the gate is evaluated per request. The
+endpoint accepts only `POST` (stateless — no SSE stream, no `Mcp-Session-Id`),
+validates the `Origin` header strictly (403 on mismatch), and requires a
+credential for everything except surface discovery (`tools/list`, `ping`,
+the resource listings).
+
+## Connecting an HTTP-capable MCP client
+
+Authenticate each request with the agent's API key (or an access token) —
+the same credential shapes every REST route accepts:
+
+```json
+{
+  "mcpServers": {
+    "jentic": {
+      "url": "https://your-jentic-host/mcp",
+      "headers": { "Authorization": "Bearer <agent-api-key>" }
+    }
+  }
+}
+```
+
+The agent detail page's **MCP tab** renders this snippet pre-filled for each
+agent when the instance serves `/mcp` (the variant is hidden otherwise). The
+same page lists the agent's MCP sessions: on this transport a "session" row
+is emitted once per client per rolling window (hours-scale), since spec
+2026-07-28 has no protocol-level sessions to count.
+
+Scopes and audit are identical to REST: the endpoint enforces the same
+per-tool scopes the fronted routes require, and executions land in the
+monitor labeled with the `mcp` origin.
+
+## Recipes: stdio-only clients
+
+Some MCP runtimes only spawn stdio servers. Two third-party bridges pump
+stdio ↔ Streamable HTTP; both keep the endpoint's per-request bearer model
+(the bridge adds the `Authorization` header, the deployment still enforces
+identity, scopes, and audit per call).
+
+### `mcp-remote` (npm)
+
+```json
+{
+  "mcpServers": {
+    "jentic": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://your-jentic-host/mcp",
+        "--header",
+        "Authorization:${JENTIC_AUTH}"
+      ],
+      "env": { "JENTIC_AUTH": "Bearer <agent-api-key>" }
+    }
+  }
+}
+```
+
+The env-var indirection is deliberate: several runtimes mangle spaces in
+`args`, and it keeps the key out of the (often synced) config file body.
+
+> **Caveat — plaintext `~/.mcp-auth`.** `mcp-remote` is an OAuth-capable
+> bridge and caches any tokens it negotiates **in plaintext under the
+> desktop user's home** (`~/.mcp-auth`). With a static `--header` bearer as
+> above nothing sensitive should land there, but treat the directory as
+> secret-bearing if you let the bridge do OAuth. A first-party,
+> credential-less stdio relay (`jentic mcp --connect <url>`) is planned to
+> replace these third-party bridges for exactly this reason.
+
+### `mcp-proxy` (PyPI)
+
+[`mcp-proxy`](https://github.com/sparfenyuk/mcp-proxy) in client mode
+bridges a stdio runtime to a Streamable HTTP server — pass
+`--transport=streamablehttp` (its default is SSE) and the bearer as a
+header. The endpoint is stateless server-side, so no session flags are
+needed on the client leg:
+
+```json
+{
+  "mcpServers": {
+    "jentic": {
+      "command": "mcp-proxy",
+      "args": [
+        "--transport=streamablehttp",
+        "--headers", "Authorization", "Bearer <agent-api-key>",
+        "https://your-jentic-host/mcp"
+      ]
+    }
+  }
+}
+```
+
+## Security posture
+
+- **Bearer per request.** There is no session to hijack; every request is
+  authenticated independently. Revoking the agent (or the key) cuts access
+  immediately.
+- **Strict `Origin` validation.** A browser-context request whose `Origin`
+  is neither the configured canonical origin (`auth.canonical_base_url`)
+  nor loopback is refused with 403 (the spec's DNS-rebinding rule).
+  Non-browser MCP clients send no `Origin` and pass.
+- **Serve it over TLS** when the deployment is reachable beyond loopback —
+  the bearer rides every request.
+- **Discovery is public by design**: `tools/list` answers without a
+  credential, like the deployment's other self-description documents
+  (`/llms.txt` advertises the endpoint only when it is enabled).
+
+For interactive OAuth (Claude/Cursor-style browser consent instead of
+bearer-paste), see [oauth-clients.md](oauth-clients.md) — the `/mcp`
+resource participates in that discovery chain when
+`server.mcp.oauth.enabled` is on.

--- a/docs/mcp-http-endpoint.md
+++ b/docs/mcp-http-endpoint.md
@@ -59,7 +59,8 @@ the same credential shapes every REST route accepts:
 The agent detail page's **MCP tab** renders this snippet pre-filled for each
 agent when the instance serves `/mcp` (the variant is hidden otherwise). The
 same page lists the agent's MCP sessions: on this transport a "session" row
-is emitted once per client per rolling window (hours-scale), since spec
+is emitted once per client per fixed six-hour UTC window (a reconnect
+straddling a window boundary can yield two rows minutes apart), since spec
 2026-07-28 has no protocol-level sessions to count.
 
 Scopes and audit are identical to REST: the endpoint enforces the same
@@ -94,7 +95,12 @@ identity, scopes, and audit per call).
 ```
 
 The env-var indirection is deliberate: several runtimes mangle spaces in
-`args`, and it keeps the key out of the (often synced) config file body.
+`args` (the no-space `Header:${VAR}` form is `mcp-remote`'s own recommended
+workaround), and the expanded header never shows up in `argv`/process
+listings. The key still lives in this config file's `env` block; to keep it
+out of the file entirely, use `mcp-remote`'s `--header-file <path>` (one
+`Name: value` line per header) and store the file outside your synced
+config.
 
 > **Caveat — plaintext `~/.mcp-auth`.** `mcp-remote` is an OAuth-capable
 > bridge and caches any tokens it negotiates **in plaintext under the
@@ -108,9 +114,11 @@ The env-var indirection is deliberate: several runtimes mangle spaces in
 
 [`mcp-proxy`](https://github.com/sparfenyuk/mcp-proxy) in client mode
 bridges a stdio runtime to a Streamable HTTP server — pass
-`--transport=streamablehttp` (its default is SSE) and the bearer as a
-header. The endpoint is stateless server-side, so no session flags are
-needed on the client leg:
+`--transport=streamablehttp` (its default is SSE) and the bearer via the
+`API_ACCESS_TOKEN` environment variable, which `mcp-proxy` reads natively
+and sends as `Authorization: Bearer <token>` (keeping the key out of `argv`
+and process listings, like the `mcp-remote` recipe above). The endpoint is
+stateless server-side, so no session flags are needed on the client leg:
 
 ```json
 {
@@ -119,9 +127,9 @@ needed on the client leg:
       "command": "mcp-proxy",
       "args": [
         "--transport=streamablehttp",
-        "--headers", "Authorization", "Bearer <agent-api-key>",
         "https://your-jentic-host/mcp"
-      ]
+      ],
+      "env": { "API_ACCESS_TOKEN": "<agent-api-key>" }
     }
   }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@ What an agent can do once an instance is running:
 
 What it does not do. Jentic One bounds what a mistaken or compromised agent can reach. It does not make an agent correct or reliable, and it does not remove the judgment call about which operations an agent should be allowed to touch at all.
 
-Agents integrate through the `jentic` CLI and the skill it generates, over MCP via the CLI's local stdio server (an `mcp` subcommand shipping in the next `jentic` release), or over plain HTTP against the deployment's own API. The deployment itself serves no HTTP MCP endpoint; MCP runs through the local server. All paths are documented below.
+Agents integrate through the `jentic` CLI and the skill it generates, over MCP via the CLI's local stdio server (an `mcp` subcommand shipping in the next `jentic` release) or the deployment's own Streamable HTTP `/mcp` endpoint (config-gated, off by default — see [docs/mcp-http-endpoint.md](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/mcp-http-endpoint.md)), or over plain HTTP against the deployment's own API. All paths are documented below.
 
 Jentic One runs on one machine and the agent runs on another. Install on both with the same bootstrap:
 

--- a/src/jentic_one/mcp/app.py
+++ b/src/jentic_one/mcp/app.py
@@ -443,7 +443,9 @@ class McpMount:
                 # clientInfo x window), clientInfo from this request's
                 # ``_meta`` (absent → client unknown, mirroring stdio lane D).
                 # Fire-and-forget; within a window the repeat cost is one
-                # set-membership check.
+                # set-membership check, and distinct clientInfo keys are
+                # capped per (agent, window) so varying ``_meta`` per request
+                # cannot mint a row per request.
                 client_name, client_version = request_client_info(body)
                 schedule_mcp_http_session_emit(
                     self.ctx,

--- a/src/jentic_one/mcp/app.py
+++ b/src/jentic_one/mcp/app.py
@@ -38,6 +38,10 @@ that owns everything the platform — not the SDK — must decide:
   resource listings are served without a credential — a client can always
   discover the tool surface before authenticating (§3.3). Everything else
   requires a resolved identity.
+- **Session telemetry** (phase-3 item 6): each authenticated POST feeds the
+  windowed ``mcp.session_started`` emit — key = (agent identity x ``_meta``
+  clientInfo x window), fire-and-forget
+  (:func:`jentic_one.shared.events.mcp_session.schedule_mcp_http_session_emit`).
 
 The resolved identity/credential ride to the tool handlers on the request's
 ASGI ``scope["state"]`` (the SDK transport attaches the Starlette ``Request``
@@ -66,7 +70,11 @@ from jentic_one.mcp.spec import served_tools
 from jentic_one.mcp.tools import CallEnv, dispatch_tool_call
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
-from jentic_one.shared.events.mcp_session import SESSION_ID_HEADER, valid_session_id_or_none
+from jentic_one.shared.events.mcp_session import (
+    SESSION_ID_HEADER,
+    schedule_mcp_http_session_emit,
+    valid_session_id_or_none,
+)
 from jentic_one.shared.models.actors import Origin as ActorOrigin
 from jentic_one.shared.web.links import deployment_base_url
 
@@ -95,6 +103,10 @@ PRE_AUTH_METHODS = frozenset(
 #: Bound on a buffered request body. The SDK transport's own bound is 4 MiB
 #: (``max_request_body_size``); this only guards the pre-auth sniff.
 _MAX_BUFFERED_BODY = 8 << 20
+
+#: The spec 2026-07-28 ``_meta`` key an MCP client SHOULD stamp its identity
+#: under on every request (there is no ``initialize`` to carry it anymore).
+CLIENT_INFO_META_KEY = "io.modelcontextprotocol/clientInfo"
 
 
 def _framework_404() -> Response:
@@ -206,6 +218,44 @@ def _body_methods(body: bytes) -> list[str] | None:
             methods.append(method)
         return methods or None
     return None
+
+
+def request_client_info(body: bytes) -> tuple[str | None, str | None]:
+    """The ``_meta`` clientInfo (name, version) in one POST body, if any.
+
+    Spec 2026-07-28: clientInfo optionally rides each request's ``params._meta``
+    under :data:`CLIENT_INFO_META_KEY` (a SHOULD — absent means client
+    unknown). The bytes-level containment check keeps the per-request cost of
+    the common no-clientInfo case to one scan instead of a JSON parse; a
+    malformed body or a non-string field degrades to unknown, never an error
+    (telemetry must not affect serving). Batched bodies yield the first
+    request that carries one.
+    """
+    if CLIENT_INFO_META_KEY.encode() not in body:
+        return (None, None)
+    try:
+        decoded = json.loads(body)
+    except ValueError:
+        return (None, None)
+    for item in decoded if isinstance(decoded, list) else [decoded]:
+        if not isinstance(item, dict):
+            continue
+        params = item.get("params")
+        if not isinstance(params, dict):
+            continue
+        meta = params.get("_meta")
+        if not isinstance(meta, dict):
+            continue
+        client_info = meta.get(CLIENT_INFO_META_KEY)
+        if not isinstance(client_info, dict):
+            continue
+        name = client_info.get("name")
+        version = client_info.get("version")
+        return (
+            name if isinstance(name, str) else None,
+            version if isinstance(version, str) else None,
+        )
+    return (None, None)
 
 
 # ── the SDK server (stateless; handlers read identity off the request state) ──
@@ -387,6 +437,21 @@ class McpMount:
             if identity is None:
                 return _unauthorized(self.ctx, request, method)
             self._stash_call_state(scope, request, identity, credential)
+            if body is not None:
+                # Phase-3 item 6: every authenticated POST may start a
+                # (windowed) MCP session — the emit key is (agent identity x
+                # clientInfo x window), clientInfo from this request's
+                # ``_meta`` (absent → client unknown, mirroring stdio lane D).
+                # Fire-and-forget; within a window the repeat cost is one
+                # set-membership check.
+                client_name, client_version = request_client_info(body)
+                schedule_mcp_http_session_emit(
+                    self.ctx,
+                    client_name=client_name,
+                    client_version=client_version,
+                    actor_id=identity.sub,
+                    actor_type=identity.actor_type.value,
+                )
 
         if method == "GET":
             # Never reaches the SDK transport: in stateless mode its

--- a/src/jentic_one/shared/events/mcp_session.py
+++ b/src/jentic_one/shared/events/mcp_session.py
@@ -1,5 +1,18 @@
 """``mcp.session_started`` emission — first authenticated request per MCP session.
 
+Two transports emit this event, sharing one dedupe machine (the seen/in-flight
+sets, the events-table lookup, and the partial unique index on
+``(type, data->>'session_id')``) but with different **keys**:
+
+- **stdio** (lane D, issue #1177): once per session UUID relayed by the Go
+  server — :func:`schedule_mcp_session_emit`, described below.
+- **HTTP** (phase-3 item 6): the daemon-native ``/mcp`` mount sees MCP
+  protocol traffic directly, and under spec 2026-07-28 there is no
+  ``initialize`` and no session id — clientInfo optionally rides each
+  request's ``_meta``. One long-lived daemon serves many identities, so the
+  emit key is once per (agent identity x clientInfo name/version) per
+  **window** — :func:`schedule_mcp_http_session_emit`.
+
 Local-MCP lane D (issue #1177). The stdio MCP server (Go, ``jentic mcp``)
 terminates all MCP protocol traffic; the backend only ever sees plain HTTP
 calls. Two request properties identify an MCP session:
@@ -37,8 +50,12 @@ pattern).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import re
+import time
+from collections.abc import Coroutine
 from dataclasses import dataclass
+from typing import Any
 
 import structlog
 from sqlalchemy.exc import IntegrityError
@@ -71,6 +88,35 @@ _MCP_UA_RE = re.compile(
 #: its own transport value and windowed dedupe key — not through this module's
 #: once-per-session-id path.
 _STDIO_TRANSPORT = "stdio"
+
+#: Transport for the mounted ``/mcp`` app's windowed emit path.
+_HTTP_TRANSPORT = "http"
+
+#: The HTTP emit window (phase-3 item 6): at most one ``mcp.session_started``
+#: per (agent identity x clientInfo name/version) per **6-hour, UTC-aligned
+#: window**. Decision + rationale (recorded in this PR, per the phase doc):
+#:
+#: - The 2-E2 per-agent sessions list is the consumer. Six hours splits a day
+#:   into at most four rows per (agent x client) — enough granularity to see
+#:   "came back this afternoon" reconnects without a busy agent spamming a
+#:   row per request (1h would allow 24/day) or a whole day collapsing into
+#:   one row that hides every reconnect (24h).
+#: - The stdio twin emits once per server process; desktop runtimes restart
+#:   the server a handful of times a working day, so hours-scale windows keep
+#:   the two transports' row volumes comparable in the same list.
+#: - Windows are **fixed UTC buckets** (``epoch // window``), not sliding
+#:   relative to the last emit: the bucket makes the dedupe key deterministic
+#:   across workers, so the existing partial unique index on
+#:   ``(type, data->>'session_id')`` enforces exactly-once per window across
+#:   the whole deployment — a sliding window cannot be expressed as a unique
+#:   key and would multiply events by worker/replica count. Worst case a
+#:   client reconnecting exactly across a bucket boundary yields two rows
+#:   minutes apart; a multi-worker deployment duplicating every window would
+#:   be strictly worse for the sessions list.
+#:
+#: A code constant, deliberately not config: the value tunes a UI list's
+#: granularity, not deployment behaviour.
+MCP_HTTP_WINDOW_SECONDS = 6 * 60 * 60
 
 #: Longest UA-derived field persisted to event ``data``. The User-Agent is
 #: untrusted input; without a cap a hostile client could grow every
@@ -157,6 +203,34 @@ async def record_mcp_session_started(
     treated as "already emitted". Other failures are logged and the seen-set
     is left untouched so the next request for the session retries.
     """
+    await _record_session_started(
+        ctx,
+        session_id=session_id,
+        transport=_STDIO_TRANSPORT,
+        client_name=ua.client_name,
+        client_version=ua.client_version,
+        actor_id=actor_id,
+        actor_type=actor_type,
+    )
+
+
+async def _record_session_started(
+    ctx: Context,
+    *,
+    session_id: str,
+    transport: str,
+    client_name: str | None,
+    client_version: str | None,
+    actor_id: str,
+    actor_type: str,
+) -> None:
+    """The transport-agnostic emit body shared by the stdio and HTTP paths.
+
+    ``session_id`` is whatever the transport's dedupe keys on — the relayed
+    session UUID for stdio, the synthetic per-window key for HTTP. Everything
+    else (table lookup, unique-index race tolerance, seen-set priming) is
+    identical.
+    """
     try:
         async with ctx.admin_db.transaction() as session:
             already_emitted = await EventRepository.exists_with_data_value(
@@ -166,7 +240,7 @@ async def record_mcp_session_started(
                 value=session_id,
             )
             if not already_emitted:
-                client_tag = McpClient.from_client_name(ua.client_name)
+                client_tag = McpClient.from_client_name(client_name)
                 await emit_event(
                     session,
                     type=EventType.MCP_SESSION_STARTED,
@@ -177,9 +251,9 @@ async def record_mcp_session_started(
                     actor_type=actor_type,
                     data={
                         "session_id": session_id,
-                        "transport": _STDIO_TRANSPORT,
-                        "client_name": ua.client_name,
-                        "client_version": ua.client_version,
+                        "transport": transport,
+                        "client_name": client_name,
+                        "client_version": client_version,
                     },
                     tags={client_tag},
                 )
@@ -221,17 +295,99 @@ def schedule_mcp_session_emit(
     if ctx is None:
         return
 
-    _in_flight.add(sid)
-    task = asyncio.create_task(
+    _spawn_emit(
+        sid,
         record_mcp_session_started(
             ctx, ua=ua, session_id=sid, actor_id=actor_id, actor_type=actor_type
-        )
+        ),
     )
+
+
+def mcp_http_window_key(
+    actor_id: str,
+    client_name: str | None,
+    client_version: str | None,
+    *,
+    now: float | None = None,
+) -> str:
+    """The HTTP emit's synthetic session id: one per (agent x client x window).
+
+    Doubles as the ``data.session_id`` the event persists, so (a) the existing
+    partial unique index enforces the once-per-window guarantee across
+    workers/replicas exactly as it enforces once-per-session-UUID for stdio,
+    and (b) the 2-E2 sessions list — which keys rows on ``session_id`` — shows
+    one meaningful row per reconnect window on a transport that has no
+    protocol session ids at all (spec 2026-07-28 removed them). The clientInfo
+    half is a short digest, not the raw strings: ``_meta`` is untrusted input
+    and the raw name/version already ride the event ``data`` capped.
+    """
+    fingerprint = hashlib.sha256(
+        f"{client_name or ''}\n{client_version or ''}".encode()
+    ).hexdigest()[:12]
+    window = int((time.time() if now is None else now) // MCP_HTTP_WINDOW_SECONDS)
+    return f"http:{actor_id}:{fingerprint}:{window}"
+
+
+def schedule_mcp_http_session_emit(
+    ctx: Context | None,
+    *,
+    client_name: str | None,
+    client_version: str | None,
+    actor_id: str,
+    actor_type: str,
+) -> None:
+    """Fire-and-forget ``mcp.session_started`` from the mounted ``/mcp`` app.
+
+    Called on every authenticated POST the mount serves (phase-3 item 6); the
+    dedupe key is the per-window synthetic id, so within one window the fast
+    path is one set-membership check. clientInfo comes from the request's
+    ``_meta`` (``io.modelcontextprotocol/clientInfo``) and is a SHOULD — an
+    absent one still emits, degrading to client-unknown exactly like the
+    stdio path (``McpClient.OTHER`` on the wire, ``client_name: null`` in
+    ``data``). Values are capped like the UA-derived fields: they persist to
+    event ``data`` and are attacker-controlled.
+    """
+    if ctx is None:
+        return
+    name = client_name.strip()[:_UA_FIELD_MAX] if client_name and client_name.strip() else None
+    version = (
+        client_version.strip()[:_UA_FIELD_MAX]
+        if client_version and client_version.strip()
+        else None
+    )
+    sid = mcp_http_window_key(actor_id, name, version)
+    if sid in _seen_sessions or sid in _in_flight:
+        return
+
+    _spawn_emit(
+        sid,
+        _record_session_started(
+            ctx,
+            session_id=sid,
+            transport=_HTTP_TRANSPORT,
+            client_name=name,
+            client_version=version,
+            actor_id=actor_id,
+            actor_type=actor_type,
+        ),
+    )
+
+
+def _spawn_emit(sid: str, record: Coroutine[Any, Any, None]) -> None:
+    """Run one emit coroutine in the background, tracked under ``sid``.
+
+    The in-flight add is synchronous, before the task is created, so two
+    concurrent first requests for one dedupe key can never both schedule.
+    Callers must have checked the seen/in-flight sets already (this always
+    schedules the coroutine it is given).
+    """
+    _in_flight.add(sid)
+    task = asyncio.create_task(record)
     _background_tasks.add(task)
 
     def _cleanup(done: asyncio.Task[None]) -> None:
         _background_tasks.discard(done)
-        # On failure the session is not in the seen-set, so dropping the
+        # On failure the key is not in the seen-set, so dropping the
         # in-flight entry lets the next request retry.
         _in_flight.discard(sid)
 

--- a/src/jentic_one/shared/events/mcp_session.py
+++ b/src/jentic_one/shared/events/mcp_session.py
@@ -118,6 +118,15 @@ _HTTP_TRANSPORT = "http"
 #: granularity, not deployment behaviour.
 MCP_HTTP_WINDOW_SECONDS = 6 * 60 * 60
 
+#: Per-agent cap on *distinct* clientInfo dedupe keys admitted per window
+#: (review M1). Without it an authenticated agent varying ``_meta`` clientInfo
+#: per request mints one events-table row per request for the whole window —
+#: the unique index dedupes identical keys only, never distinct ones. Sixteen
+#: distinct (name, version) pairs per 6-hour bucket is far beyond any legit
+#: multi-client agent (each real client is one pair per version); past the cap
+#: the emit is skipped and a warning logged once per (agent, window).
+MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW = 16
+
 #: Longest UA-derived field persisted to event ``data``. The User-Agent is
 #: untrusted input; without a cap a hostile client could grow every
 #: ``mcp.session_started`` row by kilobytes of junk.
@@ -138,7 +147,24 @@ _SEEN_SESSIONS_MAX = 4096
 #: retries.
 _in_flight: set[str] = set()
 
+#: Cap on concurrently in-flight emits (review M1): each entry holds a
+#: background task with an open admin-DB transaction, so the transient
+#: population must not be attacker-paced. At the cap new emits are *dropped*
+#: (never cleared — clearing would orphan keys whose tasks still run): the key
+#: is not in the seen-set, so a later request retries once the backlog drains.
+#: ``_background_tasks`` adds/removes in lockstep, so this bounds both sets.
+_IN_FLIGHT_MAX = 1024
+
 _background_tasks: set[asyncio.Task[None]] = set()
+
+#: Distinct dedupe keys admitted per (agent, window) on this process (review
+#: M1) — the counter behind :data:`MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW`.
+#: A count past the cap is the "warned already" sentinel, so the log fires
+#: once per (agent, window). Bounded with the seen-set clear-on-full pattern:
+#: a clear only re-opens the cap, it never mints duplicate rows (the seen-set
+#: and the unique index still dedupe identical keys).
+_agent_window_counts: dict[tuple[str, int], int] = {}
+_AGENT_WINDOW_COUNTS_MAX = 4096
 
 
 @dataclass(frozen=True, slots=True)
@@ -294,6 +320,8 @@ def schedule_mcp_session_emit(
         return
     if ctx is None:
         return
+    if not _in_flight_has_room():
+        return
 
     _spawn_emit(
         sid,
@@ -319,13 +347,23 @@ def mcp_http_window_key(
     one meaningful row per reconnect window on a transport that has no
     protocol session ids at all (spec 2026-07-28 removed them). The clientInfo
     half is a short digest, not the raw strings: ``_meta`` is untrusted input
-    and the raw name/version already ride the event ``data`` capped.
+    and the raw name/version already ride the event ``data`` capped. The
+    digest inputs are case-folded (one row per client regardless of case —
+    matching the ``McpClient`` tag's case-insensitive mapping) and
+    length-prefixed before joining, so ``("x\\ny", "z")`` and ``("x", "y\\nz")``
+    can never collide on the join delimiter.
     """
     fingerprint = hashlib.sha256(
-        f"{client_name or ''}\n{client_version or ''}".encode()
+        f"{_digest_component(client_name)}\n{_digest_component(client_version)}".encode()
     ).hexdigest()[:12]
     window = int((time.time() if now is None else now) // MCP_HTTP_WINDOW_SECONDS)
     return f"http:{actor_id}:{fingerprint}:{window}"
+
+
+def _digest_component(value: str | None) -> str:
+    """One unambiguous digest-input token: case-folded and length-prefixed."""
+    text = (value or "").casefold()
+    return f"{len(text)}:{text}"
 
 
 def schedule_mcp_http_session_emit(
@@ -345,7 +383,9 @@ def schedule_mcp_http_session_emit(
     absent one still emits, degrading to client-unknown exactly like the
     stdio path (``McpClient.OTHER`` on the wire, ``client_name: null`` in
     ``data``). Values are capped like the UA-derived fields: they persist to
-    event ``data`` and are attacker-controlled.
+    event ``data`` and are attacker-controlled. Distinct keys are capped per
+    (agent, window) — :data:`MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW` — so an
+    agent varying clientInfo per request cannot mint a row per request.
     """
     if ctx is None:
         return
@@ -355,8 +395,14 @@ def schedule_mcp_http_session_emit(
         if client_version and client_version.strip()
         else None
     )
-    sid = mcp_http_window_key(actor_id, name, version)
+    now = time.time()
+    sid = mcp_http_window_key(actor_id, name, version, now=now)
     if sid in _seen_sessions or sid in _in_flight:
+        return
+    if not _in_flight_has_room():
+        return
+    window = int(now // MCP_HTTP_WINDOW_SECONDS)
+    if not _admit_agent_window_key(actor_id, window):
         return
 
     _spawn_emit(
@@ -371,6 +417,47 @@ def schedule_mcp_http_session_emit(
             actor_type=actor_type,
         ),
     )
+
+
+def _in_flight_has_room() -> bool:
+    """Drop (never clear) new emits while the in-flight backlog is at the cap.
+
+    The dropped key is not in the seen-set, so a later request retries once
+    the backlog drains — bounded memory at the cost of a delayed row under a
+    flood, never a lost one.
+    """
+    if len(_in_flight) < _IN_FLIGHT_MAX:
+        return True
+    logger.debug("mcp_session_emit_dropped_in_flight_cap", in_flight=len(_in_flight))
+    return False
+
+
+def _admit_agent_window_key(actor_id: str, window: int) -> bool:
+    """Admit one more *distinct* HTTP dedupe key for this (agent, window).
+
+    Callers have already established the key is new (not seen, not in
+    flight). Past :data:`MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW` the emit is
+    skipped and a warning logged once per (agent, window) — one flooding
+    agent stops minting rows while every other agent's counter is untouched.
+    A retried key (failed emit) re-counts, slightly tightening the cap for
+    that agent — acceptable for a defensive bound.
+    """
+    key = (actor_id, window)
+    count = _agent_window_counts.get(key, 0)
+    if count >= MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW:
+        if count == MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW:
+            logger.warning(
+                "mcp_http_session_client_cap_reached",
+                actor_id=actor_id,
+                window=window,
+                cap=MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW,
+            )
+            _agent_window_counts[key] = count + 1
+        return False
+    if key not in _agent_window_counts and len(_agent_window_counts) >= _AGENT_WINDOW_COUNTS_MAX:
+        _agent_window_counts.clear()
+    _agent_window_counts[key] = count + 1
+    return True
 
 
 def _spawn_emit(sid: str, record: Coroutine[Any, Any, None]) -> None:

--- a/src/jentic_one/shared/web/agent_discovery.py
+++ b/src/jentic_one/shared/web/agent_discovery.py
@@ -174,15 +174,48 @@ def _render_skills_section(base: str) -> str:
     return "\n".join(lines)
 
 
-def render_llms_txt(base: str, assertion_max_ttl_seconds: int) -> str:
+def render_llms_txt(
+    base: str, assertion_max_ttl_seconds: int, *, mcp_http_enabled: bool = False
+) -> str:
     """Render the llms.txt document for a deployment base URL.
 
     Follows the llms.txt convention (H1 + blockquote summary + link sections)
     and carries the agent onboarding quickstart inline, so an LLM landing on
     ``{base}/llms.txt`` needs no further out-of-band context. The ``## Skills``
     section is computed from the shipped set's frontmatter.
+
+    ``mcp_http_enabled`` mirrors ``server.mcp.enabled`` (phase-3 item 8): with
+    the daemon-native ``/mcp`` endpoint on, the MCP paragraph advertises it
+    (plus the stdio-bridge escape hatch for stdio-only clients); with it off,
+    the document keeps the exact pre-phase-3 wording — a disabled endpoint is
+    never advertised (it answers 404, or the 3a-4 discovery challenge).
     """
     skills_section = _render_skills_section(base)
+    if mcp_http_enabled:
+        mcp_paragraph = f"""\
+This deployment is reachable over **MCP** two ways. It serves a **stateless
+Streamable HTTP endpoint at {base}/mcp** (spec revision 2026-07-28):
+configure a URL-based MCP entry pointing at it and authenticate every request
+with `Authorization: Bearer <agent API key or access token>`. Alternatively,
+the local `jentic mcp` stdio server — available in the `jentic` CLI from the
+next release; check `jentic mcp --help` — spawns on the agent machine and
+talks to this deployment with the agent's registered identity. Both expose
+the same discover → execute loop as the CLI tools. Stdio-only MCP runtimes
+can reach {base}/mcp through a stdio↔HTTP bridge such as `mcp-remote` or
+`mcp-proxy` — exact entries in the
+[MCP endpoint guide](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/mcp-http-endpoint.md).
+A 401 from the broker host is its auth-gated forward proxy, not a
+second MCP server."""
+    else:
+        mcp_paragraph = """\
+This deployment is reachable over **MCP** via the local `jentic mcp` stdio
+server — available in the `jentic` CLI from the next release; check
+`jentic mcp --help`. It exposes the same discover → execute loop as the CLI
+tools against this deployment. MCP access runs through that local server, not
+an HTTP endpoint here: `/mcp` on the control plane serves no MCP server today —
+it answers either 404 or, on deployments preparing interactive OAuth, a 401
+OAuth discovery challenge — and a 401 from the broker is its auth-gated
+forward proxy, not a hidden MCP server."""
     return f"""\
 # Jentic One
 
@@ -196,14 +229,7 @@ Agents: read the onboarding skill at {base}{SKILL_PATH} first. It is the
 canonical guide to the identity → discover → request access → execute loop —
 the same canonical guide the `jentic` CLI renders into agent runtimes.
 
-This deployment is reachable over **MCP** via the local `jentic mcp` stdio
-server — available in the `jentic` CLI from the next release; check
-`jentic mcp --help`. It exposes the same discover → execute loop as the CLI
-tools against this deployment. MCP access runs through that local server, not
-an HTTP endpoint here: `/mcp` on the control plane serves no MCP server today —
-it answers either 404 or, on deployments preparing interactive OAuth, a 401
-OAuth discovery challenge — and a 401 from the broker is its auth-gated
-forward proxy, not a hidden MCP server.
+{mcp_paragraph}
 
 If your session has `jentic` MCP tools, prefer them; use the `jentic` CLI for
 `setup`/`access` recovery and anything not exposed over MCP. Both surfaces
@@ -293,7 +319,11 @@ def get_agent_discovery_router() -> APIRouter:
     @router.get(LLMS_TXT_WELL_KNOWN_PATH, include_in_schema=False)
     async def llms_txt(request: Request, ctx: Context = Depends(get_ctx)) -> PlainTextResponse:
         base = deployment_base_url(ctx.config.auth, request)
-        body = render_llms_txt(base, ctx.config.auth.assertion_max_ttl_seconds)
+        body = render_llms_txt(
+            base,
+            ctx.config.auth.assertion_max_ttl_seconds,
+            mcp_http_enabled=ctx.config.server.mcp.enabled,
+        )
         return PlainTextResponse(body, media_type=MARKDOWN_MEDIA_TYPE)
 
     return router

--- a/src/jentic_one/shared/web/agent_discovery.py
+++ b/src/jentic_one/shared/web/agent_discovery.py
@@ -65,6 +65,14 @@ MARKDOWN_MEDIA_TYPE = "text/markdown; charset=utf-8"
 #: backend has no dependency on the un-shipped repo-root ``tools`` package.
 SKILL_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$")
 
+#: The app-state attribute :func:`jentic_one.mcp.installer.install_mcp_mount`
+#: stamps on shapes that actually carry the ``/mcp`` transport (control-plane
+#: shapes only — never standalone-auth or the broker, which serve at most the
+#: 3a-4 challenge placeholder). Read by name (not imported) so this shared
+#: module keeps zero dependency on the ``jentic_one.mcp`` layer; the installer
+#: pins the attribute as its own module constant (``_STATE_ATTR``).
+_MCP_MOUNT_STATE_ATTR = "mcp_mount"
+
 _CONTENT_PACKAGE = "jentic_one.shared.web"
 _CONTENT_DIR = "content"
 
@@ -184,11 +192,13 @@ def render_llms_txt(
     ``{base}/llms.txt`` needs no further out-of-band context. The ``## Skills``
     section is computed from the shipped set's frontmatter.
 
-    ``mcp_http_enabled`` mirrors ``server.mcp.enabled`` (phase-3 item 8): with
-    the daemon-native ``/mcp`` endpoint on, the MCP paragraph advertises it
-    (plus the stdio-bridge escape hatch for stdio-only clients); with it off,
-    the document keeps the exact pre-phase-3 wording — a disabled endpoint is
-    never advertised (it answers 404, or the 3a-4 discovery challenge).
+    ``mcp_http_enabled`` advertises the daemon-native ``/mcp`` endpoint
+    (phase-3 item 8): the serving route passes ``server.mcp.enabled`` AND-ed
+    with the surface actually carrying the mount, so a disabled or absent
+    endpoint is never advertised (it answers 404, or the 3a-4 discovery
+    challenge). The enabled arm adds the endpoint paragraph (plus the
+    stdio-bridge escape hatch for stdio-only clients); the disabled arm keeps
+    the exact pre-phase-3 wording.
     """
     skills_section = _render_skills_section(base)
     if mcp_http_enabled:
@@ -319,10 +329,18 @@ def get_agent_discovery_router() -> APIRouter:
     @router.get(LLMS_TXT_WELL_KNOWN_PATH, include_in_schema=False)
     async def llms_txt(request: Request, ctx: Context = Depends(get_ctx)) -> PlainTextResponse:
         base = deployment_base_url(ctx.config.auth, request)
+        # The enabled arm is gated on the surface actually carrying the mount,
+        # not on config alone: this router rides every standalone surface
+        # (split deployments), but the real ``/mcp`` transport is installed on
+        # control-plane shapes only. A standalone-auth/broker backend sharing
+        # a config with ``server.mcp.enabled: true`` (and no canonical base
+        # URL) would otherwise advertise ``http://<own-host>/mcp`` — a URL
+        # that very host answers with 404/401.
+        serves_mcp = getattr(request.app.state, _MCP_MOUNT_STATE_ATTR, None) is not None
         body = render_llms_txt(
             base,
             ctx.config.auth.assertion_max_ttl_seconds,
-            mcp_http_enabled=ctx.config.server.mcp.enabled,
+            mcp_http_enabled=ctx.config.server.mcp.enabled and serves_mcp,
         )
         return PlainTextResponse(body, media_type=MARKDOWN_MEDIA_TYPE)
 

--- a/tests/unit/mcp/test_mount_gate.py
+++ b/tests/unit/mcp/test_mount_gate.py
@@ -34,7 +34,7 @@ from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 from jentic_one.auth.web.routers.discovery import _MCP_PRM_PATH
-from jentic_one.mcp.app import MCP_PRM_PATH
+from jentic_one.mcp.app import CLIENT_INFO_META_KEY, MCP_PRM_PATH, request_client_info
 from jentic_one.mcp.installer import install_mcp_mount, mcp_lifespan
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.config import AuthConfig, ServerConfig
@@ -496,7 +496,126 @@ def test_batch_with_non_preauth_method_requires_credential() -> None:
         assert resp.headers["www-authenticate"] == _CHALLENGE
 
 
-# --- observability (phase-3 item 1: traces attach to the mount) ----------------
+# --- windowed session telemetry (phase-3 item 6) -------------------------------
+
+
+_CLIENT_INFO_PARAMS = {"_meta": {CLIENT_INFO_META_KEY: {"name": "cursor", "version": "0.42"}}}
+
+
+def test_authenticated_post_schedules_the_windowed_session_emit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every authenticated POST feeds the windowed emit, clientInfo from the
+    request's own ``_meta`` (spec 2026-07-28 — no initialize to carry it)."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "jentic_one.mcp.app.schedule_mcp_http_session_emit",
+        lambda ctx, **kwargs: calls.append(kwargs),
+    )
+    with make_client() as client:
+        resp = client.post(
+            "/mcp",
+            json=_rpc("tools/list", _CLIENT_INFO_PARAMS),
+            headers={**_ACCEPT, "Authorization": f"Bearer {_GOOD_BEARER}"},
+        )
+        assert resp.status_code == 200
+    assert calls == [
+        {
+            "client_name": "cursor",
+            "client_version": "0.42",
+            "actor_id": "agnt_1",
+            "actor_type": "agent",
+        }
+    ]
+
+
+def test_authenticated_post_without_client_info_schedules_unknown_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """clientInfo is a SHOULD — absent degrades to client-unknown, still fed."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "jentic_one.mcp.app.schedule_mcp_http_session_emit",
+        lambda ctx, **kwargs: calls.append(kwargs),
+    )
+    with make_client() as client:
+        client.post(
+            "/mcp",
+            json=_rpc("tools/list"),
+            headers={**_ACCEPT, "Authorization": f"Bearer {_GOOD_BEARER}"},
+        )
+    assert calls and calls[0]["client_name"] is None
+    assert calls[0]["client_version"] is None
+
+
+def test_credential_less_and_rejected_requests_never_schedule_the_emit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No resolved identity → no key to emit under: the pre-auth arm and the
+    invalid-credential 401 both skip the telemetry hook entirely."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "jentic_one.mcp.app.schedule_mcp_http_session_emit",
+        lambda ctx, **kwargs: calls.append(kwargs),
+    )
+    with make_client() as client:
+        anon = client.post("/mcp", json=_rpc("tools/list", _CLIENT_INFO_PARAMS), headers=_ACCEPT)
+        assert anon.status_code == 200
+        rejected = client.post(
+            "/mcp",
+            json=_rpc("tools/list", _CLIENT_INFO_PARAMS),
+            headers={**_ACCEPT, "Authorization": "Bearer at_expired"},
+        )
+        assert rejected.status_code == 401
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        # The happy path: params._meta carrying the spec key.
+        (
+            json.dumps(_rpc("tools/call", _CLIENT_INFO_PARAMS)),
+            ("cursor", "0.42"),
+        ),
+        # Batch: the first request carrying clientInfo wins.
+        (
+            json.dumps(
+                [
+                    _rpc("ping", id_=1),
+                    _rpc("tools/list", _CLIENT_INFO_PARAMS, id_=2),
+                ]
+            ),
+            ("cursor", "0.42"),
+        ),
+        # Name without version (version is optional inside clientInfo too).
+        (
+            json.dumps(_rpc("tools/list", {"_meta": {CLIENT_INFO_META_KEY: {"name": "codex"}}})),
+            ("codex", None),
+        ),
+        # No _meta at all.
+        (json.dumps(_rpc("tools/list")), (None, None)),
+        # Malformed JSON containing the key bytes — degrades, never raises.
+        (f'{{"{CLIENT_INFO_META_KEY}": broken', (None, None)),
+        # clientInfo present but not an object.
+        (
+            json.dumps(_rpc("tools/list", {"_meta": {CLIENT_INFO_META_KEY: "cursor"}})),
+            (None, None),
+        ),
+        # Non-string name/version fields degrade to unknown, not a crash.
+        (
+            json.dumps(
+                _rpc(
+                    "tools/list",
+                    {"_meta": {CLIENT_INFO_META_KEY: {"name": 7, "version": ["x"]}}},
+                )
+            ),
+            (None, None),
+        ),
+    ],
+)
+def test_request_client_info_parsing(body: str, expected: tuple[str | None, str | None]) -> None:
+    assert request_client_info(body.encode()) == expected
 
 
 def test_otel_route_details_resolve_the_mcp_route() -> None:

--- a/tests/unit/shared/events/test_mcp_session.py
+++ b/tests/unit/shared/events/test_mcp_session.py
@@ -17,9 +17,12 @@ import pytest
 import jentic_one.shared.events.mcp_session as mcp_session
 from jentic_one.shared.db.errors import DatabaseIntegrityError
 from jentic_one.shared.events.mcp_session import (
+    MCP_HTTP_WINDOW_SECONDS,
     McpUserAgent,
+    mcp_http_window_key,
     parse_mcp_user_agent,
     record_mcp_session_started,
+    schedule_mcp_http_session_emit,
     schedule_mcp_session_emit,
     valid_session_id_or_none,
 )
@@ -395,3 +398,208 @@ def test_seen_set_is_bounded() -> None:
     mcp_session._remember("one-more")
     assert len(mcp_session._seen_sessions) == 1
     assert "one-more" in mcp_session._seen_sessions
+
+
+# --- HTTP windowed emit (phase-3 item 6) -----------------------------------------
+
+_FROZEN_NOW = 1_700_000_000.0
+
+
+def _freeze_time(now: float = _FROZEN_NOW) -> Any:
+    return patch("jentic_one.shared.events.mcp_session.time.time", return_value=now)
+
+
+def _patch_emit(*, exists: bool = False) -> tuple[Any, Any]:
+    """Patchers for the record path: table lookup + emit_event."""
+    return (
+        patch(
+            "jentic_one.shared.events.mcp_session.EventRepository.exists_with_data_value",
+            AsyncMock(return_value=exists),
+        ),
+        patch("jentic_one.shared.events.mcp_session.emit_event", new_callable=AsyncMock),
+    )
+
+
+async def _run_scheduled_tasks() -> None:
+    for task in list(mcp_session._background_tasks):
+        await task
+    await asyncio.sleep(0)  # let the done callbacks run
+
+
+def _schedule_http(
+    ctx: Any,
+    *,
+    client_name: str | None = "cursor",
+    client_version: str | None = "0.42",
+    actor_id: str = "agnt_abc",
+) -> None:
+    schedule_mcp_http_session_emit(
+        ctx,
+        client_name=client_name,
+        client_version=client_version,
+        actor_id=actor_id,
+        actor_type="agent",
+    )
+
+
+def test_http_window_key_is_deterministic_and_axis_sensitive() -> None:
+    """Same (agent x client x window) → same key; any axis change → new key."""
+    base = mcp_http_window_key("agnt_a", "cursor", "1.0", now=_FROZEN_NOW)
+    assert base == mcp_http_window_key("agnt_a", "cursor", "1.0", now=_FROZEN_NOW)
+    # Within the same window, time does not change the key.
+    assert base == mcp_http_window_key("agnt_a", "cursor", "1.0", now=_FROZEN_NOW + 1)
+    assert base != mcp_http_window_key("agnt_b", "cursor", "1.0", now=_FROZEN_NOW)
+    assert base != mcp_http_window_key("agnt_a", "claude", "1.0", now=_FROZEN_NOW)
+    assert base != mcp_http_window_key("agnt_a", "cursor", "2.0", now=_FROZEN_NOW)
+    assert base != mcp_http_window_key(
+        "agnt_a", "cursor", "1.0", now=_FROZEN_NOW + MCP_HTTP_WINDOW_SECONDS
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_emit_carries_transport_and_windowed_session_id() -> None:
+    """The HTTP event: synthetic per-window session id, transport http, full
+    clientInfo in data, the closed McpClient tag on the telemetry side."""
+    exists_p, emit_p = _patch_emit()
+    with _freeze_time(), exists_p, emit_p as emit:
+        _schedule_http(_fake_ctx())
+        await _run_scheduled_tasks()
+
+    emit.assert_awaited_once()
+    kwargs = emit.call_args.kwargs
+    expected_sid = mcp_http_window_key("agnt_abc", "cursor", "0.42", now=_FROZEN_NOW)
+    assert kwargs["type"] == EventType.MCP_SESSION_STARTED
+    assert kwargs["actor_id"] == "agnt_abc"
+    assert kwargs["actor_type"] == "agent"
+    assert kwargs["data"] == {
+        "session_id": expected_sid,
+        "transport": "http",
+        "client_name": "cursor",
+        "client_version": "0.42",
+    }
+    assert kwargs["tags"] == {McpClient.CURSOR}
+    assert expected_sid in mcp_session._seen_sessions
+
+
+@pytest.mark.asyncio
+async def test_http_emits_once_within_window() -> None:
+    """Repeat requests inside one window are a set-membership no-op."""
+    exists_p, emit_p = _patch_emit()
+    with _freeze_time(), exists_p, emit_p as emit:
+        _schedule_http(_fake_ctx())
+        await _run_scheduled_tasks()
+        _schedule_http(_fake_ctx())
+        await _run_scheduled_tasks()
+
+    emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_reemits_after_window_rolls() -> None:
+    """The same (agent x client) emits again once the window has passed."""
+    exists_p, emit_p = _patch_emit()
+    with exists_p, emit_p as emit:
+        with _freeze_time(_FROZEN_NOW):
+            _schedule_http(_fake_ctx())
+            await _run_scheduled_tasks()
+        with _freeze_time(_FROZEN_NOW + MCP_HTTP_WINDOW_SECONDS):
+            _schedule_http(_fake_ctx())
+            await _run_scheduled_tasks()
+
+    assert emit.await_count == 2
+    sids = [c.kwargs["data"]["session_id"] for c in emit.call_args_list]
+    assert len(set(sids)) == 2
+
+
+@pytest.mark.asyncio
+async def test_http_distinct_agent_and_client_keys_do_not_collide() -> None:
+    """One daemon serves many identities: each (agent x client) pair gets its
+    own window key — never whoever sent the first request ever."""
+    exists_p, emit_p = _patch_emit()
+    with _freeze_time(), exists_p, emit_p as emit:
+        _schedule_http(_fake_ctx(), actor_id="agnt_a", client_name="cursor")
+        _schedule_http(_fake_ctx(), actor_id="agnt_b", client_name="cursor")
+        _schedule_http(_fake_ctx(), actor_id="agnt_a", client_name="claude")
+        await _run_scheduled_tasks()
+
+    assert emit.await_count == 3
+    sids = {c.kwargs["data"]["session_id"] for c in emit.call_args_list}
+    assert len(sids) == 3
+    actors = {c.kwargs["actor_id"] for c in emit.call_args_list}
+    assert actors == {"agnt_a", "agnt_b"}
+
+
+@pytest.mark.asyncio
+async def test_http_absent_client_info_emits_unknown_client() -> None:
+    """clientInfo is a SHOULD: absent still emits (mirroring stdio's
+    client-unknown degrade) with OTHER on the wire and null in data — and
+    dedupes on the same unknown-client key."""
+    exists_p, emit_p = _patch_emit()
+    with _freeze_time(), exists_p, emit_p as emit:
+        _schedule_http(_fake_ctx(), client_name=None, client_version=None)
+        await _run_scheduled_tasks()
+        _schedule_http(_fake_ctx(), client_name=None, client_version=None)
+        await _run_scheduled_tasks()
+
+    emit.assert_awaited_once()
+    kwargs = emit.call_args.kwargs
+    assert kwargs["data"]["client_name"] is None
+    assert kwargs["data"]["client_version"] is None
+    assert kwargs["tags"] == {McpClient.OTHER}
+
+
+@pytest.mark.asyncio
+async def test_http_oversized_client_info_fields_are_capped() -> None:
+    """_meta is untrusted input — persisted fields are capped like UA fields."""
+    exists_p, emit_p = _patch_emit()
+    with _freeze_time(), exists_p, emit_p as emit:
+        _schedule_http(_fake_ctx(), client_name="c" * 300, client_version="v" * 300)
+        await _run_scheduled_tasks()
+
+    kwargs = emit.call_args.kwargs
+    assert kwargs["data"]["client_name"] == "c" * 128
+    assert kwargs["data"]["client_version"] == "v" * 128
+
+
+@pytest.mark.asyncio
+async def test_http_existing_table_row_suppresses_emit_and_primes_seen() -> None:
+    """Another worker already wrote this window's row → skip, remember."""
+    exists_p, emit_p = _patch_emit(exists=True)
+    with _freeze_time(), exists_p, emit_p as emit:
+        _schedule_http(_fake_ctx())
+        await _run_scheduled_tasks()
+
+    emit.assert_not_awaited()
+    sid = mcp_http_window_key("agnt_abc", "cursor", "0.42", now=_FROZEN_NOW)
+    assert sid in mcp_session._seen_sessions
+
+
+@pytest.mark.asyncio
+async def test_http_schedule_without_ctx_is_a_noop() -> None:
+    with patch(
+        "jentic_one.shared.events.mcp_session._record_session_started",
+        new_callable=AsyncMock,
+    ) as record:
+        _schedule_http(None)
+
+    record.assert_not_awaited()
+    assert not mcp_session._background_tasks
+
+
+@pytest.mark.asyncio
+async def test_http_window_keys_ride_the_bounded_seen_set() -> None:
+    """Long-lived daemon, many identities: the window keys land in the same
+    capped seen-set as stdio session ids — memory stays bounded."""
+    for i in range(mcp_session._SEEN_SESSIONS_MAX):
+        mcp_session._remember(f"filler-{i}")
+
+    exists_p, emit_p = _patch_emit()
+    with _freeze_time(), exists_p, emit_p:
+        _schedule_http(_fake_ctx())
+        await _run_scheduled_tasks()
+
+    # _remember cleared the full set before adding, so growth is impossible.
+    assert len(mcp_session._seen_sessions) == 1
+    assert mcp_http_window_key("agnt_abc", "cursor", "0.42", now=_FROZEN_NOW) in (
+        mcp_session._seen_sessions
+    )

--- a/tests/unit/shared/events/test_mcp_session.py
+++ b/tests/unit/shared/events/test_mcp_session.py
@@ -34,9 +34,11 @@ def _clear_seen_sessions():
     """Isolate the module-level dedupe state per test."""
     mcp_session._seen_sessions.clear()
     mcp_session._in_flight.clear()
+    mcp_session._agent_window_counts.clear()
     yield
     mcp_session._seen_sessions.clear()
     mcp_session._in_flight.clear()
+    mcp_session._agent_window_counts.clear()
 
 
 def _fake_ctx() -> MagicMock:
@@ -456,6 +458,30 @@ def test_http_window_key_is_deterministic_and_axis_sensitive() -> None:
     )
 
 
+def test_http_window_key_join_is_collision_free() -> None:
+    """The name/version join is unambiguous: an embedded delimiter in one
+    field can never make two distinct (name, version) pairs share a key."""
+    assert mcp_http_window_key("agnt_a", "x\ny", "z", now=_FROZEN_NOW) != mcp_http_window_key(
+        "agnt_a", "x", "y\nz", now=_FROZEN_NOW
+    )
+    # The length prefix itself cannot be spoofed by a crafted field value.
+    assert mcp_http_window_key("agnt_a", "1:a", "b", now=_FROZEN_NOW) != mcp_http_window_key(
+        "agnt_a", "1", ":ab", now=_FROZEN_NOW
+    )
+
+
+def test_http_window_key_case_folds_client_info() -> None:
+    """The key case-folds like the McpClient tag: one row per client per
+    window regardless of the case the client stamps its name/version with."""
+    assert mcp_http_window_key("agnt_a", "Cursor", "1.0", now=_FROZEN_NOW) == mcp_http_window_key(
+        "agnt_a", "cursor", "1.0", now=_FROZEN_NOW
+    )
+    # The agent axis is an opaque identifier — never folded.
+    assert mcp_http_window_key("agnt_A", "cursor", "1.0", now=_FROZEN_NOW) != mcp_http_window_key(
+        "agnt_a", "cursor", "1.0", now=_FROZEN_NOW
+    )
+
+
 @pytest.mark.asyncio
 async def test_http_emit_carries_transport_and_windowed_session_id() -> None:
     """The HTTP event: synthetic per-window session id, transport http, full
@@ -603,3 +629,125 @@ async def test_http_window_keys_ride_the_bounded_seen_set() -> None:
     assert mcp_http_window_key("agnt_abc", "cursor", "0.42", now=_FROZEN_NOW) in (
         mcp_session._seen_sessions
     )
+
+
+# --- per-agent distinct-key cap (review M1) --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_per_agent_distinct_key_cap_enforced() -> None:
+    """An agent varying clientInfo per request mints at most the capped number
+    of rows per window — beyond that, emission is skipped (and the row-per-
+    request minting the review flagged is impossible)."""
+    cap = mcp_session.MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW
+    exists_p, emit_p = _patch_emit()
+    with _freeze_time(), exists_p, emit_p as emit:
+        for i in range(cap + 10):
+            _schedule_http(_fake_ctx(), client_name=f"flood-client-{i}")
+        await _run_scheduled_tasks()
+
+    assert emit.await_count == cap
+    # Already-admitted keys keep short-circuiting on the seen-set — the cap
+    # never blocks a legitimately emitted client's repeats.
+    with _freeze_time(), exists_p, emit_p as emit_again:
+        _schedule_http(_fake_ctx(), client_name="flood-client-0")
+        await _run_scheduled_tasks()
+    assert emit_again.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_http_cap_is_per_agent_not_global() -> None:
+    """One flooding agent exhausting its cap leaves every other agent's
+    emission untouched."""
+    cap = mcp_session.MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW
+    exists_p, emit_p = _patch_emit()
+    with _freeze_time(), exists_p, emit_p as emit:
+        for i in range(cap + 5):
+            _schedule_http(_fake_ctx(), actor_id="agnt_flood", client_name=f"variant-{i}")
+        _schedule_http(_fake_ctx(), actor_id="agnt_ok", client_name="cursor")
+        await _run_scheduled_tasks()
+
+    actors = [c.kwargs["actor_id"] for c in emit.call_args_list]
+    assert actors.count("agnt_flood") == cap
+    assert actors.count("agnt_ok") == 1
+
+
+@pytest.mark.asyncio
+async def test_http_legit_multi_client_agent_under_cap_unaffected() -> None:
+    """A real agent with a handful of distinct clients emits one row each —
+    the cap only exists for pathological per-request variation."""
+    exists_p, emit_p = _patch_emit()
+    with _freeze_time(), exists_p, emit_p as emit:
+        for name in ("cursor", "claude", "codex"):
+            _schedule_http(_fake_ctx(), client_name=name)
+        await _run_scheduled_tasks()
+
+    assert emit.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_http_cap_resets_on_the_next_window() -> None:
+    """The cap is per (agent, window): a new UTC bucket admits the agent again."""
+    cap = mcp_session.MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW
+    exists_p, emit_p = _patch_emit()
+    with exists_p, emit_p as emit:
+        with _freeze_time(_FROZEN_NOW):
+            for i in range(cap + 1):
+                _schedule_http(_fake_ctx(), client_name=f"variant-{i}")
+            await _run_scheduled_tasks()
+        with _freeze_time(_FROZEN_NOW + MCP_HTTP_WINDOW_SECONDS):
+            _schedule_http(_fake_ctx(), client_name="cursor")
+            await _run_scheduled_tasks()
+
+    assert emit.await_count == cap + 1
+
+
+def test_http_cap_logs_once_per_agent_window() -> None:
+    """Crossing the cap logs a single warning; further skips are silent."""
+    cap = mcp_session.MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW
+    window = int(_FROZEN_NOW // MCP_HTTP_WINDOW_SECONDS)
+    for _ in range(cap):
+        assert mcp_session._admit_agent_window_key("agnt_abc", window)
+    with patch.object(mcp_session.logger, "warning") as warn:
+        assert not mcp_session._admit_agent_window_key("agnt_abc", window)
+        assert not mcp_session._admit_agent_window_key("agnt_abc", window)
+    warn.assert_called_once()
+
+
+def test_agent_window_counts_are_bounded() -> None:
+    """The per-(agent, window) counter dict rides the seen-set clear-on-full
+    pattern — a long-lived process fed unique agents can't grow it unbounded."""
+    window = int(_FROZEN_NOW // MCP_HTTP_WINDOW_SECONDS)
+    for i in range(mcp_session._AGENT_WINDOW_COUNTS_MAX):
+        mcp_session._agent_window_counts[(f"agnt_{i}", window)] = 1
+    assert mcp_session._admit_agent_window_key("agnt_one_more", window)
+    # The full dict was cleared before admitting the new entry.
+    assert mcp_session._agent_window_counts == {("agnt_one_more", window): 1}
+
+
+@pytest.mark.asyncio
+async def test_in_flight_cap_drops_new_emits_on_both_transports() -> None:
+    """At the in-flight cap new emits are dropped (bounded memory), never
+    cleared — the key stays retryable once the backlog drains."""
+    for i in range(mcp_session._IN_FLIGHT_MAX):
+        mcp_session._in_flight.add(f"backlog-{i}")
+
+    exists_p, emit_p = _patch_emit()
+    with _freeze_time(), exists_p, emit_p as emit:
+        _schedule_http(_fake_ctx())
+        with patch(
+            "jentic_one.shared.events.mcp_session.record_mcp_session_started",
+            new_callable=AsyncMock,
+        ) as stdio_record:
+            _schedule(_fake_ctx())
+        await _run_scheduled_tasks()
+
+    emit.assert_not_awaited()
+    stdio_record.assert_not_awaited()
+    assert not mcp_session._background_tasks
+    # Nothing was remembered, so both keys retry once the backlog drains.
+    mcp_session._in_flight.clear()
+    with _freeze_time(), exists_p, emit_p as emit_retry:
+        _schedule_http(_fake_ctx())
+        await _run_scheduled_tasks()
+    emit_retry.assert_awaited_once()

--- a/tests/unit/shared/web/test_agent_discovery.py
+++ b/tests/unit/shared/web/test_agent_discovery.py
@@ -287,6 +287,49 @@ def test_llms_txt_advertises_mcp_server(client: TestClient) -> None:
     assert "still returns 404" not in body
 
 
+def test_llms_txt_advertises_http_endpoint_only_when_enabled(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    """Phase-3 item 8: `server.mcp.enabled` flips the llms.txt MCP paragraph.
+
+    Enabled: the document advertises the Streamable HTTP endpoint at
+    ``{base}/mcp`` (bearer per request), keeps the stdio server, and points
+    stdio-only runtimes at the ``mcp-remote``/``mcp-proxy`` bridge recipes.
+    Disabled (the default, pinned by ``test_llms_txt_advertises_mcp_server``):
+    the pre-phase-3 wording — a 404-answering endpoint is never advertised.
+    """
+    config_dict = dict(sample_config_dict)
+    config_dict["server"] = {"mcp": {"enabled": True}}
+    ctx = Context(AppConfig.model_validate(config_dict))
+    app = create_combined_app(ctx, ["control"])
+    client = TestClient(app, raise_server_exceptions=False)
+    body = client.get(LLMS_TXT_PATH).text
+
+    assert "http://testserver/mcp" in body
+    assert "Streamable HTTP endpoint" in body
+    assert "Authorization: Bearer" in body
+    # The disabled-arm denial wording must be gone in this arm.
+    assert "serves no MCP server today" not in body
+    # The stdio server stays advertised; stdio-only runtimes get the bridges.
+    assert "`jentic mcp`" in body
+    assert "mcp-remote" in body
+    assert "mcp-proxy" in body
+    assert "docs/mcp-http-endpoint.md" in body
+    # The routing paragraph (§3.5) is arm-independent.
+    assert "prefer them" in body
+    assert "`backend`/`host`" in body
+
+
+def test_llms_txt_disabled_arm_never_mentions_the_endpoint_url(client: TestClient) -> None:
+    """The disabled arm is silent about the endpoint: no URL-shaped `/mcp`
+    advertisement an agent could wire an entry to (the path only appears in
+    the probe-misdiagnosis explanation)."""
+    body = client.get(LLMS_TXT_PATH).text
+    assert "http://testserver/mcp" not in body
+    assert "Streamable HTTP endpoint" not in body
+    assert "mcp-remote" not in body
+
+
 def test_render_llms_txt_stamps_base_everywhere() -> None:
     """No hardcoded host survives rendering; every link uses the given base."""
     body = render_llms_txt("https://example.test", assertion_max_ttl_seconds=300)

--- a/tests/unit/shared/web/test_agent_discovery.py
+++ b/tests/unit/shared/web/test_agent_discovery.py
@@ -30,6 +30,7 @@ from jentic_one.shared.web.agent_discovery import (
     shipped_skill_names,
 )
 from jentic_one.shared.web.app_factory import create_combined_app
+from jentic_one.wiring import build_default_container
 
 
 @pytest.fixture()
@@ -292,16 +293,18 @@ def test_llms_txt_advertises_http_endpoint_only_when_enabled(
 ) -> None:
     """Phase-3 item 8: `server.mcp.enabled` flips the llms.txt MCP paragraph.
 
-    Enabled: the document advertises the Streamable HTTP endpoint at
-    ``{base}/mcp`` (bearer per request), keeps the stdio server, and points
-    stdio-only runtimes at the ``mcp-remote``/``mcp-proxy`` bridge recipes.
+    Enabled — on a shape actually carrying the mount (the composition root's
+    container installs it on control-plane shapes): the document advertises
+    the Streamable HTTP endpoint at ``{base}/mcp`` (bearer per request), keeps
+    the stdio server, and points stdio-only runtimes at the
+    ``mcp-remote``/``mcp-proxy`` bridge recipes.
     Disabled (the default, pinned by ``test_llms_txt_advertises_mcp_server``):
     the pre-phase-3 wording — a 404-answering endpoint is never advertised.
     """
     config_dict = dict(sample_config_dict)
     config_dict["server"] = {"mcp": {"enabled": True}}
     ctx = Context(AppConfig.model_validate(config_dict))
-    app = create_combined_app(ctx, ["control"])
+    app = create_combined_app(ctx, ["control"], container=build_default_container(ctx))
     client = TestClient(app, raise_server_exceptions=False)
     body = client.get(LLMS_TXT_PATH).text
 
@@ -320,6 +323,47 @@ def test_llms_txt_advertises_http_endpoint_only_when_enabled(
     assert "`backend`/`host`" in body
 
 
+def test_llms_txt_config_only_enablement_does_not_advertise(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    """The enabled arm is shape-gated, not config-gated: an app built without
+    the composition root's mount installer (config flag on, mount absent)
+    keeps the disabled wording — the config flag alone must never advertise a
+    URL this app answers with 404/401."""
+    config_dict = dict(sample_config_dict)
+    config_dict["server"] = {"mcp": {"enabled": True}}
+    ctx = Context(AppConfig.model_validate(config_dict))
+    app = create_combined_app(ctx, ["control"])  # default container: no mount
+    client = TestClient(app, raise_server_exceptions=False)
+    body = client.get(LLMS_TXT_PATH).text
+
+    assert "http://testserver/mcp" not in body
+    assert "Streamable HTTP endpoint" not in body
+    assert "serves no MCP server today" in body
+
+
+def test_llms_txt_auth_standalone_never_advertises_the_endpoint(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    """Review L1: a standalone-auth backend sharing a `server.mcp.enabled`
+    config must not advertise ``http://<own-host>/mcp`` — that shape carries
+    only the 3a-4 challenge placeholder (404/401 on `/mcp`), never the mount.
+    The real endpoint lives on the control-plane shape (previous test)."""
+    config_dict = dict(sample_config_dict)
+    config_dict["server"] = {"mcp": {"enabled": True}}
+    config_dict["apps"] = ["auth"]
+    ctx = Context(AppConfig.model_validate(config_dict))
+    app = create_auth_app(ctx, container=build_default_container(ctx))
+    client = TestClient(app, raise_server_exceptions=False)
+    body = client.get(LLMS_TXT_PATH).text
+
+    assert "http://testserver/mcp" not in body
+    assert "Streamable HTTP endpoint" not in body
+    assert "mcp-remote" not in body
+    # The disabled arm's probe-misdiagnosis wording stays.
+    assert "serves no MCP server today" in body
+
+
 def test_llms_txt_disabled_arm_never_mentions_the_endpoint_url(client: TestClient) -> None:
     """The disabled arm is silent about the endpoint: no URL-shaped `/mcp`
     advertisement an agent could wire an entry to (the path only appears in
@@ -328,6 +372,56 @@ def test_llms_txt_disabled_arm_never_mentions_the_endpoint_url(client: TestClien
     assert "http://testserver/mcp" not in body
     assert "Streamable HTTP endpoint" not in body
     assert "mcp-remote" not in body
+
+
+#: The pre-phase-3 MCP paragraph, verbatim from the base branch's
+#: ``render_llms_txt`` — the golden for the disabled-arm byte-identity pin.
+_PRE_PHASE3_MCP_PARAGRAPH = """\
+This deployment is reachable over **MCP** via the local `jentic mcp` stdio
+server — available in the `jentic` CLI from the next release; check
+`jentic mcp --help`. It exposes the same discover → execute loop as the CLI
+tools against this deployment. MCP access runs through that local server, not
+an HTTP endpoint here: `/mcp` on the control plane serves no MCP server today —
+it answers either 404 or, on deployments preparing interactive OAuth, a 401
+OAuth discovery challenge — and a 401 from the broker is its auth-gated
+forward proxy, not a hidden MCP server."""
+
+
+def _enabled_mcp_paragraph(base: str) -> str:
+    """The enabled-arm MCP paragraph for ``base`` (golden for the swap pin)."""
+    return f"""\
+This deployment is reachable over **MCP** two ways. It serves a **stateless
+Streamable HTTP endpoint at {base}/mcp** (spec revision 2026-07-28):
+configure a URL-based MCP entry pointing at it and authenticate every request
+with `Authorization: Bearer <agent API key or access token>`. Alternatively,
+the local `jentic mcp` stdio server — available in the `jentic` CLI from the
+next release; check `jentic mcp --help` — spawns on the agent machine and
+talks to this deployment with the agent's registered identity. Both expose
+the same discover → execute loop as the CLI tools. Stdio-only MCP runtimes
+can reach {base}/mcp through a stdio↔HTTP bridge such as `mcp-remote` or
+`mcp-proxy` — exact entries in the
+[MCP endpoint guide](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/mcp-http-endpoint.md).
+A 401 from the broker host is its auth-gated forward proxy, not a
+second MCP server."""
+
+
+def test_llms_txt_disabled_arm_is_byte_identical_to_pre_phase3_render() -> None:
+    """Review N3: the disabled arm's full render is byte-identical to the
+    pre-phase-3 document — pinned by equality, not substrings.
+
+    Three properties combine into the byte-identity guarantee:
+    the kwarg default is the disabled arm (every pre-existing caller renders
+    it unchanged); the disabled arm carries the base branch's MCP paragraph
+    verbatim (the golden above); and the flag swaps exactly that paragraph
+    and nothing else, so the rest of the document is the one shared template.
+    """
+    base = "https://example.test"
+    disabled = render_llms_txt(base, assertion_max_ttl_seconds=300)
+    assert disabled == render_llms_txt(base, assertion_max_ttl_seconds=300, mcp_http_enabled=False)
+    assert _PRE_PHASE3_MCP_PARAGRAPH in disabled
+    enabled = render_llms_txt(base, assertion_max_ttl_seconds=300, mcp_http_enabled=True)
+    assert enabled == disabled.replace(_PRE_PHASE3_MCP_PARAGRAPH, _enabled_mcp_paragraph(base))
+    assert enabled != disabled
 
 
 def test_render_llms_txt_stamps_base_everywhere() -> None:


### PR DESCRIPTION
HOLD: do not merge — stacked on #1230, pending Manuel's review.

## Summary

Phase-3 items 6 and 8 for the daemon-native `/mcp` mount, stacked on the slice-1 branch (#1230). Item 6: the mounted app now emits `mcp.session_started` itself — once per (agent identity × clientInfo name/version) per window, clientInfo from each request's `_meta` (spec 2026-07-28 has no `initialize`), sharing lane D's two-plane semantics (master §3.6). Item 8: `llms.txt` advertises the endpoint when (and only when) `server.mcp.enabled` is on **and the serving shape actually carries the mount**, and stdio-only clients get `mcp-remote`/`mcp-proxy` fallback recipes.

Plan: `jentic-one-plans/themes/local-mcp/phase-3.md` items 6+8.

## Changes

**Item 6 — telemetry & events on the HTTP transport (`shared/events/mcp_session.py`, `mcp/app.py`):**

- **Window decision: 6 hours, fixed UTC buckets** (`MCP_HTTP_WINDOW_SECONDS`, a code constant — it tunes the 2-E2 sessions list's granularity, not deployment behaviour). Rationale: at most 4 rows/day per (agent × client) keeps the per-agent sessions list showing reconnects without spam (1h ⇒ up to 24 rows/day) and without hiding same-day reconnects (24h ⇒ one row). Fixed buckets rather than a sliding window because the bucket makes the dedupe key deterministic across workers — the **existing** partial unique index on `(type, data->>'session_id')` then enforces exactly-once per window deployment-wide for free (no new DB structure); a sliding window can't be expressed as a unique key and would multiply events by worker/replica count. Worst case is two rows minutes apart across a bucket boundary.
- The synthetic per-window key doubles as `data.session_id` (`http:<actor>:<clientInfo-digest>:<bucket>`), so the sessions list keys on it exactly like stdio session UUIDs (transport column renders `http` — the 2-E2 card already handles it verbatim). The digest inputs are length-prefixed and case-folded (review N2), so join collisions are impossible and one client is one row regardless of the case it stamps.
- **Per-agent minting cap (review M1):** at most `MCP_HTTP_MAX_CLIENTS_PER_AGENT_WINDOW` (16) *distinct* clientInfo dedupe keys are admitted per (agent, window) — past that, emission is skipped and a warning logged once per (agent, window). An authenticated agent varying `_meta` per request can no longer mint a row per request; other agents' counters are untouched. The in-flight emit backlog is also bounded (drop-and-retry at 1024), so `_in_flight`/`_background_tasks` can never be attacker-paced.
- Event `data`: full clientInfo (capped at 128 chars — `_meta` is untrusted), `transport: "http"`, `actor_id` = the agent; telemetry wire carries only the closed `McpClient` tag (two-plane pattern).
- **Absent-clientInfo decision: emit with client-unknown** (`McpClient.OTHER`, `client_name: null`), mirroring stdio lane D's degrade — clientInfo is a SHOULD, and a session with an unidentified client is still a session.
- Dedupe state is process-local and bounded: window keys ride the same capped (4096, clear-on-full) seen/in-flight sets as stdio session ids; the per-(agent, window) counter dict rides the same clear-on-full pattern. The record/spawn machinery is factored out of the stdio path (`_record_session_started`/`_spawn_emit`) with stdio behaviour unchanged (its tests untouched and green).
- Gate hook: after identity resolution on authenticated POSTs; the clientInfo sniff is a bytes containment check before any JSON parse, and the emit is fire-and-forget (never blocks or fails serving). No identity ⇒ no emit (pre-auth and 401 arms pinned).
- **Origin stamping: verified, not duplicated** — slice 1 already stamps `Origin.MCP` on the resolved identity and sends `jentic-mcp/<version> (http)` on the broker hop.

**Item 8 — docs + advertisement:**

- `render_llms_txt` grows a keyword-only `mcp_http_enabled` flag: the serving route passes `server.mcp.enabled` **AND-ed with the surface actually carrying the mount** (the installer's `app.state` stamp — review L1), so standalone-auth/broker shapes sharing an enabled config never advertise a `/mcp` their own host answers with 404/401. Enabled arm advertises `{base}/mcp` + bridges; **disabled arm stays byte-identical to the pre-phase-3 wording** — pinned by full-render equality against the base paragraph (review N3), plus the silence test.
- New `docs/mcp-http-endpoint.md`: enabling, URL-based client entry (matches the 2-E2 card's HTTP variant), security posture, and the stdio-only recipes: `mcp-remote` (env-indirected header — argv hygiene + the no-space mangling workaround — with `--header-file` cited as the keep-it-out-of-the-config mechanism, and the plaintext `~/.mcp-auth` caveat) and `mcp-proxy` client mode via its native `API_ACCESS_TOKEN` env var (bearer never in argv). **Deviation flagged:** the phase doc's `mcp-proxy --stateless` flag is a *server-mode* flag in mcp-proxy (verified against its README/argparse), so the client-leg recipe omits it; the endpoint is stateless server-side by construction.
- Stale "the deployment serves no HTTP MCP endpoint" claims updated to "config-gated, off by default" in `docs/cloud-vs-self-hosted.md`, repo-root `llms.txt`, and `AGENTS.md` (all keep the broker-401-probe misdiagnosis explanation).
- **UI card: deliberately untouched** — slice 1 already reveals the HTTP variant with complete copy; the bridge recipes are docs material.

**Out of scope:** item 9 (`jentic mcp --http`/`--connect`, systemd/launchd templates — parallel slice), item 7 (enterprise overlay test), any REST/config surface (no codegen needed — the window is a code constant).

## Review findings & dispositions (adversarial review, wave 1 — fixed in a157df36)

| # | Severity | Finding | Disposition |
| - | -------- | ------- | ----------- |
| M1 | Medium | No per-agent cap on distinct clientInfo dedupe keys: an authenticated agent varying `_meta` per request mints one events row per request per window; `_in_flight`/`_background_tasks` uncapped | **Fixed**: 16 distinct digests per (agent, 6h bucket), skip + warn once past the cap; in-flight backlog bounded at 1024 (drop, retry when drained). Tests: cap enforced, per-agent isolation, under-cap agents unaffected, next-window reset, counter dict bounded, both transports drop at the in-flight cap |
| L1 | Low | llms.txt advertised `/mcp` on standalone-auth/broker shapes where the mount doesn't live (dangling advertisement when `canonical_base_url` unset) | **Fixed**: advertisement gated on the installer's `app.state.mcp_mount` stamp AND config. Tests: control-plane shape advertises; auth-standalone and config-only (mount absent) renders stay silent |
| L2 | Low (docs) | mcp-remote rationale falsely claimed the env indirection keeps the key out of the config file (the `env` block is the same file) | **Fixed**: real benefits stated (argv hygiene + the no-space mangling workaround); `--header-file` cited as the actual out-of-config mechanism |
| L3 | Low (docs) | mcp-proxy recipe put the raw bearer in argv although mcp-proxy natively reads `API_ACCESS_TOKEN` | **Fixed**: recipe switched to the `API_ACCESS_TOKEN` env var, aligned with the mcp-remote advice above it |
| N1 | Nit | Doc said "rolling window"; the decided semantics are fixed UTC buckets | **Fixed**: "fixed six-hour UTC window", boundary artifact (two rows minutes apart) stated as accepted |
| N2 | Nit | Digest join collision (`("x\ny","z")` ≡ `("x","y\nz")`) and case-sensitive key vs the case-insensitive `McpClient` tag | **Fixed**: length-prefixed, case-folded digest inputs; 128-cap kept. Tests: collision-freedom (incl. crafted length prefix), case-fold on clientInfo, agent axis never folded |
| N3 | Nit | Disabled-llms.txt pin was substring-level, not the verified byte-identity | **Fixed**: full-render equality pin — golden pre-phase-3 paragraph verbatim, enabled arm equals the disabled render with exactly that paragraph swapped |

## Risk & rollback

- Low risk: no schema/migration, no config field, no REST change; the emit path is fire-and-forget behind the existing `server.mcp.enabled` gate (default off) and rides `emit_event`'s existing consent gate.
- New per-authenticated-POST work on `/mcp`: one bytes scan + one set lookup on the hot path (JSON parse only when clientInfo bytes are present); the M1 cap adds one dict lookup on the first sighting of a new key.
- Revert: revert the three commits (or the squash commit).

## Test plan

- `make lint` (ruff check + format + mypy): clean.
- `make test-fast` (full unit + arch): 3397 passed, coverage 79.3%.
- `make test-integration-sqlite`: 703 passed, 13 skipped.
- `make detect-secrets`: no new findings.
- Review wave (a157df36): ruff check + format clean; mypy clean (642 files); touched modules (`test_mcp_session.py`, `test_agent_discovery.py`, `test_mount_gate.py`) 159 passed; full unit suite 3113 passed, coverage 79.22% (≥ 70% gate); arch suite 152 passed.
- New tests: emit-once-within-window, re-emit-after-window, distinct (agent × client) keys don't collide, absent-clientInfo arm, `_meta` field capping, cross-worker table suppression, seen-set memory bound, gate-hook arms (authenticated / pre-auth / rejected credential), `_meta` parsing matrix, llms.txt enabled-arm advertisement + disabled-arm silence, plus the review-wave tests listed in the dispositions table.

## Review guide

- Start with the window-decision docstring on `MCP_HTTP_WINDOW_SECONDS` and `mcp_http_window_key` in `src/jentic_one/shared/events/mcp_session.py`; the gate hook in `src/jentic_one/mcp/app.py` is small. The review-wave commit (a157df36) adds `_admit_agent_window_key`/`_in_flight_has_room` next to the schedulers and the shape gate in `agent_discovery.py`'s llms.txt route. Docs are mechanical after that.

Made with [Cursor](https://cursor.com)
