### PR TITLE
ci(dependabot): hold back eslint 10 / typescript 7 until plugins catch up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,3 +95,17 @@ updates:
       types:
         patterns:
           - "@types/*"
+    # eslint 10 shipped ahead of its plugin ecosystem: eslint-plugin-jsx-a11y
+    # (latest 6.10.2) and eslint-plugin-react (latest 7.37.5) still declare
+    # peer eslint <=9, and typescript-eslint (latest 8.69.0) caps
+    # typescript <6.1.0 — so a grouped eslint-10 + typescript-7 PR can never
+    # `npm ci` (ERESOLVE; see PR #1266). Hold those majors back until the
+    # plugins publish eslint-10/TS-7 support, then delete these entries and
+    # let the eslint group take the coupled majors in one installable PR.
+    ignore:
+      - dependency-name: "eslint"
+        versions: [">=10"]
+      - dependency-name: "@eslint/js"
+        versions: [">=10"]
+      - dependency-name: "typescript"
+        versions: [">=7"]


### PR DESCRIPTION
## Why

The grouped eslint bump ([#1266](https://github.com/jentic/jentic-one/pull/1266)) can never install: `eslint-plugin-jsx-a11y` (latest 6.10.2) and `eslint-plugin-react` (latest 7.37.5) only declare peer support for eslint ≤9, and `typescript-eslint` (latest 8.69.0) caps `typescript <6.1.0`. Every `npm ci` in CI fails with ERESOLVE, so the PR is permanently red through no fault of the repo.

## What

Adds `ignore` entries to the `/ui` npm ecosystem for exactly the blocked majors:

- `eslint` >=10
- `@eslint/js` >=10
- `typescript` >=7 (no stable 6.x exists above the current 6.0.3 pin, so this is precise)

Once this lands, #1266 will be recreated so it shrinks to the parts that do install (`typescript-eslint` 8.67 → 8.69). Drop the entries when the plugin ecosystem publishes eslint-10/TS-7 support and the group will deliver the coupled majors as one installable PR — same rationale as the existing vite grouping comment.

Made with [Cursor](https://cursor.com)