### PR TITLE
ci(release): package-manager install channels for the CLI (winget + scoop, brew-first docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -862,6 +862,32 @@ jobs:
           fi
           # linux/darwin tarballs must still be produced (byte-shape invariant).
           ls "${dist}"/jentic_*_linux_amd64.tar.gz "${dist}"/jenticctl_*_linux_amd64.tar.gz >/dev/null
+      # The Windows package channels are generated from the zips above (the
+      # publish is skipped in snapshot mode, manifest GENERATION is not). A
+      # broken winget/scoops stanza — or one that drifts from the commands the
+      # docs advertise (`winget install Jentic.Jentic`, `scoop install jentic`)
+      # — otherwise only surfaces at tag time. The docs↔config identifier
+      # match itself is pinned by tests/arch/test_install_docs_conformance.py;
+      # this asserts the config actually yields manifests.
+      - name: Assert winget + scoop manifests generated
+        run: |
+          set -euo pipefail
+          dist=""
+          for d in dist cli/dist; do
+            [ -d "$d" ] && { dist="$d"; break; }
+          done
+          test -n "${dist}" || { echo "::error::goreleaser produced no dist dir"; exit 1; }
+          installer="$(find "${dist}/winget" -name '*.installer.yaml' 2>/dev/null | head -n1 || true)"
+          test -n "${installer}" || { echo "::error::no winget installer manifest generated under ${dist}/winget"; exit 1; }
+          echo "winget installer manifest: ${installer}"
+          grep -q '^PackageIdentifier: Jentic.Jentic$' "${installer}" \
+            || { echo "::error::winget manifest lost the Jentic.Jentic identifier the docs advertise"; exit 1; }
+          grep -q 'RelativeFilePath: jentic.exe' "${installer}" \
+            || { echo "::error::winget manifest does not install jentic.exe"; exit 1; }
+          test -f "${dist}/scoop/jentic.json" \
+            || { echo "::error::no scoop manifest generated at ${dist}/scoop/jentic.json"; exit 1; }
+          grep -q '"jentic.exe"' "${dist}/scoop/jentic.json" \
+            || { echo "::error::scoop manifest does not install jentic.exe"; exit 1; }
 
   installer:
     name: Installer script tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@
 #                      red.
 #   4. release       — GoReleaser builds the signed, checksummed jenticctl +
 #                      jentic binaries (cosign keyless via OIDC + syft SBOMs) and
-#                      pushes the Homebrew cask. This is the install (see
+#                      publishes the package channels: Homebrew cask, winget PR,
+#                      scoop bucket. This is the install (see
 #                      docs/development/releasing.md). Needs gate + smoke + publish-image so
 #                      a release never half-ships (binaries without the image).
 #
@@ -436,6 +437,17 @@ jobs:
           # PAT/App token with contents:write on jentic/homebrew-tap so the cask
           # can be pushed cross-repo (GITHUB_TOKEN is scoped to THIS repo only).
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # Windows package channels. Both are OPTIONAL: the goreleaser config
+          # skips the winget/scoop publish (with a log line) when its token is
+          # empty, so an unprovisioned secret never fails a release — it just
+          # doesn't publish that channel. Provisioning is documented in
+          # docs/development/releasing.md ("One-time setup").
+          # WINGET_TOKEN: classic PAT with public_repo — pushes manifests to
+          # the jentic/winget-pkgs fork and opens the microsoft/winget-pkgs PR.
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          # SCOOP_BUCKET_TOKEN: fine-grained PAT, contents:write on
+          # jentic/scoop-bucket only (same shape as HOMEBREW_TAP_TOKEN).
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
           COSIGN_YES: "true"
       # Pipeline review F4/E1: the app image already asserts /health .version ==
       # tag (gate job); mirror that for the CLI binaries so a bad ldflag stamp

--- a/README.md
+++ b/README.md
@@ -101,15 +101,14 @@ real secrets, TLS — is in [docs/installation/docker.md](docs/installation/dock
 ### Install the CLI
 
 ```bash
-# Auto-detects OS/arch and resolves the latest release.
-# Full matrix + verification: docs/installation/cli.md — or: brew install jentic/tap/jentic
-VER=$(curl -fsSL https://api.github.com/repos/jentic/jentic-one/releases/latest | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
-OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-curl -fsSL "https://github.com/jentic/jentic-one/releases/download/v${VER}/jentic_${VER}_${OS}_${ARCH}.tar.gz" | tar xz jentic
-sudo install jentic /usr/local/bin/
+brew install --cask jentic/tap/jentic    # macOS / Linux
+winget install Jentic.Jentic             # Windows
 
 jentic register   # connect this machine to the instance
 ```
+
+No package manager? Manual download, checksum + signature verification, and
+air-gapped transfer are in [docs/installation/cli.md](docs/installation/cli.md).
 
 ### Managed install
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ jentic register   # connect this machine to the instance
 ```
 
 No package manager? Manual download, checksum + signature verification, and
-air-gapped transfer are in [docs/installation/cli.md](docs/installation/cli.md).
+air-gapped transfer are in [docs/installation/cli.md](docs/installation/cli.md)
+— along with our Scoop bucket, which carries brand-new releases before winget
+review completes.
 
 ### Managed install
 

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -132,6 +132,66 @@ homebrew_casks:
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/jentic"]
           end
 
+# Winget (Windows). Publishes the manifest set for the `jentic` zip archives
+# (amd64 + arm64) into the jentic fork of microsoft/winget-pkgs and opens the
+# upstream PR — after that lands, `winget install Jentic.Jentic` works with no
+# bucket/tap setup. jenticctl is excluded by design (not shipped for Windows).
+#
+# The token is a CLASSIC PAT with `public_repo` scope (fine-grained tokens
+# cannot open PRs against repos they aren't installed on, and the PR targets
+# microsoft/winget-pkgs). When WINGET_TOKEN is unset/empty the entry is
+# skipped with a log line instead of failing the release — publishing starts
+# once the secret + fork exist (docs/development/releasing.md, one-time setup).
+winget:
+  - name: Jentic # second segment of the identifier; keeps the manifest path
+    # (manifests/j/Jentic/Jentic/<ver>) aligned with package_identifier, which
+    # winget-pkgs validation requires.
+    package_identifier: Jentic.Jentic
+    package_name: Jentic
+    publisher: Jentic
+    publisher_url: https://jentic.com
+    publisher_support_url: https://github.com/jentic/jentic-one/issues
+    homepage: https://jentic.com
+    short_description: "Jentic One agent CLI — search, inspect and execute governed API calls through the broker"
+    license: Apache-2.0
+    license_url: https://github.com/jentic/jentic-one/blob/main/LICENSE
+    release_notes_url: https://github.com/jentic/jentic-one/releases/tag/{{ .Tag }}
+    ids: [jentic]
+    tags: [cli, agents, api]
+    skip_upload: '{{ if envOrDefault "WINGET_TOKEN" "" }}false{{ else }}true{{ end }}'
+    repository:
+      owner: jentic
+      name: winget-pkgs
+      token: '{{ envOrDefault "WINGET_TOKEN" "" }}'
+      pull_request:
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+
+# Scoop (Windows, zero-review alternative to winget — the bucket is ours, so
+# the manifest is installable the moment the release is cut, while the winget
+# PR waits on microsoft/winget-pkgs review):
+#   scoop bucket add jentic https://github.com/jentic/scoop-bucket
+#   scoop install jentic
+# Same graceful-skip contract as winget: unset/empty SCOOP_BUCKET_TOKEN skips
+# the push (fine-grained PAT, contents: write on jentic/scoop-bucket only —
+# same shape as HOMEBREW_TAP_TOKEN).
+scoops:
+  - name: jentic
+    ids: [jentic]
+    homepage: https://jentic.com
+    description: "Jentic One agent CLI — search, inspect and execute governed API calls through the broker"
+    license: Apache-2.0
+    skip_upload: '{{ if envOrDefault "SCOOP_BUCKET_TOKEN" "" }}false{{ else }}true{{ end }}'
+    # Manifest lands at the bucket root (jentic.json) — `scoop bucket list`
+    # only counts root-level manifests.
+    repository:
+      owner: jentic
+      name: scoop-bucket
+      token: '{{ envOrDefault "SCOOP_BUCKET_TOKEN" "" }}'
+
 release:
   github:
     owner: jentic

--- a/cli/README.md
+++ b/cli/README.md
@@ -78,7 +78,21 @@ brew install --cask jentic/tap/jentic
 
 The cask installs both `jentic` and `jenticctl`.
 
-### 2. One-line download (verified binary, no compiler)
+### 2. Winget / Scoop (Windows) — agent CLI
+
+```powershell
+winget install Jentic.Jentic
+
+# or, via our Scoop bucket (carries brand-new releases before winget review completes):
+scoop bucket add jentic https://github.com/jentic/scoop-bucket
+scoop install jentic
+```
+
+Both install `jentic.exe` only — `jenticctl` is not shipped for native Windows
+(its job is Docker/compose lifecycle; use WSL, see
+[docs/installation/windows.md](../docs/installation/windows.md)).
+
+### 3. One-line download (verified binary, no compiler)
 
 ```bash
 # both binaries (default) — jentic (discover/run) + jenticctl (run the stack locally):
@@ -116,7 +130,7 @@ On a machine with **no interactive terminal** (piped `curl … | sh` in CI), the
 installer installs the binaries and then prints the exact non-interactive
 follow-up (`jenticctl install --defaults`) instead of blocking on a wizard.
 
-### 3. Manual download + verify
+### 4. Manual download + verify
 
 Grab the archive for your platform from the
 [Releases page](https://github.com/jentic/jentic-one/releases), then verify and
@@ -155,7 +169,7 @@ shipped natively for Windows, and `jentic run` (the local-agent sandbox) is
 **unsupported on native Windows** — use **WSL** for agent-sandbox and local-stack
 workflows.
 
-### 4. From source (contributors / advanced)
+### 5. From source (contributors / advanced)
 
 Build from a checkout with `make build` (below), or force the installer's
 from-source path with `JENTIC_INSTALL_METHOD=source`.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -31,7 +31,12 @@ Releases are automated with [release-please](https://github.com/googleapis/relea
      pull — see
      [`deploy/README.md`](../../deploy/README.md#self-hosted-containers--external-postgres).
    - **release** — GoReleaser builds the signed, checksummed `jenticctl` +
-     `jentic` binaries (cosign keyless + syft SBOMs) and pushes the Homebrew cask.
+     `jentic` binaries (cosign keyless + syft SBOMs) and publishes the package
+     channels: the Homebrew cask, a winget manifest PR against
+     `microsoft/winget-pkgs`, and the scoop bucket manifest. The winget/scoop
+     publishes are token-gated: with `WINGET_TOKEN` / `SCOOP_BUCKET_TOKEN`
+     unset the entry is skipped (logged, never fails the release) — see the
+     one-time setup below.
 
 Releases continue the pre-1.0 `0.x` line — see `VERSIONING.md` for the
 versioning policy.
@@ -69,7 +74,7 @@ Release-As: 0.38.3
 
 release-please then opens a `chore(main): release 0.38.3` PR; merging it cuts the
 tag and re-runs `release.yml` (now from the fixed workflow on `main`), producing
-a complete set of signed binaries + the Homebrew cask. A failed release version
+a complete set of signed binaries + the package channels (cask, winget, scoop). A failed release version
 is superseded by the next one — every release rebuilds all artifacts from
 scratch, so nothing is lost by skipping it.
 
@@ -86,6 +91,23 @@ The automation is inert until these are provisioned:
   `RELEASE_PLEASE_APP_PRIVATE_KEY`.
 - **`HOMEBREW_TAP_TOKEN`** — a fine-grained token with `contents: write` on
   `jentic/homebrew-tap` only (for the cross-repo cask push).
+- **`SCOOP_BUCKET_TOKEN`** — same shape: a fine-grained token with
+  `contents: write` on `jentic/scoop-bucket` only. Create that repo (public,
+  empty is fine — GoReleaser commits `jentic.json` to its root on each
+  release) before setting the secret.
+- **`WINGET_TOKEN`** — a **classic** PAT with `public_repo` scope
+  (fine-grained tokens cannot open cross-repo PRs against
+  `microsoft/winget-pkgs`). Fork `microsoft/winget-pkgs` into the `jentic`
+  org first; each release then pushes a manifest branch to the fork and opens
+  the upstream PR. The **first** submission goes through Microsoft's human
+  review (typically days); later versions are auto-validated by bots. Until
+  the first manifest lands, `winget install Jentic.Jentic` resolves nothing —
+  the scoop bucket is the immediate Windows channel in the meantime.
+
+Both Windows-channel secrets are **optional**: while unset, GoReleaser skips
+that publisher with a log line and the release stays green (the
+`skip_upload` templates in `cli/.goreleaser.yaml`). Provisioning the secret
+is what turns the channel on.
 
 cosign signing needs no secret — it uses the release job's OIDC token (keyless,
 via Sigstore/Fulcio).

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -99,7 +99,9 @@ The automation is inert until these are provisioned:
   (fine-grained tokens cannot open cross-repo PRs against
   `microsoft/winget-pkgs`). Fork `microsoft/winget-pkgs` into the `jentic`
   org first; each release then pushes a manifest branch to the fork and opens
-  the upstream PR. The **first** submission goes through Microsoft's human
+  the upstream PR. **Keep the fork's `master` synced** (GitHub's "Sync fork"
+  button, or a scheduled sync) — a stale fork makes the generated PR conflict
+  at tag time. The **first** submission goes through Microsoft's human
   review (typically days); later versions are auto-validated by bots. Until
   the first manifest lands, `winget install Jentic.Jentic` resolves nothing —
   the scoop bucket is the immediate Windows channel in the meantime.

--- a/docs/installation/cli.md
+++ b/docs/installation/cli.md
@@ -7,11 +7,31 @@ Two Go binaries, each its own release archive — no runtime, no dependencies:
 | `jentic` | Agent CLI — `register`, `search`, `inspect`, `execute` | Every host inside the network that calls the instance |
 | `jenticctl` | Operator CLI — install, lifecycle, admin | The admin host only |
 
-Alternatives to the manual download below: `brew install jentic/tap/jentic`
-(installs both), or the [one-line installer](../../cli/README.md#2-one-line-download-verified-binary-no-compiler)
+## Package managers (start here)
+
+```bash
+brew install --cask jentic/tap/jentic      # macOS / Linux — installs BOTH binaries
+```
+
+```powershell
+winget install Jentic.Jentic               # Windows — jentic (agent CLI) only
+
+# or, via our Scoop bucket (no Microsoft review lag on brand-new releases):
+scoop bucket add jentic https://github.com/jentic/scoop-bucket
+scoop install jentic
+```
+
+All three resolve your CPU architecture, verify the download hash, put the
+binary on `PATH`, and upgrade with the manager's native command (`brew
+upgrade`, `winget upgrade`, `scoop update`). `jenticctl` is not shipped for
+native Windows — use WSL ([windows.md](windows.md)).
+
+Everything below is the manual path: locked-down hosts, air-gapped transfer,
+or when you want to verify the supply chain yourself. There is also a
+[one-line installer script](../../cli/README.md#3-one-line-download-verified-binary-no-compiler)
 which downloads, sha256-checks, and cosign-verifies for you.
 
-## Download
+## Manual download
 
 The archive name is `<binary>_<version>_<os>_<arch>.tar.gz`. Auto-detect the
 platform and resolve the latest version:

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -173,7 +173,7 @@ Prefer one file over two `docker run`s? Two worked compose examples:
 ## 7. Connect the CLIs
 
 - **Admin host:** install `jenticctl` from the release archive
-  ([download + verify](../../cli/README.md#3-manual-download--verify)).
+  ([download + verify](../../cli/README.md#4-manual-download--verify)).
 - **Every host using the instance:** install `jentic` the same way, then
   register — an operator approves each agent in the UI:
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -39,8 +39,18 @@ run as-is. Two things Docker Desktop does for you:
 
 ## 4. The agent side — native Windows
 
-`jentic.exe` ships natively (amd64 `.zip` — download and verification in
-[cli.md](cli.md)). Agents on native Windows can `register`, `search`,
+`jentic.exe` ships natively (amd64 + arm64):
+
+```powershell
+winget install Jentic.Jentic
+
+# or, via our Scoop bucket (carries brand-new releases before winget review completes):
+scoop bucket add jentic https://github.com/jentic/scoop-bucket
+scoop install jentic
+```
+
+Manual `.zip` download and cosign verification are in [cli.md](cli.md).
+Agents on native Windows can `register`, `search`,
 `inspect`, and `execute` against the broker at `http://127.0.0.1:8100`
 thanks to the loopback forwarding above — no WSL needed on the agent side.
 

--- a/tests/arch/test_install_docs_conformance.py
+++ b/tests/arch/test_install_docs_conformance.py
@@ -27,6 +27,7 @@ scoop manifests are actually generated from this config.
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +39,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 GORELEASER_CONFIG = REPO_ROOT / "cli" / ".goreleaser.yaml"
 
 #: Directories that hold third-party or generated markdown, not our docs.
+#: (Fallback filter — the primary enumeration is `git ls-files`.)
 _EXCLUDED_DIR_NAMES = {".git", ".venv", "node_modules", "dist", ".ruff_cache", ".pytest_cache"}
 
 #: ``winget install <id>`` / ``winget upgrade <id>`` mentions.
@@ -65,10 +67,25 @@ def _release_config() -> dict[str, Any]:
 
 
 def _doc_files() -> list[Path]:
+    """Tracked markdown files plus ``llms.txt``.
+
+    Enumerates via ``git ls-files`` so untracked scratch files never trip the
+    guard; falls back to an rglob when git is unavailable (e.g. an sdist).
+    """
     docs = [REPO_ROOT / "llms.txt"]
-    for path in REPO_ROOT.rglob("*.md"):
-        if _EXCLUDED_DIR_NAMES.isdisjoint(part.lower() for part in path.parts):
-            docs.append(path)
+    try:
+        tracked = subprocess.run(
+            ["git", "ls-files", "-z", "*.md"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout
+        docs.extend(REPO_ROOT / name for name in tracked.split("\0") if name)
+    except (OSError, subprocess.CalledProcessError):
+        for path in REPO_ROOT.rglob("*.md"):
+            if _EXCLUDED_DIR_NAMES.isdisjoint(part.lower() for part in path.parts):
+                docs.append(path)
     return [doc for doc in docs if doc.is_file()]
 
 

--- a/tests/arch/test_install_docs_conformance.py
+++ b/tests/arch/test_install_docs_conformance.py
@@ -1,0 +1,173 @@
+"""Drift guards pinning documented install commands to the release config.
+
+The README and installation docs advertise package-manager one-liners
+(``brew install --cask jentic/tap/jentic``, ``winget install Jentic.Jentic``,
+``scoop install jentic``). The names those commands resolve — the Homebrew
+tap + cask, the winget package identifier, the scoop bucket + manifest — are
+all defined in one place: ``cli/.goreleaser.yaml`` (the ``homebrew_casks``,
+``winget`` and ``scoops`` publishers). Nothing else ties the two together, so
+a rename in the release config would silently strand every documented install
+command.
+
+These tests guard *referential* facts only — never prose, wording, or step
+orderings:
+
+- Every ``brew install`` / ``winget install`` / ``scoop`` mention of our
+  packages, in any tracked markdown file (plus ``llms.txt``), must match what
+  ``cli/.goreleaser.yaml`` actually publishes.
+- The winget entry itself must stay internally consistent: winget-pkgs
+  validation requires the manifest path (derived from ``name``) to match
+  ``package_identifier``, which GoReleaser does not check.
+
+The pipeline-side counterpart lives in ``.github/workflows/ci.yml``
+(``cli-artifact-smoke``): a snapshot GoReleaser build asserts the winget and
+scoop manifests are actually generated from this config.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+GORELEASER_CONFIG = REPO_ROOT / "cli" / ".goreleaser.yaml"
+
+#: Directories that hold third-party or generated markdown, not our docs.
+_EXCLUDED_DIR_NAMES = {".git", ".venv", "node_modules", "dist", ".ruff_cache", ".pytest_cache"}
+
+#: ``winget install <id>`` / ``winget upgrade <id>`` mentions.
+_WINGET_RE = re.compile(r"\bwinget (?:install|upgrade)\s+([\w.]+)")
+
+#: ``brew install [--cask] <owner>/<tap>/<name>`` mentions. Only the fully
+#: qualified triple form is matched, so unrelated ``brew install foo`` lines
+#: in third-party instructions never trip this.
+_BREW_RE = re.compile(
+    r"\bbrew (?:install|upgrade|reinstall)\s+(?:--cask\s+)?([\w.-]+/[\w.-]+/[\w.-]+)"
+)
+
+#: ``scoop bucket add <alias> <url>`` mentions.
+_SCOOP_BUCKET_RE = re.compile(r"\bscoop bucket add\s+(\S+)\s+(\S+)")
+
+#: ``scoop install <name>`` / ``scoop update <name>`` mentions (name may be
+#: bucket-qualified, e.g. ``jentic/jentic``).
+_SCOOP_INSTALL_RE = re.compile(r"\bscoop (?:install|update)\s+([\w./-]+)")
+
+
+def _release_config() -> dict[str, Any]:
+    config = yaml.safe_load(GORELEASER_CONFIG.read_text(encoding="utf-8"))
+    assert isinstance(config, dict), f"{GORELEASER_CONFIG} did not parse to a mapping"
+    return config
+
+
+def _doc_files() -> list[Path]:
+    docs = [REPO_ROOT / "llms.txt"]
+    for path in REPO_ROOT.rglob("*.md"):
+        if _EXCLUDED_DIR_NAMES.isdisjoint(part.lower() for part in path.parts):
+            docs.append(path)
+    return [doc for doc in docs if doc.is_file()]
+
+
+def _doc_lines() -> list[tuple[Path, int, str]]:
+    lines: list[tuple[Path, int, str]] = []
+    for doc in sorted(_doc_files()):
+        for lineno, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
+            lines.append((doc, lineno, line))
+    return lines
+
+
+@pytest.mark.arch
+def test_documented_install_commands_match_release_config() -> None:
+    """Every documented package-manager command resolves what we publish.
+
+    Ground truth is ``cli/.goreleaser.yaml``: the ``homebrew_casks`` entry
+    (tap repo + cask name → the ``brew install`` ref), the ``winget`` entry
+    (``package_identifier``), and the ``scoops`` entry (bucket repo + manifest
+    name). A mention that drifts — a renamed identifier, a moved bucket —
+    fails here with the file:line of the stale command.
+    """
+    config = _release_config()
+
+    cask = config["homebrew_casks"][0]
+    tap_repo = cask["repository"]
+    tap_short = tap_repo["name"].removeprefix("homebrew-")
+    expected_brew_ref = f"{tap_repo['owner']}/{tap_short}/{cask['name']}"
+
+    winget = config["winget"][0]
+    expected_winget_id = winget["package_identifier"]
+
+    scoop = config["scoops"][0]
+    scoop_repo = scoop["repository"]
+    expected_bucket_url = f"https://github.com/{scoop_repo['owner']}/{scoop_repo['name']}"
+    expected_scoop_name = scoop["name"]
+
+    violations: list[str] = []
+    for doc, lineno, line in _doc_lines():
+        where = f"{doc.relative_to(REPO_ROOT)}:{lineno}"
+
+        for ref in _BREW_RE.findall(line):
+            if "jentic" in ref and ref != expected_brew_ref:
+                violations.append(
+                    f"{where} — `brew install {ref}` does not match the published cask "
+                    f"`{expected_brew_ref}` (cli/.goreleaser.yaml homebrew_casks)"
+                )
+
+        for pkg in _WINGET_RE.findall(line):
+            if "jentic" in pkg.lower() and pkg != expected_winget_id:
+                violations.append(
+                    f"{where} — `winget install {pkg}` does not match package_identifier "
+                    f"`{expected_winget_id}` (cli/.goreleaser.yaml winget)"
+                )
+
+        for alias, url in _SCOOP_BUCKET_RE.findall(line):
+            if "jentic" not in url.lower():
+                continue
+            if url.removesuffix(".git") != expected_bucket_url:
+                violations.append(
+                    f"{where} — `scoop bucket add {alias} {url}` does not match the published "
+                    f"bucket `{expected_bucket_url}` (cli/.goreleaser.yaml scoops)"
+                )
+
+        for name in _SCOOP_INSTALL_RE.findall(line):
+            unqualified = name.rsplit("/", 1)[-1]
+            if "jentic" in unqualified.lower() and unqualified != expected_scoop_name:
+                violations.append(
+                    f"{where} — `scoop install {name}` does not match the published manifest "
+                    f"`{expected_scoop_name}` (cli/.goreleaser.yaml scoops)"
+                )
+
+    assert not violations, (
+        "Documented install commands drifted from cli/.goreleaser.yaml:\n" + "\n".join(violations)
+    )
+
+
+@pytest.mark.arch
+def test_winget_entry_is_internally_consistent() -> None:
+    """The winget entry must satisfy microsoft/winget-pkgs path validation.
+
+    winget-pkgs requires the manifest directory
+    ``manifests/<initial>/<publisher>/<name>/<version>`` to spell out the
+    ``package_identifier`` (``<publisher>.<name>``). GoReleaser derives the
+    path from the entry's ``publisher`` and ``name`` fields but never checks
+    them against ``package_identifier`` — a mismatch ships manifests the
+    upstream validation bot rejects on every release.
+    """
+    winget = _release_config()["winget"][0]
+    expected_identifier = f"{winget['publisher']}.{winget['name']}"
+    assert winget["package_identifier"] == expected_identifier, (
+        f"cli/.goreleaser.yaml winget: package_identifier "
+        f"{winget['package_identifier']!r} != publisher.name "
+        f"({expected_identifier!r}) — winget-pkgs validation rejects manifests whose "
+        "directory path does not match the identifier"
+    )
+
+    base = winget["repository"]["pull_request"]["base"]
+    assert (base["owner"], base["name"]) == ("microsoft", "winget-pkgs"), (
+        "cli/.goreleaser.yaml winget: the pull request must target "
+        f"microsoft/winget-pkgs, not {base['owner']}/{base['name']} — otherwise "
+        "`winget install` users never see the release"
+    )


### PR DESCRIPTION
## Summary

The README's CLI install was four lines of curl/sed/uname shell golf. Package managers already solve OS/arch resolution, hash verification, PATH placement and upgrades, so this makes them the front door: `brew install --cask jentic/tap/jentic` (macOS/Linux, already shipping) plus two new Windows channels published by GoReleaser — winget (`winget install Jentic.Jentic`) and a scoop bucket. Based on #1142 (the docs restructure this builds on); GitHub retargets to `main` when that merges.

## Changes

- **cli/.goreleaser.yaml** (`deploy`): new `winget` publisher (manifests for the existing Windows zips, pushed to a `jentic/winget-pkgs` fork, PR opened against `microsoft/winget-pkgs`) and `scoops` publisher (manifest committed to `jentic/scoop-bucket`). Both entries `skip_upload` with a log line when their token is empty, so an unprovisioned secret never fails a release.
- **.github/workflows/release.yml** (`ci`): pass optional `WINGET_TOKEN` / `SCOOP_BUCKET_TOKEN` secrets to GoReleaser.
- **.github/workflows/ci.yml** (`ci`): `cli-artifact-smoke` now asserts the snapshot build generates the winget manifests (identifier `Jentic.Jentic`, installs `jentic.exe`) and the scoop manifest — a broken publisher stanza fails on the PR, not at tag time.
- **tests/arch/test_install_docs_conformance.py** (`tests`): drift guard pinning every documented `brew`/`winget`/`scoop` command (all tracked markdown + llms.txt) to what `cli/.goreleaser.yaml` publishes, plus a winget internal-consistency check (`publisher.name` must spell `package_identifier` — the manifest-path shape microsoft/winget-pkgs validation requires but GoReleaser never checks).
- **README.md, docs/installation/{cli,windows,docker}.md, cli/README.md** (`docs`): install sections lead with the package-manager one-liners; the manual download + cosign verification path stays in `docs/installation/cli.md` for locked-down/air-gapped hosts.
- **docs/development/releasing.md** (`docs`): one-time channel provisioning (fork, bucket repo, token shapes) and the token-gated skip behaviour.

Out of scope: `docs/agent/install.md`'s curl-based snippet (a deterministic agent runbook that must work without a package manager) and `tools/install.sh` (still used by the wizard/source flow, no longer the advertised path).

## Risk & rollback

- **One-time setup required before the Windows channels go live** (documented in `docs/development/releasing.md`): create `jentic/scoop-bucket` + fine-grained `SCOOP_BUCKET_TOKEN`; fork `microsoft/winget-pkgs` into the org + classic `WINGET_TOKEN` (`public_repo`). Until then releases skip those channels gracefully — nothing breaks.
- **Docs advertise winget before the first manifest is accepted**: the first winget-pkgs submission goes through Microsoft review (typically days after the first tokened release). Until it lands, `winget install Jentic.Jentic` finds nothing; scoop works from the first tokened release. If that window matters, hold this until a release has shipped with the secrets provisioned.
- No product code touched. Rollback: revert the squash commit.

## Test plan

- `goreleaser check` passes (also runs per-PR in `cli-artifact-smoke`).
- Local `goreleaser release --snapshot --clean --skip=sign,sbom,publish` on OSS GoReleaser v2.18: winget manifests generated at `dist/winget/manifests/j/Jentic/Jentic/<ver>/` (path matches the identifier), `InstallerType: zip` + nested portable `jentic.exe` with alias `jentic` for amd64+arm64, correct sha256s; `dist/scoop/jentic.json` with both arches. Confirms these publishers are OSS features, not Pro.
- `uv run pytest tests/arch/` — 303 passed, including the two new tests; negative check verified (mutating the README's winget id fails with the file:line of the stale command).
- `ruff check` + `ruff format --check` + `mypy` clean on the new test file; both workflow files parse.
- Not testable pre-merge: the real winget PR / scoop push (needs a tagged release with the secrets provisioned) — the snapshot manifest assertions in CI are the standing proxy.

## Review guide

Start with `cli/.goreleaser.yaml` (the two new publishers and their skip-gating comments), then the CI smoke assertions, then the drift test; the docs edits are mechanical after that.

Made with [Cursor](https://cursor.com)