### PR TITLE
fix(auth): dedupe software_id-less DCR registrations by name + redirect set

### DIFF
--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -5987,8 +5987,12 @@ type ClientInterface interface {
 	// Register a public OAuth client anonymously (RFC 7591 subset).
 	//
 	// Returns 201 with the new ``client_id``, or 200 with the **existing** row's
-	// ``client_id`` on an exact (``software_id`` + redirect-URI set) dedupe match
-	// (D8). No client_secret is ever issued here and no registration_access_token
+	// ``client_id`` on an exact dedupe match (D8, extended per G13/#1251):
+	// (``software_id`` + redirect-URI set), falling back to (``client_name`` +
+	// redirect-URI set) for registrations without a ``software_id`` — so a
+	// pending client's awaiting-approval retry loop re-attaches instead of
+	// minting duplicate rows. No client_secret is ever issued here and no
+	// registration_access_token
 	// is returned (D12). New rows await admin approval unless the deployment
 	// auto-approves registrations (D9). The ``server.mcp.oauth.enabled`` gate
 	// lives on the route class — a disabled door 404s before this handler,
@@ -6004,8 +6008,12 @@ type ClientInterface interface {
 	// Register a public OAuth client anonymously (RFC 7591 subset).
 	//
 	// Returns 201 with the new ``client_id``, or 200 with the **existing** row's
-	// ``client_id`` on an exact (``software_id`` + redirect-URI set) dedupe match
-	// (D8). No client_secret is ever issued here and no registration_access_token
+	// ``client_id`` on an exact dedupe match (D8, extended per G13/#1251):
+	// (``software_id`` + redirect-URI set), falling back to (``client_name`` +
+	// redirect-URI set) for registrations without a ``software_id`` — so a
+	// pending client's awaiting-approval retry loop re-attaches instead of
+	// minting duplicate rows. No client_secret is ever issued here and no
+	// registration_access_token
 	// is returned (D12). New rows await admin approval unless the deployment
 	// auto-approves registrations (D9). The ``server.mcp.oauth.enabled`` gate
 	// lives on the route class — a disabled door 404s before this handler,
@@ -9642,8 +9650,12 @@ func (c *Client) UpdateNote(ctx context.Context, noteId string, params *UpdateNo
 // Register a public OAuth client anonymously (RFC 7591 subset).
 //
 // Returns 201 with the new “client_id“, or 200 with the **existing** row's
-// “client_id“ on an exact (“software_id“ + redirect-URI set) dedupe match
-// (D8). No client_secret is ever issued here and no registration_access_token
+// “client_id“ on an exact dedupe match (D8, extended per G13/#1251):
+// (“software_id“ + redirect-URI set), falling back to (“client_name“ +
+// redirect-URI set) for registrations without a “software_id“ — so a
+// pending client's awaiting-approval retry loop re-attaches instead of
+// minting duplicate rows. No client_secret is ever issued here and no
+// registration_access_token
 // is returned (D12). New rows await admin approval unless the deployment
 // auto-approves registrations (D9). The “server.mcp.oauth.enabled“ gate
 // lives on the route class — a disabled door 404s before this handler,
@@ -9669,8 +9681,12 @@ func (c *Client) RegisterOauthClientEndpointWithBody(ctx context.Context, conten
 // Register a public OAuth client anonymously (RFC 7591 subset).
 //
 // Returns 201 with the new “client_id“, or 200 with the **existing** row's
-// “client_id“ on an exact (“software_id“ + redirect-URI set) dedupe match
-// (D8). No client_secret is ever issued here and no registration_access_token
+// “client_id“ on an exact dedupe match (D8, extended per G13/#1251):
+// (“software_id“ + redirect-URI set), falling back to (“client_name“ +
+// redirect-URI set) for registrations without a “software_id“ — so a
+// pending client's awaiting-approval retry loop re-attaches instead of
+// minting duplicate rows. No client_secret is ever issued here and no
+// registration_access_token
 // is returned (D12). New rows await admin approval unless the deployment
 // auto-approves registrations (D9). The “server.mcp.oauth.enabled“ gate
 // lives on the route class — a disabled door 404s before this handler,
@@ -21690,8 +21706,12 @@ type ClientWithResponsesInterface interface {
 	// Register a public OAuth client anonymously (RFC 7591 subset).
 	//
 	// Returns 201 with the new ``client_id``, or 200 with the **existing** row's
-	// ``client_id`` on an exact (``software_id`` + redirect-URI set) dedupe match
-	// (D8). No client_secret is ever issued here and no registration_access_token
+	// ``client_id`` on an exact dedupe match (D8, extended per G13/#1251):
+	// (``software_id`` + redirect-URI set), falling back to (``client_name`` +
+	// redirect-URI set) for registrations without a ``software_id`` — so a
+	// pending client's awaiting-approval retry loop re-attaches instead of
+	// minting duplicate rows. No client_secret is ever issued here and no
+	// registration_access_token
 	// is returned (D12). New rows await admin approval unless the deployment
 	// auto-approves registrations (D9). The ``server.mcp.oauth.enabled`` gate
 	// lives on the route class — a disabled door 404s before this handler,
@@ -21707,8 +21727,12 @@ type ClientWithResponsesInterface interface {
 	// Register a public OAuth client anonymously (RFC 7591 subset).
 	//
 	// Returns 201 with the new ``client_id``, or 200 with the **existing** row's
-	// ``client_id`` on an exact (``software_id`` + redirect-URI set) dedupe match
-	// (D8). No client_secret is ever issued here and no registration_access_token
+	// ``client_id`` on an exact dedupe match (D8, extended per G13/#1251):
+	// (``software_id`` + redirect-URI set), falling back to (``client_name`` +
+	// redirect-URI set) for registrations without a ``software_id`` — so a
+	// pending client's awaiting-approval retry loop re-attaches instead of
+	// minting duplicate rows. No client_secret is ever issued here and no
+	// registration_access_token
 	// is returned (D12). New rows await admin approval unless the deployment
 	// auto-approves registrations (D9). The ``server.mcp.oauth.enabled`` gate
 	// lives on the route class — a disabled door 404s before this handler,
@@ -38885,8 +38909,12 @@ func (c *ClientWithResponses) UpdateNoteWithResponse(ctx context.Context, noteId
 // Register a public OAuth client anonymously (RFC 7591 subset).
 //
 // Returns 201 with the new “client_id“, or 200 with the **existing** row's
-// “client_id“ on an exact (“software_id“ + redirect-URI set) dedupe match
-// (D8). No client_secret is ever issued here and no registration_access_token
+// “client_id“ on an exact dedupe match (D8, extended per G13/#1251):
+// (“software_id“ + redirect-URI set), falling back to (“client_name“ +
+// redirect-URI set) for registrations without a “software_id“ — so a
+// pending client's awaiting-approval retry loop re-attaches instead of
+// minting duplicate rows. No client_secret is ever issued here and no
+// registration_access_token
 // is returned (D12). New rows await admin approval unless the deployment
 // auto-approves registrations (D9). The “server.mcp.oauth.enabled“ gate
 // lives on the route class — a disabled door 404s before this handler,
@@ -38908,8 +38936,12 @@ func (c *ClientWithResponses) RegisterOauthClientEndpointWithBodyWithResponse(ct
 // Register a public OAuth client anonymously (RFC 7591 subset).
 //
 // Returns 201 with the new “client_id“, or 200 with the **existing** row's
-// “client_id“ on an exact (“software_id“ + redirect-URI set) dedupe match
-// (D8). No client_secret is ever issued here and no registration_access_token
+// “client_id“ on an exact dedupe match (D8, extended per G13/#1251):
+// (“software_id“ + redirect-URI set), falling back to (“client_name“ +
+// redirect-URI set) for registrations without a “software_id“ — so a
+// pending client's awaiting-approval retry loop re-attaches instead of
+// minting duplicate rows. No client_secret is ever issued here and no
+// registration_access_token
 // is returned (D12). New rows await admin approval unless the deployment
 // auto-approves registrations (D9). The “server.mcp.oauth.enabled“ gate
 // lives on the route class — a disabled door 404s before this handler,

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -15451,8 +15451,12 @@ paths:
         Register a public OAuth client anonymously (RFC 7591 subset).
 
         Returns 201 with the new ``client_id``, or 200 with the **existing** row's
-        ``client_id`` on an exact (``software_id`` + redirect-URI set) dedupe match
-        (D8). No client_secret is ever issued here and no registration_access_token
+        ``client_id`` on an exact dedupe match (D8, extended per G13/#1251):
+        (``software_id`` + redirect-URI set), falling back to (``client_name`` +
+        redirect-URI set) for registrations without a ``software_id`` — so a
+        pending client's awaiting-approval retry loop re-attaches instead of
+        minting duplicate rows. No client_secret is ever issued here and no
+        registration_access_token
         is returned (D12). New rows await admin approval unless the deployment
         auto-approves registrations (D9). The ``server.mcp.oauth.enabled`` gate
         lives on the route class — a disabled door 404s before this handler,

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -15451,8 +15451,12 @@ paths:
         Register a public OAuth client anonymously (RFC 7591 subset).
 
         Returns 201 with the new ``client_id``, or 200 with the **existing** row's
-        ``client_id`` on an exact (``software_id`` + redirect-URI set) dedupe match
-        (D8). No client_secret is ever issued here and no registration_access_token
+        ``client_id`` on an exact dedupe match (D8, extended per G13/#1251):
+        (``software_id`` + redirect-URI set), falling back to (``client_name`` +
+        redirect-URI set) for registrations without a ``software_id`` — so a
+        pending client's awaiting-approval retry loop re-attaches instead of
+        minting duplicate rows. No client_secret is ever issued here and no
+        registration_access_token
         is returned (D12). New rows await admin approval unless the deployment
         auto-approves registrations (D9). The ``server.mcp.oauth.enabled`` gate
         lives on the route class — a disabled door 404s before this handler,

--- a/src/jentic_one/admin/core/schema/oauth_clients.py
+++ b/src/jentic_one/admin/core/schema/oauth_clients.py
@@ -88,10 +88,12 @@ class OAuthClient(AuditableMixin, AdminBase):
     )
     software_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     # SHA-256 hex of the sorted, exact redirect-URI set — with
-    # software_id it forms the D8 dedupe key. Maintained by the repository on
+    # software_id (or the client name, for software_id-less DCR rows) it
+    # forms the D8/G13 dedupe key. Maintained by the repository on
     # every create and redirect_uris update; NULL only on pre-3a rows whose
-    # redirect_uris have not been written since the upgrade (they carry no
-    # software_id either, so they never participate in dedupe).
+    # redirect_uris have not been written since the upgrade — a NULL
+    # fingerprint never equals a computed one, so they never participate
+    # in dedupe.
     redirect_uris_fingerprint: Mapped[str | None] = mapped_column(String(64), nullable=True)
     # server_default 'approved' is deliberate back-compat: every pre-3a row was
     # admin-created and live, so upgraded rows keep working.

--- a/src/jentic_one/admin/repos/oauth_client_repo.py
+++ b/src/jentic_one/admin/repos/oauth_client_repo.py
@@ -22,8 +22,9 @@ def redirect_uris_fingerprint(redirect_uris: list[str]) -> str:
     Order-insensitive and duplicate-insensitive (the list is normalized to a
     sorted set before hashing, matching the set comparison the DCR service's
     dedupe re-verify performs) and exact — any added, removed, or altered URI
-    changes the fingerprint. Together with ``software_id`` this is the D8
-    dedupe key for DCR registrations. URIs cannot contain raw newlines (they
+    changes the fingerprint. Paired with ``software_id`` (or with the client
+    name, for software_id-less registrations) this forms the D8/G13 dedupe
+    key for DCR registrations. URIs cannot contain raw newlines (they
     are validated URLs), so the newline join is unambiguous.
     """
     return hashlib.sha256("\n".join(sorted(set(redirect_uris))).encode()).hexdigest()
@@ -131,6 +132,38 @@ class OAuthClientRepository:
             .where(
                 OAuthClient.software_id == software_id,
                 OAuthClient.redirect_uris_fingerprint == fingerprint,
+                OAuthClient.registration_source == OAuthRegistrationSource.DCR.value,
+            )
+            .order_by(OAuthClient.created_at.asc(), OAuthClient.id.asc())
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def list_dcr_by_name_dedupe_key(
+        session: AsyncSession, name: str, fingerprint: str
+    ) -> list[OAuthClient]:
+        """List DCR rows matching the software_id-less fallback dedupe key.
+
+        The G13 fallback for clients that register without a ``software_id``
+        (Cursor, mcp-remote): exact ``(name, redirect_uris_fingerprint)``
+        match, restricted to rows that *also* carry no ``software_id`` — a
+        registration without a software identity must never adopt a row that
+        was registered with one (and the software_id path never matches NULL
+        rows), so the two key spaces stay disjoint by construction.
+
+        Same contract as :meth:`list_dcr_by_dedupe_key` otherwise: callers
+        must re-verify the exact redirect-URI set (the fingerprint is a
+        hash — collision guard), rows come back oldest first, and the caller
+        picks the dedupe winner. ``software_id IS NULL`` keys into the same
+        ``(software_id, redirect_uris_fingerprint)`` covering index.
+        """
+        stmt = (
+            select(OAuthClient)
+            .where(
+                OAuthClient.software_id.is_(None),
+                OAuthClient.redirect_uris_fingerprint == fingerprint,
+                OAuthClient.name == name,
                 OAuthClient.registration_source == OAuthRegistrationSource.DCR.value,
             )
             .order_by(OAuthClient.created_at.asc(), OAuthClient.id.asc())

--- a/src/jentic_one/auth/services/oauth_dcr_service.py
+++ b/src/jentic_one/auth/services/oauth_dcr_service.py
@@ -60,11 +60,12 @@ _DCR_ACTOR = "dcr"
 class DcrRegisterResult:
     """Result of an anonymous OAuth-client registration.
 
-    ``created`` is False when the D8 dedupe key (``software_id`` + exact
-    redirect-URI set) matched an existing row — the router answers 200 rather
-    than 201. Metadata fields echo the *request's* validated values, never
-    the stored row's live (possibly admin-edited) state; only ``client_id``
-    and ``client_id_issued_at`` come from the row.
+    ``created`` is False when a dedupe key matched an existing DCR row —
+    (``software_id`` + exact redirect-URI set), or for software_id-less
+    registrations (``client_name`` + exact redirect-URI set) — and the router
+    answers 200 rather than 201. Metadata fields echo the *request's*
+    validated values, never the stored row's live (possibly admin-edited)
+    state; only ``client_id`` and ``client_id_issued_at`` come from the row.
     """
 
     client_id: str
@@ -219,10 +220,17 @@ class OAuthDcrService:
     ) -> DcrRegisterResult:
         """Register (or dedupe to) a public OAuth client row.
 
-        Dedupe (D8): an exact (``software_id`` + redirect-URI set) match
-        returns the existing row's ``client_id`` — idempotent re-register, so a
-        cached registration or a double-register race never bricks a client.
-        No ``software_id`` → no dedupe. Never dedupes on ``software_id`` alone.
+        Dedupe (D8, extended per G13/#1251): an exact (``software_id`` +
+        redirect-URI set) match returns the existing row's ``client_id`` —
+        idempotent re-register, so a cached registration or a double-register
+        race never bricks a client. Registrations *without* a ``software_id``
+        fall back to the (``client_name`` + redirect-URI set) key against
+        rows that also carry no ``software_id`` — otherwise clients that send
+        no software identity (Cursor, mcp-remote) mint a fresh pending row on
+        every awaiting-approval retry. Never dedupes on ``software_id`` or
+        ``client_name`` alone, never across the two key spaces, and a dedupe
+        hit never mutates the stored row (status, name, and redirect set are
+        preserved verbatim).
         """
         _validate_metadata(
             redirect_uris=redirect_uris,
@@ -237,36 +245,45 @@ class OAuthDcrService:
         auto_approve = self._ctx.config.server.mcp.oauth.auto_approve_clients
         requested_set = set(redirect_uris)
         fingerprint = redirect_uris_fingerprint(redirect_uris)
+        name = client_name.strip()
 
         async def _write(session: AsyncSession) -> tuple[OAuthClient, bool]:
+            # D8 dedupe via the (software_id, redirect_uris_fingerprint)
+            # index; software_id-less registrations use the G13 fallback key
+            # (name, fingerprint) against software_id-less rows only — the
+            # two key spaces never cross-match. The fetched rows' exact URI
+            # sets are re-checked because the fingerprint is a hash
+            # (collision guard). Among multiple exact matches
+            # (double-register race) prefer approved > pending > denied,
+            # then oldest — `min` is stable and the repo returns rows
+            # oldest-first.
             if software_id:
-                # D8 dedupe via the (software_id, redirect_uris_fingerprint)
-                # index; the fetched rows' exact URI sets are re-checked
-                # because the fingerprint is a hash (collision guard). Among
-                # multiple exact matches (double-register race) prefer
-                # approved > pending > denied, then oldest — `min` is stable
-                # and the repo returns rows oldest-first.
-                matches = [
-                    candidate
-                    for candidate in await OAuthClientRepository.list_dcr_by_dedupe_key(
-                        session, software_id, fingerprint
-                    )
-                    if set(candidate.redirect_uris) == requested_set
-                ]
-                if matches:
-                    winner = min(
-                        matches,
-                        key=lambda c: _APPROVAL_PREFERENCE.get(
-                            c.approval_status, len(_APPROVAL_PREFERENCE)
-                        ),
-                    )
-                    return winner, False
+                candidates = await OAuthClientRepository.list_dcr_by_dedupe_key(
+                    session, software_id, fingerprint
+                )
+            else:
+                candidates = await OAuthClientRepository.list_dcr_by_name_dedupe_key(
+                    session, name, fingerprint
+                )
+            matches = [
+                candidate
+                for candidate in candidates
+                if set(candidate.redirect_uris) == requested_set
+            ]
+            if matches:
+                winner = min(
+                    matches,
+                    key=lambda c: _APPROVAL_PREFERENCE.get(
+                        c.approval_status, len(_APPROVAL_PREFERENCE)
+                    ),
+                )
+                return winner, False
 
             approved = auto_approve
             client = await OAuthClientRepository.create(
                 session,
                 client_id=generate_client_id(),
-                name=client_name.strip(),
+                name=name,
                 redirect_uris=redirect_uris,
                 client_secret_hash=None,
                 description=None,
@@ -338,7 +355,7 @@ class OAuthDcrService:
         return _to_result(
             client,
             created=created,
-            client_name=client_name.strip(),
+            client_name=name,
             redirect_uris=redirect_uris,
             grant_types=grant_types,
             allowed_scopes=allowed_scopes,

--- a/src/jentic_one/auth/services/oauth_dcr_service.py
+++ b/src/jentic_one/auth/services/oauth_dcr_service.py
@@ -230,7 +230,16 @@ class OAuthDcrService:
         every awaiting-approval retry. Never dedupes on ``software_id`` or
         ``client_name`` alone, never across the two key spaces, and a dedupe
         hit never mutates the stored row (status, name, and redirect set are
-        preserved verbatim).
+        preserved verbatim) — it only writes an audit entry so anonymous
+        re-attaches stay visible to admins.
+
+        A falsy or whitespace-only ``software_id`` is normalized to ``None``
+        *before* the key-space branch and the insert: ``""`` passes schema
+        validation (empty-default serializers are common) but would otherwise
+        take the fallback lookup (``IS NULL``) while storing ``""`` (NOT
+        NULL) — a row in *neither* key space that re-opens the #1251 loop.
+        Normalizing (rather than rejecting) follows RFC 7591's
+        ignore-don't-reject posture for metadata the server curtails.
         """
         _validate_metadata(
             redirect_uris=redirect_uris,
@@ -240,6 +249,7 @@ class OAuthDcrService:
         )
         if not client_name.strip():
             raise InvalidClientMetadataError("client_name is required")
+        software_id = (software_id or "").strip() or None
 
         allowed_scopes = _cap_scopes(scope)
         auto_approve = self._ctx.config.server.mcp.oauth.auto_approve_clients
@@ -276,6 +286,26 @@ class OAuthDcrService:
                     key=lambda c: _APPROVAL_PREFERENCE.get(
                         c.approval_status, len(_APPROVAL_PREFERENCE)
                     ),
+                )
+                # F2: a re-attach must leave a forensic trace — the 200-dedupe
+                # arm discloses an existing (possibly approved) client_id to
+                # an anonymous caller, and a client bouncing off a denied row
+                # retries with no other admin-visible signal. Audit row only,
+                # deliberately no event: the whole point of the dedupe is
+                # that retries stop spamming the approval queue.
+                await record_audit(
+                    session,
+                    action=AuditAction.REGISTER,
+                    target_type=AuditTargetType.OAUTH_CLIENT,
+                    target_id=winner.id,
+                    actor_type=_DCR_ACTOR,
+                    actor_id=None,
+                    after={
+                        "client_id": winner.client_id,
+                        "approval_status": winner.approval_status,
+                    },
+                    reason="anonymous DCR re-attach (dedupe hit)",
+                    origin=Origin.MCP.value,
                 )
                 return winner, False
 

--- a/src/jentic_one/auth/web/routers/oauth_client_registration.py
+++ b/src/jentic_one/auth/web/routers/oauth_client_registration.py
@@ -195,8 +195,12 @@ async def register_oauth_client_endpoint(
     """Register a public OAuth client anonymously (RFC 7591 subset).
 
     Returns 201 with the new ``client_id``, or 200 with the **existing** row's
-    ``client_id`` on an exact (``software_id`` + redirect-URI set) dedupe match
-    (D8). No client_secret is ever issued here and no registration_access_token
+    ``client_id`` on an exact dedupe match (D8, extended per G13/#1251):
+    (``software_id`` + redirect-URI set), falling back to (``client_name`` +
+    redirect-URI set) for registrations without a ``software_id`` — so a
+    pending client's awaiting-approval retry loop re-attaches instead of
+    minting duplicate rows. No client_secret is ever issued here and no
+    registration_access_token
     is returned (D12). New rows await admin approval unless the deployment
     auto-approves registrations (D9). The ``server.mcp.oauth.enabled`` gate
     lives on the route class — a disabled door 404s before this handler,

--- a/tests/integration/admin/services/test_oauth_client_lifecycle.py
+++ b/tests/integration/admin/services/test_oauth_client_lifecycle.py
@@ -339,6 +339,7 @@ async def test_pre_3a_row_reads_migration_defaults(
     assert row.registration_source == "admin"
     assert row.software_id is None
     # Pre-3a rows carry no fingerprint until their redirect_uris are next
-    # written; they have no software_id either, so they never dedupe.
+    # written; a NULL fingerprint never equals a computed one (and their
+    # registration_source is 'admin'), so they never dedupe.
     assert row.redirect_uris_fingerprint is None
     assert row.active is True

--- a/tests/integration/auth/test_oauth_dcr_registration.py
+++ b/tests/integration/auth/test_oauth_dcr_registration.py
@@ -374,6 +374,141 @@ async def test_no_software_id_reattach_to_approved_row_keeps_it_approved(
     assert refreshed.active is True
 
 
+async def test_empty_string_software_id_normalizes_to_null_key_space(
+    dcr_context: Context, clean_dcr_tables: None
+) -> None:
+    """F1 regression: ``software_id: ""`` passes schema validation and, before
+    normalization, took the fallback lookup (``IS NULL``) while *storing*
+    ``""`` (NOT NULL) — a row in neither key space that re-opened the #1251
+    loop. Falsy/whitespace software_id must normalize to NULL at the service
+    boundary, so all its spellings land in the fallback key space and dedupe
+    with each other."""
+    svc = OAuthDcrService(dcr_context)
+    first = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS, software_id="")
+    row = await _row_by_client_id(dcr_context, first.client_id)
+    assert row.software_id is None
+    assert first.software_id is None  # The response echoes the normalized value.
+
+    # Two ""-registrations dedupe to one row…
+    second = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS, software_id="")
+    assert second.created is False
+    assert second.client_id == first.client_id
+
+    # …and "", whitespace-only, and absent software_id share one key space.
+    for spelling in (None, "   "):
+        again = await svc.register(
+            client_name="Cursor", redirect_uris=_REDIRECT_URIS, software_id=spelling
+        )
+        assert again.created is False, f"software_id={spelling!r} minted a duplicate row"
+        assert again.client_id == first.client_id
+
+    async with dcr_context.admin_db.session() as session:
+        rows = (await session.execute(select(OAuthClient))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_dedupe_hit_writes_audit_row_but_no_event(
+    dcr_context: Context, clean_dcr_tables: None
+) -> None:
+    """F2: every dedupe re-attach leaves a forensic audit trace (the 200 arm
+    discloses an existing client_id to an anonymous caller), while the event
+    stream stays quiet — no fresh approval-queue alert per retry."""
+    svc = OAuthDcrService(dcr_context)
+    first = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+    second = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+    assert second.created is False
+
+    row = await _row_by_client_id(dcr_context, first.client_id)
+    async with dcr_context.admin_db.session() as session:
+        audits = (
+            (
+                await session.execute(
+                    select(AuditEntry).where(
+                        AuditEntry.target_type == AuditTargetType.OAUTH_CLIENT.value,
+                        AuditEntry.target_id == row.id,
+                        AuditEntry.action == AuditAction.REGISTER.value,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    by_reason = {audit.reason: audit for audit in audits}
+    assert set(by_reason) == {
+        "anonymous dynamic client registration",
+        "anonymous DCR re-attach (dedupe hit)",
+    }
+    reattach = by_reason["anonymous DCR re-attach (dedupe hit)"]
+    assert reattach.actor_type == "dcr"
+    assert reattach.origin == "mcp"
+    assert reattach.after is not None
+    assert reattach.after["client_id"] == first.client_id
+    assert reattach.after["approval_status"] == OAuthClientApprovalStatus.PENDING.value
+    # The event stream stays quiet: one registered event, nothing per retry.
+    events = await _events_of_type(dcr_context, EventType.OAUTH_CLIENT_REGISTERED)
+    assert len(events) == 1
+
+
+async def test_no_software_id_dedupe_denied_row_stays_denied(
+    dcr_context: Context, clean_dcr_tables: None
+) -> None:
+    """F6(b) — denied arm of the *fallback* key (the existing denied test is
+    software_id-only): a software_id-less re-registration against a denied
+    row re-attaches (created=False, same client_id) and never mints a fresh
+    pending second chance; recovery stays admin-actioned."""
+    svc = OAuthDcrService(dcr_context)
+    first = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+    row = await _row_by_client_id(dcr_context, first.client_id)
+    await OAuthClientService(dcr_context).deny(row.id, reason="not vetted", identity=_ADMIN)
+
+    second = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+
+    assert second.created is False
+    assert second.client_id == first.client_id
+    refreshed = await _row_by_client_id(dcr_context, first.client_id)
+    assert refreshed.approval_status == OAuthClientApprovalStatus.DENIED.value
+    assert refreshed.active is False
+    async with dcr_context.admin_db.session() as session:
+        rows = (await session.execute(select(OAuthClient))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_admin_created_row_never_adopted_by_anonymous_door(
+    dcr_context: Context, clean_dcr_tables: None
+) -> None:
+    """F6(c) — adversarial pin on the ``registration_source='dcr'`` filter:
+    an admin-created client with the same name + redirect set (and no
+    software_id) must never be adopted by an anonymous registration — that
+    filter is the only line between the anonymous door and admin rows."""
+    async with dcr_context.admin_db.transaction() as session:
+        admin_row = await OAuthClientRepository.create(
+            session,
+            client_id=generate_client_id(),
+            name="Cursor",
+            redirect_uris=_REDIRECT_URIS,
+            client_secret_hash=None,
+            allowed_scopes=sorted(MCP_TOOL_SCOPES),
+            token_endpoint_auth_method="none",
+            consent_model="agent",
+            registration_source="admin",
+            software_id=None,
+            approval_status=OAuthClientApprovalStatus.APPROVED.value,
+            active=True,
+            created_by=_ADMIN.sub,
+        )
+        admin_client_id = admin_row.client_id
+
+    result = await OAuthDcrService(dcr_context).register(
+        client_name="Cursor", redirect_uris=_REDIRECT_URIS
+    )
+
+    assert result.created is True
+    assert result.client_id != admin_client_id
+    async with dcr_context.admin_db.session() as session:
+        rows = (await session.execute(select(OAuthClient))).scalars().all()
+    assert len(rows) == 2
+
+
 async def test_dedupe_key_spaces_never_cross_match(
     dcr_context: Context, clean_dcr_tables: None
 ) -> None:

--- a/tests/integration/auth/test_oauth_dcr_registration.py
+++ b/tests/integration/auth/test_oauth_dcr_registration.py
@@ -277,14 +277,125 @@ async def test_dedupe_different_redirect_set_creates_new_row(
     assert second.client_id != first.client_id
 
 
-async def test_no_software_id_never_dedupes(dcr_context: Context, clean_dcr_tables: None) -> None:
-    """Without a software_id every register creates a fresh row."""
+async def test_no_software_id_same_name_and_redirect_set_dedupes(
+    dcr_context: Context, clean_dcr_tables: None
+) -> None:
+    """G13 (#1251): a software_id-less client (Cursor, mcp-remote) retrying
+    registration re-attaches to its existing row via the (client_name +
+    redirect set) fallback key — the awaiting-approval retry loop must not
+    mint a fresh pending row (34 duplicate 'Cursor' rows observed live in
+    one morning). Redirect-URI order must not matter."""
     svc = OAuthDcrService(dcr_context)
-    first = await svc.register(client_name="anon", redirect_uris=_REDIRECT_URIS)
-    second = await svc.register(client_name="anon", redirect_uris=_REDIRECT_URIS)
+    first = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+    second = await svc.register(client_name="Cursor", redirect_uris=list(reversed(_REDIRECT_URIS)))
 
-    assert first.created is True and second.created is True
+    assert first.created is True
+    assert second.created is False
+    assert second.client_id == first.client_id
+
+    async with dcr_context.admin_db.session() as session:
+        rows = (await session.execute(select(OAuthClient))).scalars().all()
+    assert len(rows) == 1
+    # No second actionable alert for the dedupe hit — the queue stays clean.
+    events = await _events_of_type(dcr_context, EventType.OAUTH_CLIENT_REGISTERED)
+    assert len(events) == 1
+
+
+async def test_no_software_id_different_name_creates_new_row(
+    dcr_context: Context, clean_dcr_tables: None
+) -> None:
+    """The fallback key is (name + redirect set), never the redirect set
+    alone: two distinct software_id-less clients sharing redirect URIs
+    (e.g. the same well-known loopback port) stay distinct rows."""
+    svc = OAuthDcrService(dcr_context)
+    first = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+    second = await svc.register(client_name="MCP CLI Proxy", redirect_uris=_REDIRECT_URIS)
+
+    assert second.created is True
     assert second.client_id != first.client_id
+
+
+async def test_no_software_id_different_redirect_set_creates_new_row(
+    dcr_context: Context, clean_dcr_tables: None
+) -> None:
+    """Never dedupe on client_name alone — a differing redirect set is a new
+    registration (the fingerprint guarantees an approved row's redirect_uris
+    are never silently widened by a re-register)."""
+    svc = OAuthDcrService(dcr_context)
+    first = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+    second = await svc.register(client_name="Cursor", redirect_uris=["http://localhost:9999/other"])
+
+    assert second.created is True
+    assert second.client_id != first.client_id
+
+
+async def test_no_software_id_dedupe_preserves_row_state(
+    dcr_context: Context, clean_dcr_tables: None
+) -> None:
+    """A fallback-key dedupe hit is read-only: the stored row keeps its
+    pending status, inactive flag, name, and redirect set verbatim — a
+    re-registration never resets the approval lifecycle."""
+    svc = OAuthDcrService(dcr_context)
+    first = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+    second = await svc.register(
+        client_name="Cursor",
+        redirect_uris=list(reversed(_REDIRECT_URIS)),
+        scope="apis:read",
+    )
+
+    assert second.created is False
+    row = await _row_by_client_id(dcr_context, first.client_id)
+    assert row.approval_status == OAuthClientApprovalStatus.PENDING.value
+    assert row.active is False
+    assert row.name == "Cursor"
+    assert row.redirect_uris == _REDIRECT_URIS
+    assert row.allowed_scopes == sorted(MCP_TOOL_SCOPES)
+
+
+async def test_no_software_id_reattach_to_approved_row_keeps_it_approved(
+    dcr_context: Context, clean_dcr_tables: None
+) -> None:
+    """Continuity across a client cache loss: a re-register against an
+    *approved* software_id-less row returns the same client_id, still
+    approved and active — no fresh approval, no fresh consent. Adopting the
+    row discloses only the (public, RFC 6749 §2.2) client_id: public clients
+    hold no secret (PKCE per flow) and consent stays per-grant."""
+    svc = OAuthDcrService(dcr_context)
+    first = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+    row = await _row_by_client_id(dcr_context, first.client_id)
+    await OAuthClientService(dcr_context).approve(row.id, identity=_ADMIN)
+
+    second = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+
+    assert second.created is False
+    assert second.client_id == first.client_id
+    refreshed = await _row_by_client_id(dcr_context, first.client_id)
+    assert refreshed.approval_status == OAuthClientApprovalStatus.APPROVED.value
+    assert refreshed.active is True
+
+
+async def test_dedupe_key_spaces_never_cross_match(
+    dcr_context: Context, clean_dcr_tables: None
+) -> None:
+    """Adversarial guard: the software_id key space and the fallback name key
+    space are disjoint. A software_id-less registration replaying an existing
+    row's name + redirect set must not adopt a row registered *with* a
+    software_id, and a software_id-bearing registration must not adopt a
+    software_id-less row of the same name + redirect set."""
+    svc = OAuthDcrService(dcr_context)
+    with_sid = await svc.register(
+        client_name="Cursor", redirect_uris=_REDIRECT_URIS, software_id="com.cursor.ide"
+    )
+
+    without_sid = await svc.register(client_name="Cursor", redirect_uris=_REDIRECT_URIS)
+    assert without_sid.created is True
+    assert without_sid.client_id != with_sid.client_id
+
+    other_sid = await svc.register(
+        client_name="Cursor", redirect_uris=_REDIRECT_URIS, software_id="com.evil.other"
+    )
+    assert other_sid.created is True
+    assert other_sid.client_id not in {with_sid.client_id, without_sid.client_id}
 
 
 async def test_approve_verb_emits_event_and_settles_registration_alert(

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -28515,7 +28515,7 @@
     },
     "/oauth-clients": {
       "post": {
-        "description": "Register a public OAuth client anonymously (RFC 7591 subset).\n\nReturns 201 with the new ``client_id``, or 200 with the **existing** row's\n``client_id`` on an exact (``software_id`` + redirect-URI set) dedupe match\n(D8). No client_secret is ever issued here and no registration_access_token\nis returned (D12). New rows await admin approval unless the deployment\nauto-approves registrations (D9). The ``server.mcp.oauth.enabled`` gate\nlives on the route class — a disabled door 404s before this handler,\nits body validation, or the rate limiter ever run.",
+        "description": "Register a public OAuth client anonymously (RFC 7591 subset).\n\nReturns 201 with the new ``client_id``, or 200 with the **existing** row's\n``client_id`` on an exact dedupe match (D8, extended per G13/#1251):\n(``software_id`` + redirect-URI set), falling back to (``client_name`` +\nredirect-URI set) for registrations without a ``software_id`` — so a\npending client's awaiting-approval retry loop re-attaches instead of\nminting duplicate rows. No client_secret is ever issued here and no\nregistration_access_token\nis returned (D12). New rows await admin approval unless the deployment\nauto-approves registrations (D9). The ``server.mcp.oauth.enabled`` gate\nlives on the route class — a disabled door 404s before this handler,\nits body validation, or the rate limiter ever run.",
         "operationId": "registerOauthClientEndpoint",
         "requestBody": {
           "content": {

--- a/ui/src/shared/api/generated/services/OAuthClientsService.ts
+++ b/ui/src/shared/api/generated/services/OAuthClientsService.ts
@@ -267,8 +267,12 @@ export class OAuthClientsService {
      * Register a public OAuth client anonymously (RFC 7591 subset).
      *
      * Returns 201 with the new ``client_id``, or 200 with the **existing** row's
-     * ``client_id`` on an exact (``software_id`` + redirect-URI set) dedupe match
-     * (D8). No client_secret is ever issued here and no registration_access_token
+     * ``client_id`` on an exact dedupe match (D8, extended per G13/#1251):
+     * (``software_id`` + redirect-URI set), falling back to (``client_name`` +
+     * redirect-URI set) for registrations without a ``software_id`` — so a
+     * pending client's awaiting-approval retry loop re-attaches instead of
+     * minting duplicate rows. No client_secret is ever issued here and no
+     * registration_access_token
      * is returned (D12). New rows await admin approval unless the deployment
      * auto-approves registrations (D9). The ``server.mcp.oauth.enabled`` gate
      * lives on the route class — a disabled door 404s before this handler,


### PR DESCRIPTION
## Summary

With the approval-first default (`auto_approve_clients=false`, #1247), a DCR client parked `pending` gets the D7 awaiting-approval page from `/authorize` — no OAuth callback ever fires, so strict clients (Cursor 3.19.7 observed) treat auth as failed, drop their cached registration, and re-register on every retry. Cursor sends no `software_id`, so the D8 dedupe key `(software_id, redirect_uris_fingerprint)` never matched and every retry minted a fresh pending row: **34 duplicate "Cursor" `oauth_clients` rows accumulated in one morning of live testing** (G13, gap register in the plans repo; approach approved by Manuel 2026-09-04). Each duplicate also broke continuity: a client that lost its local cache came back as a brand-new client, forcing a fresh approval and a fresh consent.

This PR extends the DCR dedupe with a fallback identity for software_id-less registrations, so a re-registering client re-attaches to its existing row instead of minting a new one.

## Changes

- `auth` — `OAuthDcrService.register`: registrations **with** a `software_id` keep the existing D8 key untouched; registrations **without** one now dedupe on the fallback key `(client_name, redirect_uris_fingerprint)`, matched only against DCR-source rows that *also* carry no `software_id`. Winner selection is shared with the D8 path (approved > pending > denied, then oldest — the F6 race rule).
- `auth` — falsy/whitespace-only `software_id` (`""`, `"   "`) is normalized to `None` at the service boundary, before both the key-space branch and the insert (review F1): `""` passes schema validation but previously took the `IS NULL` lookup while *storing* `""` — a row in neither key space that re-opened the #1251 loop for empty-default serializers. The response echoes the normalized value. Normalizing (not rejecting) follows RFC 7591's ignore-don't-reject posture.
- `auth` — every dedupe re-attach now writes an **audit row** (actor `dcr`, reason `"anonymous DCR re-attach (dedupe hit)"`, `after={client_id, approval_status}`, origin `mcp`) so anonymous re-attaches — including probes of the 200-oracle and denied-row retries — are admin-visible (review F2). Deliberately **no event**: retries must not spam the approval queue, which is the point of the fix.
- `admin` — `OAuthClientRepository.list_dcr_by_name_dedupe_key`: the fallback lookup. `software_id IS NULL` keys into the existing `(software_id, redirect_uris_fingerprint)` covering index — **no new index, no migration** (the columns already exist).
- Response contract unchanged: 201 on create, 200 echoing the existing row's `client_id` on a dedupe hit — the pre-existing D8 contract. RFC 7591 §3.2.1 prescribes 201 for a *new* registration; a re-attach is deliberately not one, and Cursor's MCP SDK accepts the 200 shape (proven live by the D8 path since 3a).
- Docstring/comment updates in the router, model, and lifecycle test where they asserted "no software_id → no dedupe"; regenerated `openapi/` + `ui/openapi.json` (route description only).
- Out of scope (tracked separately in the G13 design candidates): registration rate-limit tightening (stays as-is per the approved design), the approval-queue collapse-duplicates UI affordance, the P2 approval-in-flow page that removes the retry trigger itself, and the reviewer's two hardening options (require `software_id` for approved re-attach; tighter registration bucket) — follow-up issue material.

## Risk & rollback

- Auth surface (anonymous DCR door, `POST /oauth-clients`). **Security analysis of re-attach** — the fallback key is client-chosen data, so assume an attacker replays an approved client's `client_name` + exact redirect URIs:
  - They receive the existing `client_id` — public information per RFC 6749 §2.2 (it travels in browser URLs and is echoed to any registrant).
  - They get **no** `client_secret`: this door only mints public clients (`token_endpoint_auth_method=none`); auth is PKCE-bound per flow.
  - They **cannot mutate** the row: a dedupe hit is read-only — approval status, stored name, scopes, and redirect set are preserved verbatim; a differing redirect set is a different fingerprint and therefore a *new* registration, so an approved client's redirect URIs can never be widened by re-registration.
  - **The honest D7 delta (review F3):** pre-PR, an exact-replay impersonator landed `pending` and stalled at the admin gate; post-PR they skip it and can drive `/authorize` under the victim's name. This is accepted deliberately because (a) consent remains unconditional for registered clients — the user must log in, see the consent page, and actively pick an agent; (b) the authorization code is delivered only to a URI in the **victim's** registered set — for the loopback URIs this door's clientele uses, interception requires co-residency on the victim's machine, and a co-resident attacker can generally read the real client's cached registration anyway; (c) the pre-PR gate had no discriminating power against exact replays — an impersonator's fresh registration was content-identical to the real client's, and the 34-duplicate queue made rubber-stamping the realistic outcome. The gate's real value there was friction + visibility; the F2 audit row restores the visibility half, which is the recoverable one.
  - The two key spaces never cross-match: a software_id-less replay cannot adopt a row registered *with* a `software_id`, and vice versa (`test_dedupe_key_spaces_never_cross_match`); with F1's normalization, `""`/whitespace spellings land in the fallback key space rather than escaping both. The `registration_source='dcr'` filter keeps admin-created rows out of reach of the anonymous door entirely (pinned adversarially).
  - Residual: a 200-vs-201 existence oracle for a (name, redirect-set) pair — now audit-logged per probe (F2) and bounded by the unchanged per-IP registration rate limit.
- **Denied rows re-attach** (same policy as D8): a denied client stays denied instead of getting a fresh pending second chance. **Pre-squat variant (review F4):** an attacker can pre-register a not-yet-installed client's (name, well-known redirect set), eat a denial, and the real client will later silently re-attach to the denied row. Recovery is admin-actioned: the admin **re-approves** the denied row (deny is reversible — the recovery arm is covered by `test_denied_then_approved_recovery_emits_approved_event`) or **deletes/deactivates** it so the next registration mints a fresh pending row. The F2 audit trail is what surfaces the stuck client: repeated `"anonymous DCR re-attach (dedupe hit)"` entries against a denied row are the signal to look.
- Known dedupe misses (accepted): an admin renaming a software_id-less row takes it out of the fallback key — a client re-registering after that mints a new pending row (treated as a distinct identity, which the rename arguably made it); a client that later starts sending `software_id` re-registers once. Concurrent same-key registrations can still race to two rows (no unique index — consistent with no-migration); the winner rule deterministically converges later retries (review F5, accepted as-is).
- No migration, no config change. Rollback: revert the squash commit.

## Test plan

- New integration tests (`tests/integration/auth/test_oauth_dcr_registration.py`, real DB per the no-DB-mocking rule; replaces the now-obsolete `test_no_software_id_never_dedupes`): same name + redirect set → same `client_id`, no new row, no second admin alert; different name → new row; different redirect set → new row; dedupe hit preserves pending/inactive/name/redirects/scopes verbatim; approved-row re-attach stays approved + active; software_id ↔ name key spaces never cross-match; **F1 regression** — two `software_id=""` registrations dedupe to one row and `""`/whitespace/absent spellings share one key space with `software_id IS NULL` stored; **F2** — dedupe hit writes the audit row (reason, actor, after) with no event; **F6(b)** — fallback-arm denied re-attach stays denied; **F6(c)** — an admin-source row with matching name + fingerprint is never adopted by the anonymous door.
- Existing D8 suite (software_id dedupe, F6 race preference, denied re-attach, metadata echo minimization) unchanged and passing; router unit tests already pin the 200-dedupe response shape.
- Gates run locally at `1f38c46b`: `make lint` (ruff check + format + mypy, 1222 files) clean, `make detect-secrets` clean, `make test-arch` **153 passed**, `make test-unit` **3250 passed**, `make test-integration-sqlite` **740 passed, 13 skipped**. `make openapi` regenerated with no drift.

## Review guide

- Start with `OAuthDcrService.register` (the normalization line, the two-key branch, and the audited dedupe arm), then `list_dcr_by_name_dedupe_key` (the `software_id IS NULL` + `registration_source='dcr'` scoping is the security seam), then the adversarial tests.

Closes #1251