### PR TITLE
fix(auth): accept RFC 8252 private-use redirect schemes on the anonymous DCR door

### DIFF
--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -2199,8 +2199,10 @@ type OAuthClientRegistrationRequest struct {
 	ClientName      string  `json:"client_name"`
 
 	// GrantTypes Subset of ['authorization_code', 'refresh_token'].
-	GrantTypes   *[]string `json:"grant_types,omitempty"`
-	RedirectUris []string  `json:"redirect_uris"`
+	GrantTypes *[]string `json:"grant_types,omitempty"`
+
+	// RedirectUris 1-20 redirect URIs. `https` always; `http` for loopback hosts only; RFC 8252 §7.1 private-use (custom) schemes are accepted for native apps (browser-executable and other dangerous schemes are rejected).
+	RedirectUris []string `json:"redirect_uris"`
 
 	// ResponseTypes Only ['code'] is supported.
 	ResponseTypes   *[]string `json:"response_types,omitempty"`

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -3507,6 +3507,7 @@ components:
           description: Subset of ['authorization_code', 'refresh_token'].
           title: Grant Types
         redirect_uris:
+          description: 1-20 redirect URIs. `https` always; `http` for loopback hosts only; RFC 8252 §7.1 private-use (custom) schemes are accepted for native apps (browser-executable and other dangerous schemes are rejected).
           items:
             type: string
           maxItems: 20

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -3507,6 +3507,7 @@ components:
           description: Subset of ['authorization_code', 'refresh_token'].
           title: Grant Types
         redirect_uris:
+          description: 1-20 redirect URIs. `https` always; `http` for loopback hosts only; RFC 8252 §7.1 private-use (custom) schemes are accepted for native apps (browser-executable and other dangerous schemes are rejected).
           items:
             type: string
           maxItems: 20

--- a/src/jentic_one/admin/services/oauth_client_service.py
+++ b/src/jentic_one/admin/services/oauth_client_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import re
 from functools import partial
 from urllib.parse import urlparse
 
@@ -37,6 +38,24 @@ logger = structlog.get_logger(__name__)
 _MAX_REDIRECT_URIS = 20
 _MAX_REDIRECT_URI_LENGTH = 2048
 
+#: Hosts for which an ``http`` redirect_uri is acceptable (RFC 8252 §7.3
+#: loopback redirects). Applies on every door — the private-use-scheme
+#: allowance never widens ``http``.
+_LOOPBACK_HOSTS = ("localhost", "127.0.0.1", "::1")
+
+#: Schemes that must never be a redirect target, even where RFC 8252 §7.1
+#: private-use schemes are accepted (the anonymous DCR door): browser-
+#: executable schemes (``javascript``/``data``/``vbscript``/``blob``/
+#: ``about``), local-resource schemes (``file``/``chrome``), and registered
+#: transport schemes a native app has no business claiming as a callback
+#: (``ws``/``wss``/``ftp``). Matched case-insensitively.
+_PRIVATE_USE_SCHEME_DENYLIST = frozenset(
+    {"javascript", "data", "file", "vbscript", "blob", "about", "chrome", "ws", "wss", "ftp"}
+)
+
+#: RFC 3986 §3.1 scheme grammar: ``ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )``.
+_RFC3986_SCHEME_RE = re.compile(r"[A-Za-z][A-Za-z0-9+.-]*")
+
 
 @functools.cache
 def _dummy_argon2_hash() -> str:
@@ -53,8 +72,21 @@ def _dummy_argon2_hash() -> str:
     return hash_password("dummy-timing-equalizer")
 
 
-def _validate_redirect_uris(uris: list[str]) -> None:
-    """Validate that all redirect URIs are well-formed HTTPS URLs (http only for localhost)."""
+def _validate_redirect_uris(uris: list[str], *, allow_private_use_schemes: bool = False) -> None:
+    """Validate redirect URIs: HTTPS always; http only for the loopback hosts.
+
+    ``allow_private_use_schemes=True`` is the anonymous-DCR arm (RFC 8252
+    §7.1): native apps redirect to a private-use scheme they control, e.g.
+    ``cursor://anysphere.cursor-mcp/oauth/callback`` or the reverse-DNS shape
+    ``com.example.app:/oauth/callback``, with mandatory PKCE (S256) as the
+    compensating control. On that arm the scheme must match the RFC 3986
+    scheme grammar, must not be in :data:`_PRIVATE_USE_SCHEME_DENYLIST`, and
+    the URI must carry a non-empty opaque part after the scheme. ``https``
+    and loopback-``http`` rules are identical on both arms.
+
+    Admin/platform-created clients keep the strict default: only ``https``
+    (or loopback ``http``) redirect URIs are accepted.
+    """
     if not uris:
         raise InvalidInputError("at least one redirect_uri is required")
     if len(uris) > _MAX_REDIRECT_URIS:
@@ -66,14 +98,29 @@ def _validate_redirect_uris(uris: list[str]) -> None:
                 f"redirect_uri exceeds maximum length of {_MAX_REDIRECT_URI_LENGTH}"
             )
         parsed = urlparse(uri)
-        if not parsed.scheme or not parsed.netloc:
+        scheme = parsed.scheme.lower()
+        is_web_scheme = scheme in ("https", "http")
+        # An authority (netloc) is required for https/http on every door, and
+        # for every scheme on the strict door (preserves its historic "invalid
+        # redirect_uri" rejection of opaque forms like ``javascript:alert(1)``).
+        requires_netloc = is_web_scheme or not allow_private_use_schemes
+        if not parsed.scheme or (requires_netloc and not parsed.netloc):
             raise InvalidInputError(f"invalid redirect_uri: {uri}")
         if parsed.fragment:
             raise InvalidInputError(f"redirect_uri must not contain a fragment component: {uri}")
-        if parsed.scheme not in ("https", "http"):
+        if is_web_scheme:
+            if scheme == "http" and parsed.hostname not in _LOOPBACK_HOSTS:
+                raise InvalidInputError(f"http redirect_uri only allowed for localhost: {uri}")
+            continue
+        if not allow_private_use_schemes:
             raise InvalidInputError(f"redirect_uri must use https or http: {uri}")
-        if parsed.scheme == "http" and parsed.hostname not in ("localhost", "127.0.0.1", "::1"):
-            raise InvalidInputError(f"http redirect_uri only allowed for localhost: {uri}")
+        # --- private-use (custom) scheme arm — anonymous DCR door only ---
+        if not _RFC3986_SCHEME_RE.fullmatch(parsed.scheme):
+            raise InvalidInputError(f"invalid redirect_uri scheme: {uri}")
+        if scheme in _PRIVATE_USE_SCHEME_DENYLIST:
+            raise InvalidInputError(f"redirect_uri scheme '{scheme}' is not allowed: {uri}")
+        if not parsed.netloc and not parsed.path:
+            raise InvalidInputError(f"invalid redirect_uri: {uri}")
 
 
 def _is_approved(client: OAuthClient) -> bool:

--- a/src/jentic_one/admin/services/oauth_client_service.py
+++ b/src/jentic_one/admin/services/oauth_client_service.py
@@ -44,17 +44,71 @@ _MAX_REDIRECT_URI_LENGTH = 2048
 _LOOPBACK_HOSTS = ("localhost", "127.0.0.1", "::1")
 
 #: Schemes that must never be a redirect target, even where RFC 8252 §7.1
-#: private-use schemes are accepted (the anonymous DCR door): browser-
-#: executable schemes (``javascript``/``data``/``vbscript``/``blob``/
-#: ``about``), local-resource schemes (``file``/``chrome``), and registered
-#: transport schemes a native app has no business claiming as a callback
-#: (``ws``/``wss``/``ftp``). Matched case-insensitively.
+#: private-use schemes are accepted (the anonymous DCR door). A denylist can
+#: never cover attacker-installed *local* handlers — that residual is inherent
+#: to §7.1 and PKCE/consent-compensated — but schemes with **built-in** UA/OS
+#: dispatch behavior (no local install needed) are the server's job to block.
+#: Matched case-insensitively against the RAW scheme (see the charset check
+#: below); schemes ending in ``-extension`` are rejected as a class.
 _PRIVATE_USE_SCHEME_DENYLIST = frozenset(
-    {"javascript", "data", "file", "vbscript", "blob", "about", "chrome", "ws", "wss", "ftp"}
+    {
+        # Browser-executable / script schemes.
+        "javascript",
+        "data",
+        "vbscript",
+        "blob",
+        "about",
+        # Local-resource / browser-internal schemes (extension schemes are
+        # additionally caught by the ``-extension`` suffix rule).
+        "file",
+        "chrome",
+        "chrome-extension",
+        "moz-extension",
+        "safari-extension",
+        "view-source",
+        "filesystem",
+        "resource",
+        "res",
+        "jar",
+        # OS dispatch schemes with side effects and no install step: Android
+        # intents / app links, the Windows protocol-handler CVE class
+        # (ms-msdt is Follina), packaged-app schemes.
+        "intent",
+        "android-app",
+        "ms-msdt",
+        "search-ms",
+        "ms-officecmd",
+        "ms-appx",
+        "ms-appx-web",
+        # Compose/dialer schemes — dispatch side effects, never a callback.
+        "mailto",
+        "tel",
+        "sms",
+        "callto",
+        # Registered transport/remote-session schemes a native app has no
+        # business claiming as a callback.
+        "ws",
+        "wss",
+        "ftp",
+        "ssh",
+        "vnc",
+        "smb",
+    }
 )
 
 #: RFC 3986 §3.1 scheme grammar: ``ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )``.
 _RFC3986_SCHEME_RE = re.compile(r"[A-Za-z][A-Za-z0-9+.-]*")
+
+#: The full RFC 3986 URI character set (unreserved + gen-delims + sub-delims
+#: + ``%``), enforced against the RAW string *before* any parsing on every
+#: door. ``urlparse`` strips ``\t\r\n`` anywhere and leading/trailing
+#: C0-controls/space before parsing (CVE-era hardening), so without this
+#: check a raw string carrying control bytes validates clean yet is stored —
+#: and later emitted into a ``Location`` header — with the bytes intact
+#: (and a NUL byte 500s on Postgres TEXT while SQLite accepts it: a backend
+#: divergence). This also rejects raw ``\\``, whitespace, and unencoded
+#: non-ASCII, which WHATWG browsers parse differently from ``urlparse``.
+_RFC3986_URI_CHARS_RE = re.compile(r"[A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=%]*\Z")
 
 
 @functools.cache
@@ -74,6 +128,12 @@ def _dummy_argon2_hash() -> str:
 
 def _validate_redirect_uris(uris: list[str], *, allow_private_use_schemes: bool = False) -> None:
     """Validate redirect URIs: HTTPS always; http only for the loopback hosts.
+
+    Every door additionally requires the RAW string to stay inside the
+    RFC 3986 URI character set (no whitespace/control bytes — they survive
+    ``urlparse``'s pre-parse stripping and would otherwise be stored and
+    emitted verbatim), bans ``#`` outright, and rejects userinfo in http(s)
+    authorities (WHATWG/urlparse authority-parsing divergence).
 
     ``allow_private_use_schemes=True`` is the anonymous-DCR arm (RFC 8252
     §7.1): native apps redirect to a private-use scheme they control, e.g.
@@ -97,27 +157,52 @@ def _validate_redirect_uris(uris: list[str], *, allow_private_use_schemes: bool 
             raise InvalidInputError(
                 f"redirect_uri exceeds maximum length of {_MAX_REDIRECT_URI_LENGTH}"
             )
+        # Charset gate on the RAW string, before urlparse can sanitize: no
+        # whitespace, no control chars (NUL/CR/LF/TAB included), no backslash,
+        # no unencoded non-ASCII — on every door (review-1246 F2).
+        if not _RFC3986_URI_CHARS_RE.fullmatch(uri):
+            raise InvalidInputError(
+                f"redirect_uri contains characters outside the RFC 3986 URI set: {uri!r}"
+            )
+        # Fragment ban checked as raw '#' presence: ``parsed.fragment`` is
+        # falsy for a trailing bare ``#`` (``cursor://h/cb#``), which would
+        # otherwise slip through and mint ``…#?code=…`` redirects violating
+        # RFC 6749 §3.1.2 byte-wise (review-1246 F3).
+        if "#" in uri:
+            raise InvalidInputError(f"redirect_uri must not contain a fragment component: {uri}")
+        # The scheme is taken from the RAW string (prefix up to the first
+        # ':') so grammar and denylist checks can never be masked by parser
+        # sanitization; the charset gate above guarantees urlparse sees the
+        # same bytes we validate (review-1246 F2).
+        raw_scheme, colon, _ = uri.partition(":")
+        scheme = raw_scheme.lower() if colon else ""
         parsed = urlparse(uri)
-        scheme = parsed.scheme.lower()
         is_web_scheme = scheme in ("https", "http")
         # An authority (netloc) is required for https/http on every door, and
         # for every scheme on the strict door (preserves its historic "invalid
         # redirect_uri" rejection of opaque forms like ``javascript:alert(1)``).
         requires_netloc = is_web_scheme or not allow_private_use_schemes
-        if not parsed.scheme or (requires_netloc and not parsed.netloc):
+        if not scheme or (requires_netloc and not parsed.netloc):
             raise InvalidInputError(f"invalid redirect_uri: {uri}")
-        if parsed.fragment:
-            raise InvalidInputError(f"redirect_uri must not contain a fragment component: {uri}")
         if is_web_scheme:
+            # Userinfo has no place in a redirect target, and WHATWG browsers
+            # split the authority around '@' differently from urlparse —
+            # ``http://evil.com@localhost/cb`` validates as loopback here but
+            # navigates a browser to evil.com. Backslash divergence is already
+            # excluded by the charset gate above (review-1246 F5).
+            if "@" in parsed.netloc:
+                raise InvalidInputError(
+                    f"redirect_uri must not contain userinfo in the authority: {uri}"
+                )
             if scheme == "http" and parsed.hostname not in _LOOPBACK_HOSTS:
                 raise InvalidInputError(f"http redirect_uri only allowed for localhost: {uri}")
             continue
         if not allow_private_use_schemes:
             raise InvalidInputError(f"redirect_uri must use https or http: {uri}")
         # --- private-use (custom) scheme arm — anonymous DCR door only ---
-        if not _RFC3986_SCHEME_RE.fullmatch(parsed.scheme):
+        if not _RFC3986_SCHEME_RE.fullmatch(raw_scheme):
             raise InvalidInputError(f"invalid redirect_uri scheme: {uri}")
-        if scheme in _PRIVATE_USE_SCHEME_DENYLIST:
+        if scheme in _PRIVATE_USE_SCHEME_DENYLIST or scheme.endswith("-extension"):
             raise InvalidInputError(f"redirect_uri scheme '{scheme}' is not allowed: {uri}")
         if not parsed.netloc and not parsed.path:
             raise InvalidInputError(f"invalid redirect_uri: {uri}")

--- a/src/jentic_one/auth/services/authorize_service.py
+++ b/src/jentic_one/auth/services/authorize_service.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.admin.core.permissions import ALL_PERMISSIONS
 from jentic_one.admin.core.schema.agents import Agent
@@ -393,6 +394,21 @@ class AuthorizeService:
         if auth_code.expires_at <= datetime.now(UTC):
             raise InvalidGrantError("authorization code expired")
 
+    async def _redirect_uri_currently_registered(
+        self, session: AsyncSession, *, client_id: str, redirect_uri: str
+    ) -> bool:
+        """True iff ``redirect_uri`` is in the client's CURRENT redirect set.
+
+        Platform clients read from config, registered clients from the live
+        row. A missing row fails closed — a code was minted for this
+        client_id, so absence means the registration vanished mid-flow.
+        """
+        for pc in self._ctx.config.auth.platform_clients:
+            if pc.client_id == client_id:
+                return redirect_uri in pc.redirect_uris
+        client = await OAuthClientRepository.get_by_client_id(session, client_id)
+        return client is not None and redirect_uri in client.redirect_uris
+
     async def exchange_code(
         self,
         *,
@@ -434,6 +450,15 @@ class AuthorizeService:
 
             if auth_code.redirect_uri != redirect_uri:
                 raise InvalidGrantError("redirect_uri mismatch")
+
+            # The code row pins the authorize-time value, but an admin may
+            # have narrowed the client's redirect set inside the code TTL —
+            # re-validate against the client's *live* set so a mid-flow
+            # narrowing invalidates in-flight codes (review-1246 F6).
+            if not await self._redirect_uri_currently_registered(
+                session, client_id=client_id, redirect_uri=redirect_uri
+            ):
+                raise InvalidGrantError("redirect_uri is no longer registered for this client")
 
             if not _verify_pkce(code_verifier, auth_code.code_challenge):
                 raise InvalidGrantError("PKCE verification failed")

--- a/src/jentic_one/auth/services/oauth_dcr_service.py
+++ b/src/jentic_one/auth/services/oauth_dcr_service.py
@@ -136,7 +136,11 @@ def _validate_metadata(
                 f"unsupported response_types: {sorted(unsupported)} (allowed: ['code'])"
             )
     try:
-        _validate_redirect_uris(redirect_uris)
+        # RFC 8252 §7.1: native apps (this door's clientele) may claim a
+        # private-use redirect scheme; PKCE (S256, mandatory on the public-
+        # client flow) is the compensating control. The admin door keeps the
+        # strict https-or-loopback-http default.
+        _validate_redirect_uris(redirect_uris, allow_private_use_schemes=True)
     except InvalidInputError as exc:
         # The canonical validator is admin-tier; translate to the auth taxonomy
         # so the auth surface's error handler maps it (invalid_client_metadata).

--- a/src/jentic_one/auth/web/schemas/oauth_client_registration.py
+++ b/src/jentic_one/auth/web/schemas/oauth_client_registration.py
@@ -23,7 +23,19 @@ class OAuthClientRegistrationRequest(BaseModel):
     # Client-claimed and untrusted (phishing) — consent UIs render the
     # redirect-URI origin prominently, never the name alone (§4.2).
     client_name: str = Field(min_length=1, max_length=255)
-    redirect_uris: list[str] = Field(min_length=1, max_length=20)
+    # Native MCP clients are RFC 8252 apps: alongside https (always) and
+    # loopback http, §7.1 private-use schemes (e.g. ``cursor://…``,
+    # ``com.example.app:/…``) are accepted on this door — PKCE S256 is the
+    # compensating control. Dangerous schemes (javascript/data/file/…) are
+    # rejected; admin-created clients stay https-or-loopback-http only.
+    redirect_uris: list[str] = Field(
+        min_length=1,
+        max_length=20,
+        description="1-20 redirect URIs. `https` always; `http` for loopback "
+        "hosts only; RFC 8252 §7.1 private-use (custom) schemes are accepted "
+        "for native apps (browser-executable and other dangerous schemes are "
+        "rejected).",
+    )
     token_endpoint_auth_method: str | None = Field(
         default=None,
         description="Must be 'none' if supplied — this endpoint only registers "

--- a/tests/integration/auth/test_oauth_dcr_native_redirect_flow.py
+++ b/tests/integration/auth/test_oauth_dcr_native_redirect_flow.py
@@ -1,0 +1,416 @@
+"""Integration test: the RFC 8252 §7.1 private-use redirect flow, end to end.
+
+Issue #1245 (found in v0.38.0 E2E T7): Cursor's MCP OAuth integration
+registers via anonymous DCR with ``redirect_uris:
+["cursor://anysphere.cursor-mcp/oauth/callback"]`` and was hard-blocked by the
+https-only redirect validator. This suite runs the whole loosened path against
+the real routers and database — DCR register → admin approve → /authorize →
+consent → /oauth/token — with a ``cursor://`` redirect, and pins the two
+boundaries that must NOT loosen: the admin client-creation door stays
+https-only, and PKCE (S256) stays mandatory regardless of redirect scheme.
+
+Only the IdP round-trip is replaced, by the established consent-web pattern:
+the consent handle the callback would have written is seeded directly.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+from collections.abc import AsyncGenerator, Generator
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import delete, select
+
+from jentic_one.admin.core.schema.audit import AuditEntry
+from jentic_one.admin.core.schema.events import Event
+from jentic_one.admin.core.schema.oauth_clients import OAuthClient
+from jentic_one.admin.repos import ExternalIdentityRepository
+from jentic_one.admin.services.errors import InvalidInputError
+from jentic_one.admin.services.oauth_client_service import OAuthClientService
+from jentic_one.auth.services.errors import AuthServiceError
+from jentic_one.auth.web.errors import service_error_handler
+from jentic_one.auth.web.routers import authorize, oauth, oauth_client_registration
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.context import Context
+from jentic_one.shared.models.events import EventType
+from jentic_one.shared.models.oauth_clients import OAuthClientApprovalStatus
+from jentic_one.shared.state.backend import MemoryStateBackend
+from tests.integration.auth.seeds import CODE_VERIFIER, code_challenge, seed_agent, seed_user
+
+pytestmark = pytest.mark.integration
+
+_ADMIN = Identity(sub="usr_native_admin", email="native-admin@test.local")
+_CURSOR_REDIRECT = "cursor://anysphere.cursor-mcp/oauth/callback"
+_IDP_AUTHORIZE = "https://idp.test.local/authorize"
+_DCR_ACTOR = "dcr"
+
+
+@pytest.fixture()
+def native_flow_ctx(integration_context: Context) -> Generator[Context, None, None]:
+    """Integration context with the DCR door open, the approval queue on, and
+    a (never-contacted) IdP configured so GET /authorize can build its hop.
+
+    All mutated config is restored — AppConfig is shared session state.
+    """
+    oauth_cfg = integration_context.config.server.mcp.oauth
+    idp_cfg = integration_context.config.auth.idp
+    prior = (
+        oauth_cfg.enabled,
+        oauth_cfg.auto_approve_clients,
+        idp_cfg.enabled,
+        idp_cfg.authorization_endpoint,
+        idp_cfg.client_id,
+    )
+    oauth_cfg.enabled = True
+    oauth_cfg.auto_approve_clients = False
+    idp_cfg.enabled = True
+    idp_cfg.authorization_endpoint = _IDP_AUTHORIZE
+    idp_cfg.client_id = "upstream-idp-client"
+    yield integration_context
+    (
+        oauth_cfg.enabled,
+        oauth_cfg.auto_approve_clients,
+        idp_cfg.enabled,
+        idp_cfg.authorization_endpoint,
+        idp_cfg.client_id,
+    ) = prior
+
+
+@pytest.fixture()
+async def clean_dcr_clients(integration_context: Context) -> AsyncGenerator[None, None]:
+    """Remove DCR-registered client rows plus their audit entries and events.
+
+    ``clean_grants`` (the shared conftest fixture) only removes clients seeded
+    with ``created_by=SEED_MARKER``; the DCR front door stamps
+    ``created_by='dcr'``, so those rows need their own cleanup.
+    """
+
+    async def _clean() -> None:
+        async with integration_context.admin_db.transaction() as session:
+            result = await session.execute(
+                select(OAuthClient.id).where(OAuthClient.created_by == _DCR_ACTOR)
+            )
+            ids = [row[0] for row in result.all()]
+            if ids:
+                await session.execute(delete(AuditEntry).where(AuditEntry.target_id.in_(ids)))
+            await session.execute(
+                delete(Event).where(
+                    Event.type.in_(
+                        [EventType.OAUTH_CLIENT_REGISTERED, EventType.OAUTH_CLIENT_APPROVED]
+                    )
+                )
+            )
+            await session.execute(delete(OAuthClient).where(OAuthClient.created_by == _DCR_ACTOR))
+
+    await _clean()
+    yield
+    await _clean()
+
+
+def _make_app(ctx: Context) -> FastAPI:
+    """DCR + authorize + token routers wired to the REAL context."""
+    app = FastAPI()
+    app.include_router(oauth_client_registration.router)
+    app.include_router(authorize.router)
+    app.include_router(oauth.router)
+    app.add_exception_handler(AuthServiceError, service_error_handler)
+    app.state.ctx = ctx
+    app.state.auth_state_backend = MemoryStateBackend()
+    return app
+
+
+def _web_client(app: FastAPI) -> AsyncClient:
+    # httpx+ASGITransport (not TestClient) so the handlers run on the same
+    # event loop as the session-scoped DB engines.
+    return AsyncClient(transport=ASGITransport(app=app), base_url="https://testserver")
+
+
+async def _register_cursor_client(client: AsyncClient) -> str:
+    """Anonymous DCR with Cursor's real-world metadata; returns the client_id."""
+    resp = await client.post(
+        "/oauth-clients",
+        json={
+            "client_name": "Cursor",
+            "redirect_uris": [_CURSOR_REDIRECT],
+            "token_endpoint_auth_method": "none",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "software_id": "anysphere.cursor-mcp",
+            "application_type": "native",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["redirect_uris"] == [_CURSOR_REDIRECT]
+    return str(body["client_id"])
+
+
+async def _approve_client(ctx: Context, client_id: str) -> None:
+    async with ctx.admin_db.session() as session:
+        row = (
+            await session.execute(select(OAuthClient).where(OAuthClient.client_id == client_id))
+        ).scalar_one()
+        assert row.approval_status == OAuthClientApprovalStatus.PENDING.value
+        row_id = row.id
+    await OAuthClientService(ctx).approve(row_id, identity=_ADMIN)
+
+
+async def _seed_consent_handle(
+    app: FastAPI,
+    *,
+    client_id: str,
+    external_subject: str,
+    email: str,
+    state: str,
+    scope: str = "openid apis:read",
+) -> str:
+    """Write the consent handle the IdP callback would have stored."""
+    handle = secrets.token_urlsafe(16)
+    payload = json.dumps(
+        {
+            "claims": {
+                "external_subject": external_subject,
+                "email": email,
+                "email_verified": True,
+                "first_name": "Native",
+                "last_name": "Flow",
+            },
+            "redirect_uri": _CURSOR_REDIRECT,
+            "original_state": state,
+            "client_id": client_id,
+            "code_challenge": code_challenge(CODE_VERIFIER),
+            "scope": scope,
+            "nonce": None,
+            "client_name": "Cursor",
+            "client_description": None,
+            "user_email": email,
+            "iat": int(time.time()),
+        }
+    ).encode()
+    await app.state.auth_state_backend.set(f"consent-handle:{handle}", payload, ttl_s=300.0)
+    return handle
+
+
+async def _link_external_identity(ctx: Context, *, user_id: str, external_subject: str) -> None:
+    async with ctx.admin_db.session() as session:
+        await ExternalIdentityRepository.create(
+            session,
+            provider=ctx.config.auth.idp.provider,
+            external_subject=external_subject,
+            user_id=user_id,
+            email=f"{user_id}@grants.test",
+            created_by=user_id,
+        )
+        await session.commit()
+
+
+async def _mint_code_via_consent(
+    app: FastAPI,
+    client: AsyncClient,
+    *,
+    client_id: str,
+    external_subject: str,
+    email: str,
+    agent_id: str,
+    state: str,
+) -> str:
+    """Consent-approve with a cursor:// redirect; returns the minted code."""
+    handle = await _seed_consent_handle(
+        app,
+        client_id=client_id,
+        external_subject=external_subject,
+        email=email,
+        state=state,
+    )
+    resp = await client.post(
+        "/oauth/consent",
+        data={"consent_token": handle, "action": "approve", "agent_id": agent_id},
+    )
+    assert resp.status_code == 302, resp.text
+    location = resp.headers["location"]
+    # The 302 target IS the private-use redirect, carrying code + state.
+    assert location.startswith(f"{_CURSOR_REDIRECT}?")
+    query = parse_qs(urlsplit(location).query)
+    assert query["state"] == [state]
+    assert query["code"], location
+    return query["code"][0]
+
+
+async def test_full_dcr_to_token_flow_with_private_use_redirect(
+    native_flow_ctx: Context, clean_grants: None, clean_dcr_clients: None
+) -> None:
+    """DCR register → approve → /authorize → consent → /oauth/token, all with
+    Cursor's ``cursor://`` redirect (RFC 8252 §7.1)."""
+    ctx = native_flow_ctx
+    owner_id = await seed_user(ctx, "usr_native_owner")
+    agent_id = await seed_agent(
+        ctx, owner_id=owner_id, scopes=["apis:read"], name="native-flow-agent"
+    )
+    await _link_external_identity(ctx, user_id=owner_id, external_subject="ext-native-owner")
+
+    app = _make_app(ctx)
+    async with _web_client(app) as client:
+        # 1 — anonymous DCR accepts the private-use redirect (was: 400).
+        client_id = await _register_cursor_client(client)
+
+        # 2 — the row lands pending; the admin approve verb activates it.
+        await _approve_client(ctx, client_id)
+
+        # 3 — /authorize accepts the exact-match cursor:// redirect and hops
+        # to the IdP (the redirect target passed validation before the hop).
+        authorize_params = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": _CURSOR_REDIRECT,
+            "code_challenge": code_challenge(CODE_VERIFIER),
+            "code_challenge_method": "S256",
+            "scope": "apis:read",
+            "state": "native-state-1",
+        }
+        resp = await client.get("/authorize", params=authorize_params)
+        assert resp.status_code == 302
+        assert resp.headers["location"].startswith(f"{_IDP_AUTHORIZE}?")
+
+        # 3b — exact-string matching has no normalization loopholes: a
+        # variant of the registered URI is bounced before any redirect.
+        for attack in (
+            "cursor://anysphere.cursor-mcp/oauth/callback/",
+            "cursor://anysphere.cursor-mcp/oauth/callback?extra=1",
+            "CURSOR://anysphere.cursor-mcp/oauth/callback",
+            "cursor://anysphere.cursor-mcp.evil.example/oauth/callback",
+        ):
+            resp = await client.get(
+                "/authorize", params={**authorize_params, "redirect_uri": attack}
+            )
+            assert resp.status_code == 302
+            assert resp.headers["location"] == "/error?error=invalid_redirect_uri", attack
+
+        # 4 — consent approve 302s to the private-use redirect with code+state.
+        code = await _mint_code_via_consent(
+            app,
+            client,
+            client_id=client_id,
+            external_subject="ext-native-owner",
+            email=f"{owner_id}@grants.test",
+            agent_id=agent_id,
+            state="native-state-1",
+        )
+
+        # 5 — the public-client (secret-less) token exchange succeeds with the
+        # PKCE verifier; the grant channel mints no id_token (D11).
+        resp = await client.post(
+            "/oauth/token",
+            json={
+                "grant_type": "authorization_code",
+                "code": code,
+                "code_verifier": CODE_VERIFIER,
+                "redirect_uri": _CURSOR_REDIRECT,
+                "client_id": client_id,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["access_token"]
+        assert body["refresh_token"]
+        assert body.get("id_token") is None
+
+
+async def test_pkce_stays_mandatory_for_private_use_redirect_clients(
+    native_flow_ctx: Context, clean_grants: None, clean_dcr_clients: None
+) -> None:
+    """Pin: loosening the redirect scheme never loosens PKCE (the compensating
+    control) — S256-only at /authorize, verifier checked at /oauth/token."""
+    ctx = native_flow_ctx
+    owner_id = await seed_user(ctx, "usr_native_pkce")
+    agent_id = await seed_agent(
+        ctx, owner_id=owner_id, scopes=["apis:read"], name="native-pkce-agent"
+    )
+    await _link_external_identity(ctx, user_id=owner_id, external_subject="ext-native-pkce")
+
+    app = _make_app(ctx)
+    async with _web_client(app) as client:
+        client_id = await _register_cursor_client(client)
+        await _approve_client(ctx, client_id)
+
+        # /authorize rejects a non-S256 challenge method outright.
+        resp = await client.get(
+            "/authorize",
+            params={
+                "response_type": "code",
+                "client_id": client_id,
+                "redirect_uri": _CURSOR_REDIRECT,
+                "code_challenge": code_challenge(CODE_VERIFIER),
+                "code_challenge_method": "plain",
+                "scope": "apis:read",
+                "state": "pkce-state",
+            },
+        )
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        assert location.startswith(f"{_CURSOR_REDIRECT}?")
+        assert "error=invalid_request" in location
+        assert "only+S256+is+supported" in location or "only%20S256%20is%20supported" in location
+
+        # A wrong PKCE verifier fails the exchange…
+        code = await _mint_code_via_consent(
+            app,
+            client,
+            client_id=client_id,
+            external_subject="ext-native-pkce",
+            email=f"{owner_id}@grants.test",
+            agent_id=agent_id,
+            state="pkce-state",
+        )
+        resp = await client.post(
+            "/oauth/token",
+            json={
+                "grant_type": "authorization_code",
+                "code": code,
+                "code_verifier": "wrong-verifier-wrong-verifier-wrong-verifier",
+                "redirect_uri": _CURSOR_REDIRECT,
+                "client_id": client_id,
+            },
+        )
+        assert resp.status_code == 400, resp.text
+
+        # …and a missing verifier never reaches the exchange at all.
+        resp = await client.post(
+            "/oauth/token",
+            json={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": _CURSOR_REDIRECT,
+                "client_id": client_id,
+            },
+        )
+        assert resp.status_code == 400, resp.text
+
+
+async def test_admin_client_creation_door_still_rejects_private_use_schemes(
+    native_flow_ctx: Context, clean_grants: None, clean_dcr_clients: None
+) -> None:
+    """Pin: the RFC 8252 §7.1 allowance is DCR-only — the admin door keeps the
+    strict https-or-loopback-http rule and writes no row for a cursor:// URI."""
+    ctx = native_flow_ctx
+    with pytest.raises(InvalidInputError, match="redirect_uri must use https or http"):
+        await OAuthClientService(ctx).create(
+            name="cursor-via-admin",
+            redirect_uris=[_CURSOR_REDIRECT],
+            identity=_ADMIN,
+        )
+    async with ctx.admin_db.session() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(OAuthClient).where(OAuthClient.name == "cursor-via-admin")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert list(rows) == []

--- a/tests/integration/auth/test_oauth_dcr_native_redirect_flow.py
+++ b/tests/integration/auth/test_oauth_dcr_native_redirect_flow.py
@@ -414,3 +414,86 @@ async def test_admin_client_creation_door_still_rejects_private_use_schemes(
             .all()
         )
     assert list(rows) == []
+
+
+async def test_dcr_http_door_rejects_dispatch_schemes_and_control_chars(
+    native_flow_ctx: Context, clean_grants: None, clean_dcr_clients: None
+) -> None:
+    """Pin (review-1246 F1/F2 at the HTTP door): ``intent://`` and raw
+    control-char/whitespace redirect URIs are 400s, and no row is written."""
+    ctx = native_flow_ctx
+    app = _make_app(ctx)
+    async with _web_client(app) as client:
+        for bad_redirect in (
+            "intent://scan/",
+            "cursor://h/cb\n",
+            "cursor://h/cb\x00",
+            " cursor://h/cb",
+            "cursor://h/cb#",
+        ):
+            resp = await client.post(
+                "/oauth-clients",
+                json={
+                    "client_name": "Hostile",
+                    "redirect_uris": [bad_redirect],
+                    "token_endpoint_auth_method": "none",
+                },
+            )
+            assert resp.status_code == 400, (bad_redirect, resp.text)
+    async with ctx.admin_db.session() as session:
+        rows = (
+            (await session.execute(select(OAuthClient).where(OAuthClient.name == "Hostile")))
+            .scalars()
+            .all()
+        )
+    assert list(rows) == []
+
+
+async def test_mid_flow_redirect_narrowing_invalidates_inflight_code(
+    native_flow_ctx: Context, clean_grants: None, clean_dcr_clients: None
+) -> None:
+    """review-1246 F6: an admin narrowing the client's redirect set inside the
+    code TTL invalidates codes minted for the removed URI — the token leg
+    re-validates against the client's *live* set, not just the code row."""
+    ctx = native_flow_ctx
+    owner_id = await seed_user(ctx, "usr_native_narrow")
+    agent_id = await seed_agent(
+        ctx, owner_id=owner_id, scopes=["apis:read"], name="native-narrow-agent"
+    )
+    await _link_external_identity(ctx, user_id=owner_id, external_subject="ext-native-narrow")
+
+    app = _make_app(ctx)
+    async with _web_client(app) as client:
+        client_id = await _register_cursor_client(client)
+        await _approve_client(ctx, client_id)
+
+        code = await _mint_code_via_consent(
+            app,
+            client,
+            client_id=client_id,
+            external_subject="ext-native-narrow",
+            email=f"{owner_id}@grants.test",
+            agent_id=agent_id,
+            state="narrow-state-1",
+        )
+
+        # Narrow the live redirect set out from under the in-flight code.
+        # (Simulated at the row level: the admin PATCH door is strict and
+        # cannot even re-submit a cursor:// set — see the strict-door pins.)
+        async with ctx.admin_db.transaction() as session:
+            row = (
+                await session.execute(select(OAuthClient).where(OAuthClient.client_id == client_id))
+            ).scalar_one()
+            row.redirect_uris = ["https://replaced.example.com/cb"]
+
+        resp = await client.post(
+            "/oauth/token",
+            json={
+                "grant_type": "authorization_code",
+                "code": code,
+                "code_verifier": CODE_VERIFIER,
+                "redirect_uri": _CURSOR_REDIRECT,
+                "client_id": client_id,
+            },
+        )
+        assert resp.status_code == 400, resp.text

--- a/tests/unit/admin/services/test_oauth_client_service.py
+++ b/tests/unit/admin/services/test_oauth_client_service.py
@@ -80,6 +80,90 @@ def test_rejects_javascript_scheme() -> None:
         _validate_redirect_uris(["javascript:alert(1)"])
 
 
+# ---------- private-use schemes (RFC 8252 §7.1 — anonymous DCR arm only) ----------
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "cursor://anysphere.cursor-mcp/oauth/callback",
+        "com.example.app:/oauth/callback",
+        "com.example.app://callback",
+        "my-app+beta.x://cb",
+    ],
+)
+def test_private_use_scheme_rejected_on_strict_door(uri: str) -> None:
+    """Pin: admin/platform client creation never accepts a custom scheme."""
+    with pytest.raises(InvalidInputError):
+        _validate_redirect_uris([uri])
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "cursor://anysphere.cursor-mcp/oauth/callback",
+        "com.example.app:/oauth/callback",
+        "com.example.app://callback",
+        "my-app+beta.x://cb",
+    ],
+)
+def test_private_use_scheme_accepted_on_dcr_arm(uri: str) -> None:
+    """RFC 8252 §7.1: native apps redirect to a scheme they control."""
+    _validate_redirect_uris([uri], allow_private_use_schemes=True)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "javascript:alert(1)",
+        "JAVASCRIPT:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "file:///etc/passwd",
+        "vbscript:msgbox(1)",
+        "blob:https://example.com/uuid",
+        "about:blank",
+        "chrome://settings",
+        "ws://example.com/cb",
+        "wss://example.com/cb",
+        "ftp://example.com/cb",
+    ],
+)
+def test_dangerous_schemes_rejected_even_on_dcr_arm(uri: str) -> None:
+    """The §7.1 allowance never opens browser-executable or registered schemes."""
+    with pytest.raises(InvalidInputError):
+        _validate_redirect_uris([uri], allow_private_use_schemes=True)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        # No opaque part after the scheme — nowhere to deliver the code.
+        "cursor://",
+        "cursor:",
+        # Fragments are banned on every arm (RFC 6749 §3.1.2).
+        "cursor://anysphere.cursor-mcp/cb#fragment",
+        # No scheme at all.
+        "anysphere.cursor-mcp/cb",
+    ],
+)
+def test_malformed_private_use_uris_rejected_on_dcr_arm(uri: str) -> None:
+    with pytest.raises(InvalidInputError):
+        _validate_redirect_uris([uri], allow_private_use_schemes=True)
+
+
+def test_dcr_arm_keeps_http_loopback_only() -> None:
+    """The private-use allowance never widens http beyond the loopback hosts."""
+    _validate_redirect_uris(["http://localhost:33418/cb"], allow_private_use_schemes=True)
+    with pytest.raises(InvalidInputError, match="http redirect_uri only allowed for localhost"):
+        _validate_redirect_uris(["http://example.com/cb"], allow_private_use_schemes=True)
+
+
+def test_dcr_arm_keeps_https_authority_requirement() -> None:
+    """https URIs still need an authority on the DCR arm."""
+    with pytest.raises(InvalidInputError, match="invalid redirect_uri"):
+        _validate_redirect_uris(["https://"], allow_private_use_schemes=True)
+
+
 # ---------- verify_client_secret ----------
 
 

--- a/tests/unit/admin/services/test_oauth_client_service.py
+++ b/tests/unit/admin/services/test_oauth_client_service.py
@@ -126,12 +126,99 @@ def test_private_use_scheme_accepted_on_dcr_arm(uri: str) -> None:
         "ws://example.com/cb",
         "wss://example.com/cb",
         "ftp://example.com/cb",
+        # review-1246 F1: schemes with built-in UA/OS dispatch behavior.
+        "intent://scan/",
+        "INTENT://scan/",
+        "android-app://com.evil.app",
+        "ms-msdt:/id",
+        "search-ms:query=x",
+        "ms-officecmd:x",
+        "ms-appx://app/cb",
+        "ms-appx-web://app/cb",
+        "chrome-extension://abcdef/cb",
+        "moz-extension://abcdef/cb",
+        "safari-extension://abcdef/cb",
+        # Any *-extension scheme is rejected as a class, not just the listed ones.
+        "ms-browser-extension://abcdef/cb",
+        "view-source:https://example.com/",
+        "filesystem:https://example.com/temp/f",
+        "resource://gre/x",
+        "res://ieframe.dll/x",
+        "jar:https://example.com/a.jar!/x",
+        "mailto:a@example.com",
+        "tel:+15551234567",
+        "sms:+15551234567",
+        "callto:+15551234567",
+        "ssh://host/x",
+        "vnc://host/x",
+        "smb://host/share",
     ],
 )
 def test_dangerous_schemes_rejected_even_on_dcr_arm(uri: str) -> None:
     """The §7.1 allowance never opens browser-executable or registered schemes."""
     with pytest.raises(InvalidInputError):
         _validate_redirect_uris([uri], allow_private_use_schemes=True)
+
+
+@pytest.mark.parametrize("allow_private_use_schemes", [False, True])
+@pytest.mark.parametrize(
+    "uri",
+    [
+        # review-1246 F2 payloads: urlparse strips these before parsing, so
+        # without the raw-charset gate they validate clean but store raw.
+        " cursor://h/cb",
+        "cursor://h/cb\n",
+        "cur\tsor://h/cb",
+        "cursor://h/cb\x00",
+        "cursor://h/cb\r\nSet-Cookie: x=1",
+        " https://example.com/cb",
+        "https://example.com/cb\n",
+        "https://exam ple.com/cb",
+        "https://example.com/cb\x00",
+        "https://example.com/cb\r\nSet-Cookie: x=1",
+    ],
+)
+def test_control_chars_and_whitespace_rejected_on_every_door(
+    uri: str, allow_private_use_schemes: bool
+) -> None:
+    """review-1246 F2: the RAW string must satisfy the RFC 3986 charset —
+    whitespace and control bytes (NUL/CR/LF/TAB) are rejected before parsing
+    on both the strict and the DCR arm."""
+    with pytest.raises(InvalidInputError, match="outside the RFC 3986 URI set"):
+        _validate_redirect_uris([uri], allow_private_use_schemes=allow_private_use_schemes)
+
+
+@pytest.mark.parametrize("allow_private_use_schemes", [False, True])
+@pytest.mark.parametrize("uri", ["cursor://h/cb#", "https://example.com/cb#"])
+def test_empty_fragment_rejected_on_every_door(uri: str, allow_private_use_schemes: bool) -> None:
+    """review-1246 F3: a trailing bare '#' yields a falsy ``parsed.fragment``
+    but still produces ``…#?code=…`` redirects — '#' presence is what's banned."""
+    with pytest.raises(InvalidInputError, match="fragment"):
+        _validate_redirect_uris([uri], allow_private_use_schemes=allow_private_use_schemes)
+
+
+@pytest.mark.parametrize("allow_private_use_schemes", [False, True])
+def test_userinfo_authority_rejected_on_every_door(allow_private_use_schemes: bool) -> None:
+    """review-1246 F5: ``http://evil.com@localhost/cb`` parses as loopback in
+    urlparse but WHATWG browsers navigate to evil.com — userinfo is banned."""
+    for uri in (
+        "http://evil.com@localhost/cb",
+        "https://evil.com@example.com/cb",
+    ):
+        with pytest.raises(InvalidInputError, match="userinfo"):
+            _validate_redirect_uris([uri], allow_private_use_schemes=allow_private_use_schemes)
+
+
+@pytest.mark.parametrize("allow_private_use_schemes", [False, True])
+def test_backslash_authority_rejected_on_every_door(allow_private_use_schemes: bool) -> None:
+    """review-1246 F5: WHATWG treats '\\' as '/' in special schemes, so
+    ``http://evil.com\\@localhost/cb`` is host evil.com to a browser while
+    urlparse sees loopback — the raw charset gate rejects the backslash."""
+    with pytest.raises(InvalidInputError, match="outside the RFC 3986 URI set"):
+        _validate_redirect_uris(
+            ["http://evil.com\\@localhost/cb"],
+            allow_private_use_schemes=allow_private_use_schemes,
+        )
 
 
 @pytest.mark.parametrize(
@@ -736,6 +823,29 @@ async def test_update_allows_reactivation_of_approved_client(
 
     assert view.active is True
     mock_repo.update.assert_awaited_once()
+
+
+@patch("jentic_one.admin.services.oauth_client_service.record_audit", new_callable=AsyncMock)
+@patch("jentic_one.admin.services.oauth_client_service.OAuthClientRepository")
+async def test_update_rejects_private_use_scheme_redirects(
+    mock_repo: MagicMock, mock_audit: AsyncMock
+) -> None:
+    """Pin (review-1246 P5): the PATCH door keeps strict validation — an admin
+    update can never introduce a custom-scheme redirect, and nothing is written."""
+    ctx = _make_transactional_ctx()
+    mock_repo.get_by_id = AsyncMock(return_value=_full_row())
+    mock_repo.update = AsyncMock()
+
+    svc = OAuthClientService(ctx)
+    with pytest.raises(InvalidInputError, match="redirect_uri must use https or http"):
+        await svc.update(
+            "oac_1",
+            redirect_uris=["cursor://anysphere.cursor-mcp/oauth/callback"],
+            identity=_make_identity(),
+        )
+
+    mock_repo.update.assert_not_awaited()
+    mock_audit.assert_not_awaited()
 
 
 # ---------- create: public vs confidential ----------

--- a/tests/unit/auth/test_oauth_dcr_validation.py
+++ b/tests/unit/auth/test_oauth_dcr_validation.py
@@ -130,6 +130,13 @@ def test_private_use_scheme_redirects_accepted_on_dcr_door(uri: str) -> None:
         "file:///etc/passwd",
         "cursor://anysphere.cursor-mcp/cb#fragment",
         "cursor://",
+        # review-1246 F1/F2/F3/F5 pins on the DCR door's taxonomy.
+        "intent://scan/",
+        "cursor://h/cb#",
+        "cursor://h/cb\n",
+        "cursor://h/cb\x00",
+        "http://evil.com@localhost/cb",
+        "http://evil.com\\@localhost/cb",
     ],
 )
 def test_dangerous_or_malformed_private_use_redirects_rejected(uri: str) -> None:

--- a/tests/unit/auth/test_oauth_dcr_validation.py
+++ b/tests/unit/auth/test_oauth_dcr_validation.py
@@ -106,6 +106,38 @@ def test_localhost_http_and_https_redirects_accepted(uri: str) -> None:
     _validate(redirect_uris=[uri])
 
 
+@pytest.mark.parametrize(
+    "uri",
+    [
+        # Cursor's real-world MCP OAuth callback (RFC 8252 §7.1).
+        "cursor://anysphere.cursor-mcp/oauth/callback",
+        # Reverse-DNS private-use scheme, both §7.1 shapes.
+        "com.example.app:/oauth/callback",
+        "com.example.app://callback",
+    ],
+)
+def test_private_use_scheme_redirects_accepted_on_dcr_door(uri: str) -> None:
+    """RFC 8252 §7.1: native apps (Cursor, Claude Code, …) register private-use
+    redirect schemes on this door; PKCE S256 is the compensating control."""
+    _validate(redirect_uris=[uri])
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "javascript:alert(1)",
+        "data:text/html,x",
+        "file:///etc/passwd",
+        "cursor://anysphere.cursor-mcp/cb#fragment",
+        "cursor://",
+    ],
+)
+def test_dangerous_or_malformed_private_use_redirects_rejected(uri: str) -> None:
+    """The §7.1 allowance keeps the denylist and well-formedness checks."""
+    with pytest.raises(InvalidClientMetadataError):
+        _validate(redirect_uris=[uri])
+
+
 # ---------- scope capping (§4.2: capped to the MCP tool-scope set) ----------
 
 

--- a/tests/unit/auth/web/test_consent_agent_picker.py
+++ b/tests/unit/auth/web/test_consent_agent_picker.py
@@ -15,6 +15,7 @@ import time
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -78,6 +79,7 @@ def _seed_consent_handle(
     *,
     scope: str = "openid apis:read apis:write",
     handle: str = _HANDLE,
+    redirect_uri: str = _REDIRECT_URI,
 ) -> None:
     payload = json.dumps(
         {
@@ -88,7 +90,7 @@ def _seed_consent_handle(
                 "first_name": "Agent",
                 "last_name": "Owner",
             },
-            "redirect_uri": _REDIRECT_URI,
+            "redirect_uri": redirect_uri,
             "original_state": "xyz",
             "client_id": _CLIENT_ID,
             "code_challenge": "challenge",
@@ -161,6 +163,45 @@ def test_agent_model_page_renders_picker_with_own_active_agents(
     svc.list_consentable_agents.assert_awaited_once_with("usr_owner")
     # Rendering must not provision: only the read-only resolver ran.
     svc.provision_from_claims.assert_not_awaited()
+
+
+@patch("jentic_one.auth.web.routers.authorize.AuthorizeService")
+@patch("jentic_one.auth.web.routers.authorize.OAuthClientService")
+def test_agent_model_page_renders_private_use_scheme_origin(
+    mock_client_svc_cls: MagicMock,
+    mock_authorize_cls: MagicMock,
+) -> None:
+    """RFC 8252 §7.1 DCR clients: the consent page renders the private-use
+    redirect target (``scheme://authority``) just as prominently as an https
+    origin — it stays the one client-controlled string the user can verify."""
+    client, backend = _make_app()
+    _seed_consent_handle(backend, redirect_uri="cursor://anysphere.cursor-mcp/oauth/callback")
+    mock_client_svc_cls.return_value.get_by_client_id = AsyncMock(
+        return_value=_client_view(allowed_scopes=["apis:read"])
+    )
+    svc = _mock_authorize_svc(agents=[_agent_option()])
+    mock_authorize_cls.return_value = svc
+
+    resp = client.get("/oauth/consent", params={"ch": _HANDLE})
+
+    assert resp.status_code == 200
+    assert "cursor://anysphere.cursor-mcp" in resp.text
+
+
+@pytest.mark.parametrize(
+    ("redirect_uri", "expected"),
+    [
+        ("https://mcpapp.example.com/callback", "https://mcpapp.example.com"),
+        ("cursor://anysphere.cursor-mcp/oauth/callback", "cursor://anysphere.cursor-mcp"),
+        # No authority component — fall back to the full (short) URI rather
+        # than rendering a bare scheme the user can't compare to anything.
+        ("com.example.app:/oauth/callback", "com.example.app:/oauth/callback"),
+    ],
+)
+def test_redirect_origin_renders_sensibly_for_all_accepted_shapes(
+    redirect_uri: str, expected: str
+) -> None:
+    assert authorize._redirect_origin(redirect_uri) == expected
 
 
 @patch("jentic_one.auth.web.routers.authorize.AuthorizeService")

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -5467,6 +5467,7 @@
             "title": "Grant Types"
           },
           "redirect_uris": {
+            "description": "1-20 redirect URIs. `https` always; `http` for loopback hosts only; RFC 8252 §7.1 private-use (custom) schemes are accepted for native apps (browser-executable and other dangerous schemes are rejected).",
             "items": {
               "type": "string"
             },

--- a/ui/src/shared/api/generated/models/OAuthClientRegistrationRequest.ts
+++ b/ui/src/shared/api/generated/models/OAuthClientRegistrationRequest.ts
@@ -15,6 +15,9 @@ export type OAuthClientRegistrationRequest = {
      * Subset of ['authorization_code', 'refresh_token'].
      */
     grant_types?: (Array<string> | null);
+    /**
+     * 1-20 redirect URIs. `https` always; `http` for loopback hosts only; RFC 8252 §7.1 private-use (custom) schemes are accepted for native apps (browser-executable and other dangerous schemes are rejected).
+     */
     redirect_uris: Array<string>;
     /**
      * Only ['code'] is supported.


### PR DESCRIPTION
## Summary

Cursor's MCP OAuth integration cannot connect: it registers via anonymous DCR with `redirect_uris: ["cursor://anysphere.cursor-mcp/oauth/callback"]` and the https-only redirect validator rejects it (`redirect_uri must use https or http: cursor://…`). Native MCP clients are RFC 8252 apps, and [§7.1](https://www.rfc-editor.org/rfc/rfc8252#section-7.1) legitimizes private-use URI schemes for public clients — PKCE S256, already mandatory on our public-client flow, is the compensating control. This accepts private-use schemes **on the anonymous DCR door only**; admin/platform-created clients keep the strict https-only rule. Found in v0.38.0 E2E real-client testing (T7).

A follow-up security review of this PR produced a hardening wave (second commit), folded in before merge — see Changes.

## Changes

- `admin/services/oauth_client_service.py`: `_validate_redirect_uris` gains an explicit `allow_private_use_schemes: bool = False` parameter. All existing checks stay for all doors (≥1 URI, max count/length, no fragment, scheme present, https needs an authority, http loopback-only). The new arm (flag on) additionally requires: RFC 3986 scheme grammar, scheme not in a case-insensitive denylist, and a non-empty opaque part (`cursor://host/path` and `com.example.app:/callback` shapes both parse).
- `auth/services/oauth_dcr_service.py`: the anonymous DCR door is the **only** caller passing `allow_private_use_schemes=True`.
- `auth/web/schemas/oauth_client_registration.py`: `redirect_uris` field description documents the accepted schemes (feeds the OpenAPI spec).
- Codegen: regenerated `openapi/control/control.openapi.yaml`, `ui/openapi.json`, and the UI client model (doc-comment-only diff). `docs/reference/endpoints.*` unchanged.
- **Review hardening wave** (all doors unless noted):
  - Denylist extended with schemes carrying built-in UA/OS dispatch behavior (`intent`, `android-app`, `ms-msdt`, `search-ms`, `ms-officecmd`, `ms-appx`/`ms-appx-web`, `chrome-extension`/`moz-extension`/`safari-extension` plus any `*-extension` as a class, `view-source`, `filesystem`, `resource`, `res`, `jar`, `mailto`, `tel`, `sms`, `callto`, `ssh`, `vnc`, `smb`).
  - RFC 3986 charset enforced against the **raw** string before parsing: whitespace and control bytes (NUL/CR/LF/TAB) survive `urlparse`'s pre-parse stripping and were previously stored raw (NUL also diverges SQLite-vs-Postgres). Scheme grammar + denylist now run on the raw scheme prefix.
  - Fragment ban checks raw `#` presence (a trailing bare `#` has a falsy `parsed.fragment`).
  - http(s) authorities reject userinfo (`@`); raw `\` is rejected by the charset gate (WHATWG/urlparse authority-parsing divergence).
  - `auth/services/authorize_service.py`: the code exchange re-validates the presented `redirect_uri` against the client's **live** redirect set (config for platform clients, row for registered clients), so an admin narrowing the set mid-flow invalidates in-flight codes.
- Out of scope: no change to the authorize-leg exact-string matching, the consent flow logic, or the DCR request schema shape.

## Risk & rollback

This deliberately loosens redirect-URI validation on an anonymous endpoint, so the security analysis in full:

- **Deployment posture with OSS defaults**: `auto_approve_clients` defaults to **true** in OSS, so the anonymous DCR door mints instantly active clients — no admin reviews the registered redirect scheme, and the control set is exactly **denylist + consent page + PKCE**. (The master `server.mcp.oauth.enabled = false` default keeps the whole door 404'd until deliberately enabled.) PR #1247 (in flight) flips the default to approval-first; once it lands, the admin approval queue applies by default and pending clients cannot enter any OAuth flow until approved.
- **Why PKCE compensates**: private-use schemes have no ownership registry, so a malicious app on the same device could claim `cursor://`. RFC 8252 §7.1's answer is PKCE — the interceptor of a redirect (code+state) cannot redeem the code without the in-memory `code_verifier`. Our server already enforces S256-only at `/authorize` (`code_challenge` is a required query param) and requires + verifies `code_verifier` at `/oauth/token`; DCR-minted rows are always `token_endpoint_auth_method='none'` public clients on that flow. Pinned by `test_pkce_stays_mandatory_for_private_use_redirect_clients`.
- **Denylist**: browser-executable (`javascript`, `data`, `vbscript`, `blob`, `about`), local-resource/browser-internal (`file`, `chrome`, extension schemes, `view-source`, `filesystem`, `resource`, `res`, `jar`), OS-dispatch (`intent`, `android-app`, `ms-msdt`, `search-ms`, `ms-officecmd`, `ms-appx[-web]`), compose/dialer (`mailto`, `tel`, `sms`, `callto`), and registered transport/remote-session (`ws`, `wss`, `ftp`, `ssh`, `vnc`, `smb`) schemes are rejected case-insensitively against the raw scheme, on top of the RFC 3986 scheme-grammar and raw-charset checks. A denylist cannot cover attacker-installed local handlers — that residual is inherent to RFC 8252 §7.1 and is the PKCE/consent-compensated case above.
- **Doors unchanged**: admin/platform client creation (`OAuthClientService.create`/`update`) still calls the validator with the strict default — pinned by `test_private_use_scheme_rejected_on_strict_door`, the direct PATCH-door pin `test_update_rejects_private_use_scheme_redirects`, and `test_admin_client_creation_door_still_rejects_private_use_schemes`. `http` stays loopback-only and `https` still requires an authority on both arms. The charset/fragment/userinfo hardening applies to the strict door too (a no-op for RFC 3986-valid URIs).
- **No normalization loopholes**: authorize-time matching stays exact-string (`redirect_uri in client.redirect_uris`), the token exchange re-checks `auth_code.redirect_uri != redirect_uri` **and** re-validates against the client's live redirect set. The integration tests assert trailing-slash, added-query, case-variant, and suffix-host variants of the registered `cursor://` URI are all bounced, and that a mid-flow narrowing of the redirect set 400s an in-flight code.
- Rollback: revert the squash commit — no migrations, no config, no API-shape change.

## Test plan

- Unit matrix in `tests/unit/admin/services/test_oauth_client_service.py`: cursor:// + reverse-DNS shapes accepted on the DCR arm and rejected on the strict door; dangerous-scheme denylist incl. the extended dispatch-scheme set and `*-extension` class; control-char/whitespace, empty-fragment, userinfo, and backslash-authority rejections on **both** doors (review payloads verbatim); PATCH-door strict pin; http-loopback and https-authority rules unchanged on the DCR arm.
- `tests/unit/auth/test_oauth_dcr_validation.py`: DCR-door metadata validation accepts cursor:// and both §7.1 reverse-DNS shapes; rejects `javascript:`/`data:`/`file:`/fragment/`cursor://` plus `intent://`, bare-`#`, control-char, and userinfo/backslash payloads.
- `tests/unit/auth/web/test_consent_agent_picker.py`: consent page renders `cursor://anysphere.cursor-mcp` as the redirect target; `_redirect_origin` pinned for all accepted URI shapes.
- `tests/integration/auth/test_oauth_dcr_native_redirect_flow.py`: full DCR → approve → `/authorize` (IdP hop) → consent → `/oauth/token` flow against the real routers + DB with a `cursor://` redirect; PKCE and admin-door pins; HTTP-door 400s (no row written) for `intent://` and control-char registrations; mid-flow redirect-set narrowing invalidates an in-flight code at the token leg.
- Gates re-run on the final state: `ruff check` + `ruff format --check` (clean), `mypy` src (1221 files) + tests (578 files) (clean), unit 3241 passed (coverage 79.3%), arch 297 passed, SQLite integration 731 passed, `make openapi` drift-free (the hardening wave is codegen-silent). UI and Go CLI untouched by the fix wave.

## Review guide

- Start with `_validate_redirect_uris` in `src/jentic_one/admin/services/oauth_client_service.py` — the whole behavior change is the branch structure there; scrutinize the strict-door arm for byte-compatibility.
- Then the one-flag caller in `oauth_dcr_service.py` and the live-set re-validation in `auth/services/authorize_service.py` (`exchange_code`); everything else is tests and codegen output.

Closes #1245

Made with [Cursor](https://cursor.com)