### PR TITLE
docs(deploy): buyer guide chart URI -> the re-listed product's jentic/charts/jentic-one

### DIFF
--- a/docs/installation/aws-marketplace.md
+++ b/docs/installation/aws-marketplace.md
@@ -77,7 +77,7 @@ aws ecr get-login-password --region us-east-1 \
     709825985650.dkr.ecr.us-east-1.amazonaws.com
 
 helm install jentic-one \
-  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one \
+  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/charts/jentic-one \
   --version <version> --namespace jentic-one --create-namespace \
   --set global.serviceAccount.name=jentic-one \
   --set global.awsmp.licenseSecret=<from-launch-page>
@@ -95,7 +95,7 @@ mismatch (including `localhost` vs `127.0.0.1`) fails with `invalid_grant`
 
 ```bash
 helm upgrade jentic-one \
-  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one \
+  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/charts/jentic-one \
   --version <version> -n jentic-one --reuse-values \
   --set app.extraEnv.JENTIC__AUTH__CANONICAL_BASE_URL=https://jentic.example.com
 ```
@@ -147,7 +147,7 @@ overrides:
 
 ```bash
 helm upgrade jentic-one \
-  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one \
+  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/charts/jentic-one \
   --version <new-version> -n jentic-one --reset-values \
   --set global.serviceAccount.name=jentic-one \
   --set app.extraEnv.JENTIC__AUTH__CANONICAL_BASE_URL=<url>


### PR DESCRIPTION
Follow-up to #1235: the buyer-facing install guide merged (#1187 + the docs/installation move) still points at the original listing's chart repo. Swap the three `oci://` URIs to the re-listed product's `jentic/charts/jentic-one` (product `prod-cwonumew2jeyo`, created 2026-09-03 — see #1235 for the full context).

Docs-only; no rendered-chart or code impact.

Made with [Cursor](https://cursor.com)