### PR TITLE
fix(auth): omit unset optional members from OAuth responses

### DIFF
--- a/src/jentic_one/auth/web/routers/oauth.py
+++ b/src/jentic_one/auth/web/routers/oauth.py
@@ -226,6 +226,13 @@ _TOKEN_REQUEST_BODY: dict[str, object] = {
     "/oauth/token",
     dependencies=[Depends(_check_token_rate_limit)],
     openapi_extra=_TOKEN_REQUEST_BODY,
+    # RFC 6749 §5.1 + OIDC Core §3.1.3.3: optional members the grant did not
+    # mint (id_token on grant-bearing agent-channel codes per D11, refresh_token
+    # on grants that don't rotate one) are omitted from the response, never
+    # emitted as JSON null — strict clients (mcp-remote's zod schema, Cursor's
+    # MCP SDK) reject nulls and drop the whole token response. Same posture as
+    # the DCR door's RFC 7591 omission (oauth_client_registration.py).
+    response_model_exclude_none=True,
 )
 async def token_endpoint(
     request: Request,
@@ -566,7 +573,13 @@ async def revoke_endpoint(
 router.include_router(revocation_router)
 
 
-@router.post("/oauth/introspect")
+@router.post(
+    "/oauth/introspect",
+    # RFC 7662 §2.2: members the server has no value for are omitted from the
+    # introspection response, never emitted as JSON null (the inactive-token
+    # body is exactly `{"active": false}`).
+    response_model_exclude_none=True,
+)
 async def introspect_endpoint(
     body: IntrospectRequest,
     identity: Identity = get_current_identity(allow_expired_password=True),

--- a/src/jentic_one/auth/web/routers/registration.py
+++ b/src/jentic_one/auth/web/routers/registration.py
@@ -35,7 +35,15 @@ def _extract_rat(request: Request) -> str:
     return auth[7:]
 
 
-@router.post("/register", status_code=201)
+@router.post(
+    "/register",
+    status_code=201,
+    # RFC 7591 §3.2.1: optional response members without a value (claim_token
+    # on the OSS single-user default — no claim-token minter installed) are
+    # omitted, never emitted as JSON null. Same posture as the anonymous DCR
+    # door (oauth_client_registration.py) and /oauth/token.
+    response_model_exclude_none=True,
+)
 async def register_endpoint(
     body: RegisterRequest,
     reg_svc: RegistrationService = Depends(get_registration_service),

--- a/tests/unit/auth/web/test_oauth_response_shape.py
+++ b/tests/unit/auth/web/test_oauth_response_shape.py
@@ -1,0 +1,194 @@
+"""Unit tests pinning the raw JSON shape of OAuth token-plane responses.
+
+RFC 6749 §5.1 / OIDC Core §3.1.3.3 (token endpoint) and RFC 7662 §2.2
+(introspection): optional members the server has no value for are OMITTED
+from the response body — never serialized as JSON ``null``. Strict clients
+(mcp-remote 0.8.3's zod schema, Cursor's MCP SDK) reject a null ``id_token``
+or ``refresh_token`` and drop the whole token response, which live-broke
+Claude Desktop's refresh exchange. Pinned on the raw JSON body, mirroring
+the anonymous DCR door's omission tests
+(test_oauth_client_registration_router.py, PR #1250).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from jentic_one.auth.services.errors import AuthServiceError
+from jentic_one.auth.web.errors import service_error_handler
+from jentic_one.auth.web.routers import oauth
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.config import AuthConfig, PlatformClientConfig
+from jentic_one.shared.web.deps import resolve_identity
+
+_PLATFORM_CLIENT_ID = "jentic-one-spa"
+_PUBLIC_CLIENT_ID = "oc_public_mcp_client"
+
+
+def _fake_identity() -> Identity:
+    return Identity(sub="usr_test", email="test@example.com", permissions=[])
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(oauth.router)
+    app.add_exception_handler(AuthServiceError, service_error_handler)
+    app.dependency_overrides[resolve_identity] = _fake_identity
+
+    mock_ctx = MagicMock()
+    mock_ctx.config.auth = AuthConfig(
+        canonical_base_url="https://auth.example.com",
+        platform_clients=[
+            PlatformClientConfig(
+                client_id=_PLATFORM_CLIENT_ID,
+                redirect_uris=["https://app.example.com/auth/callback"],
+            )
+        ],
+    )
+    app.state.ctx = mock_ctx
+    return TestClient(app)
+
+
+# ---------- /oauth/token: RFC 6749 §5.1 + OIDC Core §3.1.3.3 ----------
+
+
+@patch("jentic_one.auth.web.routers.oauth.OAuthClientService")
+@patch("jentic_one.auth.web.routers.oauth.AuthorizeService")
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_agent_channel_code_exchange_omits_unset_id_token(
+    mock_token_cls: MagicMock,
+    mock_authorize_cls: MagicMock,
+    mock_oauth_svc_cls: MagicMock,
+    client: TestClient,
+) -> None:
+    """A grant-bearing (agent-channel) code mints no id_token (D11): the
+    member is absent from the raw body, not ``"id_token": null``."""
+    mock_oauth_svc = MagicMock()
+    mock_oauth_svc.authenticate_for_token_endpoint = AsyncMock(return_value=True)
+    mock_oauth_svc_cls.return_value = mock_oauth_svc
+
+    mock_authorize_svc = MagicMock()
+    mock_authorize_svc.precheck_auth_code = AsyncMock(return_value=None)
+    mock_authorize_svc.exchange_code = AsyncMock(return_value=("at_agent", "rt_agent", None))
+    mock_authorize_cls.return_value = mock_authorize_svc
+    mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
+
+    resp = client.post(
+        "/oauth/token",
+        json={
+            "grant_type": "authorization_code",
+            "code": "auth_code_agent",
+            "code_verifier": "verifier_agent",
+            "redirect_uri": "http://localhost:33418/callback",
+            "client_id": _PUBLIC_CLIENT_ID,
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["access_token"] == "at_agent"
+    assert data["refresh_token"] == "rt_agent"
+    assert "id_token" not in data
+    # Belt-and-braces: the raw body carries no null members at all.
+    assert b"null" not in resp.content
+
+
+@patch("jentic_one.auth.web.routers.oauth.AuthorizeService")
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_user_channel_code_exchange_keeps_set_id_token(
+    mock_token_cls: MagicMock,
+    mock_authorize_cls: MagicMock,
+    client: TestClient,
+) -> None:
+    """exclude_none must not drop members that ARE set: a user-channel
+    exchange that mints an id_token still returns it."""
+    mock_authorize_svc = MagicMock()
+    mock_authorize_svc.precheck_auth_code = AsyncMock(return_value=None)
+    mock_authorize_svc.exchange_code = AsyncMock(
+        return_value=("at_user", "rt_user", "id_token_user")
+    )
+    mock_authorize_cls.return_value = mock_authorize_svc
+    mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
+
+    resp = client.post(
+        "/oauth/token",
+        json={
+            "grant_type": "authorization_code",
+            "code": "auth_code_user",
+            "code_verifier": "verifier_user",
+            "redirect_uri": "https://app.example.com/auth/callback",
+            "client_id": _PLATFORM_CLIENT_ID,
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id_token"] == "id_token_user"
+    assert data["refresh_token"] == "rt_user"
+    assert b"null" not in resp.content
+
+
+@patch("jentic_one.auth.web.routers.oauth.OAuthClientService")
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_refresh_exchange_omits_unset_optional_members(
+    mock_token_cls: MagicMock,
+    mock_oauth_svc_cls: MagicMock,
+    client: TestClient,
+) -> None:
+    """The refresh_token grant never mints an id_token: the member is absent
+    from the raw body — the ``"id_token": null`` here is what strict clients
+    (mcp-remote 0.8.3 zod) rejected, breaking Claude Desktop's refresh leg."""
+    mock_oauth_svc = MagicMock()
+    mock_oauth_svc.is_public_client = AsyncMock(return_value=True)
+    mock_oauth_svc_cls.return_value = mock_oauth_svc
+
+    mock_token_svc = MagicMock(access_ttl_seconds=3600)
+    mock_token_svc.refresh = AsyncMock(return_value=("at_new", "rt_new"))
+    mock_token_cls.return_value = mock_token_svc
+
+    resp = client.post(
+        "/oauth/token",
+        json={
+            "grant_type": "refresh_token",
+            "refresh_token": "rt_old",
+            "client_id": _PUBLIC_CLIENT_ID,
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["access_token"] == "at_new"
+    assert data["refresh_token"] == "rt_new"
+    assert "id_token" not in data
+    assert b"null" not in resp.content
+
+
+# ---------- /oauth/introspect: RFC 7662 §2.2 ----------
+
+
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_introspect_inactive_token_body_is_exactly_active_false(
+    mock_token_cls: MagicMock,
+    client: TestClient,
+) -> None:
+    """RFC 7662 §2.2: for an inactive/unknown token the body is exactly
+    ``{"active": false}`` — the unset optional members (sub, scope, exp,
+    token_type) are omitted, never serialized as JSON null."""
+    mock_token_svc = MagicMock()
+    mock_token_svc.introspect = AsyncMock(return_value={"active": False})
+    mock_token_cls.return_value = mock_token_svc
+
+    resp = client.post(
+        "/oauth/introspect",
+        json={"token": "at_unknown"},
+        headers={"Authorization": "Bearer platform-token"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"active": False}
+    assert b"null" not in resp.content

--- a/tests/unit/auth/web/test_registration_router.py
+++ b/tests/unit/auth/web/test_registration_router.py
@@ -67,6 +67,65 @@ def test_post_register_returns_201(mock_svc_cls: MagicMock, client: TestClient) 
 
 
 @patch("jentic_one.auth.web.routers.registration.RegistrationService")
+def test_post_register_omits_unset_claim_token_not_null(
+    mock_svc_cls: MagicMock, client: TestClient
+) -> None:
+    """RFC 7591 §3.2.1: on the OSS single-user default no claim-token minter
+    is installed, so ``claim_token`` is OMITTED from the response body —
+    never serialized as JSON ``null`` (the DCR-door/#1250 posture)."""
+    mock_instance = MagicMock()
+    mock_instance.register = AsyncMock(
+        return_value=RegisterResult(
+            client_id="agnt_abc123",
+            registration_access_token="rat_secret",
+            registration_client_uri="https://auth.example.com/register/agnt_abc123",
+            status="pending",
+        )
+    )
+    mock_svc_cls.return_value = mock_instance
+
+    resp = client.post(
+        "/register",
+        json={
+            "client_name": "my-agent",
+            "jwks": {"keys": [{"kty": "OKP", "crv": "Ed25519", "x": "dGVzdA", "kid": "k1"}]},
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "claim_token" not in data
+    # Belt-and-braces: the raw body carries no null members at all.
+    assert b"null" not in resp.content
+
+
+@patch("jentic_one.auth.web.routers.registration.RegistrationService")
+def test_post_register_keeps_set_claim_token(mock_svc_cls: MagicMock, client: TestClient) -> None:
+    """exclude_none must not drop a claim_token that IS minted (multi-user
+    deployments with a claim-token minter installed)."""
+    mock_instance = MagicMock()
+    mock_instance.register = AsyncMock(
+        return_value=RegisterResult(
+            client_id="agnt_abc123",
+            registration_access_token="rat_secret",
+            registration_client_uri="https://auth.example.com/register/agnt_abc123",
+            status="pending",
+            claim_token="clm_secret",
+        )
+    )
+    mock_svc_cls.return_value = mock_instance
+
+    resp = client.post(
+        "/register",
+        json={
+            "client_name": "my-agent",
+            "jwks": {"keys": [{"kty": "OKP", "crv": "Ed25519", "x": "dGVzdA", "kid": "k1"}]},
+        },
+    )
+    assert resp.status_code == 201
+    assert resp.json()["claim_token"] == "clm_secret"
+
+
+@patch("jentic_one.auth.web.routers.registration.RegistrationService")
 def test_get_register_poll_returns_200(mock_svc_cls: MagicMock, client: TestClient) -> None:
     mock_instance = MagicMock()
     mock_instance.poll_status = AsyncMock(


### PR DESCRIPTION
## Summary

`POST /oauth/token` serializes unset optional members as JSON `null` — `"id_token": null` on every grant-bearing (agent-channel) code exchange (D11: those codes deliberately mint no id_token) and on every `refresh_token` exchange. RFC 6749 §5.1 and OIDC Core define these members as **omitted when absent, never null**. Strict clients reject the null and drop the whole token response — mcp-remote 0.8.3's zod schema and Cursor's MCP SDK both do — which live-broke Claude Desktop's refresh exchange during T7 testing. Same defect class as the anonymous DCR door fixed in #1250; same cure: `response_model_exclude_none=True` on the route decorator, with an RFC-citing comment.

## Changes

- `auth` — `POST /oauth/token` (`routers/oauth.py`): `response_model_exclude_none=True`. Unset `id_token`/`refresh_token` are now omitted from the body (RFC 6749 §5.1 + OIDC Core §3.1.3.3). This is the fix for the live breakage.
- `auth` — `POST /oauth/introspect` (`routers/oauth.py`): same decorator, per the same-defect audit. RFC 7662 §2.2: the inactive-token body is now exactly `{"active": false}`; previously it carried `sub/scope/exp/token_type: null`.
- `auth` — `POST /register` (`routers/registration.py`): same decorator. RFC 7591 §3.2.1 posture; `claim_token` is documented as "omitted on the OSS single-user default" but was serialized as `null`.
- Tests: new `tests/unit/auth/web/test_oauth_response_shape.py` pins the raw JSON body (agent-channel code exchange with no id_token, refresh exchange, set-id_token retention, introspect inactive shape); `test_registration_router.py` gains omitted-vs-set `claim_token` tests. All follow the #1250 test pattern (`"key" not in data` + `b"null" not in resp.content`).

Audited and **deliberately left alone**:
- `POST /oauth/mint` — `MintResponse` has no optional members; nothing to omit.
- `POST /oauth/revoke` — returns an empty 200 (JSON arm) / hand-built RFC 6749 §5.2 error bodies (form arm); no Pydantic response model, no nulls.
- Discovery documents (`routers/discovery.py`) — hand-built dicts with no null members; the root RFC 8414 doc is pinned byte-identical by a golden test.
- `GET /auth/idp` — emits `provider: null` when IdP login is disabled, but it is an internal SPA capability descriptor, not an RFC document; the SPA reads the key.
- Platform admin APIs (`agents.py`, `service_accounts.py`, `oauth_grants.py`, `identity.py`) — nullable fields there are the platform's normal JSON contract (UI TS client models them as nullable); no absence-vs-null spec semantics.

## Risk & rollback

- Touches the OAuth token-plane response shapes (`/oauth/token`, `/oauth/introspect`, `/register`). Omission of previously-null keys is safe for tolerant readers (the Go CLI's `encoding/json` treats absent and null identically; the UI TS client models these as optional) and is what strict clients require.
- Generated OpenAPI spec is unchanged (`make openapi` produced no drift — `exclude_none` affects serialization, not schema).
- Revert: revert the squash commit.

## Test plan

- `make check` — ruff, ruff format, mypy all green (the `score` step needs a `JENTIC_API_KEY`/Docker image not available in this environment; the spec it scores is untouched by this PR).
- `make detect-secrets` — clean.
- `make test-arch` — 153 passed.
- `make test-unit` — 3256 passed, coverage 79.34%.
- Empirical verification on the live stack (hot-patched worktree): with the decorator fix, both the authorization_code and refresh_token legs return bodies with no null keys, and Claude Desktop's refresh exchange succeeds.

Closes #1253

Made with [Cursor](https://cursor.com)