### PR TITLE
fix(deploy): mount app-secrets on admin/registry and share the parts-mode jwt_secret

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -444,7 +444,7 @@
         "filename": "deploy/helm/values/local-parts.yaml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 92
+        "line_number": 105
       }
     ],
     "docker/local-setup/docker-compose.yaml": [
@@ -2171,5 +2171,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-04T12:50:33Z"
+  "generated_at": "2026-09-04T13:21:33Z"
 }

--- a/deploy/helm/jentic-one/charts/admin/templates/config-configmap.yaml
+++ b/deploy/helm/jentic-one/charts/admin/templates/config-configmap.yaml
@@ -1,0 +1,1 @@
+{{ include "common.config-file.configmap" . }}

--- a/deploy/helm/jentic-one/charts/admin/templates/deployment.yaml
+++ b/deploy/helm/jentic-one/charts/admin/templates/deployment.yaml
@@ -28,9 +28,22 @@ spec:
             - name: {{ $k }}
               value: {{ $v | quote }}
 {{- end }}
+{{ include "common.config-file.env" . | indent 12 }}
+{{ include "common.app-secrets.env" . | indent 12 }}
 {{ include "common.logging-env" . | indent 12 }}
 {{ include "common.metrics-env" . | indent 12 }}
 {{ include "common.db-env" . | indent 12 }}
+{{- $cfgMount := (include "common.config-file.mount" . | trim) }}
+{{- $encMount := (include "common.app-secrets.mount" . | trim) }}
+{{- if or $cfgMount $encMount }}
+          volumeMounts:
+{{- with $cfgMount }}
+{{ . | indent 12 }}
+{{- end }}
+{{- with $encMount }}
+{{ . | indent 12 }}
+{{- end }}
+{{- end }}
           readinessProbe:
             httpGet:
               path: {{ .Values.healthCheck.path | default "/health" }}
@@ -48,7 +61,18 @@ spec:
         {{- if .Values.global.observability.otel.enabled }}
 {{ include "common.otel-sidecar" . | indent 8 }}
         {{- end }}
-      {{- if .Values.global.observability.otel.enabled }}
+      {{- $otel := .Values.global.observability.otel.enabled }}
+      {{- $cfg := (include "common.config-file.volume" . | trim) }}
+      {{- $enc := (include "common.app-secrets.volume" . | trim) }}
+      {{- if or $otel $cfg $enc }}
       volumes:
+      {{- if $otel }}
 {{ include "common.otel-config-volume" . | indent 8 }}
+      {{- end }}
+      {{- with $cfg }}
+{{ . | indent 8 }}
+      {{- end }}
+      {{- with $enc }}
+{{ . | indent 8 }}
+      {{- end }}
       {{- end }}

--- a/deploy/helm/jentic-one/charts/registry/templates/config-configmap.yaml
+++ b/deploy/helm/jentic-one/charts/registry/templates/config-configmap.yaml
@@ -1,0 +1,1 @@
+{{ include "common.config-file.configmap" . }}

--- a/deploy/helm/jentic-one/charts/registry/templates/deployment.yaml
+++ b/deploy/helm/jentic-one/charts/registry/templates/deployment.yaml
@@ -28,9 +28,22 @@ spec:
             - name: {{ $k }}
               value: {{ $v | quote }}
 {{- end }}
+{{ include "common.config-file.env" . | indent 12 }}
+{{ include "common.app-secrets.env" . | indent 12 }}
 {{ include "common.logging-env" . | indent 12 }}
 {{ include "common.metrics-env" . | indent 12 }}
 {{ include "common.db-env" . | indent 12 }}
+{{- $cfgMount := (include "common.config-file.mount" . | trim) }}
+{{- $encMount := (include "common.app-secrets.mount" . | trim) }}
+{{- if or $cfgMount $encMount }}
+          volumeMounts:
+{{- with $cfgMount }}
+{{ . | indent 12 }}
+{{- end }}
+{{- with $encMount }}
+{{ . | indent 12 }}
+{{- end }}
+{{- end }}
           readinessProbe:
             httpGet:
               path: {{ .Values.healthCheck.path | default "/health" }}
@@ -48,7 +61,18 @@ spec:
         {{- if .Values.global.observability.otel.enabled }}
 {{ include "common.otel-sidecar" . | indent 8 }}
         {{- end }}
-      {{- if .Values.global.observability.otel.enabled }}
+      {{- $otel := .Values.global.observability.otel.enabled }}
+      {{- $cfg := (include "common.config-file.volume" . | trim) }}
+      {{- $enc := (include "common.app-secrets.volume" . | trim) }}
+      {{- if or $otel $cfg $enc }}
       volumes:
+      {{- if $otel }}
 {{ include "common.otel-config-volume" . | indent 8 }}
+      {{- end }}
+      {{- with $cfg }}
+{{ . | indent 8 }}
+      {{- end }}
+      {{- with $enc }}
+{{ . | indent 8 }}
+      {{- end }}
       {{- end }}

--- a/deploy/helm/values/local-parts.yaml
+++ b/deploy/helm/values/local-parts.yaml
@@ -32,6 +32,14 @@ registry:
     # specs from in-cluster ClusterIPs (kind service CIDR is in 10/8).
     JENTIC__INGEST__EGRESS__ALLOWED_INTERNAL_DOMAINS: .svc.cluster.local
     JENTIC__INGEST__EGRESS__ALLOWED_PRIVATE_SUBNETS: 10.0.0.0/8
+    # Shared with admin/control below: parts mode splits the issuer and the
+    # verifiers across pods, and the app no longer ships a jwt_secret default
+    # (a per-process random is generated instead — see
+    # config._require_or_generate_secret), so cross-pod verification needs an
+    # explicit shared value. LOCAL/SMOKE-ONLY throwaway, like the passwords
+    # under global.databases. Production parts installs use
+    # global.appSecrets (one generated Secret mounted on every surface).
+    JENTIC__ADMIN__AUTH__JWT_SECRET: local-parts-dev-jwt-secret  # pragma: allowlist secret
 
 admin:
   enabled: true
@@ -45,12 +53,17 @@ admin:
     # the gateway on kind host port 8000 — or every token exchange fails
     # 400 invalid_grant. See the longer note in local-combined.yaml.
     JENTIC__AUTH__CANONICAL_BASE_URL: http://localhost:8000
+    # See the note on registry.extraEnv — this pod is the JWT issuer.
+    JENTIC__ADMIN__AUTH__JWT_SECRET: local-parts-dev-jwt-secret  # pragma: allowlist secret
 
 control:
   enabled: true
   service:
     type: NodePort
     nodePort: 30083
+  extraEnv:
+    # See the note on registry.extraEnv — this pod verifies the same JWTs.
+    JENTIC__ADMIN__AUTH__JWT_SECRET: local-parts-dev-jwt-secret  # pragma: allowlist secret
   # Credential-at-rest encryption keyset (+ the platform OAuth2 provider) —
   # same contract as combined mode (see local-combined.yaml): `entries` is a
   # list, which the flat JENTIC__* env-var convention cannot express, and

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -344,3 +344,56 @@ def test_render_app_secrets_conflict_with_config_file() -> None:
     )
     assert result.returncode != 0
     assert "mutually exclusive" in result.stderr
+
+
+@pytest.mark.smoke
+def test_render_app_secrets_reach_every_python_surface() -> None:
+    """generate=true mounts the release Secret on ALL Python surfaces.
+
+    Found live: admin and registry never had the app-secrets wiring, which the
+    old CHANGE-ME jwt_secret code default masked — every pod silently agreed on
+    the placeholder. Once the default became generate-per-process (the AWS
+    Marketplace static-password fix), parts-mode pods disagreed on jwt_secret
+    and cross-surface JWT verification 401'd. The issuer (admin) and every
+    verifier must mount the SAME Secret.
+    """
+    result = _helm_template(
+        "--set",
+        "app.enabled=false",
+        "--set",
+        "admin.enabled=true",
+        "--set",
+        "registry.enabled=true",
+        "--set",
+        "control.enabled=true",
+        "--set",
+        "global.appSecrets.generate=true",
+        "--set",
+        "global.databases.registry.password=x",
+        "--set",
+        "global.databases.control.password=x",
+        "--set",
+        "global.databases.admin.password=x",
+        "--set",
+        "postgresql.auth.password=x",
+    )
+    assert result.returncode == 0, result.stderr
+    # admin + registry + control each mount the generated Secret and point
+    # the loader at it (app disabled here; broker is off by default).
+    assert result.stdout.count("mountPath: /etc/jentic/app-secrets") == 3
+    assert result.stdout.count("name: JENTIC_CONFIG_FILE") == 3
+
+
+@pytest.mark.smoke
+def test_render_parts_overlay_shares_jwt_secret() -> None:
+    """The parts smoke overlay pins one jwt_secret across issuer + verifiers.
+
+    Dev overlays use inline env (not appSecrets — control's configFile keyset
+    is mutually exclusive with it), so the shared value must be stated
+    explicitly on every surface that mints or checks admin JWTs. Without it,
+    each pod generates its own per-process secret and POST /apis 401s — the
+    exact failure the v0.38.2 release smoke caught.
+    """
+    result = _helm_template("-f", str(VALUES_DIR / "local-parts.yaml"))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.count("name: JENTIC__ADMIN__AUTH__JWT_SECRET") == 3


### PR DESCRIPTION
## Why

The [v0.38.2 release run's Helm smoke failed in parts mode](https://github.com/jentic/jentic-one/actions/runs/33876057350/job/101033224599) — `POST /apis` 401-spam. Same failure will hit `main`'s smoke for #1255's merge commit.

Root cause: **the admin and registry deployment templates never had the `config-file`/`app-secrets` wiring** that app/control/broker carry. The gap was invisible for as long as the app shipped a static `jwt_secret` default — every parts-mode pod silently agreed on `CHANGE-ME-IN-PRODUCTION`. #1255 replaced that default with a per-process random (the AWS Marketplace static-password fix), so the issuer (admin) and the verifiers (registry/control) stopped agreeing and cross-surface JWT verification broke.

So this is a latent chart bug the placeholder was masking — it would equally have bitten any production parts-mode install running `JENTIC_ENV=production` with `global.appSecrets`.

## What

- **Chart**: `admin` + `registry` deployments now render `common.config-file.*` and `common.app-secrets.*` exactly like app/control/broker (env, volumeMounts, volumes, + the `config-configmap.yaml` template each subchart needs). Production parts installs with `global.appSecrets.generate=true` now get the one release-scoped Secret on every surface that mints or verifies JWTs.
- **Dev overlay**: `local-parts.yaml` pins one throwaway `JENTIC__ADMIN__AUTH__JWT_SECRET` across admin/registry/control via `extraEnv` (`global.appSecrets` can't be used there — it's mutually exclusive with control's `configFile` keyset, and the guard correctly fails the render). Same dev-literal convention as the `global.databases` passwords in that file, `pragma: allowlist secret` comments included. Pepper/state_secret stay per-pod — only one surface each uses them.
- **Render tests** (both future-proofing the gap):
  - `test_render_app_secrets_reach_every_python_surface` — under `generate=true`, every enabled Python surface mounts the Secret + gets `JENTIC_CONFIG_FILE`
  - `test_render_parts_overlay_shares_jwt_secret` — the parts overlay pins exactly 3 copies of the shared env var

## Verification

- `helm lint` + full `tests/smoke/test_helm_render.py` (18) green; marketplace overlay render unchanged (app+broker only)
- The appSecrets↔configFile mutual-exclusion guard verified still firing
- lint/mypy clean

After merge this needs to ride the 0.38.2 hotfix (tag will be re-cut — the failed run published no artifacts).

Made with [Cursor](https://cursor.com)