### PR TITLE
fix(auth): include the RFC 6749 §5.1 scope member in every token response

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,21 +164,21 @@
         "filename": "cli/client/generated/control/client.go",
         "hashed_secret": "36c46a098c7543cc8569553d4a8946bc7df395c9",
         "is_verified": false,
-        "line_number": 3851
+        "line_number": 3854
       },
       {
         "type": "Secret Keyword",
         "filename": "cli/client/generated/control/client.go",
         "hashed_secret": "dc0acf6e95f2dcba19616d63c275e8a749126f89",
         "is_verified": false,
-        "line_number": 5134
+        "line_number": 5137
       },
       {
         "type": "Secret Keyword",
         "filename": "cli/client/generated/control/client.go",
         "hashed_secret": "8cf6cb4d35e002c25f800782aab43af23d9e1f2c",
         "is_verified": false,
-        "line_number": 7889
+        "line_number": 7892
       }
     ],
     "cli/client/generated/control/spec.yaml": [
@@ -187,7 +187,7 @@
         "filename": "cli/client/generated/control/spec.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 19568
+        "line_number": 19573
       }
     ],
     "cli/internal/cli/api/admin_providers.go": [
@@ -492,7 +492,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 19568
+        "line_number": 19573
       }
     ],
     "release-please-config.json": [
@@ -1712,7 +1712,16 @@
         "filename": "tests/unit/auth/web/test_oauth_client_credentials.py",
         "hashed_secret": "bee7a0aa6017e98bbfbae6b7b1dfb5c64105172b",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 136
+      }
+    ],
+    "tests/unit/auth/web/test_oauth_response_shape.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/auth/web/test_oauth_response_shape.py",
+        "hashed_secret": "9251c77b74cbfe6c2e1fbf5f7eeb6e14bd1ba37a",
+        "is_verified": false,
+        "line_number": 294
       }
     ],
     "tests/unit/broker/test_execute_credential_name.py": [
@@ -2171,5 +2180,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-04T13:21:33Z"
+  "generated_at": "2026-09-04T15:25:51Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -187,7 +187,7 @@
         "filename": "cli/client/generated/control/spec.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 19573
+        "line_number": 19574
       }
     ],
     "cli/internal/cli/api/admin_providers.go": [
@@ -492,7 +492,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 19573
+        "line_number": 19574
       }
     ],
     "release-please-config.json": [
@@ -1721,7 +1721,7 @@
         "filename": "tests/unit/auth/web/test_oauth_response_shape.py",
         "hashed_secret": "9251c77b74cbfe6c2e1fbf5f7eeb6e14bd1ba37a",
         "is_verified": false,
-        "line_number": 294
+        "line_number": 299
       }
     ],
     "tests/unit/broker/test_execute_credential_name.py": [
@@ -2180,5 +2180,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-04T15:25:51Z"
+  "generated_at": "2026-09-04T16:04:57Z"
 }

--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -2986,8 +2986,8 @@ type TokenResponse struct {
 	IdToken      *string `json:"id_token,omitempty"`
 	RefreshToken *string `json:"refresh_token,omitempty"`
 
-	// Scope Space-delimited effective scopes of the minted access token (RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes (client ceiling / consent-grant intersection), so the granted set may be narrower than requested and clients must not assume they got what they asked for.
-	Scope     string  `json:"scope"`
+	// Scope Space-delimited effective scopes of the minted access token (RFC 6749 §3.3), computed the way the platform's resolvers enforce them (live scope grants ∩ client ceiling ∩ consent-grant scopes for agent and service-account tokens), so the granted set may be narrower than requested and clients must not assume they got what they asked for. Present on every response whose token carries at least one scope; OMITTED (never the ABNF-invalid empty string) only when the effective set is empty — reachable solely on legs where the client requested no scopes at the token endpoint (the token request carries no scope parameter, and consent fails closed on an empty intersection).
+	Scope     *string `json:"scope,omitempty"`
 	TokenType *string `json:"token_type,omitempty"`
 }
 

--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -2985,7 +2985,10 @@ type TokenResponse struct {
 	ExpiresIn    int     `json:"expires_in"`
 	IdToken      *string `json:"id_token,omitempty"`
 	RefreshToken *string `json:"refresh_token,omitempty"`
-	TokenType    *string `json:"token_type,omitempty"`
+
+	// Scope Space-delimited effective scopes of the minted access token (RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes (client ceiling / consent-grant intersection), so the granted set may be narrower than requested and clients must not assume they got what they asked for.
+	Scope     string  `json:"scope"`
+	TokenType *string `json:"token_type,omitempty"`
 }
 
 // ToolkitAgentListResponse Paginated list of agents bound to a toolkit.

--- a/cli/client/generated/control/required.gen.go
+++ b/cli/client/generated/control/required.gen.go
@@ -253,8 +253,10 @@ func (SetPermissionsRequest) RequiredFields() []string        { return []string{
 func (Sigv4CreateRequest) RequiredFields() []string {
 	return []string{"access_key_id", "api", "aws_region", "aws_service", "name", "secret_access_key", "type"}
 }
-func (Sigv4UpdateRequest) RequiredFields() []string       { return []string{"type"} }
-func (TokenResponse) RequiredFields() []string            { return []string{"access_token", "expires_in"} }
+func (Sigv4UpdateRequest) RequiredFields() []string { return []string{"type"} }
+func (TokenResponse) RequiredFields() []string {
+	return []string{"access_token", "expires_in", "scope"}
+}
 func (ToolkitAgentListResponse) RequiredFields() []string { return []string{"data", "has_more"} }
 func (ToolkitAgentResponse) RequiredFields() []string {
 	return []string{"agent_id", "agent_name", "bound_at", "status"}

--- a/cli/client/generated/control/required.gen.go
+++ b/cli/client/generated/control/required.gen.go
@@ -253,10 +253,8 @@ func (SetPermissionsRequest) RequiredFields() []string        { return []string{
 func (Sigv4CreateRequest) RequiredFields() []string {
 	return []string{"access_key_id", "api", "aws_region", "aws_service", "name", "secret_access_key", "type"}
 }
-func (Sigv4UpdateRequest) RequiredFields() []string { return []string{"type"} }
-func (TokenResponse) RequiredFields() []string {
-	return []string{"access_token", "expires_in", "scope"}
-}
+func (Sigv4UpdateRequest) RequiredFields() []string       { return []string{"type"} }
+func (TokenResponse) RequiredFields() []string            { return []string{"access_token", "expires_in"} }
 func (ToolkitAgentListResponse) RequiredFields() []string { return []string{"data", "has_more"} }
 func (ToolkitAgentResponse) RequiredFields() []string {
 	return []string{"agent_id", "agent_name", "bound_at", "status"}

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -5547,6 +5547,10 @@ components:
           - type: 'null'
           title: Refresh Token
           x-sensitive: true
+        scope:
+          description: 'Space-delimited effective scopes of the minted access token (RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes (client ceiling / consent-grant intersection), so the granted set may be narrower than requested and clients must not assume they got what they asked for.'
+          title: Scope
+          type: string
         token_type:
           default: bearer
           title: Token Type
@@ -5554,6 +5558,7 @@ components:
       required:
       - access_token
       - expires_in
+      - scope
       title: TokenResponse
       type: object
     ToolkitAgentListResponse:

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -5548,9 +5548,11 @@ components:
           title: Refresh Token
           x-sensitive: true
         scope:
-          description: 'Space-delimited effective scopes of the minted access token (RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes (client ceiling / consent-grant intersection), so the granted set may be narrower than requested and clients must not assume they got what they asked for.'
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Space-delimited effective scopes of the minted access token (RFC 6749 §3.3), computed the way the platform's resolvers enforce them (live scope grants ∩ client ceiling ∩ consent-grant scopes for agent and service-account tokens), so the granted set may be narrower than requested and clients must not assume they got what they asked for. Present on every response whose token carries at least one scope; OMITTED (never the ABNF-invalid empty string) only when the effective set is empty — reachable solely on legs where the client requested no scopes at the token endpoint (the token request carries no scope parameter, and consent fails closed on an empty intersection).
           title: Scope
-          type: string
         token_type:
           default: bearer
           title: Token Type
@@ -5558,7 +5560,6 @@ components:
       required:
       - access_token
       - expires_in
-      - scope
       title: TokenResponse
       type: object
     ToolkitAgentListResponse:

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -5547,6 +5547,10 @@ components:
           - type: 'null'
           title: Refresh Token
           x-sensitive: true
+        scope:
+          description: 'Space-delimited effective scopes of the minted access token (RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes (client ceiling / consent-grant intersection), so the granted set may be narrower than requested and clients must not assume they got what they asked for.'
+          title: Scope
+          type: string
         token_type:
           default: bearer
           title: Token Type
@@ -5554,6 +5558,7 @@ components:
       required:
       - access_token
       - expires_in
+      - scope
       title: TokenResponse
       type: object
     ToolkitAgentListResponse:

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -5548,9 +5548,11 @@ components:
           title: Refresh Token
           x-sensitive: true
         scope:
-          description: 'Space-delimited effective scopes of the minted access token (RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes (client ceiling / consent-grant intersection), so the granted set may be narrower than requested and clients must not assume they got what they asked for.'
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Space-delimited effective scopes of the minted access token (RFC 6749 §3.3), computed the way the platform's resolvers enforce them (live scope grants ∩ client ceiling ∩ consent-grant scopes for agent and service-account tokens), so the granted set may be narrower than requested and clients must not assume they got what they asked for. Present on every response whose token carries at least one scope; OMITTED (never the ABNF-invalid empty string) only when the effective set is empty — reachable solely on legs where the client requested no scopes at the token endpoint (the token request carries no scope parameter, and consent fails closed on an empty intersection).
           title: Scope
-          type: string
         token_type:
           default: bearer
           title: Token Type
@@ -5558,7 +5560,6 @@ components:
       required:
       - access_token
       - expires_in
-      - scope
       title: TokenResponse
       type: object
     ToolkitAgentListResponse:

--- a/src/jentic_one/auth/services/assertion_service.py
+++ b/src/jentic_one/auth/services/assertion_service.py
@@ -69,8 +69,13 @@ class AssertionService:
         self._ctx = ctx
         self._jti_cache = _get_jti_cache(ctx.config.auth.assertion_max_ttl_seconds)
 
-    async def verify_and_exchange(self, assertion: str) -> tuple[str, str]:
-        """Verify a JWT assertion and return (access_token, refresh_token)."""
+    async def verify_and_exchange(self, assertion: str) -> tuple[str, str, list[str]]:
+        """Verify a JWT assertion and return (access_token, refresh_token, scopes).
+
+        ``scopes`` is the agent's live ``actor_scope_grants`` set stamped on
+        the minted pair, returned so the token endpoint can report the
+        effective scope per RFC 6749 §5.1.
+        """
         try:
             unverified_header = jwt.get_unverified_header(assertion)
         except jwt.exceptions.DecodeError:
@@ -163,7 +168,7 @@ class AssertionService:
         token_svc = TokenService(self._ctx)
         access_token, refresh_token = await token_svc.issue_pair(agent.id, ActorType.AGENT, scopes)
 
-        return access_token, refresh_token
+        return access_token, refresh_token, scopes
 
     @property
     def _expected_audience(self) -> str:

--- a/src/jentic_one/auth/services/authorize_service.py
+++ b/src/jentic_one/auth/services/authorize_service.py
@@ -417,13 +417,17 @@ class AuthorizeService:
         redirect_uri: str,
         client_id: str,
         oauth_client_id: str | None = None,
-    ) -> tuple[str, str, str | None]:
+    ) -> tuple[str, str, str | None, list[str]]:
         """Exchange auth code + PKCE verifier for tokens.
 
-        Returns (access_token, refresh_token, id_token). Grant-bearing codes
-        mint actor=AGENT tokens bound to the consent grant and
-        return ``id_token=None`` (D11 — no OIDC identity on the agent
-        channel); plain codes keep the act-as-user path with an id_token.
+        Returns (access_token, refresh_token, id_token, scopes). ``scopes`` is
+        the effective scope set stamped on the minted tokens — for
+        grant-bearing codes the consent-time D2 triple intersection, for plain
+        codes the authorize-time snapshot — so the token endpoint can report
+        it per RFC 6749 §5.1. Grant-bearing codes mint actor=AGENT tokens
+        bound to the consent grant and return ``id_token=None`` (D11 — no OIDC
+        identity on the agent channel); plain codes keep the act-as-user path
+        with an id_token.
         """
         code_hash = _hash_code(code)
         now = datetime.now(UTC)
@@ -524,7 +528,7 @@ class AuthorizeService:
                 oauth_client_id=oauth_client_id,
                 oauth_grant_id=grant_id,
             )
-            return access_token, refresh_token, None
+            return access_token, refresh_token, None, grant_scopes
 
         scopes = auth_code.scopes.split() if auth_code.scopes else ["openid"]
         access_token, refresh_token = await self._token_svc.issue_pair(
@@ -539,7 +543,7 @@ class AuthorizeService:
             nonce=auth_code.nonce,
         )
 
-        return access_token, refresh_token, id_token
+        return access_token, refresh_token, id_token, scopes
 
     async def _resolve_or_create_user(self, claims: IdpClaims) -> str:
         """Resolve external identity to existing user or create a new one.

--- a/src/jentic_one/auth/services/authorize_service.py
+++ b/src/jentic_one/auth/services/authorize_service.py
@@ -34,7 +34,7 @@ from jentic_one.auth.core.idp import (
     get_default_idp_grants,
 )
 from jentic_one.auth.services.errors import InvalidGrantError, UserNotAdmittedError
-from jentic_one.auth.services.token_service import TokenService
+from jentic_one.auth.services.token_service import TokenService, resolve_effective_scopes
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit
 from jentic_one.shared.config import AuthConfig
 from jentic_one.shared.context import Context
@@ -421,10 +421,12 @@ class AuthorizeService:
         """Exchange auth code + PKCE verifier for tokens.
 
         Returns (access_token, refresh_token, id_token, scopes). ``scopes`` is
-        the effective scope set stamped on the minted tokens — for
-        grant-bearing codes the consent-time D2 triple intersection, for plain
-        codes the authorize-time snapshot — so the token endpoint can report
-        it per RFC 6749 §5.1. Grant-bearing codes mint actor=AGENT tokens
+        the effective set the minted access token will actually enforce,
+        reported per RFC 6749 §5.1: for grant-bearing (agent-channel) codes it
+        is recomputed at exchange time the way the live resolvers enforce it
+        (agent live grants ∩ client ceiling ∩ consent-grant scopes, via
+        :func:`resolve_effective_scopes`); for plain codes it is the
+        authorize-time snapshot. Grant-bearing codes mint actor=AGENT tokens
         bound to the consent grant and return ``id_token=None`` (D11 — no OIDC
         identity on the agent channel); plain codes keep the act-as-user path
         with an id_token.
@@ -434,6 +436,7 @@ class AuthorizeService:
         grant_id: str | None = None
         grant_agent_id: str | None = None
         grant_scopes: list[str] = []
+        grant_effective_scopes: list[str] = []
 
         async with self._ctx.admin_db.transaction() as session:
             auth_code = await AuthorizationCodeRepository.get_by_hash(
@@ -491,6 +494,25 @@ class AuthorizeService:
                 grant_id = grant.id
                 grant_agent_id = grant.agent_id
                 grant_scopes = list(grant.scopes)
+                # Reported set (RFC 6749 §5.1) — the resolvers ignore the
+                # snapshot for agent tokens and enforce live grants ∩ client
+                # ceiling ∩ grant scopes from the token's first use, so the
+                # consent-time D2 set alone would over-report a scope revoked
+                # inside the code TTL (the consent-time snapshot is not
+                # trusted across the TTL — same posture as the gates above).
+                grant_effective_scopes = await resolve_effective_scopes(
+                    session,
+                    actor_id=grant.agent_id,
+                    actor_type=ActorType.AGENT,
+                    snapshot_scopes=grant_scopes,
+                    is_ephemeral=False,
+                    client_ceiling=(
+                        frozenset(oauth_client.allowed_scopes)
+                        if oauth_client.allowed_scopes is not None
+                        else None
+                    ),
+                    grant_ceiling=frozenset(grant.scopes),
+                )
 
             user = await UserRepository.get_by_id(session, auth_code.user_id)
 
@@ -528,7 +550,7 @@ class AuthorizeService:
                 oauth_client_id=oauth_client_id,
                 oauth_grant_id=grant_id,
             )
-            return access_token, refresh_token, None, grant_scopes
+            return access_token, refresh_token, None, grant_effective_scopes
 
         scopes = auth_code.scopes.split() if auth_code.scopes else ["openid"]
         access_token, refresh_token = await self._token_svc.issue_pair(
@@ -543,6 +565,13 @@ class AuthorizeService:
             nonce=auth_code.nonce,
         )
 
+        # Reported (§5.1) as granted at authorize time, deliberately: the user
+        # channel's set may include OIDC passthrough scopes (openid/email/…)
+        # that are consumed by the id_token and never enforced as platform
+        # permissions, and enforcement additionally intersects the *live*
+        # client ceiling at resolve time. Standard OIDC posture — the scope
+        # member tells the client what its authorization covers (including
+        # the identity scopes), not the platform-permission subset.
         return access_token, refresh_token, id_token, scopes
 
     async def _resolve_or_create_user(self, claims: IdpClaims) -> str:

--- a/src/jentic_one/auth/services/service_account_auth_service.py
+++ b/src/jentic_one/auth/services/service_account_auth_service.py
@@ -111,10 +111,13 @@ class ServiceAccountAuthService:
 
     async def authenticate_client_credentials(
         self, client_id: str, client_secret: str
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, list[str]]:
         """Verify client_id + client_secret, issue an access+refresh pair.
 
-        Returns (access_token, refresh_token).
+        Returns (access_token, refresh_token, scopes). ``scopes`` is the
+        service account's live ``actor_scope_grants`` set stamped on the
+        minted pair, returned so the token endpoint can report the effective
+        scope per RFC 6749 §5.1.
         Raises InvalidGrantError on authentication failure.
         """
         async with self._ctx.admin_db.session() as session:
@@ -147,7 +150,10 @@ class ServiceAccountAuthService:
             origin=None,
         )
 
-        return await self._token_svc.issue_pair(client_id, ActorType.SERVICE_ACCOUNT, scopes)
+        access_token, refresh_token = await self._token_svc.issue_pair(
+            client_id, ActorType.SERVICE_ACCOUNT, scopes
+        )
+        return access_token, refresh_token, scopes
 
     async def mint_task_token(
         self,

--- a/src/jentic_one/auth/services/token_service.py
+++ b/src/jentic_one/auth/services/token_service.py
@@ -71,6 +71,44 @@ def _apply_scope_ceiling(scopes: list[str], ceiling: frozenset[str] | None) -> l
     return [s for s in scopes if s in ceiling]
 
 
+async def resolve_effective_scopes(
+    session: AsyncSession,
+    *,
+    actor_id: str,
+    actor_type: str,
+    snapshot_scopes: list[str],
+    is_ephemeral: bool,
+    client_ceiling: frozenset[str] | None,
+    grant_ceiling: frozenset[str] | None,
+) -> list[str]:
+    """The scope set the live resolvers actually enforce for a token.
+
+    Non-ephemeral AGENT/SERVICE_ACCOUNT tokens draw scopes *live* from
+    ``actor_scope_grants`` — the mint-time snapshot is dead weight for
+    enforcement on these actor types (scope edits take effect immediately by
+    design). Ephemeral mints and USER tokens keep their snapshot. Either
+    starting set is then intersected with the issuing client's
+    ``allowed_scopes`` ceiling and the consent grant's scope set.
+
+    This is the single source of truth shared by the enforcement path
+    (:meth:`TokenService.resolve_access_token`) and the RFC 6749 §5.1
+    reporting paths (:meth:`TokenService.refresh`,
+    ``AuthorizeService.exchange_code``), so the ``scope`` member a token
+    response reports can never diverge from what the minted token enforces.
+    The broker's ``InProcessTokenResolver`` re-implements the same math over
+    raw SQL (it deliberately imports nothing from ``auth``); the
+    grant-channel integration suite pins all three against each other.
+    """
+    scopes = snapshot_scopes
+    if not is_ephemeral and actor_type in (ActorType.AGENT, ActorType.SERVICE_ACCOUNT):
+        grants = await ActorScopeGrantRepository.list_for_actor(
+            session, actor_id, actor_type=actor_type
+        )
+        scopes = [g.scope for g in grants]
+    scopes = _apply_scope_ceiling(scopes, client_ceiling)
+    return _apply_scope_ceiling(scopes, grant_ceiling)
+
+
 async def _resolve_grant_gate(
     session: AsyncSession, oauth_grant_id: str | None
 ) -> tuple[bool, frozenset[str] | None]:
@@ -246,9 +284,13 @@ class TokenService:
     ) -> tuple[str, str, list[str]]:
         """Rotate a refresh token. Returns (access_token, refresh_token, scopes).
 
-        ``scopes`` is the rotated pair's mint-time snapshot (carried over from
-        the consumed refresh token), returned so the token endpoint can report
-        the effective scope per RFC 6749 §5.1.
+        ``scopes`` is the rotated access token's *effective* set, computed at
+        rotation time exactly the way the live resolvers enforce it
+        (:func:`resolve_effective_scopes`): live ``actor_scope_grants`` ∩
+        client ceiling ∩ grant scopes for non-ephemeral AGENT/SA actors, the
+        family snapshot ∩ ceilings for USER actors. The token rows still
+        carry the family's mint-time snapshot — enforcement for AGENT/SA
+        ignores it, and re-stamping would break USER-token semantics.
 
         Implements reuse detection: if the refresh token has already been consumed,
         the entire token family is revoked. Uses SELECT FOR UPDATE to prevent TOCTOU
@@ -261,6 +303,8 @@ class TokenService:
         token_hash = _hash_token(refresh_token)
         reuse_detected = False
         client_mismatch = False
+        client_ceiling: frozenset[str] | None = None
+        grant_ceiling: frozenset[str] | None = None
 
         async with self._ctx.admin_db.transaction() as session:
             rt = await RefreshTokenRepository.get_by_hash(session, token_hash, for_update=True)
@@ -284,6 +328,8 @@ class TokenService:
                     # active off, but a pending row force-set active must
                     # still never mint tokens.
                     raise InvalidGrantError("issuing OAuth client has been deactivated")
+                if oauth_client.allowed_scopes is not None:
+                    client_ceiling = frozenset(oauth_client.allowed_scopes)
                 if client_id is None:
                     raise InvalidGrantError("client authentication required")
                 if client_id != rt.oauth_client_id:
@@ -333,13 +379,30 @@ class TokenService:
                         )
                         if grant is None or grant.status != OAuthGrantStatus.ACTIVE.value:
                             raise InvalidGrantError("consent grant has been revoked")
+                        grant_ceiling = frozenset(grant.scopes)
 
                     if not await _actor_is_active(session, rt.actor_id, rt.actor_type):
                         raise InvalidGrantError("actor is not active")
 
                     access_plain = _generate_token(ACCESS_TOKEN_PREFIX)
                     refresh_plain = _generate_token(REFRESH_TOKEN_PREFIX)
-                    scopes = list(rt.scopes)
+                    snapshot = list(rt.scopes)
+                    # Reported set (RFC 6749 §5.1) — computed the way the
+                    # resolvers will enforce it for the new access token, not
+                    # the family snapshot: for AGENT/SA actors the resolvers
+                    # ignore the snapshot and re-derive live on every request,
+                    # so reporting rt.scopes would over-report scopes revoked
+                    # since the original mint (and under-report ones granted
+                    # since) — the exact #1260 failure mode.
+                    scopes = await resolve_effective_scopes(
+                        session,
+                        actor_id=rt.actor_id,
+                        actor_type=rt.actor_type,
+                        snapshot_scopes=snapshot,
+                        is_ephemeral=False,
+                        client_ceiling=client_ceiling,
+                        grant_ceiling=grant_ceiling,
+                    )
                     now = datetime.now(UTC)
 
                     await AccessTokenRepository.create(
@@ -347,7 +410,7 @@ class TokenService:
                         token_hash=_hash_token(access_plain),
                         actor_id=rt.actor_id,
                         actor_type=rt.actor_type,
-                        scopes=scopes,
+                        scopes=snapshot,
                         token_family_id=rt.token_family_id,
                         expires_at=now + timedelta(seconds=self.access_ttl_seconds),
                         created_by=rt.actor_id,
@@ -359,7 +422,7 @@ class TokenService:
                         token_hash=_hash_token(refresh_plain),
                         actor_id=rt.actor_id,
                         actor_type=rt.actor_type,
-                        scopes=scopes,
+                        scopes=snapshot,
                         token_family_id=rt.token_family_id,
                         expires_at=now + timedelta(seconds=self._refresh_ttl),
                         created_by=rt.actor_id,
@@ -556,7 +619,6 @@ class TokenService:
                 if not grant_active:
                     return None
 
-            scopes = list(at.scopes)
             parent_actor_id: str | None = None
             if at.actor_type == ActorType.AGENT:
                 # One lookup serves both parent resolution and the status check.
@@ -566,22 +628,19 @@ class TokenService:
             else:
                 actor_active = await _actor_is_active(session, at.actor_id, at.actor_type)
 
-            if not at.is_ephemeral and at.actor_type in (
-                ActorType.AGENT,
-                ActorType.SERVICE_ACCOUNT,
-            ):
-                grants = await ActorScopeGrantRepository.list_for_actor(
-                    session, at.actor_id, actor_type=at.actor_type
-                )
-                scopes = [g.scope for g in grants]
-
-            if client_scope_ceiling is not None:
-                scopes = [s for s in scopes if s in client_scope_ceiling]
-
-            if grant_scope_ceiling is not None:
-                # Fourth leg of the quadruple intersection: token
-                # snapshot ∩ agent live grants ∩ client ceiling ∩ grant scopes.
-                scopes = [s for s in scopes if s in grant_scope_ceiling]
+            # Live grants (non-ephemeral AGENT/SA) or snapshot (ephemeral,
+            # USER), intersected with the client ceiling and the grant's
+            # scope set (the quadruple intersection) — via the same helper
+            # the §5.1 reporting paths use, so reported == enforced.
+            scopes = await resolve_effective_scopes(
+                session,
+                actor_id=at.actor_id,
+                actor_type=at.actor_type,
+                snapshot_scopes=list(at.scopes),
+                is_ephemeral=at.is_ephemeral,
+                client_ceiling=client_scope_ceiling,
+                grant_ceiling=grant_scope_ceiling,
+            )
 
         active = at.revoked_at is None and at.expires_at > now and actor_active
         return Identity(

--- a/src/jentic_one/auth/services/token_service.py
+++ b/src/jentic_one/auth/services/token_service.py
@@ -241,8 +241,14 @@ class TokenService:
 
         return access_plain, refresh_plain
 
-    async def refresh(self, refresh_token: str, *, client_id: str | None = None) -> tuple[str, str]:
-        """Rotate a refresh token. Returns a new (access_token, refresh_token) pair.
+    async def refresh(
+        self, refresh_token: str, *, client_id: str | None = None
+    ) -> tuple[str, str, list[str]]:
+        """Rotate a refresh token. Returns (access_token, refresh_token, scopes).
+
+        ``scopes`` is the rotated pair's mint-time snapshot (carried over from
+        the consumed refresh token), returned so the token endpoint can report
+        the effective scope per RFC 6749 §5.1.
 
         Implements reuse detection: if the refresh token has already been consumed,
         the entire token family is revoked. Uses SELECT FOR UPDATE to prevent TOCTOU
@@ -333,6 +339,7 @@ class TokenService:
 
                     access_plain = _generate_token(ACCESS_TOKEN_PREFIX)
                     refresh_plain = _generate_token(REFRESH_TOKEN_PREFIX)
+                    scopes = list(rt.scopes)
                     now = datetime.now(UTC)
 
                     await AccessTokenRepository.create(
@@ -340,7 +347,7 @@ class TokenService:
                         token_hash=_hash_token(access_plain),
                         actor_id=rt.actor_id,
                         actor_type=rt.actor_type,
-                        scopes=list(rt.scopes),
+                        scopes=scopes,
                         token_family_id=rt.token_family_id,
                         expires_at=now + timedelta(seconds=self.access_ttl_seconds),
                         created_by=rt.actor_id,
@@ -352,7 +359,7 @@ class TokenService:
                         token_hash=_hash_token(refresh_plain),
                         actor_id=rt.actor_id,
                         actor_type=rt.actor_type,
-                        scopes=list(rt.scopes),
+                        scopes=scopes,
                         token_family_id=rt.token_family_id,
                         expires_at=now + timedelta(seconds=self._refresh_ttl),
                         created_by=rt.actor_id,
@@ -382,7 +389,7 @@ class TokenService:
         if client_mismatch:
             raise InvalidGrantError("client_id mismatch")
 
-        return access_plain, refresh_plain
+        return access_plain, refresh_plain, scopes
 
     async def revoke(self, token: str, *, identity: Identity) -> None:
         """Revoke a token. No-op if not found or not owned by actor (RFC 7009)."""

--- a/src/jentic_one/auth/web/routers/oauth.py
+++ b/src/jentic_one/auth/web/routers/oauth.py
@@ -279,7 +279,7 @@ async def token_endpoint(
             ):
                 raise InvalidGrantError("invalid_client")
             third_party_client_id = body.client_id
-        access_token, refresh_token, id_token = await authorize_svc.exchange_code(
+        access_token, refresh_token, id_token, scopes = await authorize_svc.exchange_code(
             code=body.code,
             code_verifier=body.code_verifier,
             redirect_uri=body.redirect_uri,
@@ -292,23 +292,27 @@ async def token_endpoint(
             id_token=id_token,
             token_type="bearer",
             expires_in=token_svc.access_ttl_seconds,
+            scope=" ".join(scopes),
         )
 
     if body.grant_type == _JWT_BEARER_GRANT:
         if not body.assertion:
             raise InvalidGrantError("assertion is required for grant_type=jwt-bearer")
-        access_token, refresh_token = await assertion_svc.verify_and_exchange(body.assertion)
+        access_token, refresh_token, scopes = await assertion_svc.verify_and_exchange(
+            body.assertion
+        )
         return TokenResponse(
             access_token=access_token,
             refresh_token=refresh_token,
             token_type="bearer",
             expires_in=token_svc.access_ttl_seconds,
+            scope=" ".join(scopes),
         )
 
     if body.grant_type == _CLIENT_CREDENTIALS_GRANT:
         if not body.client_id or not body.client_secret:
             raise InvalidGrantError("client_id and client_secret are required")
-        access_token, refresh_token = await sa_auth_svc.authenticate_client_credentials(
+        access_token, refresh_token, scopes = await sa_auth_svc.authenticate_client_credentials(
             body.client_id, body.client_secret
         )
         return TokenResponse(
@@ -316,6 +320,7 @@ async def token_endpoint(
             refresh_token=refresh_token,
             token_type="bearer",
             expires_in=sa_auth_svc.access_ttl_seconds,
+            scope=" ".join(scopes),
         )
 
     if body.grant_type != "refresh_token":
@@ -336,7 +341,7 @@ async def token_endpoint(
         # verify_client_secret above: NULL-hash rows short-circuit to False).
         verified_client_id = body.client_id
 
-    access_token, refresh_token = await token_svc.refresh(
+    access_token, refresh_token, scopes = await token_svc.refresh(
         body.refresh_token, client_id=verified_client_id
     )
     return TokenResponse(
@@ -344,6 +349,7 @@ async def token_endpoint(
         refresh_token=refresh_token,
         token_type="bearer",
         expires_in=token_svc.access_ttl_seconds,
+        scope=" ".join(scopes),
     )
 
 

--- a/src/jentic_one/auth/web/routers/oauth.py
+++ b/src/jentic_one/auth/web/routers/oauth.py
@@ -117,6 +117,24 @@ _CLIENT_CREDENTIALS_GRANT = "client_credentials"
 _AUTHORIZATION_CODE_GRANT = "authorization_code"
 
 
+def _scope_member(scopes: list[str]) -> str | None:
+    """Serialize an effective scope set for the RFC 6749 §5.1 ``scope`` member.
+
+    Space-delimited per §3.3 — whose ABNF (``scope-token *( SP scope-token )``)
+    forbids an empty value, so an empty effective set is OMITTED (None +
+    ``response_model_exclude_none``), never emitted as ``""``. Omission is
+    honest here: no grant leg of this endpoint accepts a scope parameter in
+    the token request, and the consent flow fails closed on an empty
+    intersection (``no_grantable_scopes``), so an empty set can only mean the
+    caller never asked for scopes at this endpoint (zero-grant agents/SAs on
+    the jwt-bearer/client-credentials legs) or every grant was revoked
+    post-mint (refresh leg) — a live, reversible administrative state the
+    platform deliberately distinguishes from revocation, which fails the
+    exchange closed instead.
+    """
+    return " ".join(scopes) if scopes else None
+
+
 def get_token_service(ctx: Context = Depends(get_ctx)) -> TokenService:
     return TokenService(ctx)
 
@@ -292,7 +310,7 @@ async def token_endpoint(
             id_token=id_token,
             token_type="bearer",
             expires_in=token_svc.access_ttl_seconds,
-            scope=" ".join(scopes),
+            scope=_scope_member(scopes),
         )
 
     if body.grant_type == _JWT_BEARER_GRANT:
@@ -306,7 +324,7 @@ async def token_endpoint(
             refresh_token=refresh_token,
             token_type="bearer",
             expires_in=token_svc.access_ttl_seconds,
-            scope=" ".join(scopes),
+            scope=_scope_member(scopes),
         )
 
     if body.grant_type == _CLIENT_CREDENTIALS_GRANT:
@@ -320,7 +338,7 @@ async def token_endpoint(
             refresh_token=refresh_token,
             token_type="bearer",
             expires_in=sa_auth_svc.access_ttl_seconds,
-            scope=" ".join(scopes),
+            scope=_scope_member(scopes),
         )
 
     if body.grant_type != "refresh_token":
@@ -349,7 +367,7 @@ async def token_endpoint(
         refresh_token=refresh_token,
         token_type="bearer",
         expires_in=token_svc.access_ttl_seconds,
-        scope=" ".join(scopes),
+        scope=_scope_member(scopes),
     )
 
 

--- a/src/jentic_one/auth/web/schemas/oauth.py
+++ b/src/jentic_one/auth/web/schemas/oauth.py
@@ -28,12 +28,18 @@ class TokenResponse(BaseModel):
     id_token: str | None = Field(default=None, json_schema_extra=SENSITIVE)
     token_type: str = "bearer"
     expires_in: int
-    scope: str = Field(
+    scope: str | None = Field(
+        default=None,
         description="Space-delimited effective scopes of the minted access token "
-        "(RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes "
-        "(client ceiling / consent-grant intersection), so the granted set may be "
-        "narrower than requested and clients must not assume they got what they "
-        "asked for."
+        "(RFC 6749 §3.3), computed the way the platform's resolvers enforce them "
+        "(live scope grants ∩ client ceiling ∩ consent-grant scopes for agent and "
+        "service-account tokens), so the granted set may be narrower than requested "
+        "and clients must not assume they got what they asked for. Present on every "
+        "response whose token carries at least one scope; OMITTED (never the "
+        "ABNF-invalid empty string) only when the effective set is empty — reachable "
+        "solely on legs where the client requested no scopes at the token endpoint "
+        "(the token request carries no scope parameter, and consent fails closed on "
+        "an empty intersection).",
     )
 
 

--- a/src/jentic_one/auth/web/schemas/oauth.py
+++ b/src/jentic_one/auth/web/schemas/oauth.py
@@ -28,6 +28,13 @@ class TokenResponse(BaseModel):
     id_token: str | None = Field(default=None, json_schema_extra=SENSITIVE)
     token_type: str = "bearer"
     expires_in: int
+    scope: str = Field(
+        description="Space-delimited effective scopes of the minted access token "
+        "(RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes "
+        "(client ceiling / consent-grant intersection), so the granted set may be "
+        "narrower than requested and clients must not assume they got what they "
+        "asked for."
+    )
 
 
 class MintRequest(BaseModel):

--- a/tests/integration/auth/seeds.py
+++ b/tests/integration/auth/seeds.py
@@ -132,7 +132,7 @@ async def mint_grant_channel_tokens(
         scopes=" ".join(grant_scopes),
         grant_id=grant_id,
     )
-    access, refresh, id_token = await authorize_svc.exchange_code(
+    access, refresh, id_token, _scopes = await authorize_svc.exchange_code(
         code=code,
         code_verifier=CODE_VERIFIER,
         redirect_uri=REDIRECT_URI,

--- a/tests/integration/auth/test_oauth_grant_channel.py
+++ b/tests/integration/auth/test_oauth_grant_channel.py
@@ -175,7 +175,7 @@ async def test_plain_code_keeps_user_actor_and_id_token(
         "jentic_one.auth.services.authorize_service.issue_id_token",
         return_value="hdr.payload.sig",
     ) as mock_issue:
-        access, _refresh, id_token = await authorize_svc.exchange_code(
+        access, _refresh, id_token, _scopes = await authorize_svc.exchange_code(
             code=code,
             code_verifier=_CODE_VERIFIER,
             redirect_uri=_REDIRECT_URI,
@@ -432,7 +432,7 @@ async def test_refresh_rotation_recheck_and_lineage_propagation(
     )
 
     token_svc = TokenService(integration_context)
-    access2, refresh2 = await token_svc.refresh(refresh, client_id=_CLIENT_ID)
+    access2, refresh2, _scopes2 = await token_svc.refresh(refresh, client_id=_CLIENT_ID)
     resolved = await token_svc.resolve_access_token(access2)
     assert resolved is not None and resolved.oauth_grant_id == grant_id
 

--- a/tests/integration/auth/test_oauth_grant_channel.py
+++ b/tests/integration/auth/test_oauth_grant_channel.py
@@ -302,6 +302,99 @@ async def test_grant_scopes_cap_agent_live_scopes(
         assert resolved.permissions == ["apis:read"]
 
 
+# --- reported scope == enforced scope (PR #1262 review, findings 1+2) --------
+
+
+async def test_refresh_reports_live_narrowed_scope_not_snapshot(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """Reviewer repro: consent grants ``a b`` → admin revokes the agent's
+    ``b`` grant (immediate effect by design) → client refreshes. The §5.1
+    ``scope`` member must report exactly what the rotated access token
+    enforces (the live intersection, [a]) — NOT the family's mint-time
+    snapshot ("a b"), which both resolvers deliberately ignore for
+    non-ephemeral agent tokens."""
+    user_id = await _seed_user(integration_context, "usr_g_rep_refresh")
+    agent_id = await _seed_agent(
+        integration_context, owner_id=user_id, scopes=["apis:read", "apis:write"]
+    )
+    await _seed_client(integration_context, allowed_scopes=["apis:read", "apis:write"])
+    _grant_id, _access, refresh, _ = await _mint_grant_channel_tokens(
+        integration_context,
+        user_id=user_id,
+        agent_id=agent_id,
+        grant_scopes=["apis:read", "apis:write"],
+    )
+
+    # apis:write revoked between mint and rotation.
+    async with integration_context.admin_db.session() as session:
+        await ActorScopeGrantRepository.revoke(session, actor_id=agent_id, scope="apis:write")
+        await session.commit()
+
+    token_svc = TokenService(integration_context)
+    new_access, _new_refresh, reported = await token_svc.refresh(refresh, client_id=_CLIENT_ID)
+    assert reported == ["apis:read"]
+
+    # reported == enforced, on BOTH resolvers.
+    broker = InProcessTokenResolver(integration_context.admin_db)
+    for resolver in (token_svc, broker):
+        resolved = await resolver.resolve_access_token(new_access)
+        assert resolved is not None and resolved.active is True
+        assert resolved.permissions == reported
+
+
+async def test_exchange_reports_live_narrowed_scope_not_consent_snapshot(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """A scope revocation landing inside the code TTL (consent → exchange):
+    the exchange response reports the live intersection the token enforces
+    from first use, not the consent-time D2 snapshot on the grant row."""
+    user_id = await _seed_user(integration_context, "usr_g_rep_exch")
+    agent_id = await _seed_agent(
+        integration_context, owner_id=user_id, scopes=["apis:read", "apis:write"]
+    )
+    await _seed_client(integration_context, allowed_scopes=["apis:read", "apis:write"])
+    grant_svc = OAuthGrantService(integration_context)
+    authorize_svc = AuthorizeService(integration_context)
+    grant_id = await grant_svc.create_grant(
+        user_id=user_id,
+        oauth_client_id=_CLIENT_ID,
+        agent_id=agent_id,
+        scopes=["apis:read", "apis:write"],
+        client_name="Grant Channel App",
+    )
+    code = await authorize_svc.issue_authorization_code(
+        user_id=user_id,
+        client_id=_CLIENT_ID,
+        redirect_uri=_REDIRECT_URI,
+        code_challenge=_code_challenge(_CODE_VERIFIER),
+        scopes="apis:read apis:write",
+        grant_id=grant_id,
+    )
+
+    # apis:write revoked inside the code TTL, before the exchange.
+    async with integration_context.admin_db.session() as session:
+        await ActorScopeGrantRepository.revoke(session, actor_id=agent_id, scope="apis:write")
+        await session.commit()
+
+    access, _refresh, id_token, reported = await authorize_svc.exchange_code(
+        code=code,
+        code_verifier=_CODE_VERIFIER,
+        redirect_uri=_REDIRECT_URI,
+        client_id=_CLIENT_ID,
+        oauth_client_id=_CLIENT_ID,
+    )
+    assert id_token is None
+    assert reported == ["apis:read"]
+
+    token_svc = TokenService(integration_context)
+    broker = InProcessTokenResolver(integration_context.admin_db)
+    for resolver in (token_svc, broker):
+        resolved = await resolver.resolve_access_token(access)
+        assert resolved is not None and resolved.active is True
+        assert resolved.permissions == reported
+
+
 # --- the three kill radii, on BOTH resolvers --------------------------------
 
 

--- a/tests/integration/auth/test_oauth_rfc7009_revocation.py
+++ b/tests/integration/auth/test_oauth_rfc7009_revocation.py
@@ -206,7 +206,7 @@ async def test_access_revoke_kills_token_but_grant_survives(
     assert revoked is not None and revoked.active is False
     assert await _grant_status(ctx, grant_id) == "active"
     # The client can still re-obtain access: the refresh channel survives.
-    new_access, _new_refresh = await token_svc.refresh(refresh, client_id=_CLIENT_ID)
+    new_access, _new_refresh, _scopes = await token_svc.refresh(refresh, client_id=_CLIENT_ID)
     resolved = await token_svc.resolve_access_token(new_access)
     assert resolved is not None and resolved.active is True
     assert await _rfc7009_events(ctx, grant_id) == []

--- a/tests/integration/auth/test_token_endpoints.py
+++ b/tests/integration/auth/test_token_endpoints.py
@@ -138,10 +138,11 @@ async def test_refresh_rotation(
     user_id = await _seed_user(integration_context, "usr_test2")
     access1, refresh1 = await token_service.issue_pair(user_id, ActorType.USER, ["read"])
 
-    access2, refresh2 = await token_service.refresh(refresh1)
+    access2, refresh2, scopes2 = await token_service.refresh(refresh1)
 
     assert access2.startswith("at_")
     assert refresh2.startswith("rt_")
+    assert scopes2 == ["read"]
     assert access2 != access1
     assert refresh2 != refresh1
 
@@ -159,7 +160,7 @@ async def test_reuse_detection(
     user_id = await _seed_user(integration_context, "usr_test3")
     _access1, refresh1 = await token_service.issue_pair(user_id, ActorType.USER, ["read"])
 
-    access2, _refresh2 = await token_service.refresh(refresh1)
+    access2, _refresh2, _scopes2 = await token_service.refresh(refresh1)
 
     with pytest.raises(InvalidGrantError, match="reuse detected"):
         await token_service.refresh(refresh1)
@@ -454,7 +455,7 @@ async def test_disabled_agent_cannot_refresh_to_fresh_tokens(
     # The rejected attempt must not have consumed the refresh token: after
     # re-enable, the same token still rotates normally (no reuse trip).
     await _set_agent_status(integration_context, agent_id, ActorStatus.ACTIVE)
-    access2, refresh2 = await token_service.refresh(refresh)
+    access2, refresh2, _scopes2 = await token_service.refresh(refresh)
     assert access2.startswith("at_")
     assert refresh2.startswith("rt_")
 

--- a/tests/unit/auth/test_assertion_service.py
+++ b/tests/unit/auth/test_assertion_service.py
@@ -92,10 +92,11 @@ async def test_verify_and_exchange_happy_path(
 
     svc = AssertionService(ctx)
     assertion = _make_assertion(private_key)
-    access, refresh = await svc.verify_and_exchange(assertion)
+    access, refresh, scopes = await svc.verify_and_exchange(assertion)
 
     assert access == "at_new"
     assert refresh == "rt_new"
+    assert scopes == ["read"]
 
 
 @patch("jentic_one.auth.services.assertion_service.AgentRepository")

--- a/tests/unit/auth/test_service_account_auth_service.py
+++ b/tests/unit/auth/test_service_account_auth_service.py
@@ -105,10 +105,11 @@ async def test_authenticate_client_credentials_success(
 
     with patch.object(svc._token_svc, "issue_pair", new_callable=AsyncMock) as mock_issue:
         mock_issue.return_value = ("at_new", "rt_new")
-        access, refresh = await svc.authenticate_client_credentials("sva_test123", secret)
+        access, refresh, scopes = await svc.authenticate_client_credentials("sva_test123", secret)
 
     assert access == "at_new"
     assert refresh == "rt_new"
+    assert scopes == ["capabilities:execute", "capabilities:read"]
     mock_issue.assert_called_once_with(
         "sva_test123", "service_account", ["capabilities:execute", "capabilities:read"]
     )

--- a/tests/unit/auth/test_token_service.py
+++ b/tests/unit/auth/test_token_service.py
@@ -168,7 +168,7 @@ async def test_refresh_rotation_returns_new_pair(
     mock_user_repo.get_by_id = AsyncMock(return_value=_make_user_row())
 
     svc = TokenService(ctx)
-    access, refresh = await svc.refresh("rt_oldtoken")
+    access, refresh, _scopes = await svc.refresh("rt_oldtoken")
 
     assert access.startswith(ACCESS_TOKEN_PREFIX)
     assert refresh.startswith(REFRESH_TOKEN_PREFIX)
@@ -666,7 +666,7 @@ async def test_refresh_approved_client_still_rotates(
     mock_client_repo.get_by_client_id = AsyncMock(return_value=client_row)
 
     svc = TokenService(ctx)
-    access, refresh = await svc.refresh("rt_ok", client_id="oc_approved")
+    access, refresh, _scopes = await svc.refresh("rt_ok", client_id="oc_approved")
 
     assert access.startswith(ACCESS_TOKEN_PREFIX)
     assert refresh.startswith(REFRESH_TOKEN_PREFIX)

--- a/tests/unit/auth/test_token_service.py
+++ b/tests/unit/auth/test_token_service.py
@@ -175,6 +175,44 @@ async def test_refresh_rotation_returns_new_pair(
     mock_rt_repo.consume.assert_called_once()
 
 
+@patch("jentic_one.auth.services.token_service.ActorScopeGrantRepository")
+@patch("jentic_one.auth.services.token_service.AgentRepository")
+@patch("jentic_one.auth.services.token_service.RefreshTokenRepository")
+@patch("jentic_one.auth.services.token_service.AccessTokenRepository")
+async def test_refresh_reports_live_agent_scopes_not_snapshot(
+    mock_at_repo: MagicMock,
+    mock_rt_repo: MagicMock,
+    mock_agent_repo: MagicMock,
+    mock_scope_repo: MagicMock,
+) -> None:
+    """The reported set mirrors what the resolvers enforce for agent tokens:
+    live actor_scope_grants at rotation time — NOT the family's mint-time
+    snapshot, which enforcement ignores for non-ephemeral AGENT/SA actors.
+    The minted rows still carry the snapshot (USER-token semantics depend on
+    the carry-over; enforcement for agents ignores it either way)."""
+    ctx = _make_ctx()
+    rt_row = _make_refresh_token_row(
+        actor_id="agnt_live", actor_type="agent", scopes=["apis:read", "apis:write"]
+    )
+    mock_rt_repo.get_by_hash = AsyncMock(return_value=rt_row)
+    mock_rt_repo.create = AsyncMock(return_value=MagicMock(id="rt_next"))
+    mock_rt_repo.consume = AsyncMock()
+    mock_at_repo.create = AsyncMock()
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row(status="active"))
+    # Live grants have narrowed since mint: apis:write was revoked.
+    live_grant = MagicMock()
+    live_grant.scope = "apis:read"
+    mock_scope_repo.list_for_actor = AsyncMock(return_value=[live_grant])
+
+    svc = TokenService(ctx)
+    _access, _refresh, scopes = await svc.refresh("rt_oldtoken")
+
+    assert scopes == ["apis:read"]
+    # The new token rows keep the family snapshot, unchanged.
+    assert mock_at_repo.create.call_args.kwargs["scopes"] == ["apis:read", "apis:write"]
+    assert mock_rt_repo.create.call_args.kwargs["scopes"] == ["apis:read", "apis:write"]
+
+
 @patch("jentic_one.auth.services.token_service.RefreshTokenRepository")
 @patch("jentic_one.auth.services.token_service.AccessTokenRepository")
 async def test_refresh_consumed_token_triggers_reuse_detection(
@@ -663,6 +701,7 @@ async def test_refresh_approved_client_still_rotates(
     client_row = MagicMock()
     client_row.active = True
     client_row.approval_status = "approved"
+    client_row.allowed_scopes = None
     mock_client_repo.get_by_client_id = AsyncMock(return_value=client_row)
 
     svc = TokenService(ctx)

--- a/tests/unit/auth/web/test_oauth_auth_code.py
+++ b/tests/unit/auth/web/test_oauth_auth_code.py
@@ -58,7 +58,7 @@ def test_platform_client_does_not_set_oauth_client_id(
     mock_authorize_svc = MagicMock()
     mock_authorize_svc.precheck_auth_code = AsyncMock(return_value=None)
     mock_authorize_svc.exchange_code = AsyncMock(
-        return_value=("at_platform", "rt_platform", "id_token_platform")
+        return_value=("at_platform", "rt_platform", "id_token_platform", ["openid"])
     )
     mock_authorize_cls.return_value = mock_authorize_svc
     mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
@@ -100,7 +100,7 @@ def test_third_party_client_sets_oauth_client_id(
     mock_authorize_svc = MagicMock()
     mock_authorize_svc.precheck_auth_code = AsyncMock(return_value=None)
     mock_authorize_svc.exchange_code = AsyncMock(
-        return_value=("at_third_party", "rt_third_party", "id_token_third_party")
+        return_value=("at_third_party", "rt_third_party", "id_token_third_party", ["openid"])
     )
     mock_authorize_cls.return_value = mock_authorize_svc
     mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
@@ -183,7 +183,7 @@ def test_public_client_exchanges_without_secret(
     mock_authorize_svc = MagicMock()
     mock_authorize_svc.precheck_auth_code = AsyncMock(return_value=None)
     mock_authorize_svc.exchange_code = AsyncMock(
-        return_value=("at_public", "rt_public", "id_token_public")
+        return_value=("at_public", "rt_public", "id_token_public", ["openid"])
     )
     mock_authorize_cls.return_value = mock_authorize_svc
     mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
@@ -262,7 +262,7 @@ def test_refresh_public_client_passes_client_id_without_secret(
     mock_oauth_svc_cls.return_value = mock_oauth_svc
 
     mock_token_svc = MagicMock(access_ttl_seconds=3600)
-    mock_token_svc.refresh = AsyncMock(return_value=("at_new", "rt_new"))
+    mock_token_svc.refresh = AsyncMock(return_value=("at_new", "rt_new", ["apis:read"]))
     mock_token_cls.return_value = mock_token_svc
 
     resp = client.post(
@@ -293,7 +293,7 @@ def test_refresh_non_public_client_without_secret_stays_unverified(
     mock_oauth_svc_cls.return_value = mock_oauth_svc
 
     mock_token_svc = MagicMock(access_ttl_seconds=3600)
-    mock_token_svc.refresh = AsyncMock(return_value=("at_new", "rt_new"))
+    mock_token_svc.refresh = AsyncMock(return_value=("at_new", "rt_new", ["apis:read"]))
     mock_token_cls.return_value = mock_token_svc
 
     resp = client.post(

--- a/tests/unit/auth/web/test_oauth_client_credentials.py
+++ b/tests/unit/auth/web/test_oauth_client_credentials.py
@@ -67,7 +67,7 @@ def test_client_credentials_success(
 ) -> None:
     mock_sa_auth = MagicMock()
     mock_sa_auth.authenticate_client_credentials = AsyncMock(
-        return_value=("at_sa_token", "rt_sa_token")
+        return_value=("at_sa_token", "rt_sa_token", ["capabilities:execute"])
     )
     mock_sa_auth.access_ttl_seconds = 3600
     mock_sa_auth_cls.return_value = mock_sa_auth
@@ -88,6 +88,7 @@ def test_client_credentials_success(
     assert data["refresh_token"] == "rt_sa_token"
     assert data["token_type"] == "bearer"
     assert data["expires_in"] == 3600
+    assert data["scope"] == "capabilities:execute"
 
 
 @patch("jentic_one.auth.web.routers.oauth.ServiceAccountAuthService")

--- a/tests/unit/auth/web/test_oauth_jwt_bearer.py
+++ b/tests/unit/auth/web/test_oauth_jwt_bearer.py
@@ -36,7 +36,7 @@ def test_jwt_bearer_grant_success(
 ) -> None:
     mock_assertion_instance = MagicMock()
     mock_assertion_instance.verify_and_exchange = AsyncMock(
-        return_value=("at_new_token", "rt_new_token")
+        return_value=("at_new_token", "rt_new_token", ["apis:read", "apis:write"])
     )
     mock_assertion_cls.return_value = mock_assertion_instance
 
@@ -57,6 +57,7 @@ def test_jwt_bearer_grant_success(
     assert data["refresh_token"] == "rt_new_token"
     assert data["token_type"] == "bearer"
     assert data["expires_in"] == 3600
+    assert data["scope"] == "apis:read apis:write"
 
 
 @patch("jentic_one.auth.web.routers.oauth.AssertionService")

--- a/tests/unit/auth/web/test_oauth_response_shape.py
+++ b/tests/unit/auth/web/test_oauth_response_shape.py
@@ -8,6 +8,14 @@ or ``refresh_token`` and drop the whole token response, which live-broke
 Claude Desktop's refresh exchange. Pinned on the raw JSON body, mirroring
 the anonymous DCR door's omission tests
 (test_oauth_client_registration_router.py, PR #1250).
+
+RFC 6749 §5.1 also REQUIRES the ``scope`` member whenever the granted scope
+differs from the requested one — and the platform downscopes routinely
+(effective scope = client ceiling ∩ grant scopes; the D2 triple intersection
+on the agent channel). Every grant leg therefore always carries ``scope``
+with the minted token's effective (post-intersection) value, so strict
+clients (mcp-remote pins requested_scope) learn what they actually hold
+instead of presenting tokens for scopes they were never granted (#1260).
 """
 
 from __future__ import annotations
@@ -74,7 +82,9 @@ def test_agent_channel_code_exchange_omits_unset_id_token(
 
     mock_authorize_svc = MagicMock()
     mock_authorize_svc.precheck_auth_code = AsyncMock(return_value=None)
-    mock_authorize_svc.exchange_code = AsyncMock(return_value=("at_agent", "rt_agent", None))
+    mock_authorize_svc.exchange_code = AsyncMock(
+        return_value=("at_agent", "rt_agent", None, ["apis:read"])
+    )
     mock_authorize_cls.return_value = mock_authorize_svc
     mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
 
@@ -94,6 +104,8 @@ def test_agent_channel_code_exchange_omits_unset_id_token(
     assert data["access_token"] == "at_agent"
     assert data["refresh_token"] == "rt_agent"
     assert "id_token" not in data
+    # RFC 6749 §5.1: the effective scope is always present in the raw body.
+    assert b'"scope":"apis:read"' in resp.content
     # Belt-and-braces: the raw body carries no null members at all.
     assert b"null" not in resp.content
 
@@ -110,7 +122,7 @@ def test_user_channel_code_exchange_keeps_set_id_token(
     mock_authorize_svc = MagicMock()
     mock_authorize_svc.precheck_auth_code = AsyncMock(return_value=None)
     mock_authorize_svc.exchange_code = AsyncMock(
-        return_value=("at_user", "rt_user", "id_token_user")
+        return_value=("at_user", "rt_user", "id_token_user", ["openid", "email"])
     )
     mock_authorize_cls.return_value = mock_authorize_svc
     mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
@@ -130,6 +142,8 @@ def test_user_channel_code_exchange_keeps_set_id_token(
     data = resp.json()
     assert data["id_token"] == "id_token_user"
     assert data["refresh_token"] == "rt_user"
+    # Scopes are space-delimited (RFC 6749 §3.3), not a JSON array.
+    assert data["scope"] == "openid email"
     assert b"null" not in resp.content
 
 
@@ -148,7 +162,7 @@ def test_refresh_exchange_omits_unset_optional_members(
     mock_oauth_svc_cls.return_value = mock_oauth_svc
 
     mock_token_svc = MagicMock(access_ttl_seconds=3600)
-    mock_token_svc.refresh = AsyncMock(return_value=("at_new", "rt_new"))
+    mock_token_svc.refresh = AsyncMock(return_value=("at_new", "rt_new", ["apis:read"]))
     mock_token_cls.return_value = mock_token_svc
 
     resp = client.post(
@@ -165,6 +179,127 @@ def test_refresh_exchange_omits_unset_optional_members(
     assert data["access_token"] == "at_new"
     assert data["refresh_token"] == "rt_new"
     assert "id_token" not in data
+    # The refresh leg reports the rotated pair's effective scope too (§5.1).
+    assert b'"scope":"apis:read"' in resp.content
+    assert b"null" not in resp.content
+
+
+@patch("jentic_one.auth.web.routers.oauth.OAuthClientService")
+@patch("jentic_one.auth.web.routers.oauth.AuthorizeService")
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_downscoped_exchange_reports_narrowed_scope_not_requested(
+    mock_token_cls: MagicMock,
+    mock_authorize_cls: MagicMock,
+    mock_oauth_svc_cls: MagicMock,
+    client: TestClient,
+) -> None:
+    """Requested > granted: the response carries the NARROWED effective scope.
+
+    The consent-time D2 triple intersection (requested ∩ agent live grants ∩
+    client ceiling) mints a grant narrower than what the client asked for at
+    /authorize. RFC 6749 §5.1 REQUIRES the token response to say so — a strict
+    client (mcp-remote pins requested_scope) would otherwise present the token
+    for scopes it never got and hit confusing downstream 403s. Here the client
+    requested three scopes but the intersection kept exactly one: the raw body
+    carries only the narrowed value, never an echo of the request.
+    """
+    mock_oauth_svc = MagicMock()
+    mock_oauth_svc.authenticate_for_token_endpoint = AsyncMock(return_value=True)
+    mock_oauth_svc_cls.return_value = mock_oauth_svc
+
+    mock_authorize_svc = MagicMock()
+    mock_authorize_svc.precheck_auth_code = AsyncMock(return_value=None)
+    # Requested at /authorize: "apis:read toolkits:read toolkits:execute".
+    # The exchange mints the post-intersection grant set: apis:read only.
+    mock_authorize_svc.exchange_code = AsyncMock(
+        return_value=("at_narrow", "rt_narrow", None, ["apis:read"])
+    )
+    mock_authorize_cls.return_value = mock_authorize_svc
+    mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
+
+    resp = client.post(
+        "/oauth/token",
+        json={
+            "grant_type": "authorization_code",
+            "code": "auth_code_narrow",
+            "code_verifier": "verifier_narrow",
+            "redirect_uri": "http://localhost:33418/callback",
+            "client_id": _PUBLIC_CLIENT_ID,
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["access_token"] == "at_narrow"
+    # The narrowed scope, exactly — not the broader requested set.
+    assert data["scope"] == "apis:read"
+    assert b'"scope":"apis:read"' in resp.content
+    assert b"toolkits:read" not in resp.content
+    assert b"toolkits:execute" not in resp.content
+    assert b"null" not in resp.content
+
+
+@patch("jentic_one.auth.web.routers.oauth.AssertionService")
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_jwt_bearer_exchange_includes_effective_scope(
+    mock_token_cls: MagicMock,
+    mock_assertion_cls: MagicMock,
+    client: TestClient,
+) -> None:
+    """The jwt-bearer leg reports the agent's live-grant scope set (§5.1),
+    space-delimited per RFC 6749 §3.3."""
+    mock_assertion_svc = MagicMock()
+    mock_assertion_svc.verify_and_exchange = AsyncMock(
+        return_value=("at_agent_jwt", "rt_agent_jwt", ["apis:read", "capabilities:read"])
+    )
+    mock_assertion_cls.return_value = mock_assertion_svc
+    mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
+
+    resp = client.post(
+        "/oauth/token",
+        json={
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": "eyJ.test.assertion",
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["access_token"] == "at_agent_jwt"
+    assert data["scope"] == "apis:read capabilities:read"
+    assert b'"scope":"apis:read capabilities:read"' in resp.content
+    assert b"null" not in resp.content
+
+
+@patch("jentic_one.auth.web.routers.oauth.ServiceAccountAuthService")
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_client_credentials_exchange_includes_effective_scope(
+    mock_token_cls: MagicMock,
+    mock_sa_auth_cls: MagicMock,
+    client: TestClient,
+) -> None:
+    """The client_credentials leg reports the SA's live-grant scope set (§5.1)."""
+    mock_sa_auth = MagicMock(access_ttl_seconds=3600)
+    mock_sa_auth.authenticate_client_credentials = AsyncMock(
+        return_value=("at_sa", "rt_sa", ["capabilities:execute"])
+    )
+    mock_sa_auth_cls.return_value = mock_sa_auth
+    mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
+
+    resp = client.post(
+        "/oauth/token",
+        json={
+            "grant_type": "client_credentials",
+            "client_id": "sva_test123",
+            "client_secret": "jcs_secret_value",
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["access_token"] == "at_sa"
+    assert data["scope"] == "capabilities:execute"
+    assert b'"scope":"capabilities:execute"' in resp.content
     assert b"null" not in resp.content
 
 

--- a/tests/unit/auth/web/test_oauth_response_shape.py
+++ b/tests/unit/auth/web/test_oauth_response_shape.py
@@ -11,11 +11,16 @@ the anonymous DCR door's omission tests
 
 RFC 6749 §5.1 also REQUIRES the ``scope`` member whenever the granted scope
 differs from the requested one — and the platform downscopes routinely
-(effective scope = client ceiling ∩ grant scopes; the D2 triple intersection
-on the agent channel). Every grant leg therefore always carries ``scope``
-with the minted token's effective (post-intersection) value, so strict
-clients (mcp-remote pins requested_scope) learn what they actually hold
-instead of presenting tokens for scopes they were never granted (#1260).
+(effective scope = live scope grants ∩ client ceiling ∩ grant scopes; the D2
+triple intersection on the agent channel). Every grant leg therefore carries
+``scope`` with the minted token's effective (post-intersection, as-enforced)
+value, so strict clients (mcp-remote pins requested_scope) learn what they
+actually hold instead of presenting tokens for scopes they were never
+granted (#1260). One exception, forced by §3.3's ABNF (``scope-token`` is
+1*): an EMPTY effective set cannot be serialized, so the member is omitted —
+reachable only where the caller requested no scopes at this endpoint (the
+token request has no scope parameter; consent fails closed on an empty
+intersection) or where every grant was revoked post-mint.
 """
 
 from __future__ import annotations
@@ -300,6 +305,41 @@ def test_client_credentials_exchange_includes_effective_scope(
     assert data["access_token"] == "at_sa"
     assert data["scope"] == "capabilities:execute"
     assert b'"scope":"capabilities:execute"' in resp.content
+    assert b"null" not in resp.content
+
+
+@patch("jentic_one.auth.web.routers.oauth.AssertionService")
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_empty_effective_scope_set_omits_the_scope_member(
+    mock_token_cls: MagicMock,
+    mock_assertion_cls: MagicMock,
+    client: TestClient,
+) -> None:
+    """A zero-grant agent (jwt-bearer, no scope requestable at this endpoint)
+    mints a token with an empty effective set. RFC 6749 §3.3's ABNF forbids
+    ``"scope": ""`` (scope-token is 1*), so the member is OMITTED from the
+    raw body — never emitted as the empty string, never as JSON null."""
+    mock_assertion_svc = MagicMock()
+    mock_assertion_svc.verify_and_exchange = AsyncMock(
+        return_value=("at_zero_grant", "rt_zero_grant", [])
+    )
+    mock_assertion_cls.return_value = mock_assertion_svc
+    mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
+
+    resp = client.post(
+        "/oauth/token",
+        json={
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": "eyJ.test.assertion",
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["access_token"] == "at_zero_grant"
+    assert "scope" not in data
+    assert b'"scope"' not in resp.content
+    assert b'""' not in resp.content
     assert b"null" not in resp.content
 
 

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -8620,9 +8620,16 @@
             "x-sensitive": true
           },
           "scope": {
-            "description": "Space-delimited effective scopes of the minted access token (RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes (client ceiling / consent-grant intersection), so the granted set may be narrower than requested and clients must not assume they got what they asked for.",
-            "title": "Scope",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Space-delimited effective scopes of the minted access token (RFC 6749 §3.3), computed the way the platform's resolvers enforce them (live scope grants ∩ client ceiling ∩ consent-grant scopes for agent and service-account tokens), so the granted set may be narrower than requested and clients must not assume they got what they asked for. Present on every response whose token carries at least one scope; OMITTED (never the ABNF-invalid empty string) only when the effective set is empty — reachable solely on legs where the client requested no scopes at the token endpoint (the token request carries no scope parameter, and consent fails closed on an empty intersection).",
+            "title": "Scope"
           },
           "token_type": {
             "default": "bearer",
@@ -8632,8 +8639,7 @@
         },
         "required": [
           "access_token",
-          "expires_in",
-          "scope"
+          "expires_in"
         ],
         "title": "TokenResponse",
         "type": "object"

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -8619,6 +8619,11 @@
             "title": "Refresh Token",
             "x-sensitive": true
           },
+          "scope": {
+            "description": "Space-delimited effective scopes of the minted access token (RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes (client ceiling / consent-grant intersection), so the granted set may be narrower than requested and clients must not assume they got what they asked for.",
+            "title": "Scope",
+            "type": "string"
+          },
           "token_type": {
             "default": "bearer",
             "title": "Token Type",
@@ -8627,7 +8632,8 @@
         },
         "required": [
           "access_token",
-          "expires_in"
+          "expires_in",
+          "scope"
         ],
         "title": "TokenResponse",
         "type": "object"

--- a/ui/src/shared/api/generated/models/TokenResponse.ts
+++ b/ui/src/shared/api/generated/models/TokenResponse.ts
@@ -10,6 +10,10 @@ export type TokenResponse = {
     expires_in: number;
     id_token?: (string | null);
     refresh_token?: (string | null);
+    /**
+     * Space-delimited effective scopes of the minted access token (RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes (client ceiling / consent-grant intersection), so the granted set may be narrower than requested and clients must not assume they got what they asked for.
+     */
+    scope: string;
     token_type?: string;
 };
 

--- a/ui/src/shared/api/generated/models/TokenResponse.ts
+++ b/ui/src/shared/api/generated/models/TokenResponse.ts
@@ -11,9 +11,9 @@ export type TokenResponse = {
     id_token?: (string | null);
     refresh_token?: (string | null);
     /**
-     * Space-delimited effective scopes of the minted access token (RFC 6749 §3.3). Always present (RFC 6749 §5.1): the platform downscopes (client ceiling / consent-grant intersection), so the granted set may be narrower than requested and clients must not assume they got what they asked for.
+     * Space-delimited effective scopes of the minted access token (RFC 6749 §3.3), computed the way the platform's resolvers enforce them (live scope grants ∩ client ceiling ∩ consent-grant scopes for agent and service-account tokens), so the granted set may be narrower than requested and clients must not assume they got what they asked for. Present on every response whose token carries at least one scope; OMITTED (never the ABNF-invalid empty string) only when the effective set is empty — reachable solely on legs where the client requested no scopes at the token endpoint (the token request carries no scope parameter, and consent fails closed on an empty intersection).
      */
-    scope: string;
+    scope?: (string | null);
     token_type?: string;
 };
 


### PR DESCRIPTION
## Summary

`POST /oauth/token` responses omitted the `scope` member, so clients never learned when the platform downscoped them. RFC 6749 §5.1 makes `scope` REQUIRED whenever the granted scope differs from the requested one — and this platform downscopes routinely: enforcement is the live intersection (live `actor_scope_grants` ∩ client `allowed_scopes` ceiling ∩ consent-grant scopes) recomputed on every resolve by both `TokenService.resolve_access_token` and the broker's `InProcessTokenResolver`, and the agent channel mints from the consent-time D2 triple intersection (`auth/web/routers/authorize.py::_effective_agent_scopes`). Strict clients (mcp-remote pins `requested_scope`) then presented tokens for scopes they were never granted and hit confusing downstream 403s. Every grant leg now reports the effective scope **computed the same way the resolvers enforce it** — reported == enforced by construction.

## Changes

- `auth`: `TokenResponse` (`auth/web/schemas/oauth.py`) gains `scope: str | None` (space-delimited per RFC 6749 §3.3), populated on every leg that mints a non-empty effective set and OMITTED when the set is empty (see Risk below for why).
- `auth`: new shared helper `resolve_effective_scopes()` in `auth/services/token_service.py` — the single source of truth for "what does this token actually enforce" (live grants ∩ client ceiling ∩ grant scopes for non-ephemeral AGENT/SA actors; snapshot ∩ ceilings for USER/ephemeral). Consumed by:
  - `TokenService.resolve_access_token` (the enforcement path — refactored onto the helper),
  - `TokenService.refresh` (reports the live intersection at rotation time, NOT the family's mint-time snapshot, which enforcement ignores for AGENT/SA),
  - `AuthorizeService.exchange_code` agent channel (reports the live intersection at exchange time — a scope revocation landing inside the code TTL is reflected, consistent with the "consent-time snapshot is not trusted across the TTL" posture).
  The broker resolver re-implements the same math over raw SQL by design (no `auth` imports); the grant-channel integration suite pins all three against each other.
- `auth`: jwt-bearer / client_credentials legs report the live `actor_scope_grants` set stamped at mint; the user channel reports the authorize-time snapshot (documented in place: OIDC passthrough scopes are consumed by the id_token, never enforced as platform permissions — standard OIDC posture).
- Token/audit rows are untouched: rotation and exchange still stamp the family/consent snapshot; only the *reported* member changed.
- Regenerated codegen artifacts: `openapi/control/control.openapi.yaml`, `ui/openapi.json`, UI client (`scope?: string`), Go CLI client (`Scope *string \`json:"scope,omitempty"\``).
- Out of scope: `/oauth/mint` (`MintResponse`, caller supplies the exact scopes) and RFC 7662 introspection's empty-string `scope` posture.

## Risk & rollback

- Public API shape change: `/oauth/token` 200 bodies gain an optional `scope` member. Additive and §5.1-legal; verified tolerant in mcp-remote 0.8.3's vendored zod schema (`scope: z.string().optional()`).
- **Empty-set posture (deliberate):** when the effective set is empty the member is omitted — never `""`, which RFC 6749 §3.3's ABNF (`scope-token` is `1*NQCHAR`) forbids. Omission cannot contradict a request at this endpoint: no grant leg's token request carries a `scope` parameter, and the consent flow fails closed on an empty D2 intersection (`no_grantable_scopes`), so "requested scopes, granted none" tokens are not mintable via consent. Empty sets are reachable only for zero-grant agents/SAs (nothing requested) or when every scope grant is revoked post-mint (refresh leg) — the latter is a live, reversible administrative state the platform deliberately distinguishes from revocation (grant revoke / actor disable already fail the exchange closed with `invalid_grant`); erroring `invalid_scope` there would conflate narrowing-to-zero with revocation and break recovery-by-regrant.
- Scope *enforcement* semantics are unchanged (`resolve_access_token` is a pure refactor onto the shared helper; the resolver-parity integration tests pass unchanged). Reporting is point-in-time: grants can still change between rotation and use — inherent, and the resolvers re-derive live either way.
- Revert: revert the squash commit and re-run `make openapi` + client codegen.

## Test plan

- Reviewer's repro pinned in `tests/integration/auth/test_oauth_grant_channel.py`: consent `apis:read apis:write` → revoke `apis:write` → refresh: response reports exactly `apis:read` and BOTH resolvers enforce the same set (`test_refresh_reports_live_narrowed_scope_not_snapshot`); same for a revocation inside the auth-code TTL (`test_exchange_reports_live_narrowed_scope_not_consent_snapshot`). Suite run: `JENTIC_TEST_BACKEND=sqlite uv run pytest tests/integration/auth -m integration` — 89 passed.
- `tests/unit/auth/test_token_service.py::test_refresh_reports_live_agent_scopes_not_snapshot`: agent refresh returns the live set while the minted rows keep the snapshot.
- `tests/unit/auth/web/test_oauth_response_shape.py` (raw-bytes style): every grant leg carries `scope` with the effective value; `test_downscoped_exchange_reports_narrowed_scope_not_requested` pins requested > granted → NARROWED value only; `test_empty_effective_scope_set_omits_the_scope_member` pins empty set → member absent, never `""`/null.
- Full local gate: `ruff format --check` + `ruff check` clean, `mypy` clean (1223 files), `make detect-secrets` clean, `make test-arch` 153 passed, `make test-unit` 3264 passed (coverage 79.36%).

Closes #1260