### PR TITLE
test(ui): fix DocsPage Broker-reference flake that broke main CI (not #1237 skew)

### DIFF
--- a/ui/src/modules/docs/__tests__/DocsPage.test.tsx
+++ b/ui/src/modules/docs/__tests__/DocsPage.test.tsx
@@ -24,6 +24,7 @@ import {
 	renderWithProviders,
 	screen,
 	within,
+	waitFor,
 	checkA11y,
 	createErrorHandler,
 } from '@/__tests__/test-utils';
@@ -145,7 +146,15 @@ function seedDocsHandlers(overrides: { reference?: unknown } = {}) {
 		),
 		// Resolved relative to document.baseURI in the client; match by suffix.
 		http.get('*/cli-reference.json', () => HttpResponse.json(CLI)),
-		http.get('*/broker-openapi.json', () => HttpResponse.json(BROKER_SPEC)),
+		// Delayed on purpose: the Broker spec is a query independent of the main
+		// docs query, so its reference mounts strictly after the hero appears.
+		// The delay pins that ordering so the Broker test exercises the real
+		// "spec still loading when the page is already up" path every run
+		// instead of only under CI load (where it flaked before).
+		http.get('*/broker-openapi.json', async () => {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return HttpResponse.json(BROKER_SPEC);
+		}),
 	);
 }
 
@@ -191,8 +200,15 @@ describe('DocsPage', () => {
 		expect(screen.getByRole('heading', { name: 'Broker API' })).toBeInTheDocument();
 
 		// Its operation is lazily mounted under a namespaced anchor so it never
-		// collides with the control-plane reference; scroll it into view to mount.
+		// collides with the control-plane reference. The Broker spec resolves on
+		// its own query, strictly after the hero (the handler above delays it),
+		// so wait for the anchor placeholder to exist before scrolling — a
+		// one-shot scroll against a not-yet-rendered anchor silently no-ops and
+		// the operation never mounts (the pre-fix CI flake on main).
 		const brokerOpId = `broker-${operationAnchorId('POST', '/{upstream_url}')}`;
+		await waitFor(() => {
+			expect(document.getElementById(brokerOpId)).not.toBeNull();
+		});
 		await act(async () => {
 			document.getElementById(brokerOpId)?.scrollIntoView();
 		});


### PR DESCRIPTION
## Summary

Main's CI (run [33757245240](https://github.com/jentic/jentic-one/actions/runs/33757245240), commit `29a98b30`) is red on the UI job: `DocsPage > renders the Broker reference as its own section from its own spec` fails with `Unable to find an element with the text: Execute a POST against an upstream API`. The root cause is a **timing race in the test itself**, not merge skew and not a defect in #1237: the squash commit's tree is byte-identical to the green PR-branch tree (`git rev-parse 07abc83c^{tree} 29a98b30^{tree}` → both `5c5f18fb…`), so the same code passed on the branch by timing luck and lost the race on main's run (three retries, same failure).

The race: the Broker spec loads on its own React Query (`useBrokerSpec`), independent of the main docs query the test awaits via the hero text. The test then did a **one-shot** `document.getElementById(brokerOpId)?.scrollIntoView()`. When the Broker query hadn't resolved yet, the anchor didn't exist, the optional-chained scroll silently no-op'd, the `LazyMount` block never entered the viewport (it mounts later, below the fold, where the IntersectionObserver never fires), and `findByText` timed out. Reproduced deterministically on `29a98b30` by adding 300 ms latency to the Broker MSW handler — exact same `TestingLibraryElementError`.

## Changes

- `ui/src/modules/docs/__tests__/DocsPage.test.tsx`: `waitFor` the Broker operation anchor to exist before scrolling it into view.
- Same file: the seeded Broker MSW handler now responds after 200 ms, pinning the "page is up, Broker spec still loading" ordering so the test exercises the race path on every run instead of only under CI load. (Pre-fix, this delay makes the test fail 100% of the time; post-fix it passes.)
- Out of scope: the generated spec artifacts (`ui/openapi.json`, `docs/reference/*`, `cli/client/generated/*`) — inspected and confirmed **not** involved; the test seeds all four docs sources itself via MSW, and the CI log shows the fixture body being served.

## Risk & rollback

- Low risk: test-only change, no product code touched. Revert the squash commit if needed.

## Test plan

- `cd ui && npx vitest run src/modules/docs/__tests__/DocsPage.test.tsx --retry=0` — fails on `29a98b30` with the delayed handler (exact CI error), passes with the fix.
- `cd ui && npm run lint:fix` — clean.
- `cd ui && npm run build` — clean.
- `cd ui && npm run test:run` — full browser-mode suite, 129 files / 1185 tests passed.
- No Python/Go/codegen changes, so ruff/mypy/Go/spec-drift gates don't apply.

Made with [Cursor](https://cursor.com)