### PR TITLE
chore(deploy): gate Marketplace entitlement on the users dimension only

### DIFF
--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -82,18 +82,24 @@ app:
   # secret. Safe here because global.appSecrets generates real values.
   extraEnv:
     JENTIC_ENV: "production"
-    # Entitlement gate (contract pricing, dimensions users + executions —
-    # decided 2026-08-20; `contract` is the config default so only the IDs are
-    # set). IDs are the RE-LISTED product's (prod-cwonumew2jeyo, created
-    # 2026-09-03 for the 12-month-only public offer — the original listing's
-    # offer terms were unfixable post-release). Enabled together with the
-    # checkout-shape/check-in fix — a release carrying this env MUST ship
-    # that client (Count+Value entitlements, CheckInLicense after checkout)
-    # or entitled buyers lock themselves out.
+    # Entitlement gate. IDs are the RE-LISTED product's (prod-cwonumew2jeyo,
+    # created 2026-09-03 for the 12-month-only public offer — the original
+    # listing's offer terms were unfixable post-release). Enabled together
+    # with the checkout-shape/check-in fix — a release carrying this env MUST
+    # ship that client (Count+Value entitlements, CheckInLicense after
+    # checkout) or entitled buyers lock themselves out.
+    #
+    # Gate on `users` ONLY (2026-09-03). The public offer's card is
+    # buyer-configurable and its constraints are locked loosen-only, so the
+    # price rides users ($20k/unit) with executions at $0 (documents the 50k
+    # on the agreement). Gating on users makes the paid dimension the only
+    # valid license and turns a $0 executions-only cart into a 503 — and it
+    # removes the old both-dimensions requirement that would have rejected
+    # every self-service public buyer.
     JENTIC__ENTITLEMENT__ENABLED: "true"
     JENTIC__ENTITLEMENT__PRODUCT_CODE: "ed4bj3dbc8w2r80qtnbxbboub"
     JENTIC__ENTITLEMENT__LICENSE_SKU: "prod-cwonumew2jeyo"
-    JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users,executions"
+    JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users"
 
 broker:
   enabled: true
@@ -106,7 +112,7 @@ broker:
     JENTIC__ENTITLEMENT__ENABLED: "true"
     JENTIC__ENTITLEMENT__PRODUCT_CODE: "ed4bj3dbc8w2r80qtnbxbboub"
     JENTIC__ENTITLEMENT__LICENSE_SKU: "prod-cwonumew2jeyo"
-    JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users,executions"
+    JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users"
     JENTIC__APPS: "broker"
 
 registry:

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -207,7 +207,12 @@ def test_render_marketplace_entitlement_env() -> None:
     assert out.count("name: JENTIC__ENTITLEMENT__ENABLED") == 2  # app + broker
     assert out.count('value: "ed4bj3dbc8w2r80qtnbxbboub"') == 2  # product code
     assert out.count('value: "prod-cwonumew2jeyo"') == 2  # product ID (SKU)
-    assert out.count('value: "users,executions"') == 2
+    # Gate on `users` ONLY: the public card is buyer-configurable (constraints
+    # locked loosen-only), so the price rides users with executions at $0 —
+    # requiring both dimensions would reject every self-service public buyer,
+    # and a $0 executions-only cart must NOT mint a valid license.
+    assert out.count('value: "users"') == 2
+    assert "users,executions" not in out
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

Completes the flat-\$20k public pricing setup on the re-listed Marketplace product ([#1235](https://github.com/jentic/jentic-one/pull/1235) context). Probing the released public offer (2026-09-03) established that rate-card constraints are **locked loosen-only** after release — the card is permanently buyer-configurable, so quantity/dimension locks can't express "one price, both dimensions". The pricing now rides the `users` dimension ($20,000/unit, P12M-only) with `executions` at $0 (the $0 line documents the 50,000 executions on the buyer's agreement).

This PR aligns the runtime gate: `JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS` goes from `users,executions` to `users` on both app and broker.

## Why users-only

- A self-service public buyer can check out any dimension subset; requiring **both** would 503 every public purchase that isn't exactly the instructed cart (this was tracked as the "either-dimension leniency" pre-public blocker — dissolved by this change).
- A $0 `executions`-only cart mints a license the gate now ignores → 503, no free rides.
- Config-only: `license_dimensions` is already a list setting; no client code changes.

## Test plan

- `tests/smoke/test_helm_render.py -k marketplace` — 4 passed; the entitlement render test now pins `users` on both pods and asserts `users,executions` is gone.

Ships with the next release/chart publish; the currently listed 0.37.5 still gates on both dimensions, which is safe while the product is Limited (the test license carries both).

Made with [Cursor](https://cursor.com)