### PR TITLE
fix(mcp): answer 405, not the 401 challenge, to credential-less GET /mcp

### DIFF
--- a/docs/mcp-http-endpoint.md
+++ b/docs/mcp-http-endpoint.md
@@ -38,7 +38,15 @@ Flipping the flag needs no rebuild; the gate is evaluated per request. The
 endpoint accepts only `POST` (stateless — no SSE stream, no `Mcp-Session-Id`),
 validates the `Origin` header strictly (403 on mismatch), and requires a
 credential for everything except surface discovery (`tools/list`, `ping`,
-the resource listings).
+the resource listings). A `GET`/`HEAD` that offers **no** credential answers
+`405 Method Not Allowed` (`Allow: POST`) rather than an auth challenge: no
+caller ever gets a stream here, and the MCP SDK reads the 405 as "no stream
+offered" without starting an OAuth flow — challenging that probe made
+OAuth-capable bridges (`mcp-remote` ≤ 0.8.3) launch concurrent flows that
+clobbered each other's PKCE verifier
+([#1256](https://github.com/jentic/jentic-one/issues/1256)). A request that
+presents a credential — valid, expired, or garbage — keeps the standard
+401-challenge contract on every method.
 
 ## Connecting an HTTP-capable MCP client
 

--- a/src/jentic_one/mcp/app.py
+++ b/src/jentic_one/mcp/app.py
@@ -32,7 +32,16 @@ that owns everything the platform — not the SDK — must decide:
   FastAPI dependency: a Starlette mount is a separate ASGI app, so parent
   route dependencies never run here. A missing/invalid credential answers the
   same 401 challenge contract as the placeholder (the ``resource_metadata`` pointer riding
-  only when the OAuth discovery surface is on to serve it).
+  only when the OAuth discovery surface is on to serve it) — EXCEPT a
+  credential-less GET/HEAD, which answers the stream refusal (405) instead:
+  this endpoint never offers a GET stream (stateless), so an unauthenticated
+  GET could never receive one even after authenticating, and challenging it
+  makes SDK-based proxy clients (``mcp-remote`` ≤ 0.8.3) launch concurrent
+  OAuth flows off their fallback-test/main GET-stream arms that clobber each
+  other's PKCE verifier — guaranteed ``invalid_grant``
+  (https://github.com/jentic/jentic-one/issues/1256). A request that DOES
+  present a credential (any ``Authorization`` header or API-key header, even
+  a garbage one) keeps the challenge contract on every method.
 - **The pre-auth whitelist**: ``tools/list``, the SDK's legacy ``initialize``
   fallback (+ ``notifications/initialized``), ``ping``, and the public
   resource listings are served without a credential — a client can always
@@ -136,6 +145,24 @@ def _unauthorized(ctx: Context, request: Request, method: str) -> Response:
     if method == "HEAD":
         return Response(status_code=401, headers=headers)
     return JSONResponse(status_code=401, content={"detail": "Unauthorized"}, headers=headers)
+
+
+def _stream_refusal(method: str) -> Response:
+    """The GET-stream refusal: 405 + ``Allow: POST`` (HEAD: headers, no body).
+
+    ``Allow`` advertises what the mount actually serves — POST only. The gate
+    itself refuses GET (stateless: no server-initiated stream to offer), and
+    the SDK transport refuses DELETE in stateless mode (no session to
+    terminate), so neither belongs in the list. HEAD mirrors GET's status and
+    headers without a body (RFC 9110 §9.3.2).
+    """
+    if method == "HEAD":
+        return Response(status_code=405, headers={"Allow": "POST"})
+    return JSONResponse(
+        status_code=405,
+        content={"detail": "Method Not Allowed"},
+        headers={"Allow": "POST"},
+    )
 
 
 def _is_loopback_origin_host(hostname: str) -> bool:
@@ -424,6 +451,27 @@ class McpMount:
                 return JSONResponse(status_code=413, content={"detail": "Request body too large"})
 
         if credential is None:
+            if method in ("GET", "HEAD") and not self._credential_offered(request):
+                # A request that offers NO credential at all (no Authorization
+                # header, no API-key header) gets the stream refusal, not the
+                # challenge: this stateless endpoint never serves a GET stream
+                # (the post-auth arm below answers the same 405), so there is
+                # nothing a token would unlock and no reason to invite one.
+                # Challenging here is what made SDK-based proxy clients
+                # (mcp-remote ≤ 0.8.3) launch OAuth flows off their
+                # fallback-test and main GET-stream arms concurrently with the
+                # tools/call arm — one per-process `state`, a verifier file
+                # keyed by state → flows clobber each other's PKCE verifier →
+                # guaranteed invalid_grant. The 405 is the MCP Streamable HTTP
+                # spec's own "server does not offer an SSE stream at this
+                # endpoint" answer, which the SDK handles WITHOUT entering its
+                # auth path — leaving only the POST-armed flow, the one that
+                # actually awaits and consumes the auth code.
+                # https://github.com/jentic/jentic-one/issues/1256
+                # A GET that DOES present a credential — valid, expired, or
+                # garbage — keeps today's contract exactly (challenge on
+                # failure, 405 after successful auth).
+                return _stream_refusal(method)
             methods = _body_methods(body) if body is not None else None
             pre_auth = (
                 method == "POST"
@@ -461,11 +509,7 @@ class McpMount:
             # ever ride and that never ends — each such request would pin a
             # connection + task for the life of the process. json_response
             # mode governs POST responses only, so the gate owns this refusal.
-            return JSONResponse(
-                status_code=405,
-                content={"detail": "Method Not Allowed"},
-                headers={"Allow": "POST"},
-            )
+            return _stream_refusal(method)
 
         if body is None:
             return receive
@@ -480,6 +524,17 @@ class McpMount:
         if authorization and authorization.startswith("Bearer "):
             return authorization.removeprefix("Bearer ")
         return None
+
+    def _credential_offered(self, request: Request) -> bool:
+        """Whether the request presents ANY credential-bearing header.
+
+        Deliberately broader than :meth:`_extract_credential`: a non-Bearer
+        ``Authorization`` header (e.g. ``Basic``) yields no extractable
+        credential, but the caller still ATTEMPTED to authenticate — such a
+        request keeps the 401 challenge contract rather than the
+        credential-less GET/HEAD stream refusal.
+        """
+        return bool(request.headers.get("authorization") or request.headers.get("x-jentic-api-key"))
 
     async def _resolve_identity(self, credential: str, request: Request) -> Identity | None:
         """The REST resolvers' verification logic, mount-side.

--- a/tests/unit/mcp/test_mount_gate.py
+++ b/tests/unit/mcp/test_mount_gate.py
@@ -7,9 +7,14 @@ Pins the four ``server.mcp.enabled`` x ``server.mcp.oauth.enabled`` arms:
 ====================  =====================  =======================================
 off (default)         off (default)          the framework's plain 404 (as pre-placeholder)
 off                   on                     the placeholder's discovery challenge, verbatim
-on                    off                    401 bare ``Bearer`` without a credential
+on                    off                    401 bare ``Bearer`` on a rejected credential
 on                    on                     401 + ``resource_metadata`` pointer
 ====================  =====================  =======================================
+
+On the enabled arms a credential-LESS GET/HEAD is the exception to the
+challenge: it answers the 405 stream refusal (no stream is served to any
+caller, and the 401 triggered mcp-remote's concurrent-flow PKCE clobber —
+issue #1256).
 
 plus the mount-owned request checks on the enabled arms: strict ``Origin``
 validation (403 on spoof), the pre-auth whitelist (``tools/list`` without a
@@ -153,9 +158,14 @@ def test_oauth_only_arm_falls_back_to_request_host_when_canonical_empty() -> Non
 # --- arms 3+4: endpoint on — auth required, challenge shape per oauth arm ----
 
 
-@pytest.mark.parametrize("method", ("GET", "DELETE", "PUT", "PATCH", "HEAD", "OPTIONS"))
+@pytest.mark.parametrize("method", ("DELETE", "PUT", "PATCH", "OPTIONS"))
 def test_enabled_credential_less_non_post_is_challenged(method: str) -> None:
-    """Only POSTed pre-auth JSON-RPC methods pass without a credential."""
+    """Only POSTed pre-auth JSON-RPC methods pass without a credential.
+
+    GET/HEAD are deliberately absent: a credential-less GET/HEAD answers the
+    stream refusal (405) instead of the challenge — see
+    ``test_credential_less_get_is_405_stream_refusal`` and issue #1256.
+    """
     with make_client(oauth_enabled=True) as client:
         resp = client.request(method, "/mcp")
         assert resp.status_code == 401
@@ -165,9 +175,10 @@ def test_enabled_credential_less_non_post_is_challenged(method: str) -> None:
 def test_enabled_with_oauth_off_challenges_with_bare_bearer() -> None:
     """No discovery surface → nothing to point at: the challenge is scheme-only
     (the PRM path would 404, so advertising it would break spec-following
-    clients mid-chain)."""
+    clients mid-chain). A credential must be OFFERED to draw the challenge on
+    GET (credential-less GET is the 405 stream refusal — issue #1256)."""
     with make_client(oauth_enabled=False) as client:
-        resp = client.get("/mcp")
+        resp = client.get("/mcp", headers={"Authorization": "Bearer at_garbage"})
         assert resp.status_code == 401
         assert resp.headers["www-authenticate"] == "Bearer"
 
@@ -229,11 +240,61 @@ def test_authenticated_get_is_405_and_never_reaches_the_sse_arm() -> None:
         assert resp.json() == {"detail": "Method Not Allowed"}
 
 
-def test_credential_less_get_stays_401_not_405() -> None:
-    """Auth precedes method semantics: an unauthenticated GET keeps answering
-    the 401 challenge (the placeholder contract), never a method tell."""
-    with make_client(oauth_enabled=True) as client:
+@pytest.mark.parametrize("oauth_enabled", [True, False])
+def test_credential_less_get_is_405_stream_refusal(oauth_enabled: bool) -> None:
+    """Issue #1256: a GET offering NO credential answers the stream refusal
+    (405 + ``Allow: POST``), never the challenge.
+
+    This endpoint is stateless — it serves no GET stream to ANY caller (the
+    authenticated arm answers the same 405), so a challenge here invites a
+    token that unlocks nothing. Worse, it is the exact trigger for
+    mcp-remote's (≤ 0.8.3) concurrent-OAuth-flow PKCE clobber: the SDK's
+    fallback-test and main-transport GET-stream arms each launch a
+    fire-and-forget flow off this 401 while the tools/call arm launches the
+    one flow that actually consumes the code — one per-process ``state``, a
+    verifier file keyed by state, guaranteed ``invalid_grant``. The MCP
+    Streamable HTTP spec's own answer for "server does not offer an SSE
+    stream at this endpoint" is 405, which the SDK handles without entering
+    its auth path. (This flips the pre-#1256 pin that auth preceded method
+    semantics on GET — deliberately.)
+    """
+    with make_client(oauth_enabled=oauth_enabled) as client:
         resp = client.get("/mcp", headers={"Accept": "text/event-stream"})
+        assert resp.status_code == 405
+        assert resp.headers["allow"] == "POST"
+        assert "www-authenticate" not in resp.headers
+        assert resp.json() == {"detail": "Method Not Allowed"}
+
+
+def test_credential_less_head_mirrors_the_get_stream_refusal() -> None:
+    """HEAD answers GET's status and headers without a body (RFC 9110
+    §9.3.2) — a credential-less HEAD gets the same 405 refusal, not the
+    challenge, so the two probes never disagree about the resource."""
+    with make_client(oauth_enabled=True) as client:
+        resp = client.head("/mcp")
+        assert resp.status_code == 405
+        assert resp.headers["allow"] == "POST"
+        assert "www-authenticate" not in resp.headers
+        assert resp.content == b""
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"Authorization": "Bearer at_garbage"},  # garbage bearer
+        {"Authorization": "Basic dXNlcjpwYXNz"},  # non-Bearer scheme
+        {"X-Jentic-Api-Key": "jak_garbage"},  # garbage API key
+    ],
+)
+def test_get_offering_a_bad_credential_keeps_the_401_challenge(
+    headers: dict[str, str],
+) -> None:
+    """Issue #1256 keeps the challenge contract for every request that
+    ATTEMPTS to authenticate: a presented-but-rejected credential (any
+    ``Authorization`` scheme, or the API-key header) still draws the 401 +
+    ``WWW-Authenticate`` — only the credential-LESS GET/HEAD moved to 405."""
+    with make_client(oauth_enabled=True) as client:
+        resp = client.get("/mcp", headers=headers)
         assert resp.status_code == 401
         assert resp.headers["www-authenticate"] == _CHALLENGE
         assert "allow" not in resp.headers


### PR DESCRIPTION
## Summary

`mcp-remote` (≤ 0.8.3, and potentially other MCP-TS-SDK-based bridges) deterministically fails OAuth against our `/mcp` mount: because the §3.3 pre-auth whitelist serves `initialize`/`tools/list` without a credential, the proxy goes live unauthenticated and its *only* 401s arrive mid-session and **concurrently** — the SDK fallback-test GET stream, the main GET stream, and the first `tools/call` POST. Each 401 launches an OAuth flow on the same provider, which holds one per-process `state` and a PKCE-verifier file keyed only by state → the flows clobber each other's verifier → guaranteed `invalid_grant` and orphaned auth codes. This PR answers **405 Method Not Allowed** (instead of the 401 challenge) to a `GET`/`HEAD` on `/mcp` that offers **no credential at all**, which removes both GET-armed flows without touching any authenticated behavior or the pre-auth whitelist itself.

## Mechanism (experiment-proven, 100% deterministic)

Lab: a mock server implementing OAuth discovery + a strictly-validating token endpoint + an `/mcp` with a `whitelist|strict` posture switch, driven by real `npx mcp-remote@0.8.3` fed a Claude-like stdio session:

| Run | Posture | Transport | authorize hits | states | PKCE challenges per state | token POSTs | PKCE match | `tools/call` |
|---|---|---|---|---|---|---|---|---|
| 1 | whitelist (ours) | http-only | **4** | 1 | **4** | 2 | ✗ ✗ (`invalid_grant`) | **error** |
| 2 | strict (all-401) | http-only | 1 | 1 | 1 | 1 | ✓ | ok |
| 3 | whitelist (ours) | default | **4** | 1 | **4** | 2 | ✗ ✗ | **error** |
| 4 | strict (all-401) | default | 1 | 1 | 1 | 1 | ✓ | ok |

Root cause is upstream (`NodeOAuthClientProvider._state` fixed per process; verifier file keyed by state only; the `_startOrAuthSse` arm fires `auth()` with no code consumer — a dead promise), but our whitelist posture is the trigger: against a strict server the very first `initialize` 401s **serially**, before any concurrency exists, and everything works.

## Why 405 (fix rationale + spec angle)

- This endpoint is **stateless** (`StreamableHTTPSessionManager(stateless=True)`, JSON responses): it never serves a GET stream to *any* caller — an authenticated GET already answers 405 + `Allow: POST` (pinned pre-existing behavior). So a 401 on an unauthenticated GET invited a token that unlocks nothing.
- The MCP Streamable HTTP transport spec ("Listening for Messages from the Server") is explicit: on a client `GET`, *"the server MUST either return `Content-Type: text/event-stream` … **or else return HTTP 405 Method Not Allowed**, indicating that the server does not offer an SSE stream at this endpoint."* Our conditional 405 is spec-compatible — an unauthenticated GET can never receive a stream, so 405 is a truthful "no stream offered here". The SDK treats it exactly that way, **without entering its auth path** — removing two of the three racing arms and leaving only the POST-armed flow, the one that actually awaits and consumes the auth code (the strict runs show the single-flow path succeeds).
- `Allow: POST` advertises what the mount actually serves: the gate refuses GET, and the SDK transport refuses DELETE in stateless mode (no session to terminate).

## Changes

- `src/jentic_one/mcp/app.py` (control-plane `/mcp` mount): in the credential-less gate arm, `GET`/`HEAD` with **no** `Authorization` and no `X-Jentic-Api-Key` header now answer the same `_stream_refusal` (405 + `Allow: POST`; HEAD mirrors GET's status/headers with no body per RFC 9110 §9.3.2) that the authenticated GET arm already answered. Presence of *any* credential-bearing header — valid, expired, garbage, or a non-Bearer scheme like `Basic` — keeps today's contract exactly (401 challenge with `WWW-Authenticate` on failure).
- `tests/unit/mcp/test_mount_gate.py`: flipped the pre-#1256 pin `test_credential_less_get_stays_401_not_405` ("auth precedes method semantics") into `test_credential_less_get_is_405_stream_refusal` with the rationale and issue link inline; added HEAD-mirrors-GET and presented-bad-credential (garbage bearer / `Basic` / garbage API key → 401 challenge, unchanged) pins; `GET`/`HEAD` removed from the generic credential-less-non-POST challenge parametrize (DELETE/PUT/PATCH/OPTIONS unchanged).
- `docs/mcp-http-endpoint.md`: documented the credential-less GET/HEAD → 405 posture.
- **Deliberately out of scope:** the §3.3 pre-auth whitelist stays; POST/DELETE gate arms unchanged; the disabled-door 404 arm and the oauth-only discovery-challenge placeholder arm (both strict/serial — they don't race) unchanged; the Go CLI's `mcp-daemon` is unaffected: token-less mode already 405s GET, and the token-gated mode answers credential-less GET with a serial 401 before any transport concurrency exists — no race to fix there.

## What stays pinned (unchanged contracts, re-verified by existing tests)

- `mcp.enabled=off, oauth=off` → plain 404 on every method, no `Allow`/`WWW-Authenticate` tell.
- `mcp.enabled=off, oauth=on` → the placeholder's discovery challenge (401 + `resource_metadata`) on every method — including GET (strict posture; no transport exists there, and all-401 does not race).
- Unauth `POST initialize`/`tools/list` → whitelisted 200; unauth `tools/call` POST → 401 challenge; mixed batches → 401.
- Authenticated GET → 405 + `Allow: POST` (pre-existing MINOR-3 pin, now shared with the new arm).
- Presented-but-rejected credential → 401 + challenge on every method.

## Risk & rollback

- Touches the auth gate of the `/mcp` mount, but only the **credential-less GET/HEAD** path: no route, scope, credential-resolution, or whitelist change. A spec-following client that wanted the challenge from GET still gets it from any non-whitelisted POST (and the discovery documents are independently served).
- Deliberate contract flip: the "auth precedes method semantics on GET" pin is replaced (test updated with rationale, not deleted).
- Residual (documented in the experiment report): two *concurrent* unauthorized `tools/call`s could still race the POST arm upstream — but clients serialize calls in practice, and only upstream can fix its missing single-flight guard.
- Rollback: revert the squash commit.

## Test plan

- `make check` equivalent, all green: `ruff check` + `ruff format --check` clean, `mypy` clean (1221 files), `detect-secrets` clean, `make test-arch` **152 passed**.
- `make test-unit` → **3246 passed** (includes the 5 new/updated gate pins in `tests/unit/mcp/test_mount_gate.py`).
- `make test-integration-sqlite` → **731 passed, 13 skipped** (Postgres-only skips). Postgres integration lane left to CI (the local shared fixture DB serves live services and was off-limits).
- `make score` not run locally (requires `JENTIC_API_KEY`; the step is also disabled in CI) — no OpenAPI surface is touched.
- Root-cause evidence: 4 deterministic lab runs of real `mcp-remote@0.8.3` against a posture-switchable mock (whitelist → 4 same-state flows, PKCE mismatch, `invalid_grant`; strict → 1 flow, success), logs and machine-readable summaries retained.

Closes #1256

Made with [Cursor](https://cursor.com)
