### PR TITLE
chore(deploy): re-point the Marketplace overlay at the re-listed product

### DIFF
--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -16,7 +16,7 @@
 # publishing") are set, so forks and pre-listing releases skip cleanly:
 #   MARKETPLACE_ECR_ROLE_ARN — IAM role trusting GitHub's OIDC provider
 #   MARKETPLACE_ECR_CHART    — full chart repo URI from the Marketplace portal
-#                              (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one).
+#                              (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one/jentic-one).
 #                              The final path segment MUST equal the chart
 #                              name (`helm push` derives it from Chart.yaml).
 #

--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -16,7 +16,7 @@
 # publishing") are set, so forks and pre-listing releases skip cleanly:
 #   MARKETPLACE_ECR_ROLE_ARN — IAM role trusting GitHub's OIDC provider
 #   MARKETPLACE_ECR_CHART    — full chart repo URI from the Marketplace portal
-#                              (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one/jentic-one).
+#                              (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/charts/jentic-one).
 #                              The final path segment MUST equal the chart
 #                              name (`helm push` derives it from Chart.yaml).
 #

--- a/.github/workflows/marketplace-mirror.yml
+++ b/.github/workflows/marketplace-mirror.yml
@@ -13,7 +13,7 @@
 # skip cleanly):
 #   MARKETPLACE_ECR_ROLE_ARN     — IAM role trusting GitHub's OIDC provider
 #   MARKETPLACE_ECR_POSTGRES     — full mirror repo URI from the portal
-#                                  (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql)
+#                                  (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one-psql)
 #
 # Tag contract: pushes the source tag (matching the Helm values pin) and the
 # source digest as a tag suffix — tags float, digests pin, same as the app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,7 @@ jobs:
       #   MARKETPLACE_ECR_ROLE_ARN — IAM role trusting GitHub's OIDC provider,
       #                              scoped to this repo's release workflow
       #   MARKETPLACE_ECR_IMAGE    — full repo URI from the Marketplace portal
-      #                              (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app)
+      #                              (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one-app)
       #
       # configure-aws-credentials is credential-issuing: it must stay after
       # every third-party installer (same posture as the GHCR login above) and

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1126,9 +1126,14 @@ values are sensitive; the trust policy below is what protects the role):
 | Variable | Value |
 | -------- | ----- |
 | `MARKETPLACE_ECR_ROLE_ARN` | The IAM role below, e.g. `arn:aws:iam::<seller-account-id>:role/jentic-one-marketplace-publish` |
-| `MARKETPLACE_ECR_IMAGE` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app` |
-| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql` — the bundled-DB mirror of the official `postgres` image (the first-party `charts/postgresql` subchart). Needs the repo's ARN in the role policy below |
-| `MARKETPLACE_ECR_CHART` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one` — the Helm chart as an OCI artifact (the listing's deployment-template URI). The final path segment **must equal the chart name** (`jentic-one`): `helm push` derives it from `Chart.yaml` |
+| `MARKETPLACE_ECR_IMAGE` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one-app` |
+| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one-psql` — the bundled-DB mirror of the official `postgres` image (the first-party `charts/postgresql` subchart). Needs the repo's ARN in the role policy below |
+| `MARKETPLACE_ECR_CHART` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one/jentic-one` — the Helm chart as an OCI artifact (the listing's deployment-template URI). The final path segment **must equal the chart name** (`jentic-one`): `helm push` derives it from `Chart.yaml` |
+
+These paths belong to the re-listed product (`prod-cwonumew2jeyo`, created
+2026-09-03 — a fresh listing was the only way to fix the public offer's
+locked pricing terms); the original listing's `jentic/jentic-one-*` repos are
+retired with it.
 
 Once set:
 
@@ -1250,9 +1255,9 @@ portal (`aws-marketplace` actions may be required by newer portal setups; add
         "ecr:DescribeImages"
       ],
       "Resource": [
-        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-app",
-        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-psql",
-        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one"
+        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/one-app",
+        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/one-psql",
+        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/one/jentic-one"
       ]
     }
   ]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1128,7 +1128,7 @@ values are sensitive; the trust policy below is what protects the role):
 | `MARKETPLACE_ECR_ROLE_ARN` | The IAM role below, e.g. `arn:aws:iam::<seller-account-id>:role/jentic-one-marketplace-publish` |
 | `MARKETPLACE_ECR_IMAGE` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one-app` |
 | `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one-psql` — the bundled-DB mirror of the official `postgres` image (the first-party `charts/postgresql` subchart). Needs the repo's ARN in the role policy below |
-| `MARKETPLACE_ECR_CHART` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one/jentic-one` — the Helm chart as an OCI artifact (the listing's deployment-template URI). The final path segment **must equal the chart name** (`jentic-one`): `helm push` derives it from `Chart.yaml` |
+| `MARKETPLACE_ECR_CHART` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/charts/jentic-one` — the Helm chart as an OCI artifact (the listing's deployment-template URI). The final path segment **must equal the chart name** (`jentic-one`): `helm push` derives it from `Chart.yaml` |
 
 These paths belong to the re-listed product (`prod-cwonumew2jeyo`, created
 2026-09-03 — a fresh listing was the only way to fix the public offer's
@@ -1257,7 +1257,7 @@ portal (`aws-marketplace` actions may be required by newer portal setups; add
       "Resource": [
         "arn:aws:ecr:us-east-1:709825985650:repository/jentic/one-app",
         "arn:aws:ecr:us-east-1:709825985650:repository/jentic/one-psql",
-        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/one/jentic-one"
+        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/charts/jentic-one"
       ]
     }
   ]

--- a/deploy/helm/jentic-one/charts/postgresql/values.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/values.yaml
@@ -6,7 +6,7 @@ image:
   registry: docker.io
   # For registries that embed a namespace (e.g. the AWS Marketplace mirror),
   # keep the split form — registry "709825985650.dkr.ecr.us-east-1.amazonaws.com",
-  # repository "jentic/jentic-one-psql". (Do NOT blank the registry and stuff
+  # repository "jentic/one-psql". (Do NOT blank the registry and stuff
   # the full path into repository: Helm renders it fine, but AWS Marketplace's
   # chart validator composes refs from these exact keys and chokes on an
   # empty registry.)

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -70,7 +70,7 @@ global:
 app:
   enabled: true
   image:
-    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app"
+    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one-app"
     # Stamped to the release version (X.Y.Z, no v — that's the tag the image
     # is pushed to Marketplace ECR under) by marketplace-chart.yml's bake
     # step. Empty here (falls back to global.image.tag), but the baked chart
@@ -84,33 +84,30 @@ app:
     JENTIC_ENV: "production"
     # Entitlement gate (contract pricing, dimensions users + executions —
     # decided 2026-08-20; `contract` is the config default so only the IDs are
-    # set). IDs verified against the live listing 2026-08-28. Enabled together
-    # with the checkout-shape/check-in fix — a release carrying this env MUST
-    # ship that client (Count+Value entitlements, CheckInLicense after
-    # checkout) or entitled buyers lock themselves out.
+    # set). IDs are the RE-LISTED product's (prod-cwonumew2jeyo, created
+    # 2026-09-03 for the 12-month-only public offer — the original listing's
+    # offer terms were unfixable post-release). Enabled together with the
+    # checkout-shape/check-in fix — a release carrying this env MUST ship
+    # that client (Count+Value entitlements, CheckInLicense after checkout)
+    # or entitled buyers lock themselves out.
     JENTIC__ENTITLEMENT__ENABLED: "true"
-    JENTIC__ENTITLEMENT__PRODUCT_CODE: "dwhxz1v53k58ew6pr7qzieumd"
-    JENTIC__ENTITLEMENT__LICENSE_SKU: "prod-dd2p2s65dysv6"
+    JENTIC__ENTITLEMENT__PRODUCT_CODE: "ed4bj3dbc8w2r80qtnbxbboub"
+    JENTIC__ENTITLEMENT__LICENSE_SKU: "prod-cwonumew2jeyo"
     JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users,executions"
 
 broker:
   enabled: true
   image:
-    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app"
+    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/one-app"
     tag: ""  # stamped by the bake step — same reasoning as app.image.tag
   extraEnv:
     JENTIC_ENV: "production"  # same reasoning as app.extraEnv above
     # Entitlement gate — same values and caveat as app.extraEnv above.
     JENTIC__ENTITLEMENT__ENABLED: "true"
-    JENTIC__ENTITLEMENT__PRODUCT_CODE: "dwhxz1v53k58ew6pr7qzieumd"
-    JENTIC__ENTITLEMENT__LICENSE_SKU: "prod-dd2p2s65dysv6"
+    JENTIC__ENTITLEMENT__PRODUCT_CODE: "ed4bj3dbc8w2r80qtnbxbboub"
+    JENTIC__ENTITLEMENT__LICENSE_SKU: "prod-cwonumew2jeyo"
     JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users,executions"
     JENTIC__APPS: "broker"
-  # Entitlement wiring — same caveat as app above:
-  #   JENTIC__ENTITLEMENT__ENABLED: "true"
-  #   JENTIC__ENTITLEMENT__PRODUCT_CODE: "<product code from the portal>"
-  #   JENTIC__ENTITLEMENT__LICENSE_SKU: "<product ID from the portal>"
-  #   JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users,executions"
 
 registry:
   enabled: false
@@ -134,7 +131,7 @@ postgresql:
   enabled: true
   image:
     registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com"
-    repository: "jentic/jentic-one-psql"
+    repository: "jentic/one-psql"
     # The Alpine mirror (deploy/docker/postgres-mirror.Dockerfile) — Alpine
     # because AWS's scanner blocks on Debian's won't-fix glibc CVEs; the
     # mirror workflow pushes the tag it reads from that Dockerfile's FROM pin.

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -205,8 +205,8 @@ def test_render_marketplace_entitlement_env() -> None:
     assert result.returncode == 0, result.stderr
     out = result.stdout
     assert out.count("name: JENTIC__ENTITLEMENT__ENABLED") == 2  # app + broker
-    assert out.count('value: "dwhxz1v53k58ew6pr7qzieumd"') == 2  # product code
-    assert out.count('value: "prod-dd2p2s65dysv6"') == 2  # product ID (SKU)
+    assert out.count('value: "ed4bj3dbc8w2r80qtnbxbboub"') == 2  # product code
+    assert out.count('value: "prod-cwonumew2jeyo"') == 2  # product ID (SKU)
     assert out.count('value: "users,executions"') == 2
 
 


### PR DESCRIPTION
## Summary

The original container product's public offer released with pricing terms AWS won't amend post-release (term type + rate-card durations lock at `ReleaseOffer`, confirmed via Catalog API attempts and AWS support). A **new product** was created 2026-09-03 so the public offer can be 12-month-only, shaped while still Draft. This PR swaps the code-side identifiers to the new listing:

- **Entitlement IDs** (app + broker env in `deploy/helm/values/aws-marketplace.yaml`, pinned by the render test): product code `dwhxz1v53k58ew6pr7qzieumd` → `ed4bj3dbc8w2r80qtnbxbboub`, SKU `prod-dd2p2s65dysv6` → `prod-cwonumew2jeyo`
- **ECR paths**: `jentic/jentic-one-app` → `jentic/one-app`, `jentic/jentic-one-psql` → `jentic/one-psql`, chart `jentic/jentic-one` → `jentic/charts/jentic-one` (the chart repo's final path segment must equal the chart name — `helm push` derives it, and `marketplace-chart.yml` gates on it)
- Docs: `deploy/README.md` repo-variable table + publish-role ECR ARNs; workflow header comments

## After merge (operational, not in this PR)

- Update repo **variables**: `MARKETPLACE_ECR_IMAGE`, `MARKETPLACE_ECR_POSTGRES`, `MARKETPLACE_ECR_CHART` to the new paths
- Infra: publish role's ECR resource ARNs → new repos (pattern of infrastructure-live#568/#570/#572)
- Re-publish artifacts (release publish job / `marketplace-mirror` / `marketplace-chart`) against the new repos
- The buyer-facing `docs/installation/aws-marketplace.md` lives on the unmerged `docs/installation` branch — its ECR paths need the same swap there

## Test plan

- [x] `uv run pytest tests/smoke/test_helm_render.py` — 16 passed (includes the entitlement-env render test now pinning the new IDs)
- [ ] After variables/infra move: re-run a release publish end-to-end against the new repos

Made with [Cursor](https://cursor.com)
