### PR TITLE
fix(auth): omit unset optional metadata from the anonymous DCR response

### DIFF
--- a/src/jentic_one/auth/web/routers/oauth_client_registration.py
+++ b/src/jentic_one/auth/web/routers/oauth_client_registration.py
@@ -174,6 +174,10 @@ async def _check_registration_rate_limit(request: Request, ctx: Context = Depend
     status_code=201,
     summary="Register OAuth client (anonymous DCR)",
     response_model=OAuthClientRegistrationResponse,
+    # RFC 7591 §3.2.1: unset optional metadata (software_id, software_version,
+    # application_type) is omitted from the response, never emitted as JSON
+    # null — strict clients (Cursor's MCP SDK zod schema) reject nulls.
+    response_model_exclude_none=True,
     dependencies=[Depends(_check_registration_rate_limit)],
     responses={
         400: {

--- a/tests/unit/auth/web/test_oauth_client_registration_router.py
+++ b/tests/unit/auth/web/test_oauth_client_registration_router.py
@@ -22,14 +22,14 @@ _BODY = {
 }
 
 
-def _result(*, created: bool) -> DcrRegisterResult:
+def _result(*, created: bool, software_id: str | None = "com.cursor.ide") -> DcrRegisterResult:
     return DcrRegisterResult(
         client_id="oc_abc123",
         client_name="Cursor",
         redirect_uris=["http://localhost:33418/callback"],
         grant_types=["authorization_code", "refresh_token"],
         scope="apis:read capabilities:execute",
-        software_id="com.cursor.ide",
+        software_id=software_id,
         software_version=None,
         application_type=None,
         client_id_issued_at=1_700_000_000,
@@ -79,9 +79,44 @@ def test_register_returns_201_with_rfc7591_shape(mock_svc_cls: MagicMock) -> Non
     assert data["token_endpoint_auth_method"] == "none"
     assert data["grant_types"] == ["authorization_code", "refresh_token"]
     assert data["response_types"] == ["code"]
+    # Registered optional metadata is echoed back (exclude_none must not
+    # drop members that ARE set).
+    assert data["software_id"] == "com.cursor.ide"
     # No secret and no RFC 7592 management surface (D12).
     assert "client_secret" not in data
     assert "registration_access_token" not in data
+
+
+@patch("jentic_one.auth.web.routers.oauth_client_registration.OAuthDcrService")
+@pytest.mark.parametrize(("created", "expected_status"), [(True, 201), (False, 200)])
+def test_unset_optional_metadata_is_omitted_not_null(
+    mock_svc_cls: MagicMock, created: bool, expected_status: int
+) -> None:
+    """RFC 7591 §3.2.1: optional metadata the client did not register is
+    OMITTED from the response body — never serialized as JSON ``null``.
+    Strict clients (Cursor's MCP SDK zod schema: software_id /
+    software_version must be string-or-absent) reject a null, drop their
+    stored client info, and loop re-registering. Pinned on the raw JSON
+    body for both the 201-create and 200 D8-dedupe arms."""
+    mock_svc_cls.return_value.register = AsyncMock(
+        return_value=_result(created=created, software_id=None)
+    )
+    client = _make_client()
+
+    body = {
+        "client_name": "Cursor",
+        "redirect_uris": ["http://localhost:33418/callback"],
+        "token_endpoint_auth_method": "none",
+    }
+    resp = client.post("/oauth-clients", json=body)
+
+    assert resp.status_code == expected_status
+    data = resp.json()
+    assert "software_id" not in data
+    assert "software_version" not in data
+    assert "application_type" not in data
+    # Belt-and-braces: the raw body carries no null members at all.
+    assert b"null" not in resp.content
 
 
 @patch("jentic_one.auth.web.routers.oauth_client_registration.OAuthDcrService")


### PR DESCRIPTION
## Summary

The anonymous DCR door `POST /oauth-clients` returns unset optional RFC 7591 metadata as JSON `null` (`"software_id": null, "software_version": null, "application_type": null`). RFC 7591 §3.2.1 semantics are that the server returns the *registered* metadata — unset optional members are **omitted**, never emitted as `null`. Strict clients break on the nulls: Cursor's MCP SDK validates the stored client information with a zod schema requiring `software_id`/`software_version` to be string-or-absent, so it rejects the registration response on every connect, clears its OAuth credentials, and re-registers in a loop. Observed live with Cursor as the MCP client:

```
Client error: invalid_type … expected string, received null   (software_id, software_version)
```

Root cause: `OAuthClientRegistrationResponse` declares the three metadata echoes as `str | None = None`, and the route serialized the model with default settings, so `None` became `null` on the wire.

## Changes

- `auth/web/routers/oauth_client_registration.py`: add `response_model_exclude_none=True` to the `POST /oauth-clients` route, with a comment citing RFC 7591 §3.2.1 and strict clients (Cursor). Safe here — the only `Optional` members of the response model are the three optional metadata echoes; everything else is required or defaulted non-None. This exact patch was live-verified against a running stack with Cursor: the connect loop stops and the client info persists.
- `tests/unit/auth/web/test_oauth_client_registration_router.py`: pin the contract on the **raw JSON body** — a registration without `software_id`/`software_version`/`application_type` yields a response containing none of those keys (and no `null` members at all), parametrized over both the 201-create arm and the 200 D8-dedupe arm. The existing 201-shape test now also asserts a *set* `software_id` still round-trips (exclude-none must not drop populated members).

### Audit of sibling surfaces (deliberately out of scope)

- **`POST /register` (agent DCR door) — unchanged.** It emits `claim_token: null` on the OSS default (no claim-token minter). Its docstrings across the codebase pin it as "stays byte-identical" — a phase-3a acceptance constraint on the agent door (the root RFC 8414 discovery document advertising it is pinned by a golden equality test). Its consumers are the Go CLI's hand-rolled `RegistrationResult` (`ClaimToken string`, null-tolerant) and the generated client (`*string` + `omitempty`); no strict zod client consumes it. No defect to fix, and changing its bytes would violate the stated contract for zero consumer benefit.
- **`GET /register/{agent_id}` (RFC 7592 poll) — no nullable response members**, nothing to do.
- **`POST /oauth/token` — unchanged.** It can emit `refresh_token`/`id_token` as `null` in some arms, but it is an RFC 6749 surface (whose §5.1 omission guidance is a separate question), the pre-G11 byte-identical pin belongs to `/oauth/revoke` (not this endpoint — corrected per review), and live verification showed Cursor completes the full connect flow with only the DCR-response fix — the token response nulls are not rejected by the MCP SDK.
- **`/admin/oauth-clients` — unchanged.** Admin-plane UI contract, not an RFC 7591 surface.

## Risk & rollback

- Low risk: one route's serialization narrows from `key: null` to key-absent for the three optional metadata members only; RFC 7591 clients must treat absent as unset. No auth/permission/credential behaviour changes; no migration; no config.
- `make openapi` produced **zero drift** — `response_model_exclude_none` does not change the generated schema (the members stay `string | null`-typed and optional), so no generated artifacts (spec/UI/Go client) changed.
- Rollback: revert the squash commit.

## Test plan

- `make lint` — ruff check clean, 1296 files format-clean, mypy clean (1221 source files).
- `make test-unit` — 3243 passed (coverage 79.32%); the touched router file alone: 14 passed (12 existing + 2 new parametrized arms).
- `make test-arch` — 152 passed.
- `make test-integration-sqlite` — 731 passed, 13 skipped (Postgres-only).
- `make openapi` — regenerated, no diff (no drift).
- Manual/live: the identical patch was applied to a running stack and verified with Cursor as a real MCP client — registration response carries no null members, Cursor's credential-clearing reconnect loop stops.

Made with [Cursor](https://cursor.com)


## Review

Adversarial review verdict: MERGE-READY (report: /tmp/mcp-reviews/review-1250.md). Non-blocking follow-up N1: `/oauth/token` emits `id_token: null` on the D11 MCP arm, which the current MCP SDK `OAuthTokensSchema` would reject once clients ship an SDK with the `id_token` member (upstream leniency fix typescript-sdk#2462 still open) — tracked as a separate issue.
