### PR TITLE
feat(ui): rebuild the OAuth clients settings surface

### DIFF
--- a/ui/src/modules/agents/mocks/handlers.ts
+++ b/ui/src/modules/agents/mocks/handlers.ts
@@ -1283,7 +1283,9 @@ export const agentsHandlers = [
 	}),
 	http.post('/oauth-grants/:id\\:revoke', ({ params }) => {
 		const grant = oauthGrants.find((g) => g.id === params.id);
-		if (!grant) return new HttpResponse(null, { status: 404 });
+		// Not one of OURS — fall through (the settings module registers the
+		// same kill-switch path for its admin-cross-view grants store).
+		if (!grant) return undefined;
 		// Idempotent, like the backend: re-revoking is a 204 no-op.
 		if (grant.status === 'active') {
 			grant.status = 'revoked';

--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -266,6 +266,31 @@ describe('OAuthClientsSection', () => {
 		expect(await screen.findByText('No denied clients')).toBeInTheDocument();
 	});
 
+	it('collapses noisy queue-card metadata: scope "+N more" and redirect-URI disclosure', async () => {
+		const user = userEvent.setup();
+		renderSection('/settings?tab=queue');
+		await screen.findByText('Cursor');
+
+		// Sketchy Tool is seeded noisy: 6 scopes, 3 redirect URIs.
+		await user.click(screen.getByRole('button', { name: 'Denied' }));
+		await screen.findByText('Sketchy Tool');
+
+		// Scopes render as a one-line summary — 4 preview chips, the rest
+		// behind "+N more" (a chip wall must not out-shout the decision).
+		expect(screen.getByText('apis:read')).toBeInTheDocument();
+		expect(screen.queryByText('audit:read')).not.toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: '+2 more' }));
+		expect(screen.getByText('audit:read')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Show less' }));
+		expect(screen.queryByText('audit:read')).not.toBeInTheDocument();
+
+		// >2 redirect URIs collapse behind a disclosure — the headline's
+		// origins already summarise them.
+		expect(screen.queryByText('https://sketchy.example.com/cb')).not.toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Show 3 redirect URIs' }));
+		expect(screen.getByText('https://sketchy.example.com/cb')).toBeInTheDocument();
+	});
+
 	it('has no critical a11y violations on the queue tab', async () => {
 		const { container } = renderSection('/settings?tab=queue');
 		await screen.findByText('Cursor');

--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -131,9 +131,14 @@ describe('OAuthClientsSection', () => {
 		renderSection('/settings?tab=queue');
 
 		// Origins-first (the #1264 anti-spoofing posture): the headline is the
-		// redirect-URI origin + software_id, with the type/status chips.
-		const heading = await screen.findByText('http://localhost:33418');
-		const row = heading.closest('h3');
+		// redirect-URI origins + software_id, with the type/status chips. The
+		// custom-scheme URI (WHATWG opaque origin) must render as
+		// scheme://host — NOT the literal "null" `URL.origin` serialises to.
+		const origins = await screen.findByText(
+			'http://localhost:33418, cursor://anysphere.cursor-mcp',
+		);
+		expect(origins.textContent).not.toContain('null');
+		const row = origins.closest('h3');
 		expect(row).not.toBeNull();
 		expect(within(row as HTMLElement).getByText('Public')).toBeInTheDocument();
 		expect(within(row as HTMLElement).getByText('DCR')).toBeInTheDocument();
@@ -291,6 +296,26 @@ describe('OAuthClientsSection', () => {
 		// consents render with their agents resolved from the directory.
 		expect(await within(sheet).findByText('Invoice Bot')).toBeInTheDocument();
 		expect(within(sheet).getByText('Support Triage')).toBeInTheDocument();
+
+		// The opened sheet (a body portal — outside the render container)
+		// carries no critical a11y violations either.
+		await checkA11y(document.body);
+	});
+
+	it("offers Reactivate in a zombie's detail sheet (recovery from its own console)", async () => {
+		const user = userEvent.setup();
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+
+		// The approved+inactive zombie must not be stranded: its own console
+		// (the danger zone) carries the recovery verb.
+		await user.click(screen.getByRole('button', { name: 'Inactive 1' }));
+		await screen.findByText('Legacy App');
+		await user.click(screen.getByRole('button', { name: 'View details for Legacy App' }));
+		const sheet = await screen.findByTestId('sheet-primitive');
+
+		await user.click(within(sheet).getByRole('button', { name: 'Reactivate Legacy App' }));
+		expect(await screen.findByText('Legacy App reactivated')).toBeInTheDocument();
 	});
 
 	it('revoke honours can_revoke: enabled kill switch vs. disabled with explanation', async () => {
@@ -364,6 +389,46 @@ describe('OAuthClientsSection', () => {
 		expect(screen.queryByText(/Copy this secret now/)).not.toBeInTheDocument();
 	});
 
+	it('un-restricting scopes on edit PATCHes ["*"] (tri-state), not a silent null no-op', async () => {
+		const user = userEvent.setup();
+		// Record the PATCH payload, then fall through to the store handler so
+		// the flow stays end-to-end (returning undefined defers to the next
+		// matching handler).
+		const captured: { body?: Record<string, unknown> } = {};
+		worker.use(
+			http.patch('/admin/oauth-clients/:id', async ({ request }) => {
+				captured.body = (await request.clone().json()) as Record<string, unknown>;
+				return undefined;
+			}),
+		);
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+
+		// Internal Dashboard is seeded WITH a restriction (apis:read) —
+		// unchecking the box must reset it, not silently change nothing.
+		await user.click(screen.getByRole('button', { name: 'Actions for Internal Dashboard' }));
+		await user.click(await screen.findByRole('menuitem', { name: 'Edit Internal Dashboard' }));
+		const sheet = await screen.findByTestId('sheet-primitive');
+		await user.click(within(sheet).getByRole('checkbox', { name: 'Restrict allowed scopes' }));
+		await user.click(within(sheet).getByRole('button', { name: 'Update' }));
+		await screen.findByText('OAuth client updated');
+
+		// The tri-state sentinel rides the wire (null would mean NO CHANGE)…
+		expect(captured.body?.allowed_scopes).toEqual(['*']);
+		// …and the create-only fields never ride along on PATCH.
+		expect(captured.body).not.toHaveProperty('consent_model');
+		expect(captured.body).not.toHaveProperty('token_endpoint_auth_method');
+
+		// End-to-end: the store applied the reset, so the detail sheet reads
+		// Unrestricted. (Wait out the edit sheet's exit animation first.)
+		await expect.poll(() => screen.queryByTestId('sheet-primitive')).toBeNull();
+		await user.click(
+			screen.getByRole('button', { name: 'View details for Internal Dashboard' }),
+		);
+		const detail = await screen.findByTestId('sheet-primitive');
+		expect(await within(detail).findByText('Unrestricted')).toBeInTheDocument();
+	});
+
 	it('shows the one-time secret for a new confidential client (and wipes it on close)', async () => {
 		const user = userEvent.setup();
 		renderSection();
@@ -393,6 +458,8 @@ describe('OAuthClientsSection', () => {
 		await user.click(screen.getByRole('button', { name: 'Add client' }));
 		let sheet = await screen.findByTestId('sheet-primitive');
 		await user.type(within(sheet).getByLabelText('Name'), 'half-typed-app');
+		// The opened form sheet passes axe too (body portal, so check the body).
+		await checkA11y(document.body);
 		await user.click(within(sheet).getByRole('button', { name: 'Cancel' }));
 		// Let the exit animation finish so the reopen starts from 'closed'.
 		await expect.poll(() => screen.queryByTestId('sheet-primitive')).toBeNull();

--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -127,29 +127,36 @@ describe('OAuthClientsSection', () => {
 		expect(await within(tab).findByText('1')).toBeInTheDocument();
 	});
 
-	it('deep-links to the queue via ?tab=queue and leads with the verifiable origins', async () => {
+	it('deep-links to the queue via ?tab=queue: name-led heading with the Unverified marker and adjacent origins', async () => {
 		renderSection('/settings?tab=queue');
 
-		// Origins-first (the #1264 anti-spoofing posture): the headline is the
-		// redirect-URI origins + software_id, with the type/status chips. The
-		// custom-scheme URI (WHATWG opaque origin) must render as
-		// scheme://host — NOT the literal "null" `URL.origin` serialises to.
-		const origins = await screen.findByText(
-			'http://localhost:33418, cursor://anysphere.cursor-mcp',
-		);
-		expect(origins.textContent).not.toContain('null');
-		const row = origins.closest('h3');
-		expect(row).not.toBeNull();
-		expect(within(row as HTMLElement).getByText('Public')).toBeInTheDocument();
-		expect(within(row as HTMLElement).getByText('DCR')).toBeInTheDocument();
-		expect(within(row as HTMLElement).getByText('Agent consent')).toBeInTheDocument();
-		expect(within(row as HTMLElement).getByText('Pending')).toBeInTheDocument();
-		expect(screen.getByText('com.cursor.ide')).toBeInTheDocument();
+		// Hierarchy v2: the client NAME is the heading — what humans scan for.
+		const heading = await screen.findByRole('heading', { name: 'Cursor' });
+		const card = heading.closest('article') as HTMLElement;
+		expect(card).not.toBeNull();
 
-		// The attacker-chosen display name is demoted to labelled secondary text.
-		expect(screen.getByText(/Self-reported name:/)).toBeInTheDocument();
-		expect(screen.getByText('Cursor')).toBeInTheDocument();
-		expect(within(row as HTMLElement).queryByText('Cursor')).not.toBeInTheDocument();
+		// …but it carries the anti-spoofing posture through LABELING: the
+		// Unverified chip sits beside the name, and its tooltip explains why.
+		// These pins must fail if someone removes the marker or the origins.
+		expect(within(card).getByText('Unverified')).toBeInTheDocument();
+		expect(
+			within(card).getByText(/self-reported by the client during registration/),
+		).toBeInTheDocument();
+
+		// The VERIFIABLE line sits directly under the name: origins +
+		// software_id. The custom-scheme URI (WHATWG opaque origin) must
+		// render as scheme://host — NOT the literal "null" `URL.origin`
+		// serialises to.
+		const verifiable = within(card).getByText(
+			'http://localhost:33418, cursor://anysphere.cursor-mcp · com.cursor.ide',
+		);
+		expect(verifiable.textContent).not.toContain('null');
+
+		// Status right-aligned in the header; type chips in the metadata block.
+		expect(within(card).getByText('Pending')).toBeInTheDocument();
+		expect(within(card).getByText('Public')).toBeInTheDocument();
+		expect(within(card).getByText('DCR')).toBeInTheDocument();
+		expect(within(card).getByText('Agent consent')).toBeInTheDocument();
 	});
 
 	it('approves a pending registration and empties the queue (D7 pending→approved)', async () => {

--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
 import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen, within, userEvent, checkA11y } from '@/__tests__/test-utils';
 import { worker } from '@/mocks/browser';
@@ -19,21 +20,105 @@ function renderSection(route = '/settings') {
 }
 
 describe('OAuthClientsSection', () => {
-	beforeEach(() => {
+	beforeEach(async () => {
+		// The roster swaps to stacked cards below `sm` (640px); these specs
+		// assert the desktop table grammar, so pin a desktop viewport.
+		await page.viewport(1280, 900);
 		setToken('test-token');
 		resetSettingsStore();
 	});
 
-	it('lists clients with badges and the per-client active-grant count', async () => {
+	// ------------------------------------------------------------------
+	// Roster (ClientsTable)
+	// ------------------------------------------------------------------
+
+	it('defaults to the Active segment: working fleet only, pending/denied/inactive hidden', async () => {
 		renderSection();
 
 		// The admin-registered confidential client, with its §4.8 grant count.
 		expect(await screen.findByText('Internal Dashboard')).toBeInTheDocument();
-		expect(screen.getByText('Active grants:')).toBeInTheDocument();
-		expect(screen.getByText('2')).toBeInTheDocument();
-		// Pending/denied rows are inactive → hidden from the default clients list.
+		expect(
+			screen.getByRole('button', { name: 'View grants for Internal Dashboard' }),
+		).toHaveTextContent('2');
+		// Pending, denied, and deactivated rows stay out of the default view.
+		expect(screen.queryByText('Cursor')).not.toBeInTheDocument();
 		expect(screen.queryByText('Sketchy Tool')).not.toBeInTheDocument();
+		expect(screen.queryByText('Legacy App')).not.toBeInTheDocument();
 	});
+
+	it('status segments carry live counts and Inactive surfaces the approved+inactive zombie (#1312)', async () => {
+		const user = userEvent.setup();
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+
+		// Live counts over the full include_inactive pool.
+		expect(screen.getByRole('button', { name: 'All 4' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Active 1' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Pending 1' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Denied 1' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Inactive 1' })).toBeInTheDocument();
+
+		// The zombie — approved but deactivated, invisible to both queue
+		// filters — lives under the Inactive segment with its chip.
+		await user.click(screen.getByRole('button', { name: 'Inactive 1' }));
+		expect(await screen.findByText('Legacy App')).toBeInTheDocument();
+		expect(screen.getByText('Inactive')).toBeInTheDocument();
+		expect(screen.queryByText('Internal Dashboard')).not.toBeInTheDocument();
+	});
+
+	it('never offers Reactivate on a denied row — its recovery routes to the queue', async () => {
+		const user = userEvent.setup();
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+
+		// The denied row's kebab: Review in queue, but NO Reactivate (a PATCH
+		// active=true would leave approval_status=denied — still gate-blocked).
+		await user.click(screen.getByRole('button', { name: 'Denied 1' }));
+		await screen.findByText('Sketchy Tool');
+		await user.click(screen.getByRole('button', { name: 'Actions for Sketchy Tool' }));
+		expect(
+			await screen.findByRole('menuitem', { name: 'Review in queue Sketchy Tool' }),
+		).toBeInTheDocument();
+		expect(screen.queryByRole('menuitem', { name: /Reactivate/ })).not.toBeInTheDocument();
+		await user.keyboard('{Escape}');
+
+		// The approved+inactive zombie DOES get Reactivate — the one state
+		// where a plain PATCH active=true actually un-blocks the client.
+		await user.click(screen.getByRole('button', { name: 'Inactive 1' }));
+		await screen.findByText('Legacy App');
+		await user.click(screen.getByRole('button', { name: 'Actions for Legacy App' }));
+		expect(
+			await screen.findByRole('menuitem', { name: 'Reactivate Legacy App' }),
+		).toBeInTheDocument();
+	});
+
+	it('"Review in queue" on a denied row lands on the queue tab, Denied slice', async () => {
+		const user = userEvent.setup();
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+
+		await user.click(screen.getByRole('button', { name: 'Denied 1' }));
+		await screen.findByText('Sketchy Tool');
+		await user.click(screen.getByRole('button', { name: 'Actions for Sketchy Tool' }));
+		await user.click(
+			await screen.findByRole('menuitem', { name: 'Review in queue Sketchy Tool' }),
+		);
+
+		// Queue tab, denied filter: the row re-offers Approve without Deny.
+		expect(await screen.findByText('Sketchy Tool')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Deny' })).not.toBeInTheDocument();
+	});
+
+	it('has no critical a11y violations on the clients tab', async () => {
+		const { container } = renderSection();
+		await screen.findByText('Internal Dashboard');
+		await checkA11y(container);
+	});
+
+	// ------------------------------------------------------------------
+	// Approval queue
+	// ------------------------------------------------------------------
 
 	it('carries the pending count on the Approval queue tab label', async () => {
 		renderSection();
@@ -42,17 +127,24 @@ describe('OAuthClientsSection', () => {
 		expect(await within(tab).findByText('1')).toBeInTheDocument();
 	});
 
-	it('deep-links to the queue via ?tab=queue (the rail Review action)', async () => {
+	it('deep-links to the queue via ?tab=queue and leads with the verifiable origins', async () => {
 		renderSection('/settings?tab=queue');
-		// The pending DCR registration renders with its badges (scoped to the
-		// row heading — "Pending" also names the queue's filter button).
-		const heading = await screen.findByText('Cursor');
+
+		// Origins-first (the #1264 anti-spoofing posture): the headline is the
+		// redirect-URI origin + software_id, with the type/status chips.
+		const heading = await screen.findByText('http://localhost:33418');
 		const row = heading.closest('h3');
 		expect(row).not.toBeNull();
 		expect(within(row as HTMLElement).getByText('Public')).toBeInTheDocument();
 		expect(within(row as HTMLElement).getByText('DCR')).toBeInTheDocument();
+		expect(within(row as HTMLElement).getByText('Agent consent')).toBeInTheDocument();
 		expect(within(row as HTMLElement).getByText('Pending')).toBeInTheDocument();
 		expect(screen.getByText('com.cursor.ide')).toBeInTheDocument();
+
+		// The attacker-chosen display name is demoted to labelled secondary text.
+		expect(screen.getByText(/Self-reported name:/)).toBeInTheDocument();
+		expect(screen.getByText('Cursor')).toBeInTheDocument();
+		expect(within(row as HTMLElement).queryByText('Cursor')).not.toBeInTheDocument();
 	});
 
 	it('approves a pending registration and empties the queue (D7 pending→approved)', async () => {
@@ -173,5 +265,142 @@ describe('OAuthClientsSection', () => {
 		const { container } = renderSection('/settings?tab=queue');
 		await screen.findByText('Cursor');
 		await checkA11y(container);
+	});
+
+	// ------------------------------------------------------------------
+	// Detail sheet (metadata + grants + audit)
+	// ------------------------------------------------------------------
+
+	it('opens the detail sheet from the roster name: metadata and grants render', async () => {
+		const user = userEvent.setup();
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+
+		await user.click(
+			screen.getByRole('button', { name: 'View details for Internal Dashboard' }),
+		);
+		const sheet = await screen.findByTestId('sheet-primitive');
+
+		// Metadata: consent model, client type, provenance, scope restriction.
+		expect(within(sheet).getByText('User — consent acts as the user')).toBeInTheDocument();
+		expect(within(sheet).getByText('Confidential (client secret)')).toBeInTheDocument();
+		expect(within(sheet).getByText('Admin-registered')).toBeInTheDocument();
+		expect(within(sheet).getByText('https://app.example.com/callback')).toBeInTheDocument();
+
+		// Grants (via GET /admin/oauth-grants?client_id=…): the two active
+		// consents render with their agents resolved from the directory.
+		expect(await within(sheet).findByText('Invoice Bot')).toBeInTheDocument();
+		expect(within(sheet).getByText('Support Triage')).toBeInTheDocument();
+	});
+
+	it('revoke honours can_revoke: enabled kill switch vs. disabled with explanation', async () => {
+		const user = userEvent.setup();
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+		await user.click(
+			screen.getByRole('button', { name: 'View details for Internal Dashboard' }),
+		);
+		const sheet = await screen.findByTestId('sheet-primitive');
+		await within(sheet).findByText('Invoice Bot');
+
+		// The G10 divergence: the caller can LIST ocg_2 but not revoke it —
+		// the button disables instead of offering a 403.
+		expect(
+			within(sheet).getByRole('button', { name: 'Revoke grant ocg_2 (not permitted)' }),
+		).toBeDisabled();
+
+		// The revocable grant goes through the confirm dialog.
+		await user.click(within(sheet).getByRole('button', { name: 'Revoke grant ocg_1' }));
+		const dialog = await screen.findByRole('dialog', { name: 'Revoke this grant?' });
+		await user.click(within(dialog).getByRole('button', { name: 'Revoke' }));
+		expect(await screen.findByText('Grant revoked')).toBeInTheDocument();
+	});
+
+	it('surfaces the decision history — including the deny reason — in Recent changes', async () => {
+		const user = userEvent.setup();
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+
+		// The denied client's audit trail carries the operator's deny reason,
+		// which the old UI captured and then never showed anywhere.
+		await user.click(screen.getByRole('button', { name: 'Denied 1' }));
+		await screen.findByText('Sketchy Tool');
+		await user.click(screen.getByRole('button', { name: 'View details for Sketchy Tool' }));
+		const sheet = await screen.findByTestId('sheet-primitive');
+
+		expect(await within(sheet).findByText('oauth_client.deny')).toBeInTheDocument();
+		expect(within(sheet).getByText(/unknown redirect URIs/)).toBeInTheDocument();
+	});
+
+	// ------------------------------------------------------------------
+	// Create/edit form sheet
+	// ------------------------------------------------------------------
+
+	it('creates a public agent-consent client (consent_model + token_endpoint_auth_method sent)', async () => {
+		const user = userEvent.setup();
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+
+		await user.click(screen.getByRole('button', { name: 'Add client' }));
+		const sheet = await screen.findByTestId('sheet-primitive');
+		await user.type(within(sheet).getByLabelText('Name'), 'mcp-bridge');
+		await user.type(
+			within(sheet).getByLabelText('Redirect URI 1'),
+			'https://bridge.example.com/cb',
+		);
+		await user.selectOptions(within(sheet).getByLabelText('Client type'), 'public');
+		await user.selectOptions(within(sheet).getByLabelText('Consent model'), 'agent');
+		await user.click(within(sheet).getByRole('button', { name: 'Create' }));
+
+		// The mock store echoes what the form SENT: the new roster row carries
+		// the Public (token_endpoint_auth_method=none) and Agent-consent chips.
+		const name = await screen.findByRole('button', { name: 'View details for mcp-bridge' });
+		const row = name.closest('tr');
+		expect(row).not.toBeNull();
+		expect(within(row as HTMLElement).getByText('Public')).toBeInTheDocument();
+		expect(within(row as HTMLElement).getByText('Agent consent')).toBeInTheDocument();
+
+		// Public clients are PKCE-only: no one-time secret dialog.
+		expect(screen.queryByText(/Copy this secret now/)).not.toBeInTheDocument();
+	});
+
+	it('shows the one-time secret for a new confidential client (and wipes it on close)', async () => {
+		const user = userEvent.setup();
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+
+		await user.click(screen.getByRole('button', { name: 'Add client' }));
+		const sheet = await screen.findByTestId('sheet-primitive');
+		await user.type(within(sheet).getByLabelText('Name'), 'server-app');
+		await user.type(
+			within(sheet).getByLabelText('Redirect URI 1'),
+			'https://server.example.com/cb',
+		);
+		await user.click(within(sheet).getByRole('button', { name: 'Create' }));
+
+		// Confidential default → the one-time secret dialog.
+		expect(await screen.findByText('ocs_mock_secret_once')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Done' }));
+		// Sensitive-data exception: the secret does not survive the close.
+		expect(screen.queryByText('ocs_mock_secret_once')).not.toBeInTheDocument();
+	});
+
+	it('keeps the create-form draft across a casual dismiss (dialog-state rule)', async () => {
+		const user = userEvent.setup();
+		renderSection();
+		await screen.findByText('Internal Dashboard');
+
+		await user.click(screen.getByRole('button', { name: 'Add client' }));
+		let sheet = await screen.findByTestId('sheet-primitive');
+		await user.type(within(sheet).getByLabelText('Name'), 'half-typed-app');
+		await user.click(within(sheet).getByRole('button', { name: 'Cancel' }));
+		// Let the exit animation finish so the reopen starts from 'closed'.
+		await expect.poll(() => screen.queryByTestId('sheet-primitive')).toBeNull();
+
+		// Reopen: the draft survived — the sheet is mounted persistently, not
+		// conditionally (the old implementation lost drafts here).
+		await user.click(screen.getByRole('button', { name: 'Add client' }));
+		sheet = await screen.findByTestId('sheet-primitive');
+		expect(within(sheet).getByLabelText('Name')).toHaveValue('half-typed-app');
 	});
 });

--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -19,7 +19,7 @@ import { SettingsPage } from '@/modules/settings/pages/SettingsPage';
 // The full flattened page (header + page-level TabNav + section): the page
 // owns the ?tab= wiring and the tab bar, so the surface is exercised through
 // it — rendering the section alone would leave the tabs unmounted.
-function renderSection(route = '/settings') {
+function renderSettingsPage(route = '/settings') {
 	return renderWithProviders(
 		<>
 			<SettingsPage />
@@ -42,7 +42,7 @@ async function settleHeader(): Promise<void> {
 	await waitFor(() => expect(getComputedStyle(motionEl).opacity).toBe('1'));
 }
 
-describe('OAuthClientsSection', () => {
+describe('OAuth clients surface (via SettingsPage)', () => {
 	beforeEach(async () => {
 		// The roster swaps to stacked cards below `sm` (640px); these specs
 		// assert the desktop table grammar, so pin a desktop viewport.
@@ -56,7 +56,7 @@ describe('OAuthClientsSection', () => {
 	// ------------------------------------------------------------------
 
 	it('defaults to the Active segment: working fleet only, pending/denied/inactive hidden', async () => {
-		renderSection();
+		renderSettingsPage();
 
 		// The admin-registered confidential client, with its §4.8 grant count.
 		expect(await screen.findByText('Internal Dashboard')).toBeInTheDocument();
@@ -71,7 +71,7 @@ describe('OAuthClientsSection', () => {
 
 	it('status segments carry live counts and Inactive surfaces the approved+inactive zombie (#1312)', async () => {
 		const user = userEvent.setup();
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		// Live counts over the full include_inactive pool.
@@ -91,7 +91,7 @@ describe('OAuthClientsSection', () => {
 
 	it('never offers Reactivate on a denied row — its recovery routes to the queue', async () => {
 		const user = userEvent.setup();
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		// The denied row's kebab: Review in queue, but NO Reactivate (a PATCH
@@ -117,7 +117,7 @@ describe('OAuthClientsSection', () => {
 
 	it('"Review in queue" on a denied row lands on the queue tab, Denied slice', async () => {
 		const user = userEvent.setup();
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		await user.click(screen.getByRole('button', { name: 'Denied 1' }));
@@ -134,7 +134,7 @@ describe('OAuthClientsSection', () => {
 	});
 
 	it('has no critical a11y violations on the clients tab', async () => {
-		const { container } = renderSection();
+		const { container } = renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 		await settleHeader();
 		await checkA11y(container);
@@ -145,14 +145,14 @@ describe('OAuthClientsSection', () => {
 	// ------------------------------------------------------------------
 
 	it('carries the pending count on the Approval queue tab label', async () => {
-		renderSection();
+		renderSettingsPage();
 		// One seeded pending registration → the tab badge shows 1.
 		const tab = await screen.findByRole('tab', { name: /Approval queue/ });
 		expect(await within(tab).findByText('1')).toBeInTheDocument();
 	});
 
 	it('deep-links to the queue via ?tab=queue: name-led heading with the Unverified marker and adjacent origins', async () => {
-		renderSection('/settings?tab=queue');
+		renderSettingsPage('/settings?tab=queue');
 
 		// Hierarchy v2: the client NAME is the heading — what humans scan for.
 		const heading = await screen.findByRole('heading', { name: 'Cursor' });
@@ -185,7 +185,7 @@ describe('OAuthClientsSection', () => {
 
 	it('approves a pending registration and empties the queue (D7 pending→approved)', async () => {
 		const user = userEvent.setup();
-		renderSection('/settings?tab=queue');
+		renderSettingsPage('/settings?tab=queue');
 		await screen.findByText('Cursor');
 
 		await user.click(screen.getByRole('button', { name: 'Approve' }));
@@ -200,7 +200,7 @@ describe('OAuthClientsSection', () => {
 
 	it('denies a pending registration via the reason dialog (D7 pending→denied)', async () => {
 		const user = userEvent.setup();
-		renderSection('/settings?tab=queue');
+		renderSettingsPage('/settings?tab=queue');
 		await screen.findByText('Cursor');
 
 		await user.click(screen.getByRole('button', { name: 'Deny' }));
@@ -266,7 +266,7 @@ describe('OAuthClientsSection', () => {
 
 	it('keeps the deny reason draft across a casual dismiss (dialog-state rule)', async () => {
 		const user = userEvent.setup();
-		renderSection('/settings?tab=queue');
+		renderSettingsPage('/settings?tab=queue');
 		await screen.findByText('Cursor');
 
 		await user.click(screen.getByRole('button', { name: 'Deny' }));
@@ -284,7 +284,7 @@ describe('OAuthClientsSection', () => {
 
 	it('recovers a denied client: the Denied filter re-offers Approve (D7 denied→approved)', async () => {
 		const user = userEvent.setup();
-		renderSection('/settings?tab=queue');
+		renderSettingsPage('/settings?tab=queue');
 		await screen.findByText('Cursor');
 
 		// The seeded denied row lives under the Denied filter, without a Deny verb.
@@ -299,7 +299,7 @@ describe('OAuthClientsSection', () => {
 
 	it('collapses noisy queue-card metadata: scope "+N more" and redirect-URI disclosure', async () => {
 		const user = userEvent.setup();
-		renderSection('/settings?tab=queue');
+		renderSettingsPage('/settings?tab=queue');
 		await screen.findByText('Cursor');
 
 		// Sketchy Tool is seeded noisy: 6 scopes, 3 redirect URIs.
@@ -323,7 +323,7 @@ describe('OAuthClientsSection', () => {
 	});
 
 	it('has no critical a11y violations on the queue tab', async () => {
-		const { container } = renderSection('/settings?tab=queue');
+		const { container } = renderSettingsPage('/settings?tab=queue');
 		await screen.findByText('Cursor');
 		await settleHeader();
 		await checkA11y(container);
@@ -335,7 +335,7 @@ describe('OAuthClientsSection', () => {
 
 	it('opens the detail sheet from the roster name: metadata and grants render', async () => {
 		const user = userEvent.setup();
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		await user.click(
@@ -362,7 +362,7 @@ describe('OAuthClientsSection', () => {
 
 	it("offers Reactivate in a zombie's detail sheet (recovery from its own console)", async () => {
 		const user = userEvent.setup();
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		// The approved+inactive zombie must not be stranded: its own console
@@ -378,7 +378,7 @@ describe('OAuthClientsSection', () => {
 
 	it('revoke honours can_revoke: enabled kill switch vs. disabled with explanation', async () => {
 		const user = userEvent.setup();
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 		await user.click(
 			screen.getByRole('button', { name: 'View details for Internal Dashboard' }),
@@ -401,7 +401,7 @@ describe('OAuthClientsSection', () => {
 
 	it('surfaces the decision history — including the deny reason — in Recent changes', async () => {
 		const user = userEvent.setup();
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		// The denied client's audit trail carries the operator's deny reason,
@@ -421,7 +421,7 @@ describe('OAuthClientsSection', () => {
 
 	it('creates a public agent-consent client (consent_model + token_endpoint_auth_method sent)', async () => {
 		const user = userEvent.setup();
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		await user.click(screen.getByRole('button', { name: 'Add client' }));
@@ -459,7 +459,7 @@ describe('OAuthClientsSection', () => {
 				return undefined;
 			}),
 		);
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		// Internal Dashboard is seeded WITH a restriction (apis:read) —
@@ -489,7 +489,7 @@ describe('OAuthClientsSection', () => {
 
 	it('shows the one-time secret for a new confidential client (and wipes it on close)', async () => {
 		const user = userEvent.setup();
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		await user.click(screen.getByRole('button', { name: 'Add client' }));
@@ -510,7 +510,7 @@ describe('OAuthClientsSection', () => {
 
 	it('keeps the create-form draft across a casual dismiss (dialog-state rule)', async () => {
 		const user = userEvent.setup();
-		renderSection();
+		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		await user.click(screen.getByRole('button', { name: 'Add client' }));

--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -1,22 +1,45 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { page } from 'vitest/browser';
 import { http, HttpResponse } from 'msw';
-import { renderWithProviders, screen, within, userEvent, checkA11y } from '@/__tests__/test-utils';
+import {
+	renderWithProviders,
+	screen,
+	waitFor,
+	within,
+	userEvent,
+	checkA11y,
+} from '@/__tests__/test-utils';
 import { worker } from '@/mocks/browser';
 import { setToken, type EventResponse } from '@/shared/api';
 import { Toaster } from '@/shared/ui';
 import { AgentStreamProvider, useAgentStream } from '@/shared/lib/agentStream';
 import { resetSettingsStore } from '@/modules/settings/mocks/handlers';
-import { OAuthClientsSection } from '@/modules/settings/pages/OAuthClientsSection';
+import { SettingsPage } from '@/modules/settings/pages/SettingsPage';
 
+// The full flattened page (header + page-level TabNav + section): the page
+// owns the ?tab= wiring and the tab bar, so the surface is exercised through
+// it — rendering the section alone would leave the tabs unmounted.
 function renderSection(route = '/settings') {
 	return renderWithProviders(
 		<>
-			<OAuthClientsSection />
+			<SettingsPage />
 			<Toaster />
 		</>,
 		{ route },
 	);
+}
+
+/**
+ * PageHeader's content fades in (250ms); axe sampling mid-animation sees
+ * blended colours and reports false contrast violations on the header's
+ * primary action. Wait for the motion wrapper to settle before any axe run
+ * (the CredentialsPage suite does the same for its stagger).
+ */
+async function settleHeader(): Promise<void> {
+	const h1 = await screen.findByRole('heading', { level: 1, name: 'Settings' });
+	const motionEl = h1.closest('div[style]');
+	if (!motionEl) return;
+	await waitFor(() => expect(getComputedStyle(motionEl).opacity).toBe('1'));
 }
 
 describe('OAuthClientsSection', () => {
@@ -113,6 +136,7 @@ describe('OAuthClientsSection', () => {
 	it('has no critical a11y violations on the clients tab', async () => {
 		const { container } = renderSection();
 		await screen.findByText('Internal Dashboard');
+		await settleHeader();
 		await checkA11y(container);
 	});
 
@@ -222,7 +246,7 @@ describe('OAuthClientsSection', () => {
 		const user = userEvent.setup();
 		renderWithProviders(
 			<AgentStreamProvider live={false}>
-				<OAuthClientsSection />
+				<SettingsPage />
 				<Toaster />
 				<SettleProbe />
 			</AgentStreamProvider>,
@@ -301,6 +325,7 @@ describe('OAuthClientsSection', () => {
 	it('has no critical a11y violations on the queue tab', async () => {
 		const { container } = renderSection('/settings?tab=queue');
 		await screen.findByText('Cursor');
+		await settleHeader();
 		await checkA11y(container);
 	});
 
@@ -331,6 +356,7 @@ describe('OAuthClientsSection', () => {
 
 		// The opened sheet (a body portal — outside the render container)
 		// carries no critical a11y violations either.
+		await settleHeader();
 		await checkA11y(document.body);
 	});
 
@@ -491,6 +517,7 @@ describe('OAuthClientsSection', () => {
 		let sheet = await screen.findByTestId('sheet-primitive');
 		await user.type(within(sheet).getByLabelText('Name'), 'half-typed-app');
 		// The opened form sheet passes axe too (body portal, so check the body).
+		await settleHeader();
 		await checkA11y(document.body);
 		await user.click(within(sheet).getByRole('button', { name: 'Cancel' }));
 		// Let the exit animation finish so the reopen starts from 'closed'.

--- a/ui/src/modules/settings/__tests__/SettingsPage.test.tsx
+++ b/ui/src/modules/settings/__tests__/SettingsPage.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * SettingsPage layout pins:
+ *
+ *  - the section nav is RESPONSIVE: a persistent side column at `md+`
+ *    (Button-based, `border-r` stretching with the flex row), collapsing to
+ *    the platform's horizontal `TabNav` grammar on phones — a hard `w-56`
+ *    column would eat half of a 375px screen;
+ *  - the sidebar row fills the Layout content column (`min-h-[calc(100dvh-…)]`
+ *    on the shell) so the border reaches the viewport bottom on short content
+ *    while long content still scrolls with the DOCUMENT (no nested scroll
+ *    container);
+ *  - no horizontal overflow at phone width.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
+import { setToken } from '@/shared/api';
+import { resetSettingsStore } from '@/modules/settings/mocks/handlers';
+import { SettingsPage } from '@/modules/settings/pages/SettingsPage';
+
+describe('SettingsPage', () => {
+	beforeEach(() => {
+		setToken('test-token');
+		resetSettingsStore();
+	});
+
+	it('renders the section nav as a side column on desktop, not tabs', async () => {
+		await page.viewport(1280, 900);
+		renderWithProviders(<SettingsPage />, { route: '/settings' });
+		await screen.findByText('Internal Dashboard');
+
+		// The md+ grammar: sidebar buttons inside the "Settings sections" nav…
+		expect(screen.getByRole('button', { name: 'Developer Settings' })).toBeInTheDocument();
+		// …while the mobile TabNav is display:none (role queries skip hidden).
+		expect(screen.queryByRole('tab', { name: 'Developer Settings' })).not.toBeInTheDocument();
+	});
+
+	it('collapses the section nav to horizontal tabs at phone width, without overflow', async () => {
+		await page.viewport(375, 812);
+		const { container } = renderWithProviders(<SettingsPage />, { route: '/settings' });
+		await screen.findByText('Internal Dashboard');
+
+		// The phone grammar: a TabNav above the content…
+		expect(screen.getByRole('tab', { name: 'Developer Settings' })).toBeInTheDocument();
+		// …and no side column eating half the screen.
+		expect(
+			screen.queryByRole('button', { name: 'Developer Settings' }),
+		).not.toBeInTheDocument();
+
+		// The whole surface (header, tabs, roster cards) fits 375px — the
+		// document must not scroll sideways.
+		expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+
+		await checkA11y(container);
+	});
+});

--- a/ui/src/modules/settings/__tests__/SettingsPage.test.tsx
+++ b/ui/src/modules/settings/__tests__/SettingsPage.test.tsx
@@ -1,22 +1,28 @@
 /**
- * SettingsPage layout pins:
+ * SettingsPage layout pins — the FLAT platform grammar (per review):
  *
- *  - the section nav is RESPONSIVE: a persistent side column at `md+`
- *    (Button-based, `border-r` stretching with the flex row), collapsing to
- *    the platform's horizontal `TabNav` grammar on phones — a hard `w-56`
- *    column would eat half of a 375px screen;
- *  - the sidebar row fills the Layout content column (`min-h-[calc(100dvh-…)]`
- *    on the shell) so the border reaches the viewport bottom on short content
- *    while long content still scrolls with the DOCUMENT (no nested scroll
- *    container);
+ *  - no left sidebar (it was the SPA's only one, with a single destination)
+ *    and no "Developer Settings" register — the page is PageShell +
+ *    PageHeader + ONE page-level TabNav, the AgentsPage shape;
+ *  - the header actions carry "Add client" + the page help;
+ *  - exactly one tab bar (Clients / Approval queue) — no nested tab bars,
+ *    no double headers;
  *  - no horizontal overflow at phone width.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { page } from 'vitest/browser';
-import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
+import { renderWithProviders, screen, waitFor, checkA11y } from '@/__tests__/test-utils';
 import { setToken } from '@/shared/api';
 import { resetSettingsStore } from '@/modules/settings/mocks/handlers';
 import { SettingsPage } from '@/modules/settings/pages/SettingsPage';
+
+/** Wait out PageHeader's fade-in so axe doesn't sample blended colours. */
+async function settleHeader(): Promise<void> {
+	const h1 = await screen.findByRole('heading', { level: 1, name: 'Settings' });
+	const motionEl = h1.closest('div[style]');
+	if (!motionEl) return;
+	await waitFor(() => expect(getComputedStyle(motionEl).opacity).toBe('1'));
+}
 
 describe('SettingsPage', () => {
 	beforeEach(() => {
@@ -24,33 +30,43 @@ describe('SettingsPage', () => {
 		resetSettingsStore();
 	});
 
-	it('renders the section nav as a side column on desktop, not tabs', async () => {
+	it('renders the flat page grammar: header actions + a single page-level tab bar', async () => {
 		await page.viewport(1280, 900);
 		renderWithProviders(<SettingsPage />, { route: '/settings' });
 		await screen.findByText('Internal Dashboard');
 
-		// The md+ grammar: sidebar buttons inside the "Settings sections" nav…
-		expect(screen.getByRole('button', { name: 'Developer Settings' })).toBeInTheDocument();
-		// …while the mobile TabNav is display:none (role queries skip hidden).
-		expect(screen.queryByRole('tab', { name: 'Developer Settings' })).not.toBeInTheDocument();
+		// PageHeader is the page title; the old section heading register and
+		// the sidebar's "Developer Settings" destination are gone.
+		expect(screen.getByRole('heading', { level: 1, name: 'Settings' })).toBeInTheDocument();
+		expect(screen.queryByText('Developer Settings')).not.toBeInTheDocument();
+		expect(screen.queryByText('OAuth Clients')).not.toBeInTheDocument();
+
+		// ONE tab bar, owned by the page: Clients / Approval queue.
+		expect(screen.getAllByRole('tablist')).toHaveLength(1);
+		expect(screen.getByRole('tab', { name: /Clients/ })).toBeInTheDocument();
+		expect(screen.getByRole('tab', { name: /Approval queue/ })).toBeInTheDocument();
+
+		// The section's actions folded into the header's actions slot.
+		expect(screen.getByRole('button', { name: /Add client/ })).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'Help for About OAuth Clients' }),
+		).toBeInTheDocument();
 	});
 
-	it('collapses the section nav to horizontal tabs at phone width, without overflow', async () => {
+	it('fits phone width without a sidebar or horizontal overflow', async () => {
 		await page.viewport(375, 812);
 		const { container } = renderWithProviders(<SettingsPage />, { route: '/settings' });
 		await screen.findByText('Internal Dashboard');
 
-		// The phone grammar: a TabNav above the content…
-		expect(screen.getByRole('tab', { name: 'Developer Settings' })).toBeInTheDocument();
-		// …and no side column eating half the screen.
-		expect(
-			screen.queryByRole('button', { name: 'Developer Settings' }),
-		).not.toBeInTheDocument();
+		// Same flat structure at 375px — tabs, not a w-56 column.
+		expect(screen.getByRole('tab', { name: /Clients/ })).toBeInTheDocument();
+		expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
 
 		// The whole surface (header, tabs, roster cards) fits 375px — the
 		// document must not scroll sideways.
 		expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
 
+		await settleHeader();
 		await checkA11y(container);
 	});
 });

--- a/ui/src/modules/settings/api/hooks.ts
+++ b/ui/src/modules/settings/api/hooks.ts
@@ -1,21 +1,34 @@
 /**
  * OAuth clients React Query hooks — backed by the generated OAuthClientsService.
  */
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+	ApiError,
+	AuditService,
+	AuditTargetType,
+	OAuthClientCreateRequest,
 	OAuthClientsService,
+	OAuthService,
 	PermissionsService,
 	sharedQueryKeys,
-	type OAuthClientCreateRequest,
+	type AuditResponse,
 	type OAuthClientCreateResponse,
 	type OAuthClientResponse,
 	type OAuthClientRotateSecretResponse,
 	type OAuthClientUpdateRequest,
+	type OAuthGrantAdminListResponse,
+	type OAuthGrantAdminResponse,
 	type PermissionResponse,
 } from '@/shared/api';
 import { useAgentStreamOptional } from '@/shared/lib';
 
 export type OAuthClient = OAuthClientResponse;
+export type OAuthClientGrant = OAuthGrantAdminResponse;
+export type OAuthClientAuditEntry = AuditResponse;
+// Value re-export (enum namespaces for `consent_model` /
+// `token_endpoint_auth_method`) so views build create payloads without
+// touching the @/shared/api facade directly (module-boundary lint rule).
+export { OAuthClientCreateRequest };
 
 // Derived from the shared cross-module root: the agent-stream provider
 // invalidates `sharedQueryKeys.oauthClientsRoot` when a live `oauth_client.*` /
@@ -143,8 +156,97 @@ export function useRotateOAuthClientSecret() {
 	});
 }
 
+/**
+ * One client's fresh row (`GET /admin/oauth-clients/{id}`) — the detail
+ * sheet's live source. The sheet is seeded from the roster row the user
+ * clicked, but mutations (approve, rotate, deactivate) land between open and
+ * close, so it re-reads under the shared root (every mutation above sweeps
+ * `QUERY_KEY`, which covers this slice too).
+ */
+export function useOAuthClient(id: string | null) {
+	return useQuery<OAuthClientResponse>({
+		queryKey: [...QUERY_KEY, 'detail', id],
+		queryFn: () => OAuthClientsService.getOauthClient({ id: id as string }),
+		enabled: id != null,
+	});
+}
+
+/**
+ * The consent→agent grants held against ONE client — the admin cross-view
+ * (`GET /admin/oauth-grants?client_id=…`) filtered to the detail sheet's
+ * client. Mirrors the agents module's `useAgentOauthGrants` grammar:
+ * cursor-paginated behind "Load more", status-sliced (`null` = all).
+ * Keyed under the shared oauth-clients root so client mutations and live
+ * `oauth_grant.*` events sweep it along with the roster.
+ */
+export function useOAuthClientGrants(
+	clientId: string | null,
+	status: 'active' | 'revoked' | null = 'active',
+) {
+	return useInfiniteQuery<OAuthGrantAdminListResponse>({
+		queryKey: [...QUERY_KEY, 'grants', clientId ?? '', status ?? 'all'],
+		queryFn: ({ pageParam }) =>
+			OAuthService.listOauthGrants({
+				clientId,
+				status,
+				cursor: (pageParam as string | null) ?? null,
+			}),
+		initialPageParam: null,
+		getNextPageParam: (last) => (last.has_more ? (last.next_cursor ?? null) : null),
+		enabled: clientId != null,
+	});
+}
+
+/**
+ * Revoke a consent→agent grant (§4.6 kill switch) from the client detail
+ * sheet. Sweeps the oauth-clients root (the grants slices above + the
+ * roster's per-client `active_grant_count`) and the shared oauth-grants root
+ * so the agents module's per-agent "Connected clients" panel doesn't go
+ * stale when an admin revokes from here.
+ */
+export function useRevokeOAuthClientGrant() {
+	const qc = useQueryClient();
+	return useMutation<void, Error, string>({
+		mutationFn: (grantId: string) => OAuthService.revokeOauthGrant({ grantId }),
+		onSuccess: () => {
+			void qc.invalidateQueries({ queryKey: QUERY_KEY });
+			void qc.invalidateQueries({ queryKey: sharedQueryKeys.oauthGrantsRoot });
+		},
+	});
+}
+
+/**
+ * Client-scoped audit trail for the detail sheet's "Recent changes" panel —
+ * approve/deny (with the operator's reason), deactivate, rotate, and DCR
+ * re-queue all write rows with `target_type=oauth_client`. Mirrors the agents
+ * module's `useActorAudit`: 401/403 resolve to an empty list so the panel
+ * degrades to its quiet empty state for non-admins instead of erroring.
+ * Keyed under the shared root so decision mutations refresh the trail.
+ */
+export function useOAuthClientAudit(clientId: string | null) {
+	return useQuery<AuditResponse[]>({
+		queryKey: [...QUERY_KEY, 'audit', clientId],
+		queryFn: async () => {
+			try {
+				const res = await AuditService.listAuditEntries({
+					targetType: AuditTargetType.OAUTH_CLIENT,
+					targetId: clientId as string,
+					limit: 25,
+				});
+				return res.data;
+			} catch (error) {
+				if (error instanceof ApiError && (error.status === 403 || error.status === 401)) {
+					return [];
+				}
+				throw error;
+			}
+		},
+		enabled: clientId != null,
+		staleTime: 30 * 1000,
+	});
+}
+
 export type {
-	OAuthClientCreateRequest,
 	OAuthClientCreateResponse,
 	OAuthClientRotateSecretResponse,
 	OAuthClientUpdateRequest,

--- a/ui/src/modules/settings/components/ApprovalQueue.tsx
+++ b/ui/src/modules/settings/components/ApprovalQueue.tsx
@@ -22,6 +22,7 @@ import {
 	ActorLabel,
 	Badge,
 	Button,
+	CopyButton,
 	Dialog,
 	EmptyState,
 	ErrorAlert,
@@ -114,7 +115,29 @@ function DenyClientDialog({ client, open, onClose, onConfirm, isPending }: DenyC
 	);
 }
 
-/** One registration awaiting decision, origins-first. */
+/** Scope chips shown inline before the "+N more" affordance takes over. */
+const SCOPE_PREVIEW_COUNT = 4;
+
+/** Redirect URIs listed inline before collapsing behind a disclosure. */
+const URI_INLINE_LIMIT = 2;
+
+/**
+ * One registration awaiting decision — GitHub's app-approval "review card"
+ * grammar, origins-first:
+ *
+ *  - HEADER: the verifiable identity leads (redirect-URI origins as the
+ *    heading, with the type/status chips beside it) and provenance
+ *    ("registered <timeAgo>") sits right-aligned; the attacker-chosen name
+ *    is demoted to a quiet, explicitly labelled "Self-reported name" line.
+ *  - BODY: compact muted metadata — client_id (+ copy), the full redirect
+ *    URIs (behind a disclosure when long; the heading's origins already
+ *    summarise them), and a one-line scope summary with a "+N more"
+ *    expander instead of a chip wall (13 chips must not out-shout the
+ *    decision).
+ *  - FOOTER: the decision verbs, grouped and right-anchored — Deny (quiet,
+ *    danger-tinted) before Approve (primary). Denied rows re-offer Approve
+ *    only (the deliberate denied→active recovery).
+ */
 function QueueRow({
 	client,
 	onApprove,
@@ -129,98 +152,148 @@ function QueueRow({
 	denyPending: boolean;
 }) {
 	const origins = clientOrigins(client);
+	const [scopesExpanded, setScopesExpanded] = useState(false);
+	const [urisExpanded, setUrisExpanded] = useState(false);
+
+	const scopes = client.allowed_scopes;
+	const visibleScopes =
+		scopes == null ? [] : scopesExpanded ? scopes : scopes.slice(0, SCOPE_PREVIEW_COUNT);
+	const hiddenScopeCount = scopes == null ? 0 : scopes.length - visibleScopes.length;
+	const showUriList = client.redirect_uris.length <= URI_INLINE_LIMIT || urisExpanded;
+
 	return (
-		<div className="border-border rounded-lg border p-4">
-			{/* flex-wrap: at 375px the Approve/Deny pair drops below the
-			    origins headline instead of forcing horizontal overflow. */}
-			<div className="flex flex-wrap items-start justify-between gap-3">
-				<div className="min-w-0">
-					{/* Headline = the VERIFIABLE identity: redirect-URI origins
-					    (+ software_id), never the self-chosen display name. */}
-					<h3 className="text-foreground flex flex-wrap items-center gap-2 font-medium">
+		<article className="border-border rounded-lg border">
+			{/* Header: the VERIFIABLE identity leads; provenance right-aligned. */}
+			<div className="px-4 pt-4">
+				<div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-1">
+					<h3 className="text-foreground flex min-w-0 flex-wrap items-center gap-2 font-medium">
 						<code className="min-w-0 truncate font-mono text-sm">
 							{origins.length > 0 ? origins.join(', ') : '(no redirect URIs)'}
 						</code>
 						<ClientTypeChips client={client} />
 						<ClientStatusBadges client={client} />
 					</h3>
-					{client.software_id && (
-						<p className="text-muted-foreground mt-0.5 font-mono text-xs">
-							{client.software_id}
-						</p>
-					)}
-					<p className="text-muted-foreground mt-1 text-sm">
-						Self-reported name: <span className="text-foreground">{client.name}</span>
-						{client.description && <span> — {client.description}</span>}
+					<p className="text-muted-foreground shrink-0 text-xs">
+						registered{' '}
+						<span title={formatTimestamp(client.created_at)}>
+							{timeAgo(client.created_at)}
+						</span>
+						{client.registration_source === 'admin' && client.created_by && (
+							<>
+								{' '}
+								by <ActorLabel actorId={client.created_by} />
+							</>
+						)}
 					</p>
 				</div>
-				<div className="flex shrink-0 gap-2">
-					<Button
-						size="sm"
-						onClick={(): void => onApprove(client)}
-						disabled={approvePending}
-					>
-						Approve
-					</Button>
-					{/* A denied row is already denied — the only verb it re-offers
-					    is Approve (the deliberate denied→active recovery). */}
-					{client.approval_status !== 'denied' && (
-						<Button
-							size="sm"
-							variant="outline"
-							onClick={(): void => onDeny(client)}
-							disabled={denyPending}
-						>
-							Deny
-						</Button>
+				{/* The self-chosen display name — quiet, and explicitly marked. */}
+				<p className="text-muted-foreground mt-1 text-sm">
+					Self-reported name: <span className="text-foreground">{client.name}</span>
+					{client.software_id && (
+						<code className="ml-2 font-mono text-xs">{client.software_id}</code>
 					)}
-				</div>
+					{client.description && <span> — {client.description}</span>}
+				</p>
 			</div>
-			<div className="mt-3 space-y-2 text-sm">
-				<div>
-					<span className="text-muted-foreground">Client ID: </span>
-					<code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
+
+			{/* Quiet metadata block — mono/muted, not competing with the title. */}
+			<div className="text-muted-foreground space-y-1.5 px-4 pt-3 pb-4 text-xs">
+				<p className="flex items-center gap-1">
+					<code className="bg-muted rounded px-1.5 py-0.5 font-mono">
 						{client.client_id}
 					</code>
-				</div>
-				<div>
-					<span className="text-muted-foreground">Redirect URIs: </span>
-					<ul className="text-foreground mt-1 list-inside list-disc pl-1">
+					<CopyButton
+						value={client.client_id}
+						variant="ghost"
+						size="icon"
+						className="h-5 w-5 p-0.5"
+						toastMessage="Client ID copied"
+						ariaLabel={`Copy client ID for ${client.name}`}
+					/>
+				</p>
+				{/* The heading's origins already summarise the URIs; the full
+				    list collapses behind a disclosure when it gets long. */}
+				{client.redirect_uris.length > URI_INLINE_LIMIT && (
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-auto px-1 py-0.5 text-xs"
+						aria-expanded={urisExpanded}
+						onClick={(): void => setUrisExpanded((v) => !v)}
+					>
+						{urisExpanded
+							? 'Hide redirect URIs'
+							: `Show ${client.redirect_uris.length} redirect URIs`}
+					</Button>
+				)}
+				{showUriList && (
+					<ul className="space-y-0.5">
 						{client.redirect_uris.map((uri) => (
-							<li key={uri} className="truncate font-mono text-xs">
+							<li key={uri} className="truncate font-mono">
 								{uri}
 							</li>
 						))}
 					</ul>
-				</div>
-				{client.allowed_scopes != null && (
-					<div className="flex flex-wrap items-center gap-1">
-						<span className="text-muted-foreground">Allowed scopes: </span>
-						{client.allowed_scopes.length > 0 ? (
-							client.allowed_scopes.map((scope) => (
+				)}
+				{scopes != null && (
+					<p className="flex flex-wrap items-center gap-1">
+						<span>Allowed scopes:</span>
+						{scopes.length === 0 ? (
+							<span className="text-foreground">OIDC only</span>
+						) : (
+							visibleScopes.map((scope) => (
 								<Badge key={scope} variant="default">
 									{scope}
 								</Badge>
 							))
-						) : (
-							<span className="text-foreground text-xs">OIDC only</span>
 						)}
-					</div>
+						{hiddenScopeCount > 0 && (
+							<Button
+								variant="ghost"
+								size="sm"
+								className="h-auto px-1 py-0.5 text-xs"
+								aria-expanded={false}
+								onClick={(): void => setScopesExpanded(true)}
+							>
+								+{hiddenScopeCount} more
+							</Button>
+						)}
+						{scopesExpanded && scopes.length > SCOPE_PREVIEW_COUNT && (
+							<Button
+								variant="ghost"
+								size="sm"
+								className="h-auto px-1 py-0.5 text-xs"
+								aria-expanded
+								onClick={(): void => setScopesExpanded(false)}
+							>
+								Show less
+							</Button>
+						)}
+					</p>
 				)}
-				<p className="text-muted-foreground text-xs">
-					Registered{' '}
-					<span title={formatTimestamp(client.created_at)}>
-						{timeAgo(client.created_at)}
-					</span>
-					{client.registration_source === 'admin' && client.created_by && (
-						<>
-							{' '}
-							by <ActorLabel actorId={client.created_by} />
-						</>
-					)}
-				</p>
 			</div>
-		</div>
+
+			{/* Footer: the decision, grouped and anchored — never floating in
+			    the header where it competed with the identity signal. */}
+			<footer className="border-border flex flex-wrap items-center justify-end gap-2 border-t px-4 py-3">
+				{/* A denied row is already denied — the only verb it re-offers
+				    is Approve (the deliberate denied→active recovery). */}
+				{client.approval_status !== 'denied' && (
+					<Button
+						size="sm"
+						variant="ghost"
+						className="text-danger hover:text-danger"
+						onClick={(): void => onDeny(client)}
+						disabled={denyPending}
+					>
+						{denyPending ? 'Denying…' : 'Deny'}
+					</Button>
+				)}
+				<Button size="sm" onClick={(): void => onApprove(client)} disabled={approvePending}>
+					{approvePending ? 'Approving…' : 'Approve'}
+				</Button>
+			</footer>
+		</article>
 	);
 }
 

--- a/ui/src/modules/settings/components/ApprovalQueue.tsx
+++ b/ui/src/modules/settings/components/ApprovalQueue.tsx
@@ -214,8 +214,11 @@ function QueueRow({
 					</div>
 				</div>
 				{/* The verifiable identity — origins + software_id — right under
-				    the self-reported name it keeps honest. */}
-				<p className="text-muted-foreground mt-1 min-w-0 truncate font-mono text-xs">
+				    the self-reported name it keeps honest. WRAPS rather than
+				    truncates: this is the one line whose job is verification,
+				    so extra origins must not vanish past an ellipsis (the full
+				    URI list can hide behind the >2 disclosure; this can't). */}
+				<p className="text-muted-foreground mt-1 font-mono text-xs break-all">
 					{verifiableLine}
 				</p>
 				{client.description && (
@@ -275,26 +278,18 @@ function QueueRow({
 								</Badge>
 							))
 						)}
-						{hiddenScopeCount > 0 && (
+						{/* ONE persistent toggle (the URI-disclosure pattern):
+						    swapping two conditionally-mounted buttons would drop
+						    keyboard focus to body on every click. */}
+						{scopes.length > SCOPE_PREVIEW_COUNT && (
 							<Button
 								variant="ghost"
 								size="sm"
 								className="h-auto px-1 py-0.5 text-xs"
-								aria-expanded={false}
-								onClick={(): void => setScopesExpanded(true)}
+								aria-expanded={scopesExpanded}
+								onClick={(): void => setScopesExpanded((v) => !v)}
 							>
-								+{hiddenScopeCount} more
-							</Button>
-						)}
-						{scopesExpanded && scopes.length > SCOPE_PREVIEW_COUNT && (
-							<Button
-								variant="ghost"
-								size="sm"
-								className="h-auto px-1 py-0.5 text-xs"
-								aria-expanded
-								onClick={(): void => setScopesExpanded(false)}
-							>
-								Show less
+								{scopesExpanded ? 'Show less' : `+${hiddenScopeCount} more`}
 							</Button>
 						)}
 					</p>

--- a/ui/src/modules/settings/components/ApprovalQueue.tsx
+++ b/ui/src/modules/settings/components/ApprovalQueue.tsx
@@ -1,13 +1,13 @@
 /**
- * ApprovalQueue — the D7 DCR approval queue, rebuilt origins-first.
+ * ApprovalQueue — the D7 DCR approval queue, name-led with a trust marker.
  *
- * Anti-spoofing posture (the #1264 authorize-page stance, GitHub's OAuth-app
- * review grammar): the row HEADLINE is the verifiable signal — the
- * redirect-URI origins plus the RFC 7591 `software_id` — while the
- * attacker-chosen `client_name` is demoted to secondary text explicitly
- * labelled "self-reported name". Each row also shows the allowed scopes (if
- * restricted), the consent-model chip, and registered-`timeAgo` provenance
- * (+`created_by` for admin-registered rows).
+ * Anti-spoofing posture (the #1264 authorize-page stance): the row heading is
+ * the client NAME — what humans scan for — explicitly flagged with an
+ * "Unverified" chip (the name is attacker-chosen), while the VERIFIABLE
+ * signal — redirect-URI origins + the RFC 7591 `software_id` — sits directly
+ * beneath in quiet mono for the admin to check before approving. Each row
+ * also shows the allowed scopes (if restricted), the consent-model chip, and
+ * registered-`timeAgo` provenance (+`created_by` for admin-registered rows).
  *
  * Approve activates the client (approved+active atomically); Deny keeps the
  * row (reversible — the Denied filter re-offers Approve as the recovery
@@ -31,6 +31,7 @@ import {
 	LoadingState,
 	SegmentedToggle,
 	toast,
+	Tooltip,
 	type SegmentedToggleOption,
 } from '@/shared/ui';
 import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
@@ -122,18 +123,22 @@ const SCOPE_PREVIEW_COUNT = 4;
 const URI_INLINE_LIMIT = 2;
 
 /**
- * One registration awaiting decision — GitHub's app-approval "review card"
- * grammar, origins-first:
+ * One registration awaiting decision — name-led with an explicit trust
+ * marker (hierarchy v2, per review):
  *
- *  - HEADER: the verifiable identity leads (redirect-URI origins as the
- *    heading, with the type/status chips beside it) and provenance
- *    ("registered <timeAgo>") sits right-aligned; the attacker-chosen name
- *    is demoted to a quiet, explicitly labelled "Self-reported name" line.
- *  - BODY: compact muted metadata — client_id (+ copy), the full redirect
- *    URIs (behind a disclosure when long; the heading's origins already
- *    summarise them), and a one-line scope summary with a "+N more"
- *    expander instead of a chip wall (13 chips must not out-shout the
- *    decision).
+ *  - HEADER: the client NAME is the heading — it's what humans scan for —
+ *    immediately followed by a small "Unverified" chip (tooltip explains the
+ *    name is self-reported), which carries the anti-spoofing posture through
+ *    LABELING rather than typographic demotion. Status badge + provenance
+ *    ("registered <timeAgo>") right-aligned.
+ *  - Directly under the title: the VERIFIABLE line — redirect-URI origins +
+ *    `software_id` in quiet mono. This is what the admin actually checks
+ *    before approving (the #1264 authorize-page posture); for local DCR
+ *    clients the origin is `http://127.0.0.1:…` noise as a TITLE, but it's
+ *    exactly right as the verification line.
+ *  - BODY: compact muted metadata — client_id (+ copy) with the type chips,
+ *    the full redirect URIs (behind a disclosure when long), and a one-line
+ *    scope summary with a "+N more" expander instead of a chip wall.
  *  - FOOTER: the decision verbs, grouped and right-anchored — Deny (quiet,
  *    danger-tinted) before Approve (primary). Denied rows re-offer Approve
  *    only (the deliberate denied→active recovery).
@@ -161,44 +166,63 @@ function QueueRow({
 	const hiddenScopeCount = scopes == null ? 0 : scopes.length - visibleScopes.length;
 	const showUriList = client.redirect_uris.length <= URI_INLINE_LIMIT || urisExpanded;
 
+	// One string so it reads (and truncates) as a single quiet line.
+	const verifiableLine = [
+		origins.length > 0 ? origins.join(', ') : '(no redirect URIs)',
+		client.software_id,
+	]
+		.filter(Boolean)
+		.join(' · ');
+
 	return (
 		<article className="border-border rounded-lg border">
-			{/* Header: the VERIFIABLE identity leads; provenance right-aligned. */}
+			{/* Header: the name leads (it's what humans scan for), explicitly
+			    marked Unverified; status + provenance right-aligned. */}
 			<div className="px-4 pt-4">
 				<div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-1">
-					<h3 className="text-foreground flex min-w-0 flex-wrap items-center gap-2 font-medium">
-						<code className="min-w-0 truncate font-mono text-sm">
-							{origins.length > 0 ? origins.join(', ') : '(no redirect URIs)'}
-						</code>
-						<ClientTypeChips client={client} />
-						<ClientStatusBadges client={client} />
-					</h3>
-					<p className="text-muted-foreground shrink-0 text-xs">
-						registered{' '}
-						<span title={formatTimestamp(client.created_at)}>
-							{timeAgo(client.created_at)}
-						</span>
-						{client.registration_source === 'admin' && client.created_by && (
-							<>
-								{' '}
-								by <ActorLabel actorId={client.created_by} />
-							</>
+					<div className="flex min-w-0 items-center gap-2">
+						<h3 className="text-foreground min-w-0 truncate text-base font-semibold">
+							{client.name}
+						</h3>
+						{/* The chip sits OUTSIDE the h3 so the tooltip's described
+						    text doesn't pollute the heading's accessible name. */}
+						{client.registration_source === 'dcr' && (
+							<Tooltip content="Name is self-reported by the client during registration — verify the origin below.">
+								<Badge variant="warning" className="shrink-0">
+									Unverified
+								</Badge>
+							</Tooltip>
 						)}
-					</p>
+					</div>
+					<div className="flex shrink-0 flex-wrap items-center gap-2">
+						<ClientStatusBadges client={client} />
+						<span className="text-muted-foreground text-xs">
+							registered{' '}
+							<span title={formatTimestamp(client.created_at)}>
+								{timeAgo(client.created_at)}
+							</span>
+							{client.registration_source === 'admin' && client.created_by && (
+								<>
+									{' '}
+									by <ActorLabel actorId={client.created_by} />
+								</>
+							)}
+						</span>
+					</div>
 				</div>
-				{/* The self-chosen display name — quiet, and explicitly marked. */}
-				<p className="text-muted-foreground mt-1 text-sm">
-					Self-reported name: <span className="text-foreground">{client.name}</span>
-					{client.software_id && (
-						<code className="ml-2 font-mono text-xs">{client.software_id}</code>
-					)}
-					{client.description && <span> — {client.description}</span>}
+				{/* The verifiable identity — origins + software_id — right under
+				    the self-reported name it keeps honest. */}
+				<p className="text-muted-foreground mt-1 min-w-0 truncate font-mono text-xs">
+					{verifiableLine}
 				</p>
+				{client.description && (
+					<p className="text-muted-foreground mt-1 text-sm">{client.description}</p>
+				)}
 			</div>
 
 			{/* Quiet metadata block — mono/muted, not competing with the title. */}
 			<div className="text-muted-foreground space-y-1.5 px-4 pt-3 pb-4 text-xs">
-				<p className="flex items-center gap-1">
+				<p className="flex flex-wrap items-center gap-1.5">
 					<code className="bg-muted rounded px-1.5 py-0.5 font-mono">
 						{client.client_id}
 					</code>
@@ -210,9 +234,10 @@ function QueueRow({
 						toastMessage="Client ID copied"
 						ariaLabel={`Copy client ID for ${client.name}`}
 					/>
+					<ClientTypeChips client={client} />
 				</p>
-				{/* The heading's origins already summarise the URIs; the full
-				    list collapses behind a disclosure when it gets long. */}
+				{/* The verifiable line's origins already summarise the URIs; the
+				    full list collapses behind a disclosure when it gets long. */}
 				{client.redirect_uris.length > URI_INLINE_LIMIT && (
 					<Button
 						variant="ghost"

--- a/ui/src/modules/settings/components/ApprovalQueue.tsx
+++ b/ui/src/modules/settings/components/ApprovalQueue.tsx
@@ -181,10 +181,13 @@ function QueueRow({
 			<div className="px-4 pt-4">
 				<div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-1">
 					<div className="flex min-w-0 items-center gap-2">
-						<h3 className="text-foreground min-w-0 truncate text-base font-semibold">
+						{/* h2: with the page flattened these cards sit directly
+						    under the PageHeader h1 — section-title rung of the
+						    ladder (font-heading font-semibold, page-scaffold). */}
+						<h2 className="font-heading text-foreground min-w-0 truncate text-base font-semibold">
 							{client.name}
-						</h3>
-						{/* The chip sits OUTSIDE the h3 so the tooltip's described
+						</h2>
+						{/* The chip sits OUTSIDE the h2 so the tooltip's described
 						    text doesn't pollute the heading's accessible name. */}
 						{client.registration_source === 'dcr' && (
 							<Tooltip content="Name is self-reported by the client during registration — verify the origin below.">

--- a/ui/src/modules/settings/components/ApprovalQueue.tsx
+++ b/ui/src/modules/settings/components/ApprovalQueue.tsx
@@ -131,7 +131,9 @@ function QueueRow({
 	const origins = clientOrigins(client);
 	return (
 		<div className="border-border rounded-lg border p-4">
-			<div className="flex items-start justify-between gap-3">
+			{/* flex-wrap: at 375px the Approve/Deny pair drops below the
+			    origins headline instead of forcing horizontal overflow. */}
+			<div className="flex flex-wrap items-start justify-between gap-3">
 				<div className="min-w-0">
 					{/* Headline = the VERIFIABLE identity: redirect-URI origins
 					    (+ software_id), never the self-chosen display name. */}

--- a/ui/src/modules/settings/components/ApprovalQueue.tsx
+++ b/ui/src/modules/settings/components/ApprovalQueue.tsx
@@ -1,0 +1,336 @@
+/**
+ * ApprovalQueue — the D7 DCR approval queue, rebuilt origins-first.
+ *
+ * Anti-spoofing posture (the #1264 authorize-page stance, GitHub's OAuth-app
+ * review grammar): the row HEADLINE is the verifiable signal — the
+ * redirect-URI origins plus the RFC 7591 `software_id` — while the
+ * attacker-chosen `client_name` is demoted to secondary text explicitly
+ * labelled "self-reported name". Each row also shows the allowed scopes (if
+ * restricted), the consent-model chip, and registered-`timeAgo` provenance
+ * (+`created_by` for admin-registered rows).
+ *
+ * Approve activates the client (approved+active atomically); Deny keeps the
+ * row (reversible — the Denied filter re-offers Approve as the recovery
+ * path, without a second Deny). The deny-reason dialog is mounted
+ * persistently and keeps its draft across a casual dismiss (dialog-state
+ * rule); the draft resets when the TARGET changes, which also covers the
+ * committed-deny path (the parent clears the target on success).
+ */
+import { useEffect, useRef, useState } from 'react';
+import { CheckCircle2 } from 'lucide-react';
+import {
+	ActorLabel,
+	Badge,
+	Button,
+	Dialog,
+	EmptyState,
+	ErrorAlert,
+	Input,
+	Label,
+	LoadingState,
+	SegmentedToggle,
+	toast,
+	type SegmentedToggleOption,
+} from '@/shared/ui';
+import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
+import {
+	useApproveOAuthClient,
+	useDenyOAuthClient,
+	useOAuthClientQueue,
+	type OAuthClient,
+} from '@/modules/settings/api/hooks';
+import { clientOrigins } from '@/modules/settings/components/clientStatus';
+import { ClientStatusBadges, ClientTypeChips } from '@/modules/settings/components/clientBadges';
+
+export type QueueFilter = 'pending' | 'denied';
+
+const QUEUE_FILTER_OPTIONS: SegmentedToggleOption<QueueFilter>[] = [
+	{ value: 'pending', label: 'Pending' },
+	{ value: 'denied', label: 'Denied' },
+];
+
+interface DenyClientDialogProps {
+	/** The client under decision; null only before the first Deny click. */
+	client: OAuthClient | null;
+	open: boolean;
+	onClose: () => void;
+	onConfirm: (reason: string) => void;
+	isPending: boolean;
+}
+
+/**
+ * Deny confirmation with an optional reason draft. Mounted once and toggled
+ * via `open` (dialog-state rule: persist between dismissals, reset on
+ * successful commit) — a casual Esc/backdrop dismiss keeps the half-typed
+ * reason. The draft resets when the TARGET changes (a different client's
+ * denial is a different draft), which also covers the success path: the
+ * parent clears the target after a committed deny.
+ */
+function DenyClientDialog({ client, open, onClose, onConfirm, isPending }: DenyClientDialogProps) {
+	const [reason, setReason] = useState('');
+	const lastIdRef = useRef(client?.id);
+	useEffect(() => {
+		if (lastIdRef.current !== client?.id) {
+			lastIdRef.current = client?.id;
+			setReason('');
+		}
+	}, [client?.id]);
+	return (
+		<Dialog
+			open={open && client != null}
+			onClose={onClose}
+			title="Deny OAuth Client?"
+			footer={
+				<>
+					<Button variant="outline" onClick={onClose}>
+						Cancel
+					</Button>
+					<Button
+						variant="danger"
+						onClick={(): void => onConfirm(reason.trim())}
+						disabled={isPending}
+					>
+						{isPending ? 'Denying...' : 'Deny'}
+					</Button>
+				</>
+			}
+		>
+			<div className="space-y-3">
+				<p className="text-muted-foreground">
+					<strong>{client?.name}</strong> will not be able to start authorization flows.
+					The registration is kept, so you can approve it later to reverse this.
+				</p>
+				<div>
+					<Label htmlFor="deny-reason">Reason (optional)</Label>
+					<Input
+						id="deny-reason"
+						value={reason}
+						onChange={(e): void => setReason(e.target.value)}
+						placeholder="e.g., unknown redirect URIs"
+					/>
+				</div>
+			</div>
+		</Dialog>
+	);
+}
+
+/** One registration awaiting decision, origins-first. */
+function QueueRow({
+	client,
+	onApprove,
+	onDeny,
+	approvePending,
+	denyPending,
+}: {
+	client: OAuthClient;
+	onApprove: (client: OAuthClient) => void;
+	onDeny: (client: OAuthClient) => void;
+	approvePending: boolean;
+	denyPending: boolean;
+}) {
+	const origins = clientOrigins(client);
+	return (
+		<div className="border-border rounded-lg border p-4">
+			<div className="flex items-start justify-between gap-3">
+				<div className="min-w-0">
+					{/* Headline = the VERIFIABLE identity: redirect-URI origins
+					    (+ software_id), never the self-chosen display name. */}
+					<h3 className="text-foreground flex flex-wrap items-center gap-2 font-medium">
+						<code className="min-w-0 truncate font-mono text-sm">
+							{origins.length > 0 ? origins.join(', ') : '(no redirect URIs)'}
+						</code>
+						<ClientTypeChips client={client} />
+						<ClientStatusBadges client={client} />
+					</h3>
+					{client.software_id && (
+						<p className="text-muted-foreground mt-0.5 font-mono text-xs">
+							{client.software_id}
+						</p>
+					)}
+					<p className="text-muted-foreground mt-1 text-sm">
+						Self-reported name: <span className="text-foreground">{client.name}</span>
+						{client.description && <span> — {client.description}</span>}
+					</p>
+				</div>
+				<div className="flex shrink-0 gap-2">
+					<Button
+						size="sm"
+						onClick={(): void => onApprove(client)}
+						disabled={approvePending}
+					>
+						Approve
+					</Button>
+					{/* A denied row is already denied — the only verb it re-offers
+					    is Approve (the deliberate denied→active recovery). */}
+					{client.approval_status !== 'denied' && (
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={(): void => onDeny(client)}
+							disabled={denyPending}
+						>
+							Deny
+						</Button>
+					)}
+				</div>
+			</div>
+			<div className="mt-3 space-y-2 text-sm">
+				<div>
+					<span className="text-muted-foreground">Client ID: </span>
+					<code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
+						{client.client_id}
+					</code>
+				</div>
+				<div>
+					<span className="text-muted-foreground">Redirect URIs: </span>
+					<ul className="text-foreground mt-1 list-inside list-disc pl-1">
+						{client.redirect_uris.map((uri) => (
+							<li key={uri} className="truncate font-mono text-xs">
+								{uri}
+							</li>
+						))}
+					</ul>
+				</div>
+				{client.allowed_scopes != null && (
+					<div className="flex flex-wrap items-center gap-1">
+						<span className="text-muted-foreground">Allowed scopes: </span>
+						{client.allowed_scopes.length > 0 ? (
+							client.allowed_scopes.map((scope) => (
+								<Badge key={scope} variant="default">
+									{scope}
+								</Badge>
+							))
+						) : (
+							<span className="text-foreground text-xs">OIDC only</span>
+						)}
+					</div>
+				)}
+				<p className="text-muted-foreground text-xs">
+					Registered{' '}
+					<span title={formatTimestamp(client.created_at)}>
+						{timeAgo(client.created_at)}
+					</span>
+					{client.registration_source === 'admin' && client.created_by && (
+						<>
+							{' '}
+							by <ActorLabel actorId={client.created_by} />
+						</>
+					)}
+				</p>
+			</div>
+		</div>
+	);
+}
+
+interface ApprovalQueueProps {
+	/**
+	 * Controlled filter — lifted to the section so a denied roster row's
+	 * "Review in queue" action can land directly on the Denied slice.
+	 */
+	filter: QueueFilter;
+	onFilterChange: (filter: QueueFilter) => void;
+}
+
+/**
+ * The DCR approval queue (D7): registrations land `pending` + inactive;
+ * Approve activates them, Deny keeps the row (reversible — the Denied filter
+ * re-offers Approve as the recovery path). Approval-first is the default
+ * everywhere (D7 as amended 2026-09-03): every fresh instance's first DCR
+ * client lands here. With the explicit `auto_approve_clients: true` opt-in
+ * the queue is normally empty.
+ */
+export function ApprovalQueue({ filter, onFilterChange }: ApprovalQueueProps) {
+	const { data: clients, isLoading, error } = useOAuthClientQueue(filter);
+	const approveMutation = useApproveOAuthClient();
+	const denyMutation = useDenyOAuthClient();
+	// Target + open are separate so a casual dismiss keeps the target (and the
+	// dialog's reason draft — dialog-state rule); only a committed deny clears it.
+	const [denyTarget, setDenyTarget] = useState<OAuthClient | null>(null);
+	const [denyOpen, setDenyOpen] = useState(false);
+
+	const handleApprove = async (client: OAuthClient): Promise<void> => {
+		try {
+			await approveMutation.mutateAsync(client.id);
+			toast({ title: `${client.name} approved`, variant: 'success' });
+		} catch (err) {
+			toast({
+				title: 'Failed to approve client',
+				description: err instanceof Error ? err.message : undefined,
+				variant: 'error',
+			});
+		}
+	};
+
+	const handleDeny = async (reason: string): Promise<void> => {
+		if (!denyTarget) return;
+		try {
+			await denyMutation.mutateAsync({
+				id: denyTarget.id,
+				reason: reason || undefined,
+			});
+			toast({ title: `${denyTarget.name} denied`, variant: 'success' });
+			setDenyOpen(false);
+			// Clearing the target resets the dialog's reason draft (commit path).
+			setDenyTarget(null);
+		} catch (err) {
+			toast({
+				title: 'Failed to deny client',
+				description: err instanceof Error ? err.message : undefined,
+				variant: 'error',
+			});
+		}
+	};
+
+	return (
+		<div className="space-y-4">
+			<SegmentedToggle
+				options={QUEUE_FILTER_OPTIONS}
+				value={filter}
+				onChange={onFilterChange}
+				ariaLabel="Filter queue by decision"
+			/>
+
+			{isLoading ? (
+				<LoadingState message="Loading approval queue..." />
+			) : error ? (
+				<ErrorAlert message="Failed to load the approval queue" />
+			) : !clients?.length ? (
+				<EmptyState
+					icon={<CheckCircle2 className="h-6 w-6" />}
+					title={filter === 'pending' ? 'No pending registrations' : 'No denied clients'}
+					description={
+						filter === 'pending'
+							? 'Client registrations awaiting approval will appear here.'
+							: 'Denied registrations are kept here — approving one reverses the decision.'
+					}
+				/>
+			) : (
+				<div className="space-y-4">
+					{clients.map((client) => (
+						<QueueRow
+							key={client.id}
+							client={client}
+							onApprove={(c): void => void handleApprove(c)}
+							onDeny={(c): void => {
+								setDenyTarget(c);
+								setDenyOpen(true);
+							}}
+							approvePending={approveMutation.isPending}
+							denyPending={denyMutation.isPending}
+						/>
+					))}
+				</div>
+			)}
+
+			{/* Mounted persistently (not `{target && …}`) so a casual dismiss
+			    keeps the reason draft — see DenyClientDialog. */}
+			<DenyClientDialog
+				client={denyTarget}
+				open={denyOpen}
+				onClose={(): void => setDenyOpen(false)}
+				onConfirm={(reason): void => void handleDeny(reason)}
+				isPending={denyMutation.isPending}
+			/>
+		</div>
+	);
+}

--- a/ui/src/modules/settings/components/ApprovalQueue.tsx
+++ b/ui/src/modules/settings/components/ApprovalQueue.tsx
@@ -315,8 +315,14 @@ export function ApprovalQueue({ filter, onFilterChange }: ApprovalQueueProps) {
 								setDenyTarget(c);
 								setDenyOpen(true);
 							}}
-							approvePending={approveMutation.isPending}
-							denyPending={denyMutation.isPending}
+							// Per-row pending (mutation variables carry the target id)
+							// so one in-flight decision doesn't grey out the whole queue.
+							approvePending={
+								approveMutation.isPending && approveMutation.variables === client.id
+							}
+							denyPending={
+								denyMutation.isPending && denyMutation.variables?.id === client.id
+							}
 						/>
 					))}
 				</div>

--- a/ui/src/modules/settings/components/ClientDetailSheet.tsx
+++ b/ui/src/modules/settings/components/ClientDetailSheet.tsx
@@ -43,7 +43,11 @@ import {
 	type OAuthClient,
 	type OAuthClientGrant,
 } from '@/modules/settings/api/hooks';
-import { canRotateSecret, clientOrigins } from '@/modules/settings/components/clientStatus';
+import {
+	canReactivate,
+	canRotateSecret,
+	clientOrigins,
+} from '@/modules/settings/components/clientStatus';
 import { ClientStatusBadges, ClientTypeChips } from '@/modules/settings/components/clientBadges';
 
 type GrantStatusFilter = 'active' | 'revoked' | 'all';
@@ -284,6 +288,8 @@ export interface ClientDetailSheetProps {
 	onRotate: (client: OAuthClient) => void;
 	/** Opens the section-level deactivate confirm (explains the DCR re-queue). */
 	onDeactivate: (client: OAuthClient) => void;
+	/** Fires the section-level reactivate mutation (approved+inactive only). */
+	onReactivate: (client: OAuthClient) => void;
 }
 
 export function ClientDetailSheet({
@@ -293,6 +299,7 @@ export function ClientDetailSheet({
 	onEdit,
 	onRotate,
 	onDeactivate,
+	onReactivate,
 }: ClientDetailSheetProps) {
 	// Re-read while open so decisions taken from the queue/roster (approve,
 	// rotate, deactivate) refresh the sheet; the seed row renders immediately.
@@ -313,6 +320,22 @@ export function ClientDetailSheet({
 							'Blocks new authorization flows. A deactivated client that re-registers via DCR returns to the approval queue.',
 						buttonLabel: 'Deactivate',
 						ariaLabel: `Deactivate ${client.name}`,
+						emphasis: 'outline' as const,
+					},
+				]
+			: []),
+		// The approved+inactive zombie's escape hatch — without it a
+		// deactivated client's own console offers no recovery path.
+		// (Denied rows never reach here: `canReactivate` requires approved.)
+		...(canReactivate(client)
+			? [
+					{
+						key: 'reactivate',
+						title: 'Reactivate client',
+						description:
+							'Restores the client — it can start authorization flows again immediately.',
+						buttonLabel: 'Reactivate',
+						ariaLabel: `Reactivate ${client.name}`,
 						emphasis: 'outline' as const,
 					},
 				]
@@ -468,6 +491,7 @@ export function ClientDetailSheet({
 						actions={dangerActions}
 						onAction={(key): void => {
 							if (key === 'deactivate') onDeactivate(client);
+							if (key === 'reactivate') onReactivate(client);
 							if (key === 'rotate') onRotate(client);
 						}}
 					/>

--- a/ui/src/modules/settings/components/ClientDetailSheet.tsx
+++ b/ui/src/modules/settings/components/ClientDetailSheet.tsx
@@ -1,0 +1,478 @@
+/**
+ * ClientDetailSheet — the per-client console, in the platform's detail
+ * grammar (DetailSection cards): full metadata (consent model, auth method,
+ * provenance, redirect URIs, scope restriction), the consent→agent GRANTS
+ * held against this client (mirroring the agent console's
+ * ConnectedClientsCard, via the admin cross-view `GET
+ * /admin/oauth-grants?client_id=…`), the client-scoped audit trail ("Recent
+ * changes" — where deny reasons finally surface), and a danger zone
+ * (deactivate / rotate secret, confirmed at the section level).
+ *
+ * A detail view, not a form — no drafts to preserve — but the revoke confirm
+ * is a stateless Dialog (conditional mount is fine per the dialog-state
+ * rule). The sheet re-reads the client row while open (`useOAuthClient`) so
+ * decisions taken elsewhere don't leave a stale snapshot.
+ */
+import { useState } from 'react';
+import { Info, Plug2, ShieldOff, X } from 'lucide-react';
+import {
+	ActorLabel,
+	AuditTrailCard,
+	Badge,
+	Button,
+	CopyButton,
+	DangerZone,
+	DetailSection,
+	Dialog,
+	EmptyRow,
+	ErrorAlert,
+	LoadingState,
+	SegmentedToggle,
+	SheetPrimitive,
+	Tooltip,
+	toast,
+	type AuditTrailEntry,
+	type SegmentedToggleOption,
+} from '@/shared/ui';
+import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
+import {
+	useOAuthClient,
+	useOAuthClientAudit,
+	useOAuthClientGrants,
+	useRevokeOAuthClientGrant,
+	type OAuthClient,
+	type OAuthClientGrant,
+} from '@/modules/settings/api/hooks';
+import { canRotateSecret, clientOrigins } from '@/modules/settings/components/clientStatus';
+import { ClientStatusBadges, ClientTypeChips } from '@/modules/settings/components/clientBadges';
+
+type GrantStatusFilter = 'active' | 'revoked' | 'all';
+
+const GRANT_STATUS_OPTIONS: SegmentedToggleOption<GrantStatusFilter>[] = [
+	{ value: 'active', label: 'Active' },
+	{ value: 'revoked', label: 'Revoked' },
+	{ value: 'all', label: 'All' },
+];
+
+/** Why the Revoke button is disabled — the G10 list/revoke divergence, in words. */
+const CANNOT_REVOKE_REASON =
+	'Only the user who consented to this grant, or an admin with the OAuth-clients write permission, can revoke it.';
+
+/** One dt/dd row in the metadata grid. */
+function MetaRow({ label, children }: { label: string; children: React.ReactNode }) {
+	return (
+		<div className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
+			<dt className="text-muted-foreground w-36 shrink-0 text-xs tracking-wider uppercase">
+				{label}
+			</dt>
+			<dd className="text-foreground min-w-0 flex-1 text-sm">{children}</dd>
+		</div>
+	);
+}
+
+function GrantsSection({ client }: { client: OAuthClient }) {
+	const [status, setStatus] = useState<GrantStatusFilter>('active');
+	const query = useOAuthClientGrants(client.client_id, status === 'all' ? null : status);
+	const revoke = useRevokeOAuthClientGrant();
+	const [revokeTarget, setRevokeTarget] = useState<OAuthClientGrant | null>(null);
+
+	const grants = query.data?.pages.flatMap((p) => p.data);
+
+	const handleRevoke = (): void => {
+		if (!revokeTarget) return;
+		revoke.mutate(revokeTarget.id, {
+			onSuccess: () => {
+				toast({ title: 'Grant revoked', variant: 'success' });
+				setRevokeTarget(null);
+			},
+			onError: (err) => {
+				toast({
+					title: 'Failed to revoke the grant',
+					description: err instanceof Error ? err.message : undefined,
+					variant: 'error',
+				});
+			},
+		});
+	};
+
+	return (
+		<>
+			<DetailSection
+				title="Grants"
+				icon={<Plug2 className="h-4 w-4" />}
+				titleExtra={
+					grants && grants.length > 0 ? (
+						<Badge variant="default">
+							{grants.length}
+							{query.hasNextPage ? '+' : ''}
+						</Badge>
+					) : null
+				}
+				bodyClassName="space-y-3"
+			>
+				<SegmentedToggle
+					options={GRANT_STATUS_OPTIONS}
+					value={status}
+					onChange={setStatus}
+					ariaLabel="Filter grants by status"
+				/>
+
+				{query.isPending ? (
+					<LoadingState size="sm" />
+				) : query.isError ? (
+					<ErrorAlert
+						message={
+							query.error instanceof Error
+								? query.error
+								: "Failed to load this client's grants."
+						}
+					/>
+				) : !grants || grants.length === 0 ? (
+					<EmptyRow icon={<Plug2 />}>
+						{status === 'active'
+							? `No user has consented to connect ${client.name} to an agent yet.`
+							: `${client.name} has no grants matching this filter.`}
+					</EmptyRow>
+				) : (
+					<>
+						<ul className="divide-border divide-y">
+							{grants.map((grant) => (
+								<li
+									key={grant.id}
+									className="flex flex-wrap items-start justify-between gap-3 py-3"
+								>
+									<div className="min-w-0 flex-1">
+										<p className="text-foreground flex flex-wrap items-center gap-2 text-sm font-medium">
+											<ActorLabel
+												actorId={grant.agent_id}
+												actorType="agent"
+											/>
+											{grant.status === 'revoked' && (
+												<Badge variant="danger">Revoked</Badge>
+											)}
+										</p>
+										<div className="mt-1.5 flex flex-wrap gap-1">
+											{grant.scopes.length > 0 ? (
+												grant.scopes.map((scope) => (
+													<Badge key={scope} variant="default">
+														{scope}
+													</Badge>
+												))
+											) : (
+												<span className="text-muted-foreground text-xs">
+													No scopes granted
+												</span>
+											)}
+										</div>
+										<p className="text-muted-foreground mt-1.5 text-xs">
+											Consented by <ActorLabel actorId={grant.user_id} /> ·
+											granted {timeAgo(grant.created_at)} · last used{' '}
+											{grant.last_used_at
+												? timeAgo(grant.last_used_at)
+												: 'never'}
+										</p>
+									</div>
+									{grant.status === 'active' &&
+										(grant.can_revoke ? (
+											<Button
+												variant="outline"
+												size="sm"
+												onClick={(): void => setRevokeTarget(grant)}
+												disabled={revoke.isPending}
+												aria-label={`Revoke grant ${grant.id}`}
+											>
+												<ShieldOff className="h-4 w-4" />
+												Revoke
+											</Button>
+										) : (
+											// The server says the CALLER can't revoke this
+											// grant (G10: not the consenter, not a write-set
+											// admin) — disable rather than offer a 403.
+											<Tooltip content={CANNOT_REVOKE_REASON}>
+												<Button
+													variant="outline"
+													size="sm"
+													disabled
+													aria-label={`Revoke grant ${grant.id} (not permitted)`}
+												>
+													<ShieldOff className="h-4 w-4" />
+													Revoke
+												</Button>
+											</Tooltip>
+										))}
+								</li>
+							))}
+						</ul>
+						{query.hasNextPage && (
+							<div className="flex justify-center">
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={(): void => void query.fetchNextPage()}
+									disabled={query.isFetchingNextPage}
+								>
+									{query.isFetchingNextPage ? 'Loading…' : 'Load more'}
+								</Button>
+							</div>
+						)}
+					</>
+				)}
+			</DetailSection>
+
+			{revokeTarget != null && (
+				<Dialog
+					open
+					onClose={(): void => setRevokeTarget(null)}
+					title="Revoke this grant?"
+					footer={
+						<>
+							<Button variant="outline" onClick={(): void => setRevokeTarget(null)}>
+								Cancel
+							</Button>
+							<Button
+								variant="danger"
+								disabled={revoke.isPending}
+								onClick={handleRevoke}
+							>
+								{revoke.isPending ? 'Revoking...' : 'Revoke'}
+							</Button>
+						</>
+					}
+				>
+					<p className="text-muted-foreground">
+						<strong>{client.name}</strong> will immediately lose access to{' '}
+						<strong>
+							<ActorLabel actorId={revokeTarget.agent_id} />
+						</strong>
+						: every token issued under this grant is revoked. The client must go through
+						consent again to reconnect.
+					</p>
+				</Dialog>
+			)}
+		</>
+	);
+}
+
+function AuditSection({ client }: { client: OAuthClient }) {
+	const audit = useOAuthClientAudit(client.id);
+	const entries: AuditTrailEntry[] = (audit.data ?? []).map((row) => ({
+		id: row.id,
+		action: row.action,
+		actorId: row.actor_id,
+		actorType: row.actor_type,
+		reason: row.reason,
+		occurredAt: row.occurred_at,
+	}));
+	return (
+		<AuditTrailCard
+			entries={entries}
+			isLoading={audit.isPending}
+			isError={audit.isError}
+			caption="Client-level events · admin only"
+			emptyMessage="No decisions recorded for this client yet."
+		/>
+	);
+}
+
+export interface ClientDetailSheetProps {
+	/** The roster row the sheet was opened from (seed; re-read while open). */
+	client: OAuthClient | null;
+	open: boolean;
+	onClose: () => void;
+	onEdit: (client: OAuthClient) => void;
+	/** Opens the section-level rotate confirm (then the one-time secret dialog). */
+	onRotate: (client: OAuthClient) => void;
+	/** Opens the section-level deactivate confirm (explains the DCR re-queue). */
+	onDeactivate: (client: OAuthClient) => void;
+}
+
+export function ClientDetailSheet({
+	client: seed,
+	open,
+	onClose,
+	onEdit,
+	onRotate,
+	onDeactivate,
+}: ClientDetailSheetProps) {
+	// Re-read while open so decisions taken from the queue/roster (approve,
+	// rotate, deactivate) refresh the sheet; the seed row renders immediately.
+	const detail = useOAuthClient(open && seed ? seed.id : null);
+	const client = detail.data ?? seed;
+
+	if (!client) return null;
+
+	const origins = clientOrigins(client);
+
+	const dangerActions = [
+		...(client.active
+			? [
+					{
+						key: 'deactivate',
+						title: 'Deactivate client',
+						description:
+							'Blocks new authorization flows. A deactivated client that re-registers via DCR returns to the approval queue.',
+						buttonLabel: 'Deactivate',
+						ariaLabel: `Deactivate ${client.name}`,
+						emphasis: 'outline' as const,
+					},
+				]
+			: []),
+		...(canRotateSecret(client)
+			? [
+					{
+						key: 'rotate',
+						title: 'Rotate client secret',
+						description:
+							'Invalidates the current secret immediately. Any application using the old secret loses access.',
+						buttonLabel: 'Rotate secret',
+						ariaLabel: `Rotate secret for ${client.name}`,
+						emphasis: 'outline' as const,
+					},
+				]
+			: []),
+	];
+
+	return (
+		<SheetPrimitive
+			open={open}
+			onClose={onClose}
+			side="right"
+			ariaLabel={`Details for ${client.name}`}
+			className="flex flex-col sm:w-[560px]"
+		>
+			<header className="border-border flex items-start justify-between gap-3 border-b p-5">
+				<div className="min-w-0">
+					<h2 className="text-foreground flex flex-wrap items-center gap-2 text-lg font-semibold">
+						<span className="min-w-0 truncate">{client.name}</span>
+						<ClientStatusBadges client={client} showApproved />
+						<ClientTypeChips client={client} />
+					</h2>
+					<p className="mt-1 flex items-center gap-1">
+						<code className="text-muted-foreground min-w-0 truncate font-mono text-xs">
+							{client.client_id}
+						</code>
+						<CopyButton
+							value={client.client_id}
+							variant="ghost"
+							size="icon"
+							className="h-6 w-6 shrink-0 p-1"
+							toastMessage="Client ID copied"
+							ariaLabel={`Copy client ID for ${client.name}`}
+						/>
+					</p>
+				</div>
+				<div className="flex shrink-0 items-center gap-1">
+					<Button variant="outline" size="sm" onClick={(): void => onEdit(client)}>
+						Edit
+					</Button>
+					<Button
+						variant="ghost"
+						size="icon"
+						onClick={onClose}
+						aria-label="Close details"
+					>
+						<X className="h-4 w-4" />
+					</Button>
+				</div>
+			</header>
+
+			<div className="flex-1 space-y-4 overflow-y-auto p-5">
+				<DetailSection
+					title="Configuration"
+					icon={<Info className="h-4 w-4" />}
+					bodyClassName="space-y-2.5"
+				>
+					<dl className="space-y-2.5">
+						<MetaRow label="Consent model">
+							{client.consent_model === 'agent'
+								? 'Agent — consent binds an agent'
+								: 'User — consent acts as the user'}
+						</MetaRow>
+						<MetaRow label="Client type">
+							{client.token_endpoint_auth_method === 'none'
+								? 'Public (PKCE-only, no secret)'
+								: 'Confidential (client secret)'}
+						</MetaRow>
+						<MetaRow label="Source">
+							{client.registration_source === 'dcr'
+								? 'Dynamic client registration'
+								: 'Admin-registered'}
+						</MetaRow>
+						{client.software_id && (
+							<MetaRow label="Software ID">
+								<code className="font-mono text-xs">{client.software_id}</code>
+							</MetaRow>
+						)}
+						{client.description && (
+							<MetaRow label="Description">{client.description}</MetaRow>
+						)}
+						<MetaRow label="Redirect URIs">
+							<ul className="space-y-0.5">
+								{client.redirect_uris.map((uri) => (
+									<li key={uri} className="truncate font-mono text-xs">
+										{uri}
+									</li>
+								))}
+							</ul>
+							{origins.length > 0 && (
+								<p className="text-muted-foreground mt-1 font-mono text-xs">
+									Origins: {origins.join(', ')}
+								</p>
+							)}
+						</MetaRow>
+						<MetaRow label="Allowed scopes">
+							{client.allowed_scopes == null ? (
+								'Unrestricted'
+							) : client.allowed_scopes.length === 0 ? (
+								'OIDC only (openid, email, profile)'
+							) : (
+								<span className="flex flex-wrap gap-1">
+									{client.allowed_scopes.map((scope) => (
+										<Badge key={scope} variant="default">
+											{scope}
+										</Badge>
+									))}
+								</span>
+							)}
+						</MetaRow>
+						<MetaRow label="Consent screen">
+							{client.require_consent ? 'Required' : 'Skipped (trusted client)'}
+						</MetaRow>
+						<MetaRow label="Registered">
+							<span title={formatTimestamp(client.created_at)}>
+								{timeAgo(client.created_at)}
+							</span>
+							{client.created_by && (
+								<>
+									{' '}
+									by <ActorLabel actorId={client.created_by} />
+								</>
+							)}
+						</MetaRow>
+						{client.updated_at && (
+							<MetaRow label="Updated">
+								<span title={formatTimestamp(client.updated_at)}>
+									{timeAgo(client.updated_at)}
+								</span>
+							</MetaRow>
+						)}
+					</dl>
+				</DetailSection>
+
+				<GrantsSection client={client} />
+
+				<AuditSection client={client} />
+
+				{dangerActions.length > 0 && (
+					<DangerZone
+						actions={dangerActions}
+						onAction={(key): void => {
+							if (key === 'deactivate') onDeactivate(client);
+							if (key === 'rotate') onRotate(client);
+						}}
+					/>
+				)}
+			</div>
+		</SheetPrimitive>
+	);
+}

--- a/ui/src/modules/settings/components/ClientFormSheet.tsx
+++ b/ui/src/modules/settings/components/ClientFormSheet.tsx
@@ -279,10 +279,20 @@ export function ClientFormSheet({ open, onClose, client, onSecretRevealed }: Cli
 			return;
 		}
 		setValidationError(null);
-		const scopePayload = restrictScopes ? allowedScopes : null;
 
 		try {
 			if (isEdit) {
+				// allowed_scopes is TRI-STATE on PATCH (OAuthClientUpdateRequest):
+				// null/omitted = NO CHANGE, `['*']` = reset to unrestricted, any
+				// other array = restrict to it ([] = OIDC-only). Sending null on
+				// uncheck would success-toast a silent no-op, so translate the
+				// checkbox against the client's CURRENT restriction instead.
+				let scopeUpdate: string[] | undefined;
+				if (restrictScopes) {
+					scopeUpdate = allowedScopes;
+				} else if (client.allowed_scopes != null) {
+					scopeUpdate = ['*'];
+				}
 				await updateMutation.mutateAsync({
 					id: client.id,
 					input: {
@@ -290,7 +300,7 @@ export function ClientFormSheet({ open, onClose, client, onSecretRevealed }: Cli
 						description: description.trim() || null,
 						redirect_uris: uris,
 						require_consent: requireConsent,
-						allowed_scopes: scopePayload,
+						...(scopeUpdate !== undefined ? { allowed_scopes: scopeUpdate } : {}),
 					},
 				});
 				toast({ title: 'OAuth client updated', variant: 'success' });
@@ -301,7 +311,7 @@ export function ClientFormSheet({ open, onClose, client, onSecretRevealed }: Cli
 					description: description.trim() || undefined,
 					redirect_uris: uris,
 					require_consent: requireConsent,
-					allowed_scopes: scopePayload,
+					allowed_scopes: restrictScopes ? allowedScopes : null,
 					consent_model:
 						consentModel === 'agent'
 							? OAuthClientCreateRequest.consent_model.AGENT
@@ -317,6 +327,10 @@ export function ClientFormSheet({ open, onClose, client, onSecretRevealed }: Cli
 				if (result.client_secret) {
 					onSecretRevealed?.(result.client_secret);
 				}
+				// The one-time secret has been handed to the owner's reveal
+				// dialog — don't let it linger in the mutation cache too
+				// (mirrors the rotate path's reset-after-reveal).
+				createMutation.reset();
 			}
 		} catch (err) {
 			toast({

--- a/ui/src/modules/settings/components/ClientFormSheet.tsx
+++ b/ui/src/modules/settings/components/ClientFormSheet.tsx
@@ -1,0 +1,467 @@
+/**
+ * ClientFormSheet — create/edit form for OAuth clients, as a slide-over
+ * (library-first: forms prefer `SheetPrimitive` so the roster stays visible).
+ *
+ * Dialog-state lifecycle: mounted persistently by the section (never
+ * `{open && …}`), transient flags cleared on every (re)open, the draft
+ * SEEDED only when the target identity changes, and hard-reset only on the
+ * successful-commit path — a casual Esc/backdrop dismiss keeps a half-typed
+ * draft.
+ *
+ * Create-only fields (the API accepts them at POST but not PATCH, so edit
+ * mode neither shows nor sends them): the consent model (`user` | `agent`,
+ * the MCP marker) and the client type (`confidential` | `public` →
+ * `token_endpoint_auth_method`).
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Plus, Trash2, X } from 'lucide-react';
+import {
+	Badge,
+	Button,
+	Checkbox,
+	ErrorAlert,
+	Input,
+	Label,
+	LoadingState,
+	ScopePicker,
+	Select,
+	SheetPrimitive,
+	toast,
+} from '@/shared/ui';
+import { extractResourceFromScope, type EnhancedScope } from '@/shared/lib/scopes';
+import {
+	useCreateOAuthClient,
+	useUpdateOAuthClient,
+	usePermissionCatalogue,
+	OAuthClientCreateRequest,
+	type OAuthClient,
+} from '@/modules/settings/api/hooks';
+
+/** A redirect-URI draft row with a stable key (rows can be added/removed). */
+interface UriRow {
+	key: number;
+	value: string;
+}
+
+let nextUriKey = 0;
+const makeUriRows = (uris: string[]): UriRow[] =>
+	(uris.length > 0 ? uris : ['']).map((value) => ({ key: nextUriKey++, value }));
+
+function RedirectUriList({
+	rows,
+	onChange,
+}: {
+	rows: UriRow[];
+	onChange: (rows: UriRow[]) => void;
+}) {
+	return (
+		<div className="space-y-2">
+			{rows.map((row, index) => (
+				<div key={row.key} className="flex items-center gap-2">
+					<Input
+						value={row.value}
+						onChange={(e): void =>
+							onChange(
+								rows.map((r, i) =>
+									i === index ? { ...r, value: e.target.value } : r,
+								),
+							)
+						}
+						placeholder="https://example.com/callback"
+						aria-label={`Redirect URI ${index + 1}`}
+						className="flex-1"
+					/>
+					<Button
+						type="button"
+						variant="ghost"
+						size="sm"
+						onClick={(): void => onChange(rows.filter((_, i) => i !== index))}
+						disabled={rows.length <= 1}
+						aria-label="Remove URI"
+					>
+						<Trash2 className="h-4 w-4" />
+					</Button>
+				</div>
+			))}
+			<Button
+				type="button"
+				variant="outline"
+				size="sm"
+				onClick={(): void => onChange([...rows, { key: nextUriKey++, value: '' }])}
+			>
+				<Plus className="mr-1 h-3 w-3" />
+				Add URI
+			</Button>
+		</div>
+	);
+}
+
+/**
+ * Allowed-scopes selector: the shared grouped/searchable `ScopePicker` over
+ * the platform permission catalogue (replacing the old local chip cloud),
+ * PLUS a free-text row for scopes outside the catalogue — OAuth
+ * `allowed_scopes` is an open set (a client may be restricted to scopes the
+ * catalogue doesn't know), which the shared picker deliberately doesn't
+ * model, so the custom-scope affordance stays local to this form.
+ */
+function AllowedScopesField({
+	selected,
+	onChange,
+}: {
+	selected: string[];
+	onChange: (scopes: string[]) => void;
+}) {
+	const [customInput, setCustomInput] = useState('');
+	const catalogue = usePermissionCatalogue();
+	const entries = useMemo(() => catalogue.data ?? [], [catalogue.data]);
+	const catalogueNames = useMemo(() => new Set(entries.map((p) => p.name)), [entries]);
+	const scopes: EnhancedScope[] = useMemo(
+		() =>
+			entries.map((p) => ({
+				scope: p.name,
+				description: p.description,
+				origin: 'platform' as const,
+				isRecommended: false,
+			})),
+		[entries],
+	);
+	const customScopes = selected.filter((s) => !catalogueNames.has(s));
+
+	const toggle = (scope: string): void => {
+		onChange(
+			selected.includes(scope) ? selected.filter((s) => s !== scope) : [...selected, scope],
+		);
+	};
+	const selectAll = (group?: string): void => {
+		const pool = scopes.filter((s) => !group || extractResourceFromScope(s.scope) === group);
+		onChange([...new Set([...selected, ...pool.map((s) => s.scope)])]);
+	};
+	const deselectAll = (group?: string): void => {
+		onChange(
+			group
+				? selected.filter(
+						(s) => !catalogueNames.has(s) || extractResourceFromScope(s) !== group,
+					)
+				: customScopes,
+		);
+	};
+	const addCustom = (): void => {
+		const trimmed = customInput.trim();
+		if (trimmed && !selected.includes(trimmed)) {
+			onChange([...selected, trimmed]);
+			setCustomInput('');
+		}
+	};
+
+	return (
+		<div className="space-y-3">
+			{catalogue.isPending ? (
+				<LoadingState size="sm" message="Loading permissions…" />
+			) : catalogue.error ? (
+				<ErrorAlert message={catalogue.error as Error} />
+			) : (
+				<ScopePicker
+					scopes={scopes}
+					selectedScopes={selected.filter((s) => catalogueNames.has(s))}
+					showRecommended={false}
+					onScopeToggle={toggle}
+					onSelectAll={selectAll}
+					onDeselectAll={deselectAll}
+				/>
+			)}
+			{customScopes.length > 0 && (
+				<div className="flex flex-wrap gap-1">
+					{customScopes.map((s) => (
+						<Badge key={s} variant="default" className="gap-1">
+							{s}
+							<button
+								type="button"
+								onClick={(): void => onChange(selected.filter((x) => x !== s))}
+								className="hover:text-danger cursor-pointer"
+								aria-label={`Remove scope ${s}`}
+							>
+								<X className="h-3 w-3" />
+							</button>
+						</Badge>
+					))}
+				</div>
+			)}
+			<div className="flex items-center gap-2">
+				<Input
+					value={customInput}
+					onChange={(e): void => setCustomInput(e.target.value)}
+					placeholder="custom:scope"
+					aria-label="Custom scope"
+					className="flex-1"
+					onKeyDown={(e): void => {
+						if (e.key === 'Enter') {
+							e.preventDefault();
+							addCustom();
+						}
+					}}
+				/>
+				<Button type="button" variant="outline" size="sm" onClick={addCustom}>
+					Add
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+export interface ClientFormSheetProps {
+	open: boolean;
+	onClose: () => void;
+	/** Edit target; null/undefined = create mode. */
+	client?: OAuthClient | null;
+	/** Create-mode only: the one-time secret of a new confidential client. */
+	onSecretRevealed?: (secret: string) => void;
+}
+
+export function ClientFormSheet({ open, onClose, client, onSecretRevealed }: ClientFormSheetProps) {
+	const isEdit = client != null;
+
+	const [name, setName] = useState('');
+	const [description, setDescription] = useState('');
+	const [uriRows, setUriRows] = useState<UriRow[]>(() => makeUriRows([]));
+	const [requireConsent, setRequireConsent] = useState(true);
+	const [restrictScopes, setRestrictScopes] = useState(false);
+	const [allowedScopes, setAllowedScopes] = useState<string[]>([]);
+	// Create-only knobs (the PATCH API doesn't accept them — never sent on edit).
+	const [consentModel, setConsentModel] = useState<'user' | 'agent'>('user');
+	const [clientType, setClientType] = useState<'confidential' | 'public'>('confidential');
+	const [validationError, setValidationError] = useState<string | null>(null);
+	const nameRef = useRef<HTMLInputElement>(null);
+
+	const createMutation = useCreateOAuthClient();
+	const updateMutation = useUpdateOAuthClient();
+	const isPending = createMutation.isPending || updateMutation.isPending;
+
+	// (a) Transient flags are NOT user input — clear on every (re)open.
+	useEffect(() => {
+		if (open) setValidationError(null);
+	}, [open]);
+
+	// (b) Seed-from-props only when the TARGET identity changed — not on every
+	// `open` flip, or re-opening would clobber the user's draft.
+	const identity = client?.id ?? null;
+	const lastIdentityRef = useRef<string | null | undefined>(undefined);
+	useEffect(() => {
+		if (lastIdentityRef.current === identity) return;
+		lastIdentityRef.current = identity;
+		setName(client?.name ?? '');
+		setDescription(client?.description ?? '');
+		setUriRows(makeUriRows(client?.redirect_uris ?? []));
+		setRequireConsent(client?.require_consent ?? true);
+		setRestrictScopes(client?.allowed_scopes != null);
+		setAllowedScopes(client?.allowed_scopes ?? []);
+		setConsentModel(client?.consent_model === 'agent' ? 'agent' : 'user');
+		setClientType(client?.token_endpoint_auth_method === 'none' ? 'public' : 'confidential');
+	}, [identity, client]);
+
+	// (c) Hard reset of the draft is reserved for the success path.
+	const resetDraft = (): void => {
+		setName('');
+		setDescription('');
+		setUriRows(makeUriRows([]));
+		setRequireConsent(true);
+		setRestrictScopes(false);
+		setAllowedScopes([]);
+		setConsentModel('user');
+		setClientType('confidential');
+		setValidationError(null);
+	};
+
+	const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+		e.preventDefault();
+		const uris = uriRows.map((r) => r.value.trim()).filter(Boolean);
+		if (!name.trim() || uris.length === 0) {
+			setValidationError('Name and at least one redirect URI are required.');
+			return;
+		}
+		setValidationError(null);
+		const scopePayload = restrictScopes ? allowedScopes : null;
+
+		try {
+			if (isEdit) {
+				await updateMutation.mutateAsync({
+					id: client.id,
+					input: {
+						name: name.trim(),
+						description: description.trim() || null,
+						redirect_uris: uris,
+						require_consent: requireConsent,
+						allowed_scopes: scopePayload,
+					},
+				});
+				toast({ title: 'OAuth client updated', variant: 'success' });
+				onClose();
+			} else {
+				const result = await createMutation.mutateAsync({
+					name: name.trim(),
+					description: description.trim() || undefined,
+					redirect_uris: uris,
+					require_consent: requireConsent,
+					allowed_scopes: scopePayload,
+					consent_model:
+						consentModel === 'agent'
+							? OAuthClientCreateRequest.consent_model.AGENT
+							: OAuthClientCreateRequest.consent_model.USER,
+					token_endpoint_auth_method:
+						clientType === 'public'
+							? OAuthClientCreateRequest.token_endpoint_auth_method.NONE
+							: OAuthClientCreateRequest.token_endpoint_auth_method
+									.CLIENT_SECRET_BASIC,
+				});
+				resetDraft();
+				onClose();
+				if (result.client_secret) {
+					onSecretRevealed?.(result.client_secret);
+				}
+			}
+		} catch (err) {
+			toast({
+				title: isEdit ? 'Failed to update client' : 'Failed to create client',
+				description: err instanceof Error ? err.message : undefined,
+				variant: 'error',
+			});
+		}
+	};
+
+	return (
+		<SheetPrimitive
+			open={open}
+			onClose={onClose}
+			side="right"
+			ariaLabel={isEdit ? `Edit ${client.name}` : 'Create OAuth client'}
+			initialFocus={nameRef}
+			className="flex flex-col"
+		>
+			<header className="border-border border-b p-5">
+				<h2 className="text-foreground text-lg font-semibold">
+					{isEdit ? 'Edit OAuth client' : 'Create OAuth client'}
+				</h2>
+				<p className="text-muted-foreground mt-1 text-sm">
+					{isEdit
+						? 'Update the client configuration. The client type and consent model are fixed at creation.'
+						: 'Register a third-party application that authenticates users via Jentic One.'}
+				</p>
+			</header>
+
+			<form
+				id="oauth-client-form"
+				onSubmit={(e): void => void handleSubmit(e)}
+				className="flex-1 space-y-4 overflow-y-auto p-5"
+			>
+				{validationError && <ErrorAlert message={validationError} />}
+				<div className="space-y-1.5">
+					<Label htmlFor="oauth-client-name">Name</Label>
+					<Input
+						ref={nameRef}
+						id="oauth-client-name"
+						value={name}
+						onChange={(e): void => setName(e.target.value)}
+						placeholder="e.g., my-app-production"
+						required
+					/>
+				</div>
+				<div className="space-y-1.5">
+					<Label htmlFor="oauth-client-description">Description (optional)</Label>
+					<Input
+						id="oauth-client-description"
+						value={description}
+						onChange={(e): void => setDescription(e.target.value)}
+						placeholder="e.g., Production deployment for user auth"
+					/>
+				</div>
+				<div className="space-y-1.5">
+					<Label>Redirect URIs</Label>
+					<RedirectUriList rows={uriRows} onChange={setUriRows} />
+				</div>
+
+				{!isEdit && (
+					<>
+						<div className="space-y-1.5">
+							<Label htmlFor="oauth-client-type">Client type</Label>
+							<Select
+								id="oauth-client-type"
+								value={clientType}
+								onChange={(e): void =>
+									setClientType(e.target.value as 'confidential' | 'public')
+								}
+							>
+								<option value="confidential">
+									Confidential — server-side app with a client secret
+								</option>
+								<option value="public">
+									Public — native/SPA client, PKCE only (no secret)
+								</option>
+							</Select>
+							<p className="text-muted-foreground text-xs">
+								{clientType === 'public'
+									? 'No secret is generated; the client must use PKCE.'
+									: 'A one-time secret is shown after creation.'}
+							</p>
+						</div>
+						<div className="space-y-1.5">
+							<Label htmlFor="oauth-client-consent-model">Consent model</Label>
+							<Select
+								id="oauth-client-consent-model"
+								value={consentModel}
+								onChange={(e): void =>
+									setConsentModel(e.target.value as 'user' | 'agent')
+								}
+							>
+								<option value="user">
+									User — consent lets the client act as the user
+								</option>
+								<option value="agent">
+									Agent — consent binds the client to an agent (MCP)
+								</option>
+							</Select>
+						</div>
+					</>
+				)}
+
+				<Checkbox
+					checked={requireConsent}
+					onChange={setRequireConsent}
+					size="sm"
+					id="oauth-client-require-consent"
+					ariaLabel="Require consent screen"
+				>
+					<span className="text-foreground text-sm">Require consent screen</span>
+				</Checkbox>
+
+				<div className="space-y-2">
+					<Checkbox
+						checked={restrictScopes}
+						onChange={setRestrictScopes}
+						size="sm"
+						id="oauth-client-restrict-scopes"
+						ariaLabel="Restrict allowed scopes"
+					>
+						<span className="text-foreground text-sm">Restrict allowed scopes</span>
+					</Checkbox>
+					{restrictScopes && (
+						<AllowedScopesField selected={allowedScopes} onChange={setAllowedScopes} />
+					)}
+					{restrictScopes && allowedScopes.length === 0 && (
+						<p className="text-muted-foreground text-xs">
+							No scopes selected — this client will only be able to request OIDC
+							scopes (openid, email, profile).
+						</p>
+					)}
+				</div>
+			</form>
+
+			<footer className="border-border flex items-center justify-end gap-2 border-t p-5">
+				<Button variant="secondary" onClick={onClose} disabled={isPending}>
+					Cancel
+				</Button>
+				<Button type="submit" form="oauth-client-form" loading={isPending}>
+					{isEdit ? 'Update' : 'Create'}
+				</Button>
+			</footer>
+		</SheetPrimitive>
+	);
+}

--- a/ui/src/modules/settings/components/ClientLifecycleDialogs.tsx
+++ b/ui/src/modules/settings/components/ClientLifecycleDialogs.tsx
@@ -1,0 +1,128 @@
+/**
+ * Page-level confirm/secret dialogs for the OAuth-clients section (the
+ * agents-roster grammar: row menus fire, the SECTION owns the dialogs).
+ * All three are stateless (no drafts), so conditional mounting by the owner
+ * is fine per the dialog-state rule.
+ */
+import { Button, CopyButton, Dialog } from '@/shared/ui';
+
+/**
+ * One-time secret reveal (create / rotate). Stays a `Dialog` — a blocking
+ * decision moment — and the OWNER wipes the secret on close (sensitive-data
+ * exception: the secret must not survive a dismissal).
+ */
+export function SecretDialog({
+	open,
+	onClose,
+	secret,
+	title,
+}: {
+	open: boolean;
+	onClose: () => void;
+	secret: string;
+	title: string;
+}) {
+	return (
+		<Dialog
+			open={open}
+			onClose={onClose}
+			title={title}
+			dismissOnBackdrop={false}
+			footer={<Button onClick={onClose}>Done</Button>}
+		>
+			<div className="space-y-3">
+				<p className="text-muted-foreground text-xs">
+					Copy this secret now — it is shown only once and cannot be retrieved again.
+				</p>
+				<div className="bg-card border-border flex items-center gap-2 rounded-md border p-2">
+					<code className="text-foreground min-w-0 flex-1 overflow-x-auto font-mono text-xs">
+						{secret}
+					</code>
+					<CopyButton value={secret} variant="ghost" size="icon" toastMessage={false} />
+				</div>
+			</div>
+		</Dialog>
+	);
+}
+
+export function RotateConfirmDialog({
+	open,
+	onClose,
+	onConfirm,
+	isPending,
+	clientName,
+}: {
+	open: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+	isPending: boolean;
+	clientName: string;
+}) {
+	return (
+		<Dialog
+			open={open}
+			onClose={onClose}
+			title="Rotate Client Secret?"
+			footer={
+				<>
+					<Button variant="outline" onClick={onClose}>
+						Cancel
+					</Button>
+					<Button variant="danger" onClick={onConfirm} disabled={isPending}>
+						{isPending ? 'Rotating...' : 'Rotate Secret'}
+					</Button>
+				</>
+			}
+		>
+			<p className="text-muted-foreground">
+				This will invalidate the current secret for <strong>{clientName}</strong>{' '}
+				immediately. Any application using the old secret will lose access.
+			</p>
+		</Dialog>
+	);
+}
+
+export function DeactivateConfirmDialog({
+	open,
+	onClose,
+	onConfirm,
+	isPending,
+	clientName,
+	error,
+}: {
+	open: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+	isPending: boolean;
+	clientName: string;
+	error?: unknown;
+}) {
+	return (
+		<Dialog
+			open={open}
+			onClose={onClose}
+			title="Deactivate OAuth Client?"
+			footer={
+				<>
+					<Button variant="outline" onClick={onClose}>
+						Cancel
+					</Button>
+					<Button variant="danger" onClick={onConfirm} disabled={isPending}>
+						{isPending ? 'Deactivating...' : 'Deactivate'}
+					</Button>
+				</>
+			}
+		>
+			<p className="text-muted-foreground">
+				This will prevent <strong>{clientName}</strong> from initiating new authorization
+				flows. Existing sessions are not affected. You can reactivate the client later — and
+				a deactivated client that re-registers via DCR returns to the approval queue.
+			</p>
+			{error != null && (
+				<p className="text-danger mt-2 text-sm">
+					{error instanceof Error ? error.message : 'An error occurred'}
+				</p>
+			)}
+		</Dialog>
+	);
+}

--- a/ui/src/modules/settings/components/ClientLifecycleDialogs.tsx
+++ b/ui/src/modules/settings/components/ClientLifecycleDialogs.tsx
@@ -4,7 +4,7 @@
  * All three are stateless (no drafts), so conditional mounting by the owner
  * is fine per the dialog-state rule.
  */
-import { Button, CopyButton, Dialog } from '@/shared/ui';
+import { Button, CopyButton, Dialog, ErrorAlert } from '@/shared/ui';
 
 /**
  * One-time secret reveal (create / rotate). Stays a `Dialog` — a blocking
@@ -119,9 +119,11 @@ export function DeactivateConfirmDialog({
 				a deactivated client that re-registers via DCR returns to the approval queue.
 			</p>
 			{error != null && (
-				<p className="text-danger mt-2 text-sm">
-					{error instanceof Error ? error.message : 'An error occurred'}
-				</p>
+				<div className="mt-3">
+					<ErrorAlert
+						message={error instanceof Error ? error : 'Failed to deactivate the client'}
+					/>
+				</div>
 			)}
 		</Dialog>
 	);

--- a/ui/src/modules/settings/components/ClientsTable.tsx
+++ b/ui/src/modules/settings/components/ClientsTable.tsx
@@ -1,0 +1,444 @@
+/**
+ * ClientsTable — the OAuth-clients roster in the platform's fleet-table
+ * grammar (mirrors `agents/components/ActorTable`): DataTable with an
+ * identity cell (name → detail sheet + mono client_id + copy), derived
+ * redirect-URI origins, type chips, the single-sourced status badges, the
+ * active-grant count (→ detail sheet's grants section), a registered
+ * `timeAgo` cell, and a per-row kebab for the lifecycle verbs. On phones the
+ * table swaps to stacked cards (`renderCard`).
+ *
+ * The toolbar replaces the old unlabelled "Show inactive" checkbox with
+ * status segments carrying live counts — the Inactive segment surfaces the
+ * approved-but-deactivated zombies (#1312) that used to match neither the
+ * default list nor the queue filters. The filter input is the client-side
+ * Filter affordance (status-and-filter rule), disabled when there is nothing
+ * to narrow.
+ *
+ * Hazard fix (#4 in the redesign plan): Reactivate is offered ONLY on
+ * approved+inactive rows (`canReactivate`); a denied row's kebab routes to
+ * the queue instead, where Approve is the deliberate denied→active recovery.
+ */
+import { useMemo, useRef, useState } from 'react';
+import { Filter, KeyRound, MoreHorizontal, Plus } from 'lucide-react';
+import {
+	AnchoredMenuPanel,
+	Button,
+	Card,
+	CardBody,
+	CopyButton,
+	DataTable,
+	EmptyState,
+	ErrorAlert,
+	LoadingState,
+	RefreshButton,
+	SearchInput,
+	SegmentedToggle,
+	TruncateWithTooltip,
+	menuItemClass,
+	type Column,
+} from '@/shared/ui';
+import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
+import { cn, timeAgo } from '@/shared/lib/utils';
+import type { OAuthClient } from '@/modules/settings/api/hooks';
+import {
+	CLIENT_STATUS_FILTERS,
+	CLIENT_STATUS_FILTER_LABEL,
+	canReactivate,
+	canRotateSecret,
+	clientOrigins,
+	clientStatusSegment,
+	toApprovalStatus,
+	type ClientStatusFilter,
+} from '@/modules/settings/components/clientStatus';
+import {
+	ClientStatusBadges,
+	ClientTypeChips,
+	TimeCell,
+} from '@/modules/settings/components/clientBadges';
+
+export type ClientAction = 'edit' | 'rotate' | 'deactivate' | 'reactivate' | 'review-in-queue';
+
+const ACTION_LABEL: Record<ClientAction, string> = {
+	edit: 'Edit',
+	rotate: 'Rotate secret',
+	deactivate: 'Deactivate',
+	reactivate: 'Reactivate',
+	'review-in-queue': 'Review in queue',
+};
+
+/** Scan order: undecided rows first, then the working fleet, then history. */
+const SEGMENT_ORDER: Record<Exclude<ClientStatusFilter, 'all'>, number> = {
+	pending: 0,
+	active: 1,
+	inactive: 2,
+	denied: 3,
+};
+
+/**
+ * The lifecycle verbs a row offers. Reactivate deliberately requires
+ * approved+inactive (see module comment); denied rows get "Review in queue".
+ */
+function actionsFor(client: OAuthClient): ClientAction[] {
+	const actions: ClientAction[] = ['edit'];
+	if (canRotateSecret(client)) actions.push('rotate');
+	if (client.active) actions.push('deactivate');
+	if (canReactivate(client)) actions.push('reactivate');
+	if (toApprovalStatus(client.approval_status) === 'denied') actions.push('review-in-queue');
+	return actions;
+}
+
+const DANGER_ACTIONS: ReadonlySet<ClientAction> = new Set(['deactivate']);
+
+function RowActionsMenu({
+	client,
+	pending,
+	onAction,
+}: {
+	client: OAuthClient;
+	pending: boolean;
+	onAction: (client: OAuthClient, action: ClientAction) => void;
+}) {
+	const [open, setOpen] = useState(false);
+	// Portal the panel out (AnchoredMenuPanel): the DataTable's overflow
+	// wrapper clips absolutely-positioned panels — same fix as ActorTable.
+	const triggerRef = useRef<HTMLDivElement>(null);
+	const actions = actionsFor(client);
+
+	if (actions.length === 0) return null;
+
+	return (
+		<div ref={triggerRef} className="relative inline-block">
+			<Button
+				variant="ghost"
+				size="sm"
+				aria-haspopup="menu"
+				aria-expanded={open}
+				aria-label={`Actions for ${client.name}`}
+				disabled={pending}
+				loading={pending}
+				onClick={(): void => setOpen((v) => !v)}
+			>
+				<MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+			</Button>
+			{open && (
+				<AnchoredMenuPanel
+					anchorRef={triggerRef}
+					onClose={(): void => setOpen(false)}
+					align="right"
+					className="min-w-[170px]"
+				>
+					{actions.map((action) => (
+						<button
+							key={action}
+							type="button"
+							role="menuitem"
+							className={cn(
+								menuItemClass(),
+								DANGER_ACTIONS.has(action) && 'text-danger hover:text-danger',
+							)}
+							aria-label={`${ACTION_LABEL[action]} ${client.name}`}
+							onClick={(): void => {
+								setOpen(false);
+								onAction(client, action);
+							}}
+						>
+							{ACTION_LABEL[action]}
+						</button>
+					))}
+				</AnchoredMenuPanel>
+			)}
+		</div>
+	);
+}
+
+/**
+ * Identity cell: name (a button opening the detail sheet — the roster has no
+ * per-client route, so this is the AppLink-equivalent affordance) + the mono
+ * public client_id with a copy button.
+ */
+function IdentityCell({
+	client,
+	onOpenDetail,
+}: {
+	client: OAuthClient;
+	onOpenDetail: (client: OAuthClient) => void;
+}) {
+	return (
+		<span className="flex min-w-0 flex-col">
+			<button
+				type="button"
+				onClick={(): void => onOpenDetail(client)}
+				aria-label={`View details for ${client.name}`}
+				className="font-heading text-foreground hover:text-primary focus-visible:ring-ring block max-w-full cursor-pointer truncate rounded-sm text-left text-sm font-semibold focus-visible:ring-2 focus-visible:outline-none"
+			>
+				{client.name}
+			</button>
+			<span className="flex min-w-0 items-center gap-1">
+				<code className="text-muted-foreground block truncate font-mono text-xs">
+					{client.client_id}
+				</code>
+				<CopyButton
+					value={client.client_id}
+					variant="ghost"
+					size="icon"
+					className="h-6 w-6 shrink-0 p-1"
+					toastMessage="Client ID copied"
+					ariaLabel={`Copy client ID for ${client.name}`}
+				/>
+			</span>
+		</span>
+	);
+}
+
+/** Unique redirect-URI origins, truncated with the full set on hover. */
+function OriginsCell({ client }: { client: OAuthClient }) {
+	const origins = clientOrigins(client);
+	if (origins.length === 0) return <span aria-hidden>—</span>;
+	return (
+		<TruncateWithTooltip className="text-muted-foreground max-w-[220px] font-mono text-xs">
+			{origins.join(', ')}
+		</TruncateWithTooltip>
+	);
+}
+
+interface ClientsTableProps {
+	clients: OAuthClient[] | undefined;
+	isLoading: boolean;
+	isFetching: boolean;
+	error: unknown;
+	onRefresh: () => void;
+	onOpenDetail: (client: OAuthClient) => void;
+	onAction: (client: OAuthClient, action: ClientAction) => void;
+	onCreate: () => void;
+	/** The client id with a lifecycle mutation in flight, if any. */
+	pendingId?: string | null;
+}
+
+export function ClientsTable({
+	clients,
+	isLoading,
+	isFetching,
+	error,
+	onRefresh,
+	onOpenDetail,
+	onAction,
+	onCreate,
+	pendingId,
+}: ClientsTableProps) {
+	const [filterQuery, setFilterQuery] = useState('');
+	// Default segment = Active: the working fleet. Pending/denied registrations
+	// stay out of the default view (they belong to the queue tab), preserving
+	// the old "default list hides pending" behaviour.
+	const [statusFilter, setStatusFilter] = useState<ClientStatusFilter>('active');
+	const isMobile = useMediaQuery('(max-width: 639px)');
+
+	const rows = useMemo(() => clients ?? [], [clients]);
+
+	const counts = useMemo(() => {
+		const c: Record<ClientStatusFilter, number> = {
+			all: rows.length,
+			active: 0,
+			pending: 0,
+			denied: 0,
+			inactive: 0,
+		};
+		for (const client of rows) c[clientStatusSegment(client)] += 1;
+		return c;
+	}, [rows]);
+
+	const filtered = useMemo(() => {
+		const q = filterQuery.trim().toLowerCase();
+		return rows
+			.filter((client) => {
+				if (statusFilter !== 'all' && clientStatusSegment(client) !== statusFilter) {
+					return false;
+				}
+				if (!q) return true;
+				return (
+					client.name.toLowerCase().includes(q) ||
+					client.client_id.toLowerCase().includes(q)
+				);
+			})
+			.sort(
+				(a, b) =>
+					SEGMENT_ORDER[clientStatusSegment(a)] - SEGMENT_ORDER[clientStatusSegment(b)] ||
+					b.created_at.localeCompare(a.created_at),
+			);
+	}, [rows, filterQuery, statusFilter]);
+
+	const segmentOptions = CLIENT_STATUS_FILTERS.map((value) => ({
+		value,
+		label: `${CLIENT_STATUS_FILTER_LABEL[value]} ${counts[value]}`,
+	}));
+
+	if (error) {
+		return <ErrorAlert message={error instanceof Error ? error : String(error)} />;
+	}
+
+	const table = (
+		<DataTable<OAuthClient>
+			columns={buildColumns(onOpenDetail, onAction, pendingId)}
+			data={filtered}
+			getRowKey={(row) => row.id}
+			emptyMessage="No clients match your filter."
+			ariaLabel="OAuth client list"
+			renderCard={(row) => (
+				<div className="space-y-2">
+					<div className="flex items-start justify-between gap-2">
+						<IdentityCell client={row} onOpenDetail={onOpenDetail} />
+						<RowActionsMenu
+							client={row}
+							pending={pendingId === row.id}
+							onAction={onAction}
+						/>
+					</div>
+					<div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+						<ClientStatusBadges client={row} />
+						<ClientTypeChips client={row} />
+						<span className="text-muted-foreground text-[11px]">
+							{row.active_grant_count ?? 0} grants · registered{' '}
+							{timeAgo(row.created_at)}
+						</span>
+					</div>
+				</div>
+			)}
+		/>
+	);
+
+	return (
+		<div className="space-y-4">
+			{/* ActorsToolbar-style filter + segments + refresh. Rendered inside
+			    the settings pane's own scroll container, so no sticky/backdrop
+			    treatment — that grammar assumes the page-level scroller. */}
+			<div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+				<div className="min-w-0 flex-1">
+					<SearchInput
+						value={filterQuery}
+						onValueChange={setFilterQuery}
+						placeholder="Filter clients by name or id…"
+						aria-label="Filter clients"
+						icon={<Filter className="h-3.5 w-3.5" />}
+						disabled={rows.length === 0}
+					/>
+				</div>
+				<div className="flex min-w-0 items-center gap-2">
+					<div className="min-w-0 overflow-x-auto">
+						<SegmentedToggle<ClientStatusFilter>
+							options={segmentOptions}
+							value={statusFilter}
+							onChange={setStatusFilter}
+							ariaLabel="Filter clients by status"
+							className="w-max"
+						/>
+					</div>
+					<RefreshButton
+						onRefresh={onRefresh}
+						pending={isFetching}
+						title="Refresh clients"
+						testId="oauth-clients-refresh"
+					/>
+				</div>
+			</div>
+
+			{/* Screen readers hear the fleet shape recompute after a decision. */}
+			<p className="sr-only" aria-live="polite">
+				{counts.all} total,{' '}
+				{CLIENT_STATUS_FILTERS.filter((s) => s !== 'all')
+					.map((s) => `${counts[s]} ${CLIENT_STATUS_FILTER_LABEL[s]}`)
+					.join(', ')}
+			</p>
+
+			{isLoading ? (
+				<LoadingState message="Loading OAuth clients…" />
+			) : rows.length === 0 ? (
+				<EmptyState
+					icon={<KeyRound className="h-6 w-6" />}
+					title="No OAuth clients"
+					description="Register an OAuth client to allow third-party applications to authenticate with Jentic One."
+					action={
+						<Button onClick={onCreate}>
+							<Plus className="mr-2 h-4 w-4" />
+							Create your first client
+						</Button>
+					}
+				/>
+			) : isMobile ? (
+				table
+			) : (
+				<Card>
+					<CardBody className="px-0 py-0">{table}</CardBody>
+				</Card>
+			)}
+		</div>
+	);
+}
+
+function buildColumns(
+	onOpenDetail: (client: OAuthClient) => void,
+	onAction: (client: OAuthClient, action: ClientAction) => void,
+	pendingId?: string | null,
+): Column<OAuthClient>[] {
+	return [
+		{
+			key: 'name',
+			header: 'Name',
+			className: 'max-w-[280px]',
+			render: (row) => <IdentityCell client={row} onOpenDetail={onOpenDetail} />,
+		},
+		{
+			key: 'origins',
+			header: 'Origins',
+			className: 'max-w-[240px]',
+			render: (row) => <OriginsCell client={row} />,
+		},
+		{
+			key: 'type',
+			header: 'Type',
+			className: 'whitespace-nowrap',
+			render: (row) => (
+				<span className="flex flex-wrap items-center gap-1">
+					<ClientTypeChips client={row} />
+				</span>
+			),
+		},
+		{
+			key: 'status',
+			header: 'Status',
+			className: 'w-36 whitespace-nowrap',
+			render: (row) => (
+				<span className="flex flex-wrap items-center gap-1">
+					<ClientStatusBadges client={row} showApproved />
+				</span>
+			),
+		},
+		{
+			key: 'grants',
+			header: 'Grants',
+			className: 'w-20 text-right',
+			render: (row) => (
+				<button
+					type="button"
+					onClick={(): void => onOpenDetail(row)}
+					aria-label={`View grants for ${row.name}`}
+					className="text-foreground hover:text-primary focus-visible:ring-ring cursor-pointer rounded-sm font-mono text-xs tabular-nums focus-visible:ring-2 focus-visible:outline-none"
+				>
+					{row.active_grant_count ?? 0}
+				</button>
+			),
+		},
+		{
+			key: 'created_at',
+			header: 'Registered',
+			className: 'w-32',
+			render: (row) => <TimeCell value={row.created_at} />,
+		},
+		{
+			key: 'actions',
+			header: '',
+			className: 'w-14 text-right',
+			render: (row) => (
+				<RowActionsMenu client={row} pending={pendingId === row.id} onAction={onAction} />
+			),
+		},
+	];
+}

--- a/ui/src/modules/settings/components/ClientsTable.tsx
+++ b/ui/src/modules/settings/components/ClientsTable.tsx
@@ -349,7 +349,12 @@ export function ClientsTable({
 					/>
 				</div>
 				<div className="flex min-w-0 items-center gap-2">
-					<div className="min-w-0 overflow-x-auto">
+					{/* This wrapper exists only so the segments can PAN at phone
+					    widths (they're genuinely wider than the screen there);
+					    hide-scrollbar is cosmetic for that panning. The animation
+					    itself never overflows — SegmentedToggle owns that
+					    invariant (non-overshooting spring + clip). */}
+					<div className="hide-scrollbar min-w-0 overflow-x-auto">
 						<SegmentedToggle<ClientStatusFilter>
 							options={segmentOptions}
 							value={statusFilter}

--- a/ui/src/modules/settings/components/ClientsTable.tsx
+++ b/ui/src/modules/settings/components/ClientsTable.tsx
@@ -75,6 +75,19 @@ const SEGMENT_ORDER: Record<Exclude<ClientStatusFilter, 'all'>, number> = {
 };
 
 /**
+ * What an empty grid means depends on WHICH slice is empty: an untouched
+ * filter must not blame a "filter" the user never typed, and a quiet segment
+ * should point at where the rows actually live (status-and-filter rule).
+ */
+const SEGMENT_EMPTY_MESSAGE: Record<ClientStatusFilter, string> = {
+	all: 'No clients registered yet.',
+	active: 'No active clients — check the Pending or Inactive views.',
+	pending: 'No pending clients — new DCR registrations land in the approval queue.',
+	denied: 'No denied clients.',
+	inactive: 'No inactive clients — every approved client is live.',
+};
+
+/**
  * The lifecycle verbs a row offers. Reactivate deliberately requires
  * approved+inactive (see module comment); denied rows get "Review in queue".
  */
@@ -246,25 +259,32 @@ export function ClientsTable({
 		return c;
 	}, [rows]);
 
+	// The current segment's candidate pool, BEFORE the text filter — the
+	// filter input narrows this pool, so its disabled state and the empty
+	// copy are gated on it (not on the whole roster).
+	const segmentPool = useMemo(
+		() =>
+			rows.filter(
+				(client) => statusFilter === 'all' || clientStatusSegment(client) === statusFilter,
+			),
+		[rows, statusFilter],
+	);
+
 	const filtered = useMemo(() => {
 		const q = filterQuery.trim().toLowerCase();
-		return rows
-			.filter((client) => {
-				if (statusFilter !== 'all' && clientStatusSegment(client) !== statusFilter) {
-					return false;
-				}
-				if (!q) return true;
-				return (
+		return segmentPool
+			.filter(
+				(client) =>
+					!q ||
 					client.name.toLowerCase().includes(q) ||
-					client.client_id.toLowerCase().includes(q)
-				);
-			})
+					client.client_id.toLowerCase().includes(q),
+			)
 			.sort(
 				(a, b) =>
 					SEGMENT_ORDER[clientStatusSegment(a)] - SEGMENT_ORDER[clientStatusSegment(b)] ||
 					b.created_at.localeCompare(a.created_at),
 			);
-	}, [rows, filterQuery, statusFilter]);
+	}, [segmentPool, filterQuery]);
 
 	const segmentOptions = CLIENT_STATUS_FILTERS.map((value) => ({
 		value,
@@ -280,7 +300,11 @@ export function ClientsTable({
 			columns={buildColumns(onOpenDetail, onAction, pendingId)}
 			data={filtered}
 			getRowKey={(row) => row.id}
-			emptyMessage="No clients match your filter."
+			emptyMessage={
+				filterQuery.trim()
+					? 'No clients match your filter.'
+					: SEGMENT_EMPTY_MESSAGE[statusFilter]
+			}
 			ariaLabel="OAuth client list"
 			renderCard={(row) => (
 				<div className="space-y-2">
@@ -292,6 +316,9 @@ export function ClientsTable({
 							onAction={onAction}
 						/>
 					</div>
+					{/* The verifiable origins stay visible on phones too — the
+					    card must not demote the anti-spoofing signal. */}
+					<OriginsCell client={row} />
 					<div className="flex flex-wrap items-center gap-x-3 gap-y-1">
 						<ClientStatusBadges client={row} />
 						<ClientTypeChips client={row} />
@@ -318,7 +345,7 @@ export function ClientsTable({
 						placeholder="Filter clients by name or id…"
 						aria-label="Filter clients"
 						icon={<Filter className="h-3.5 w-3.5" />}
-						disabled={rows.length === 0}
+						disabled={segmentPool.length === 0}
 					/>
 				</div>
 				<div className="flex min-w-0 items-center gap-2">

--- a/ui/src/modules/settings/components/clientBadges.tsx
+++ b/ui/src/modules/settings/components/clientBadges.tsx
@@ -1,0 +1,70 @@
+/**
+ * Presentational bits shared by the OAuth-clients roster, approval queue, and
+ * detail sheet: the approval-status badge row (single-sourced from
+ * `clientStatus.ts`), the type chips, and the relative-time cell.
+ */
+import { Badge } from '@/shared/ui';
+import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
+import type { OAuthClient } from '@/modules/settings/api/hooks';
+import {
+	APPROVAL_STATUS_LABEL,
+	APPROVAL_STATUS_VARIANT,
+	isInactiveChipVisible,
+	toApprovalStatus,
+} from '@/modules/settings/components/clientStatus';
+
+/**
+ * Approval-status badge + the orthogonal "Inactive" chip. `showApproved`
+ * opts the happy state in (detail header wants the full picture; the queue
+ * rows only ever carry pending/denied).
+ */
+export function ClientStatusBadges({
+	client,
+	showApproved = false,
+}: {
+	client: OAuthClient;
+	showApproved?: boolean;
+}) {
+	const status = toApprovalStatus(client.approval_status);
+	return (
+		<>
+			{(status !== 'approved' || showApproved) && (
+				<Badge variant={APPROVAL_STATUS_VARIANT[status]}>
+					{APPROVAL_STATUS_LABEL[status]}
+				</Badge>
+			)}
+			{isInactiveChipVisible(client) && (
+				<span className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 font-mono text-xs">
+					Inactive
+				</span>
+			)}
+		</>
+	);
+}
+
+/**
+ * Type chips: `Public` (secret-less PKCE client, D5), `DCR` (front-door
+ * registration, D8), `Agent consent` (consent binds an agent, not the user —
+ * the MCP marker). Renders nothing for a plain confidential admin client.
+ */
+export function ClientTypeChips({ client }: { client: OAuthClient }) {
+	return (
+		<>
+			{client.token_endpoint_auth_method === 'none' && (
+				<Badge variant="default">Public</Badge>
+			)}
+			{client.registration_source === 'dcr' && <Badge variant="default">DCR</Badge>}
+			{client.consent_model === 'agent' && <Badge variant="default">Agent consent</Badge>}
+		</>
+	);
+}
+
+/** Relative time with the full timestamp on hover; em-dash when unknown. */
+export function TimeCell({ value }: { value: string | null | undefined }) {
+	if (!value) return <span aria-hidden>—</span>;
+	return (
+		<span className="text-muted-foreground text-xs" title={formatTimestamp(value)}>
+			{timeAgo(value)}
+		</span>
+	);
+}

--- a/ui/src/modules/settings/components/clientStatus.ts
+++ b/ui/src/modules/settings/components/clientStatus.ts
@@ -1,0 +1,123 @@
+/**
+ * Single-sourced OAuth-client approval-status vocabulary: `status → label +
+ * Badge variant` for every surface in the module (roster, approval queue,
+ * detail sheet), so the same state never renders two ways.
+ *
+ * This is the D7 admin-approval lifecycle (`pending | approved | denied`) —
+ * a DIFFERENT closed vocabulary from the shared `ActorStatus`
+ * (`ActorStatusBadge`), which is why it lives module-local rather than
+ * extending the shared actor map: an OAuth client is not a platform actor.
+ *
+ * `active` is the ORTHOGONAL kill switch (an approved client can be
+ * deactivated without touching its approval status), so "Inactive" is a
+ * separate chip via {@link isInactiveChipVisible}, never a fourth status.
+ */
+import type { BadgeVariant } from '@/shared/ui';
+import type { OAuthClient } from '@/modules/settings/api/hooks';
+
+export type ApprovalStatus = 'pending' | 'approved' | 'denied';
+
+export const APPROVAL_STATUSES: readonly ApprovalStatus[] = ['pending', 'approved', 'denied'];
+
+export const APPROVAL_STATUS_LABEL: Record<ApprovalStatus, string> = {
+	pending: 'Pending',
+	approved: 'Approved',
+	denied: 'Denied',
+};
+
+export const APPROVAL_STATUS_VARIANT: Record<ApprovalStatus, BadgeVariant> = {
+	pending: 'pending',
+	approved: 'success',
+	denied: 'danger',
+};
+
+/** Normalise the wire string; unknown values read as `pending` (undecided). */
+export function toApprovalStatus(value: string): ApprovalStatus {
+	return (APPROVAL_STATUSES as readonly string[]).includes(value)
+		? (value as ApprovalStatus)
+		: 'pending';
+}
+
+/**
+ * Whether the orthogonal "Inactive" chip shows next to the status badge.
+ * Pending/denied rows are inactive BY CONSTRUCTION (D7), so the chip would be
+ * noise there — it only carries signal on an approved-but-deactivated row
+ * (the #1312 "zombie": matches neither queue filter, blocked at the gate).
+ */
+export function isInactiveChipVisible(client: OAuthClient): boolean {
+	return !client.active && toApprovalStatus(client.approval_status) === 'approved';
+}
+
+// ---------------------------------------------------------------------------
+// Roster status segments (the toolbar filter vocabulary)
+// ---------------------------------------------------------------------------
+
+/**
+ * The roster's status-segment vocabulary. Not the raw approval statuses:
+ * operators think in terms of "working fleet vs. needs attention", so the
+ * segments partition on the JOINT (approval_status, active) state —
+ * `inactive` is specifically the approved+deactivated zombies (#1312), while
+ * pending/denied rows live under their decision states.
+ */
+export type ClientStatusFilter = 'all' | 'active' | 'pending' | 'denied' | 'inactive';
+
+export const CLIENT_STATUS_FILTERS: readonly ClientStatusFilter[] = [
+	'all',
+	'active',
+	'pending',
+	'denied',
+	'inactive',
+];
+
+export const CLIENT_STATUS_FILTER_LABEL: Record<ClientStatusFilter, string> = {
+	all: 'All',
+	active: 'Active',
+	pending: 'Pending',
+	denied: 'Denied',
+	inactive: 'Inactive',
+};
+
+/** Which segment (other than `all`) a client row belongs to. */
+export function clientStatusSegment(client: OAuthClient): Exclude<ClientStatusFilter, 'all'> {
+	const status = toApprovalStatus(client.approval_status);
+	if (status === 'pending') return 'pending';
+	if (status === 'denied') return 'denied';
+	return client.active ? 'active' : 'inactive';
+}
+
+/**
+ * Whether a client may be reactivated from the roster. ONLY approved+inactive
+ * rows: reactivating a denied row would PATCH `active=true` while
+ * `approval_status=denied`, which the D7 gate still blocks — a success toast
+ * over a still-bricked client. A denied client's recovery path is the
+ * approval queue's Approve verb, which sets approved+active atomically.
+ */
+export function canReactivate(client: OAuthClient): boolean {
+	return !client.active && toApprovalStatus(client.approval_status) === 'approved';
+}
+
+/** Confidential clients only — public (PKCE-only) clients have no secret. */
+export function canRotateSecret(client: OAuthClient): boolean {
+	return client.active && client.token_endpoint_auth_method !== 'none';
+}
+
+// ---------------------------------------------------------------------------
+// Row/cell derivations shared by the roster, queue, and detail sheet
+// ---------------------------------------------------------------------------
+
+/**
+ * Unique `scheme://host[:port]` origins derived from the redirect URIs — the
+ * VERIFIABLE identity signal (the #1264 authorize-page posture), as opposed to
+ * the attacker-chosen client_name. Non-URL entries fall back to the raw
+ * string rather than disappearing.
+ */
+export function clientOrigins(client: Pick<OAuthClient, 'redirect_uris'>): string[] {
+	const origins = client.redirect_uris.map((uri) => {
+		try {
+			return new URL(uri).origin;
+		} catch {
+			return uri;
+		}
+	});
+	return [...new Set(origins)];
+}

--- a/ui/src/modules/settings/components/clientStatus.ts
+++ b/ui/src/modules/settings/components/clientStatus.ts
@@ -106,15 +106,24 @@ export function canRotateSecret(client: OAuthClient): boolean {
 // ---------------------------------------------------------------------------
 
 /**
- * Unique `scheme://host[:port]` origins derived from the redirect URIs — the
- * VERIFIABLE identity signal (the #1264 authorize-page posture), as opposed to
- * the attacker-chosen client_name. Non-URL entries fall back to the raw
- * string rather than disappearing.
+ * Unique origins derived from the redirect URIs — the VERIFIABLE identity
+ * signal (the #1264 authorize-page posture), as opposed to the
+ * attacker-chosen client_name.
+ *
+ * Non-special schemes (`cursor://…`, `vscode://…` — exactly the native/MCP
+ * client class this signal exists for) parse successfully under WHATWG but
+ * with an OPAQUE origin that serialises as the literal string "null", so
+ * `url.origin` alone would render "null" AND dedupe distinct custom-scheme
+ * clients into one entry. Derive `scheme://host` ourselves in that case;
+ * when the host is empty too (`myapp:/cb`), fall back to the raw URI rather
+ * than disappearing.
  */
 export function clientOrigins(client: Pick<OAuthClient, 'redirect_uris'>): string[] {
 	const origins = client.redirect_uris.map((uri) => {
 		try {
-			return new URL(uri).origin;
+			const url = new URL(uri);
+			if (url.origin !== 'null') return url.origin;
+			return url.host ? `${url.protocol}//${url.host}` : uri;
 		} catch {
 			return uri;
 		}

--- a/ui/src/modules/settings/mocks/handlers.ts
+++ b/ui/src/modules/settings/mocks/handlers.ts
@@ -117,12 +117,18 @@ export function resetSettingsStore(): void {
 			description: 'Company metrics dashboard.',
 		}),
 		// A DCR-registered PUBLIC client awaiting the D7 approval decision:
-		// inactive by construction until approved, no secret (PKCE-only).
+		// inactive by construction until approved, no secret (PKCE-only). The
+		// second redirect URI is a NON-SPECIAL scheme (WHATWG opaque origin)
+		// — exactly the native/MCP client class — pinning the queue headline's
+		// scheme://host derivation instead of a literal "null".
 		seedClient({
 			id: 'oac_pending_1',
 			client_id: 'oc_cursor_ide',
 			name: 'Cursor',
-			redirect_uris: ['http://localhost:33418/callback'],
+			redirect_uris: [
+				'http://localhost:33418/callback',
+				'cursor://anysphere.cursor-mcp/oauth/callback',
+			],
 			token_endpoint_auth_method: 'none',
 			consent_model: 'agent',
 			registration_source: 'dcr',
@@ -301,7 +307,15 @@ export const settingsHandlers = [
 		if (body.active === true && row.approval_status !== 'approved') {
 			return new HttpResponse(null, { status: 409 });
 		}
-		Object.assign(row, body, { updated_at: now() });
+		// allowed_scopes is TRI-STATE on PATCH, mirroring oauth_client_service:
+		// null/omitted = NO CHANGE, ['*'] = reset to unrestricted (stored
+		// null), any other array = restrict to it ([] = OIDC-only). A plain
+		// Object.assign would treat null as "clear" and diverge.
+		const { allowed_scopes: scopeUpdate, ...rest } = body;
+		Object.assign(row, rest, { updated_at: now() });
+		if (scopeUpdate != null) {
+			row.allowed_scopes = scopeUpdate.includes('*') ? null : scopeUpdate;
+		}
 		return HttpResponse.json(withGrantCount(row));
 	}),
 	http.delete('/admin/oauth-clients/:id', ({ params }) => {

--- a/ui/src/modules/settings/mocks/handlers.ts
+++ b/ui/src/modules/settings/mocks/handlers.ts
@@ -2,12 +2,16 @@
  * Settings MSW handlers + in-memory store — the admin OAuth-client registry
  * (`/admin/oauth-clients`), including the D7 approval lifecycle the
  * approval-queue tab drives (pending→approved/denied, denied→approved
- * recovery) and the per-client active-grant count.
+ * recovery), the admin grants cross-view (`/admin/oauth-grants`) backing the
+ * detail sheet's Grants panel, and the client-scoped audit slice
+ * (`/audit?target_type=oauth_client`) backing its "Recent changes" panel.
  *
- * Shapes match the generated `OAuthClientResponse`; the state machine mirrors
- * the backend: approve activates the row, deny keeps it (inactive) so a later
- * approve can reverse the decision. Registered additively in
- * src/mocks/handlers.ts.
+ * Shapes match the generated `OAuthClientResponse` / `OAuthGrantAdminResponse`
+ * / `AuditResponse`; the state machine mirrors the backend: approve activates
+ * the row, deny keeps it (inactive) so a later approve can reverse the
+ * decision, decision/lifecycle verbs append audit rows (deny with the
+ * operator's reason), and `active_grant_count` is computed from the grants
+ * store. Registered additively in src/mocks/handlers.ts.
  */
 import { http, HttpResponse } from 'msw';
 
@@ -29,6 +33,34 @@ interface OAuthClientRow {
 	created_at: string;
 	created_by: string | null;
 	updated_at: string | null;
+}
+
+/** One consent→agent grant in the admin cross-view (`OAuthGrantAdminResponse`). */
+interface OAuthGrantAdminRow {
+	id: string;
+	oauth_client_id: string;
+	client_name: string | null;
+	client_origin: string | null;
+	agent_id: string;
+	user_id: string;
+	scopes: string[];
+	status: 'active' | 'revoked';
+	can_revoke: boolean;
+	created_at: string;
+	revoked_at: string | null;
+	last_used_at: string | null;
+}
+
+/** One client-scoped audit row (`AuditResponse`, target_type=oauth_client). */
+interface OAuthClientAuditRow {
+	id: string;
+	action: string;
+	actor_id: string | null;
+	actor_type: string;
+	target_type: 'oauth_client';
+	target_id: string;
+	reason: string | null;
+	occurred_at: string;
 }
 
 const now = (offsetMin = 0) => new Date(Date.now() + offsetMin * 60_000).toISOString();
@@ -57,16 +89,32 @@ function seedClient(
 
 /** Mutable per-session store. Reset between tests via `resetSettingsStore()`. */
 let oauthClients: OAuthClientRow[] = [];
+let oauthGrants: OAuthGrantAdminRow[] = [];
+let oauthClientAudit: OAuthClientAuditRow[] = [];
+let auditSeq = 0;
+
+function appendAudit(row: OAuthClientRow, action: string, reason: string | null = null): void {
+	oauthClientAudit.unshift({
+		id: `aud_oac_${auditSeq++}`,
+		action,
+		actor_id: 'usr_admin_1',
+		actor_type: 'user',
+		target_type: 'oauth_client',
+		target_id: row.id,
+		reason,
+		occurred_at: now(),
+	});
+}
 
 export function resetSettingsStore(): void {
 	oauthClients = [
-		// An admin-registered confidential client, live, with grants attached.
+		// An admin-registered confidential client, live, with grants attached
+		// (the grants store below carries its two active rows).
 		seedClient({
 			id: 'oac_admin_1',
 			client_id: 'oc_dashboard',
 			name: 'Internal Dashboard',
 			description: 'Company metrics dashboard.',
-			active_grant_count: 2,
 		}),
 		// A DCR-registered PUBLIC client awaiting the D7 approval decision:
 		// inactive by construction until approved, no secret (PKCE-only).
@@ -96,13 +144,107 @@ export function resetSettingsStore(): void {
 			created_at: now(-30),
 			created_by: null,
 		}),
+		// The #1312 "zombie": approved but deactivated — matches neither queue
+		// filter, only surfaced by the roster's Inactive status segment.
+		seedClient({
+			id: 'oac_zombie_1',
+			client_id: 'oc_legacy_app',
+			name: 'Legacy App',
+			approval_status: 'approved',
+			active: false,
+			created_at: now(-240),
+			updated_at: now(-60),
+		}),
 	];
+	oauthGrants = [
+		// Active grant the mock admin CAN revoke.
+		{
+			id: 'ocg_1',
+			oauth_client_id: 'oc_dashboard',
+			client_name: 'Internal Dashboard',
+			client_origin: 'https://app.example.com',
+			agent_id: 'invoice-bot',
+			user_id: 'usr_admin_1',
+			scopes: ['apis:read'],
+			status: 'active',
+			can_revoke: true,
+			created_at: now(-90),
+			revoked_at: null,
+			last_used_at: now(-5),
+		},
+		// Active grant the CALLER may not revoke (G10: list predicate wider
+		// than revoke predicate) — the UI must disable, not offer a 403.
+		{
+			id: 'ocg_2',
+			oauth_client_id: 'oc_dashboard',
+			client_name: 'Internal Dashboard',
+			client_origin: 'https://app.example.com',
+			agent_id: 'support-triage',
+			user_id: 'usr_other_1',
+			scopes: ['apis:read', 'executions:read'],
+			status: 'active',
+			can_revoke: false,
+			created_at: now(-60),
+			revoked_at: null,
+			last_used_at: null,
+		},
+		// Revoked history row — reachable via the Revoked/All filters.
+		{
+			id: 'ocg_3',
+			oauth_client_id: 'oc_dashboard',
+			client_name: 'Internal Dashboard',
+			client_origin: 'https://app.example.com',
+			agent_id: 'invoice-bot',
+			user_id: 'usr_admin_1',
+			scopes: ['apis:read'],
+			status: 'revoked',
+			can_revoke: false,
+			created_at: now(-200),
+			revoked_at: now(-100),
+			last_used_at: now(-150),
+		},
+	];
+	// Decision history for the seeded rows: the denied client carries its
+	// deny REASON (the queue captured it; the detail sheet surfaces it).
+	oauthClientAudit = [
+		{
+			id: 'aud_oac_seed_1',
+			action: 'oauth_client.deny',
+			actor_id: 'usr_admin_1',
+			actor_type: 'user',
+			target_type: 'oauth_client',
+			target_id: 'oac_denied_1',
+			reason: 'unknown redirect URIs',
+			occurred_at: now(-25),
+		},
+		{
+			id: 'aud_oac_seed_2',
+			action: 'oauth_client.register',
+			actor_id: null,
+			actor_type: 'system',
+			target_type: 'oauth_client',
+			target_id: 'oac_admin_1',
+			reason: null,
+			occurred_at: now(-120),
+		},
+	];
+	auditSeq = 0;
 }
 
 resetSettingsStore();
 
 function genId(prefix: string): string {
 	return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** `active_grant_count` is computed on the read path, like the backend. */
+function withGrantCount(row: OAuthClientRow): OAuthClientRow {
+	return {
+		...row,
+		active_grant_count: oauthGrants.filter(
+			(g) => g.oauth_client_id === row.client_id && g.status === 'active',
+		).length,
+	};
 }
 
 export const settingsHandlers = [
@@ -115,15 +257,18 @@ export const settingsHandlers = [
 			// (those rows are inactive by construction — D7).
 			approvalStatus === 'pending' ||
 			approvalStatus === 'denied';
-		const rows = oauthClients.filter(
-			(c) =>
-				(includeInactive || c.active) &&
-				(!approvalStatus || c.approval_status === approvalStatus),
-		);
+		const rows = oauthClients
+			.filter(
+				(c) =>
+					(includeInactive || c.active) &&
+					(!approvalStatus || c.approval_status === approvalStatus),
+			)
+			.map(withGrantCount);
 		return HttpResponse.json({ data: rows, has_more: false, next_cursor: null });
 	}),
 	http.post('/admin/oauth-clients', async ({ request }) => {
 		const body = (await request.json()) as Partial<OAuthClientRow> & { name: string };
+		const authMethod = body.token_endpoint_auth_method ?? 'client_secret_basic';
 		const row = seedClient({
 			id: genId('oac'),
 			client_id: genId('oc'),
@@ -131,19 +276,22 @@ export const settingsHandlers = [
 			description: body.description ?? null,
 			redirect_uris: body.redirect_uris ?? [],
 			allowed_scopes: body.allowed_scopes ?? null,
-			token_endpoint_auth_method: body.token_endpoint_auth_method ?? 'client_secret_basic',
+			token_endpoint_auth_method: authMethod,
+			consent_model: body.consent_model ?? 'user',
 			require_consent: body.require_consent ?? true,
 			created_at: now(),
 		});
 		oauthClients.push(row);
-		return HttpResponse.json(
-			{ ...row, client_secret: 'ocs_mock_secret_once' },
-			{ status: 201 },
-		);
+		appendAudit(row, 'oauth_client.create');
+		// Public (PKCE-only) clients get no secret — mirror the backend.
+		const secret = authMethod === 'none' ? null : 'ocs_mock_secret_once';
+		return HttpResponse.json({ ...row, client_secret: secret }, { status: 201 });
 	}),
 	http.get('/admin/oauth-clients/:id', ({ params }) => {
 		const row = oauthClients.find((c) => c.id === params.id);
-		return row ? HttpResponse.json(row) : new HttpResponse(null, { status: 404 });
+		return row
+			? HttpResponse.json(withGrantCount(row))
+			: new HttpResponse(null, { status: 404 });
 	}),
 	http.patch('/admin/oauth-clients/:id', async ({ params, request }) => {
 		const row = oauthClients.find((c) => c.id === params.id);
@@ -154,12 +302,13 @@ export const settingsHandlers = [
 			return new HttpResponse(null, { status: 409 });
 		}
 		Object.assign(row, body, { updated_at: now() });
-		return HttpResponse.json(row);
+		return HttpResponse.json(withGrantCount(row));
 	}),
 	http.delete('/admin/oauth-clients/:id', ({ params }) => {
 		const row = oauthClients.find((c) => c.id === params.id);
 		if (!row) return new HttpResponse(null, { status: 404 });
 		row.active = false;
+		appendAudit(row, 'oauth_client.deactivate');
 		return new HttpResponse(null, { status: 204 });
 	}),
 	http.post('/admin/oauth-clients/:id/rotate-secret', ({ params }) => {
@@ -168,6 +317,7 @@ export const settingsHandlers = [
 		if (row.token_endpoint_auth_method === 'none') {
 			return new HttpResponse(null, { status: 409 });
 		}
+		appendAudit(row, 'oauth_client.rotate_secret');
 		return HttpResponse.json({ client_secret: 'ocs_mock_rotated_once' });
 	}),
 	// D7 approval verbs: approve activates; deny keeps the row for recovery.
@@ -177,14 +327,52 @@ export const settingsHandlers = [
 		row.approval_status = 'approved';
 		row.active = true;
 		row.updated_at = now();
-		return HttpResponse.json(row);
+		appendAudit(row, 'oauth_client.approve');
+		return HttpResponse.json(withGrantCount(row));
 	}),
-	http.post('/admin/oauth-clients/:id\\:deny', ({ params }) => {
+	http.post('/admin/oauth-clients/:id\\:deny', async ({ params, request }) => {
 		const row = oauthClients.find((c) => c.id === params.id);
 		if (!row) return new HttpResponse(null, { status: 404 });
+		const body = (await request.json().catch(() => null)) as { reason?: string } | null;
 		row.approval_status = 'denied';
 		row.active = false;
 		row.updated_at = now();
-		return HttpResponse.json(row);
+		appendAudit(row, 'oauth_client.deny', body?.reason ?? null);
+		return HttpResponse.json(withGrantCount(row));
+	}),
+	// ---- Admin grants cross-view: the detail sheet's Grants panel ----
+	http.get('/admin/oauth-grants', ({ request }) => {
+		const url = new URL(request.url);
+		const clientId = url.searchParams.get('client_id');
+		const status = url.searchParams.get('status');
+		const rows = oauthGrants.filter(
+			(g) =>
+				(!clientId || g.oauth_client_id === clientId) && (!status || g.status === status),
+		);
+		return HttpResponse.json({ data: rows, has_more: false, next_cursor: null });
+	}),
+	// The §4.6 grant kill switch. The agents module registers the same path
+	// for ITS store and falls through (returns undefined) for unknown grant
+	// ids, so this handler answers for the settings-store grants.
+	http.post('/oauth-grants/:id\\:revoke', ({ params }) => {
+		const grant = oauthGrants.find((g) => g.id === params.id);
+		if (!grant) return undefined;
+		// Idempotent, like the backend: re-revoking is a 204 no-op.
+		if (grant.status === 'active') {
+			grant.status = 'revoked';
+			grant.revoked_at = now();
+			grant.can_revoke = false;
+		}
+		return new HttpResponse(null, { status: 204 });
+	}),
+	// Client-scoped audit slice ("Recent changes"): answer only for
+	// oauth_client targets, else fall through (the agents module owns actor
+	// targets; the monitor module owns the org-wide fixture).
+	http.get('/audit', ({ request }) => {
+		const url = new URL(request.url);
+		if (url.searchParams.get('target_type') !== 'oauth_client') return undefined;
+		const targetId = url.searchParams.get('target_id');
+		const rows = oauthClientAudit.filter((a) => !targetId || a.target_id === targetId);
+		return HttpResponse.json({ data: rows, has_more: false, next_cursor: null });
 	}),
 ];

--- a/ui/src/modules/settings/mocks/handlers.ts
+++ b/ui/src/modules/settings/mocks/handlers.ts
@@ -139,10 +139,26 @@ export function resetSettingsStore(): void {
 			created_by: null,
 		}),
 		// A previously denied DCR client — the denied→approved recovery path.
+		// Deliberately noisy (many scopes, several redirect URIs) so the
+		// queue card's "+N more" scope expander and the redirect-URI
+		// disclosure have a real target.
 		seedClient({
 			id: 'oac_denied_1',
 			client_id: 'oc_sketchy_tool',
 			name: 'Sketchy Tool',
+			redirect_uris: [
+				'https://sketchy.example.com/cb',
+				'https://sketchy.example.com/cb2',
+				'https://alt.sketchy.example.com/cb',
+			],
+			allowed_scopes: [
+				'apis:read',
+				'apis:write',
+				'agents:read',
+				'agents:write',
+				'credentials:read',
+				'audit:read',
+			],
 			token_endpoint_auth_method: 'none',
 			registration_source: 'dcr',
 			approval_status: 'denied',

--- a/ui/src/modules/settings/pages/OAuthClientsSection.tsx
+++ b/ui/src/modules/settings/pages/OAuthClientsSection.tsx
@@ -266,6 +266,7 @@ export function OAuthClientsSection() {
 				onEdit={openEdit}
 				onRotate={setRotateTarget}
 				onDeactivate={setDeactivateTarget}
+				onReactivate={(client): void => void handleReactivate(client)}
 			/>
 
 			{/* Stateless confirms — conditional mounting is fine here. */}

--- a/ui/src/modules/settings/pages/OAuthClientsSection.tsx
+++ b/ui/src/modules/settings/pages/OAuthClientsSection.tsx
@@ -1,652 +1,38 @@
-import { useEffect, useRef, useState } from 'react';
+/**
+ * OAuthClientsSection — orchestration for the OAuth-clients settings surface.
+ *
+ * Composition only (the rebuild plan's decomposition): the roster
+ * (`ClientsTable`), the D7 approval queue (`ApprovalQueue`), the detail
+ * console (`ClientDetailSheet`), the create/edit form (`ClientFormSheet`),
+ * and the section-level confirm/secret dialogs. Data wiring stays in
+ * `settings/api/hooks.ts`.
+ *
+ * The active tab lives in `?tab=` so the agent rail's "Review" action on an
+ * `oauth_client.registered` alert can deep-link straight to the queue; the
+ * queue's pending/denied filter is lifted here so a denied roster row's
+ * "Review in queue" verb lands directly on the Denied slice.
+ */
+import { useState } from 'react';
 import { useSearchParams } from 'react-router';
+import { KeyRound, Plus, ShieldQuestion } from 'lucide-react';
+import { Button, PageHelp, TabNav, toast, type TabNavOption } from '@/shared/ui';
 import {
-	Plus,
-	Trash2,
-	Pencil,
-	KeyRound,
-	RotateCcw,
-	ShieldAlert,
-	ShieldQuestion,
-	CheckCircle2,
-	X,
-} from 'lucide-react';
-import {
-	Badge,
-	Button,
-	CopyButton,
-	Dialog,
-	EmptyState,
-	Input,
-	Label,
-	LoadingState,
-	PageHelp,
-	SegmentedToggle,
-	TabNav,
-	toast,
-	type SegmentedToggleOption,
-	type TabNavOption,
-} from '@/shared/ui';
-import {
-	useOAuthClients,
-	useOAuthClientQueue,
-	useApproveOAuthClient,
-	useDenyOAuthClient,
-	useCreateOAuthClient,
-	useUpdateOAuthClient,
 	useDeactivateOAuthClient,
+	useOAuthClientQueue,
+	useOAuthClients,
 	useReactivateOAuthClient,
 	useRotateOAuthClientSecret,
-	usePermissionCatalogue,
 	type OAuthClient,
 } from '@/modules/settings/api/hooks';
-
-interface SecretDialogProps {
-	open: boolean;
-	onClose: () => void;
-	secret: string;
-	title: string;
-}
-
-function SecretDialog({ open, onClose, secret, title }: SecretDialogProps) {
-	return (
-		<Dialog
-			open={open}
-			onClose={onClose}
-			title={title}
-			dismissOnBackdrop={false}
-			footer={<Button onClick={onClose}>Done</Button>}
-		>
-			<div className="space-y-3">
-				<p className="text-muted-foreground text-xs">
-					Copy this secret now — it is shown only once and cannot be retrieved again.
-				</p>
-				<div className="bg-card border-border flex items-center gap-2 rounded-md border p-2">
-					<code className="text-foreground min-w-0 flex-1 overflow-x-auto font-mono text-xs">
-						{secret}
-					</code>
-					<CopyButton value={secret} variant="ghost" size="icon" toastMessage={false} />
-				</div>
-			</div>
-		</Dialog>
-	);
-}
-
-interface RedirectUriListProps {
-	uris: string[];
-	onChange: (uris: string[]) => void;
-}
-
-const nextUriKey = { current: 0 };
-
-function RedirectUriList({ uris, onChange }: RedirectUriListProps) {
-	const [keys, setKeys] = useState(() => uris.map(() => nextUriKey.current++));
-
-	const handleChange = (index: number, value: string): void => {
-		const updated = [...uris];
-		updated[index] = value;
-		onChange(updated);
-	};
-
-	const handleRemove = (index: number): void => {
-		setKeys((prev) => prev.filter((_, i) => i !== index));
-		onChange(uris.filter((_, i) => i !== index));
-	};
-
-	const handleAdd = (): void => {
-		setKeys((prev) => [...prev, nextUriKey.current++]);
-		onChange([...uris, '']);
-	};
-
-	return (
-		<div className="space-y-2">
-			{uris.map((uri, index) => (
-				<div key={keys[index]} className="flex items-center gap-2">
-					<Input
-						value={uri}
-						onChange={(e): void => handleChange(index, e.target.value)}
-						placeholder="https://example.com/callback"
-						className="flex-1"
-					/>
-					<Button
-						type="button"
-						variant="ghost"
-						size="sm"
-						onClick={(): void => handleRemove(index)}
-						disabled={uris.length <= 1}
-						aria-label="Remove URI"
-					>
-						<Trash2 className="h-4 w-4" />
-					</Button>
-				</div>
-			))}
-			<Button type="button" variant="outline" size="sm" onClick={handleAdd}>
-				<Plus className="mr-1 h-3 w-3" />
-				Add URI
-			</Button>
-		</div>
-	);
-}
-
-interface ScopeSelectorProps {
-	scopes: string[];
-	onChange: (scopes: string[]) => void;
-}
-
-function ScopeSelector({ scopes, onChange }: ScopeSelectorProps) {
-	const [customInput, setCustomInput] = useState('');
-	const { data: catalogue = [] } = usePermissionCatalogue();
-	const catalogueNames = catalogue.map((p) => p.name);
-
-	const toggle = (scope: string): void => {
-		if (scopes.includes(scope)) {
-			onChange(scopes.filter((s) => s !== scope));
-		} else {
-			onChange([...scopes, scope]);
-		}
-	};
-
-	const addCustom = (): void => {
-		const trimmed = customInput.trim();
-		if (trimmed && !scopes.includes(trimmed)) {
-			onChange([...scopes, trimmed]);
-			setCustomInput('');
-		}
-	};
-
-	return (
-		<div className="space-y-2">
-			<div className="flex flex-wrap gap-1.5">
-				{catalogue.map((perm) => {
-					const selected = scopes.includes(perm.name);
-					return (
-						<button
-							key={perm.name}
-							type="button"
-							onClick={(): void => toggle(perm.name)}
-							title={perm.description}
-							className={`rounded-full border px-2 py-0.5 text-xs transition ${
-								selected
-									? 'border-primary bg-primary/10 text-primary'
-									: 'border-border text-muted-foreground hover:border-primary/50'
-							}`}
-						>
-							{perm.name}
-						</button>
-					);
-				})}
-			</div>
-			{scopes.filter((s) => !catalogueNames.includes(s)).length > 0 && (
-				<div className="flex flex-wrap gap-1">
-					{scopes
-						.filter((s) => !catalogueNames.includes(s))
-						.map((s) => (
-							<span
-								key={s}
-								className="border-primary bg-primary/10 text-primary inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
-							>
-								{s}
-								<button
-									type="button"
-									onClick={(): void => onChange(scopes.filter((x) => x !== s))}
-									className="hover:text-destructive"
-								>
-									<X className="h-3 w-3" />
-								</button>
-							</span>
-						))}
-				</div>
-			)}
-			<div className="flex items-center gap-2">
-				<Input
-					value={customInput}
-					onChange={(e): void => setCustomInput(e.target.value)}
-					placeholder="custom:scope"
-					className="flex-1"
-					onKeyDown={(e): void => {
-						if (e.key === 'Enter') {
-							e.preventDefault();
-							addCustom();
-						}
-					}}
-				/>
-				<Button type="button" variant="outline" size="sm" onClick={addCustom}>
-					Add
-				</Button>
-			</div>
-		</div>
-	);
-}
-
-interface CreateEditDialogProps {
-	open: boolean;
-	onClose: () => void;
-	onSecretRevealed?: (secret: string) => void;
-	client?: OAuthClient;
-}
-
-function CreateEditDialog({ open, onClose, onSecretRevealed, client }: CreateEditDialogProps) {
-	const [name, setName] = useState(client?.name ?? '');
-	const [description, setDescription] = useState(client?.description ?? '');
-	const [redirectUris, setRedirectUris] = useState<string[]>(
-		client?.redirect_uris.length ? client.redirect_uris : [''],
-	);
-	const [requireConsent, setRequireConsent] = useState(client?.require_consent ?? true);
-	const [restrictScopes, setRestrictScopes] = useState(client?.allowed_scopes != null);
-	const [allowedScopes, setAllowedScopes] = useState<string[]>(client?.allowed_scopes ?? []);
-
-	const createMutation = useCreateOAuthClient();
-	const updateMutation = useUpdateOAuthClient();
-
-	const isEdit = !!client;
-	const isPending = createMutation.isPending || updateMutation.isPending;
-
-	const handleSubmit = async (e: React.FormEvent): Promise<void> => {
-		e.preventDefault();
-		const uris = redirectUris.map((s) => s.trim()).filter(Boolean);
-
-		if (!name.trim() || uris.length === 0) {
-			toast({ title: 'Name and at least one redirect URI required', variant: 'error' });
-			return;
-		}
-
-		try {
-			const scopePayload = restrictScopes ? allowedScopes : null;
-			if (isEdit) {
-				await updateMutation.mutateAsync({
-					id: client.id,
-					input: {
-						name: name.trim(),
-						description: description.trim() || null,
-						redirect_uris: uris,
-						require_consent: requireConsent,
-						allowed_scopes: scopePayload,
-					},
-				});
-				toast({ title: 'OAuth client updated', variant: 'success' });
-				onClose();
-			} else {
-				const result = await createMutation.mutateAsync({
-					name: name.trim(),
-					description: description.trim() || undefined,
-					redirect_uris: uris,
-					require_consent: requireConsent,
-					allowed_scopes: scopePayload,
-				});
-				onClose();
-				if (result.client_secret) {
-					onSecretRevealed?.(result.client_secret);
-				}
-			}
-		} catch (err) {
-			toast({
-				title: isEdit ? 'Failed to update client' : 'Failed to create client',
-				description: err instanceof Error ? err.message : undefined,
-				variant: 'error',
-			});
-		}
-	};
-
-	return (
-		<Dialog
-			open={open}
-			onClose={onClose}
-			title={isEdit ? 'Edit OAuth Client' : 'Create OAuth Client'}
-			footer={
-				<>
-					<Button variant="outline" onClick={onClose}>
-						Cancel
-					</Button>
-					<Button type="submit" form="oauth-client-form" disabled={isPending}>
-						{isPending ? 'Saving...' : isEdit ? 'Update' : 'Create'}
-					</Button>
-				</>
-			}
-		>
-			<form
-				id="oauth-client-form"
-				onSubmit={(e): void => void handleSubmit(e)}
-				className="space-y-4"
-			>
-				<div>
-					<Label htmlFor="name">Name</Label>
-					<Input
-						id="name"
-						value={name}
-						onChange={(e): void => setName(e.target.value)}
-						placeholder="e.g., my-app-production"
-						required
-					/>
-				</div>
-				<div>
-					<Label htmlFor="description">Description (optional)</Label>
-					<Input
-						id="description"
-						value={description}
-						onChange={(e): void => setDescription(e.target.value)}
-						placeholder="e.g., Production deployment for user auth"
-					/>
-				</div>
-				<div>
-					<Label>Redirect URIs</Label>
-					<RedirectUriList uris={redirectUris} onChange={setRedirectUris} />
-				</div>
-				<div className="flex items-center gap-2">
-					<input
-						type="checkbox"
-						id="require_consent"
-						checked={requireConsent}
-						onChange={(e): void => setRequireConsent(e.target.checked)}
-						className="h-4 w-4"
-					/>
-					<Label htmlFor="require_consent">Require consent screen</Label>
-				</div>
-				<div className="space-y-2">
-					<div className="flex items-center gap-2">
-						<input
-							type="checkbox"
-							id="restrict_scopes"
-							checked={restrictScopes}
-							onChange={(e): void => setRestrictScopes(e.target.checked)}
-							className="h-4 w-4"
-						/>
-						<Label htmlFor="restrict_scopes">Restrict allowed scopes</Label>
-					</div>
-					{restrictScopes && (
-						<ScopeSelector scopes={allowedScopes} onChange={setAllowedScopes} />
-					)}
-					{restrictScopes && allowedScopes.length === 0 && (
-						<p className="text-muted-foreground text-xs">
-							No scopes selected — this client will only be able to request OIDC
-							scopes (openid, email, profile).
-						</p>
-					)}
-				</div>
-			</form>
-		</Dialog>
-	);
-}
-
-interface RotateConfirmDialogProps {
-	open: boolean;
-	onClose: () => void;
-	onConfirm: () => void;
-	isPending: boolean;
-	clientName: string;
-}
-
-function RotateConfirmDialog({
-	open,
-	onClose,
-	onConfirm,
-	isPending,
-	clientName,
-}: RotateConfirmDialogProps) {
-	return (
-		<Dialog
-			open={open}
-			onClose={onClose}
-			title="Rotate Client Secret?"
-			footer={
-				<>
-					<Button variant="outline" onClick={onClose}>
-						Cancel
-					</Button>
-					<Button variant="danger" onClick={onConfirm} disabled={isPending}>
-						{isPending ? 'Rotating...' : 'Rotate Secret'}
-					</Button>
-				</>
-			}
-		>
-			<p className="text-muted-foreground">
-				This will invalidate the current secret for <strong>{clientName}</strong>{' '}
-				immediately. Any application using the old secret will lose access.
-			</p>
-		</Dialog>
-	);
-}
-
-/**
- * Row badges shared by the clients list and the approval queue: `Public`
- * (secret-less PKCE client, D5), `DCR` (front-door registration, D8), and the
- * approval state when it isn't plain `approved` (D7).
- */
-function ClientBadges({ client }: { client: OAuthClient }) {
-	return (
-		<>
-			{client.token_endpoint_auth_method === 'none' && (
-				<Badge variant="default">Public</Badge>
-			)}
-			{client.registration_source === 'dcr' && <Badge variant="default">DCR</Badge>}
-			{client.approval_status === 'pending' && <Badge variant="pending">Pending</Badge>}
-			{client.approval_status === 'denied' && <Badge variant="danger">Denied</Badge>}
-		</>
-	);
-}
-
-interface DenyClientDialogProps {
-	/** The client under decision; null only before the first Deny click. */
-	client: OAuthClient | null;
-	open: boolean;
-	onClose: () => void;
-	onConfirm: (reason: string) => void;
-	isPending: boolean;
-}
-
-/**
- * Deny confirmation with an optional reason draft. Mounted once and toggled
- * via `open` (dialog-state rule: persist between dismissals, reset on
- * successful commit) — a casual Esc/backdrop dismiss keeps the half-typed
- * reason. The draft resets when the TARGET changes (a different client's
- * denial is a different draft), which also covers the success path: the
- * parent clears the target after a committed deny.
- */
-function DenyClientDialog({ client, open, onClose, onConfirm, isPending }: DenyClientDialogProps) {
-	const [reason, setReason] = useState('');
-	const lastIdRef = useRef(client?.id);
-	useEffect(() => {
-		if (lastIdRef.current !== client?.id) {
-			lastIdRef.current = client?.id;
-			setReason('');
-		}
-	}, [client?.id]);
-	return (
-		<Dialog
-			open={open && client != null}
-			onClose={onClose}
-			title="Deny OAuth Client?"
-			footer={
-				<>
-					<Button variant="outline" onClick={onClose}>
-						Cancel
-					</Button>
-					<Button
-						variant="danger"
-						onClick={(): void => onConfirm(reason.trim())}
-						disabled={isPending}
-					>
-						{isPending ? 'Denying...' : 'Deny'}
-					</Button>
-				</>
-			}
-		>
-			<div className="space-y-3">
-				<p className="text-muted-foreground">
-					<strong>{client?.name}</strong> will not be able to start authorization flows.
-					The registration is kept, so you can approve it later to reverse this.
-				</p>
-				<div>
-					<Label htmlFor="deny-reason">Reason (optional)</Label>
-					<Input
-						id="deny-reason"
-						value={reason}
-						onChange={(e): void => setReason(e.target.value)}
-						placeholder="e.g., unknown redirect URIs"
-					/>
-				</div>
-			</div>
-		</Dialog>
-	);
-}
-
-type QueueFilter = 'pending' | 'denied';
-
-const QUEUE_FILTER_OPTIONS: SegmentedToggleOption<QueueFilter>[] = [
-	{ value: 'pending', label: 'Pending' },
-	{ value: 'denied', label: 'Denied' },
-];
-
-/**
- * The DCR approval queue (D7): registrations land `pending` +
- * inactive; Approve activates them, Deny keeps the row (reversible — the
- * Denied filter re-offers Approve as the recovery path). Approval-first is
- * the default everywhere (D7 as amended 2026-09-03): every fresh instance's
- * first DCR client lands here. With the explicit `auto_approve_clients: true`
- * opt-in the queue is normally empty.
- */
-function ApprovalQueueTab() {
-	const [filter, setFilter] = useState<QueueFilter>('pending');
-	const { data: clients, isLoading, error } = useOAuthClientQueue(filter);
-	const approveMutation = useApproveOAuthClient();
-	const denyMutation = useDenyOAuthClient();
-	// Target + open are separate so a casual dismiss keeps the target (and the
-	// dialog's reason draft — dialog-state rule); only a committed deny clears it.
-	const [denyTarget, setDenyTarget] = useState<OAuthClient | null>(null);
-	const [denyOpen, setDenyOpen] = useState(false);
-
-	const handleApprove = async (client: OAuthClient): Promise<void> => {
-		try {
-			await approveMutation.mutateAsync(client.id);
-			toast({ title: `${client.name} approved`, variant: 'success' });
-		} catch (err) {
-			toast({
-				title: 'Failed to approve client',
-				description: err instanceof Error ? err.message : undefined,
-				variant: 'error',
-			});
-		}
-	};
-
-	const handleDeny = async (reason: string): Promise<void> => {
-		if (!denyTarget) return;
-		try {
-			await denyMutation.mutateAsync({
-				id: denyTarget.id,
-				reason: reason || undefined,
-			});
-			toast({ title: `${denyTarget.name} denied`, variant: 'success' });
-			setDenyOpen(false);
-			// Clearing the target resets the dialog's reason draft (commit path).
-			setDenyTarget(null);
-		} catch (err) {
-			toast({
-				title: 'Failed to deny client',
-				description: err instanceof Error ? err.message : undefined,
-				variant: 'error',
-			});
-		}
-	};
-
-	return (
-		<div className="space-y-4">
-			<SegmentedToggle options={QUEUE_FILTER_OPTIONS} value={filter} onChange={setFilter} />
-
-			{isLoading ? (
-				<LoadingState message="Loading approval queue..." />
-			) : error ? (
-				<p className="text-destructive">Failed to load the approval queue</p>
-			) : !clients?.length ? (
-				<EmptyState
-					icon={<CheckCircle2 className="h-6 w-6" />}
-					title={filter === 'pending' ? 'No pending registrations' : 'No denied clients'}
-					description={
-						filter === 'pending'
-							? 'Client registrations awaiting approval will appear here.'
-							: 'Denied registrations are kept here — approving one reverses the decision.'
-					}
-				/>
-			) : (
-				<div className="space-y-4">
-					{clients.map((client) => (
-						<div key={client.id} className="border-border rounded-lg border p-4">
-							<div className="flex items-start justify-between gap-3">
-								<div className="min-w-0">
-									<h3 className="text-foreground flex flex-wrap items-center gap-2 font-medium">
-										{client.name}
-										<ClientBadges client={client} />
-									</h3>
-									{client.description && (
-										<p className="text-muted-foreground text-sm">
-											{client.description}
-										</p>
-									)}
-								</div>
-								<div className="flex shrink-0 gap-2">
-									<Button
-										size="sm"
-										onClick={(): void => void handleApprove(client)}
-										disabled={approveMutation.isPending}
-									>
-										Approve
-									</Button>
-									{client.approval_status !== 'denied' && (
-										<Button
-											size="sm"
-											variant="outline"
-											onClick={(): void => {
-												setDenyTarget(client);
-												setDenyOpen(true);
-											}}
-											disabled={denyMutation.isPending}
-										>
-											Deny
-										</Button>
-									)}
-								</div>
-							</div>
-							<div className="mt-3 space-y-2 text-sm">
-								<div>
-									<span className="text-muted-foreground">Client ID: </span>
-									<code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
-										{client.client_id}
-									</code>
-								</div>
-								{client.software_id && (
-									<div>
-										<span className="text-muted-foreground">Software ID: </span>
-										<code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
-											{client.software_id}
-										</code>
-									</div>
-								)}
-								<div>
-									<span className="text-muted-foreground">Redirect URIs: </span>
-									<ul className="text-foreground mt-1 list-inside list-disc pl-1">
-										{client.redirect_uris.map((uri) => (
-											<li key={uri} className="truncate font-mono text-xs">
-												{uri}
-											</li>
-										))}
-									</ul>
-								</div>
-							</div>
-						</div>
-					))}
-				</div>
-			)}
-
-			{/* Mounted persistently (not `{target && …}`) so a casual dismiss
-			    keeps the reason draft — see DenyClientDialog. */}
-			<DenyClientDialog
-				client={denyTarget}
-				open={denyOpen}
-				onClose={(): void => setDenyOpen(false)}
-				onConfirm={(reason): void => void handleDeny(reason)}
-				isPending={denyMutation.isPending}
-			/>
-		</div>
-	);
-}
+import { ClientsTable, type ClientAction } from '@/modules/settings/components/ClientsTable';
+import { ApprovalQueue, type QueueFilter } from '@/modules/settings/components/ApprovalQueue';
+import { ClientDetailSheet } from '@/modules/settings/components/ClientDetailSheet';
+import { ClientFormSheet } from '@/modules/settings/components/ClientFormSheet';
+import {
+	DeactivateConfirmDialog,
+	RotateConfirmDialog,
+	SecretDialog,
+} from '@/modules/settings/components/ClientLifecycleDialogs';
 
 const SECTION_TABS = ['clients', 'queue'] as const;
 type SectionTab = (typeof SECTION_TABS)[number];
@@ -656,14 +42,13 @@ function isSectionTab(value: string | null): value is SectionTab {
 }
 
 export function OAuthClientsSection() {
-	// Tab lives in `?tab=` so the rail's "Review" action on an
-	// `oauth_client.registered` alert can deep-link straight to the queue.
 	const [searchParams, setSearchParams] = useSearchParams();
 	const tabParam = searchParams.get('tab');
 	const activeTab: SectionTab = isSectionTab(tabParam) ? tabParam : 'clients';
 	// Fetched at section level so the queue tab label can carry the pending
 	// count even while the clients tab is active.
 	const { data: pendingClients } = useOAuthClientQueue('pending');
+	const [queueFilter, setQueueFilter] = useState<QueueFilter>('pending');
 
 	const setTab = (tab: SectionTab): void => {
 		setSearchParams(
@@ -677,42 +62,42 @@ export function OAuthClientsSection() {
 		);
 	};
 
-	const tabOptions: TabNavOption<SectionTab>[] = [
-		{ value: 'clients', label: 'Clients', icon: <KeyRound className="h-4 w-4" /> },
-		{
-			value: 'queue',
-			label: 'Approval queue',
-			icon: <ShieldQuestion className="h-4 w-4" />,
-			count: pendingClients?.length || undefined,
-		},
-	];
+	// One include_inactive read backs the roster: the status segments partition
+	// the joint (approval_status, active) state client-side — including the
+	// approved+inactive zombies the old "Show inactive" checkbox hid (#1312).
+	const clientsQuery = useOAuthClients(true);
 
+	// Sheet/dialog targets. Target + open are separate for the sheets so a
+	// dismissal keeps the mounted component (and any draft) alive.
 	const [createOpen, setCreateOpen] = useState(false);
-	const [editClient, setEditClient] = useState<OAuthClient | null>(null);
-	const [deleteTarget, setDeleteTarget] = useState<OAuthClient | null>(null);
+	const [editTarget, setEditTarget] = useState<OAuthClient | null>(null);
+	const [editOpen, setEditOpen] = useState(false);
+	const [detailTarget, setDetailTarget] = useState<OAuthClient | null>(null);
+	const [detailOpen, setDetailOpen] = useState(false);
+	const [deactivateTarget, setDeactivateTarget] = useState<OAuthClient | null>(null);
 	const [rotateTarget, setRotateTarget] = useState<OAuthClient | null>(null);
 	const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
 	const [secretDialogTitle, setSecretDialogTitle] = useState('Client Secret');
-	const [showInactive, setShowInactive] = useState(false);
 
-	const { data: clients, isLoading, error, refetch } = useOAuthClients(showInactive);
 	const deactivateMutation = useDeactivateOAuthClient();
 	const reactivateMutation = useReactivateOAuthClient();
 	const rotateMutation = useRotateOAuthClientSecret();
+	const inFlight = [deactivateMutation, reactivateMutation, rotateMutation].find(
+		(m) => m.isPending,
+	);
+	const pendingId = typeof inFlight?.variables === 'string' ? inFlight.variables : null;
 
-	const handleDeactivate = async (): Promise<void> => {
-		if (!deleteTarget) return;
-		try {
-			await deactivateMutation.mutateAsync(deleteTarget.id);
-			toast({ title: 'OAuth client deactivated', variant: 'success' });
-			setDeleteTarget(null);
-		} catch (err) {
-			toast({
-				title: 'Failed to deactivate client',
-				description: err instanceof Error ? err.message : undefined,
-				variant: 'error',
-			});
-		}
+	const openDetail = (client: OAuthClient): void => {
+		setDetailTarget(client);
+		setDetailOpen(true);
+	};
+
+	const openEdit = (client: OAuthClient): void => {
+		// Close the detail sheet first — two stacked right-side sheets would
+		// double the focus traps and both would answer the same Escape.
+		setDetailOpen(false);
+		setEditTarget(client);
+		setEditOpen(true);
 	};
 
 	const handleReactivate = async (client: OAuthClient): Promise<void> => {
@@ -722,6 +107,44 @@ export function OAuthClientsSection() {
 		} catch (err) {
 			toast({
 				title: 'Failed to reactivate client',
+				description: err instanceof Error ? err.message : undefined,
+				variant: 'error',
+			});
+		}
+	};
+
+	const handleAction = (client: OAuthClient, action: ClientAction): void => {
+		switch (action) {
+			case 'edit':
+				openEdit(client);
+				break;
+			case 'rotate':
+				setRotateTarget(client);
+				break;
+			case 'deactivate':
+				setDeactivateTarget(client);
+				break;
+			case 'reactivate':
+				// Only reachable for approved+inactive rows (`canReactivate`) —
+				// a denied row's recovery is the queue's Approve verb instead.
+				void handleReactivate(client);
+				break;
+			case 'review-in-queue':
+				setQueueFilter('denied');
+				setTab('queue');
+				break;
+		}
+	};
+
+	const handleDeactivate = async (): Promise<void> => {
+		if (!deactivateTarget) return;
+		try {
+			await deactivateMutation.mutateAsync(deactivateTarget.id);
+			toast({ title: 'OAuth client deactivated', variant: 'success' });
+			setDeactivateTarget(null);
+		} catch (err) {
+			toast({
+				title: 'Failed to deactivate client',
 				description: err instanceof Error ? err.message : undefined,
 				variant: 'error',
 			});
@@ -744,10 +167,15 @@ export function OAuthClientsSection() {
 		}
 	};
 
-	const handleSecretRevealed = (secret: string): void => {
-		setSecretDialogTitle('Client Secret Created');
-		setRevealedSecret(secret);
-	};
+	const tabOptions: TabNavOption<SectionTab>[] = [
+		{ value: 'clients', label: 'Clients', icon: <KeyRound className="h-4 w-4" /> },
+		{
+			value: 'queue',
+			label: 'Approval queue',
+			icon: <ShieldQuestion className="h-4 w-4" />,
+			count: pendingClients?.length || undefined,
+		},
+	];
 
 	return (
 		<section>
@@ -782,8 +210,8 @@ export function OAuthClientsSection() {
 								body: 'OAuth callbacks are only allowed to URLs in this list. Include all environments (dev, staging, prod).',
 							},
 							{
-								heading: 'Consent screen',
-								body: 'When enabled, users see a consent screen before authorizing. Disable for trusted first-party apps.',
+								heading: 'Approval queue',
+								body: 'Clients that register themselves (DCR) wait in the queue until an admin approves them. Judge a registration by its redirect-URI origins — the name is self-reported.',
 							},
 						]}
 					/>
@@ -798,229 +226,59 @@ export function OAuthClientsSection() {
 				className="mb-4"
 			/>
 
-			{activeTab === 'queue' && <ApprovalQueueTab />}
+			{activeTab === 'queue' && (
+				<ApprovalQueue filter={queueFilter} onFilterChange={setQueueFilter} />
+			)}
 
 			{activeTab === 'clients' && (
-				<>
-					<div className="mb-4 flex items-center justify-between">
-						<div className="flex items-center gap-2">
-							<input
-								type="checkbox"
-								id="show-inactive"
-								checked={showInactive}
-								onChange={(e): void => setShowInactive(e.target.checked)}
-								className="h-4 w-4"
-							/>
-							<Label htmlFor="show-inactive" className="text-sm">
-								Show inactive
-							</Label>
-						</div>
-						<Button variant="ghost" size="sm" onClick={(): void => void refetch()}>
-							Refresh
-						</Button>
-					</div>
-
-					{isLoading ? (
-						<LoadingState message="Loading OAuth clients..." />
-					) : error ? (
-						<p className="text-destructive">Failed to load OAuth clients</p>
-					) : !clients?.length ? (
-						<EmptyState
-							icon={<KeyRound className="h-6 w-6" />}
-							title="No OAuth clients"
-							description="Register an OAuth client to allow third-party applications to authenticate with Jentic One."
-							action={
-								<Button onClick={(): void => setCreateOpen(true)}>
-									<Plus className="mr-2 h-4 w-4" />
-									Create your first client
-								</Button>
-							}
-						/>
-					) : (
-						<div className="space-y-4">
-							{clients.map((client) => (
-								<div
-									key={client.id}
-									className={`border-border rounded-lg border p-4 ${!client.active ? 'opacity-50' : ''}`}
-								>
-									<div className="flex items-start justify-between">
-										<div>
-											<h3 className="text-foreground flex flex-wrap items-center gap-2 font-medium">
-												{client.name}
-												<ClientBadges client={client} />
-												{!client.active && (
-													<span className="bg-muted text-muted-foreground rounded px-1.5 py-0.5 text-xs">
-														Inactive
-													</span>
-												)}
-											</h3>
-											{client.description && (
-												<p className="text-muted-foreground text-sm">
-													{client.description}
-												</p>
-											)}
-										</div>
-										<div className="flex gap-1">
-											{client.active &&
-												client.token_endpoint_auth_method !== 'none' && (
-													<Button
-														variant="ghost"
-														size="sm"
-														onClick={(): void =>
-															setRotateTarget(client)
-														}
-														title="Rotate secret"
-													>
-														<ShieldAlert className="h-4 w-4" />
-													</Button>
-												)}
-											<Button
-												variant="ghost"
-												size="sm"
-												onClick={(): void => setEditClient(client)}
-											>
-												<Pencil className="h-4 w-4" />
-											</Button>
-											{client.active ? (
-												<Button
-													variant="ghost"
-													size="sm"
-													onClick={(): void => setDeleteTarget(client)}
-												>
-													<Trash2 className="h-4 w-4" />
-												</Button>
-											) : (
-												<Button
-													variant="ghost"
-													size="sm"
-													onClick={(): void =>
-														void handleReactivate(client)
-													}
-													disabled={reactivateMutation.isPending}
-												>
-													<RotateCcw className="h-4 w-4" />
-												</Button>
-											)}
-										</div>
-									</div>
-									<div className="mt-3 space-y-2 text-sm">
-										<div>
-											<span className="text-muted-foreground">
-												Client ID:{' '}
-											</span>
-											<code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
-												{client.client_id}
-											</code>
-											<CopyButton
-												value={client.client_id}
-												variant="ghost"
-												size="icon"
-											/>
-										</div>
-										<div>
-											<span className="text-muted-foreground">
-												Redirect URIs:{' '}
-											</span>
-											<ul className="text-foreground mt-1 list-inside list-disc pl-1">
-												{client.redirect_uris.map((uri) => (
-													<li
-														key={uri}
-														className="truncate font-mono text-xs"
-													>
-														{uri}
-													</li>
-												))}
-											</ul>
-										</div>
-										<div>
-											<span className="text-muted-foreground">
-												Consent required:{' '}
-											</span>
-											<span className="text-foreground">
-												{client.require_consent ? 'Yes' : 'No'}
-											</span>
-										</div>
-										<div>
-											<span className="text-muted-foreground">
-												Active grants:{' '}
-											</span>
-											<span className="text-foreground">
-												{client.active_grant_count}
-											</span>
-										</div>
-										{client.allowed_scopes != null && (
-											<div>
-												<span className="text-muted-foreground">
-													Allowed scopes:{' '}
-												</span>
-												<span className="text-foreground">
-													{client.allowed_scopes.length > 0
-														? client.allowed_scopes.join(', ')
-														: 'OIDC only'}
-												</span>
-											</div>
-										)}
-									</div>
-								</div>
-							))}
-						</div>
-					)}
-				</>
-			)}
-
-			{createOpen && (
-				<CreateEditDialog
-					key="create"
-					open={createOpen}
-					onClose={(): void => setCreateOpen(false)}
-					onSecretRevealed={handleSecretRevealed}
+				<ClientsTable
+					clients={clientsQuery.data}
+					isLoading={clientsQuery.isLoading}
+					isFetching={clientsQuery.isFetching}
+					error={clientsQuery.error}
+					onRefresh={(): void => void clientsQuery.refetch()}
+					onOpenDetail={openDetail}
+					onAction={handleAction}
+					onCreate={(): void => setCreateOpen(true)}
+					pendingId={pendingId}
 				/>
 			)}
 
-			{editClient && (
-				<CreateEditDialog
-					key={editClient.id}
-					open={!!editClient}
-					onClose={(): void => setEditClient(null)}
-					client={editClient}
-				/>
-			)}
+			{/* Sheets are mounted persistently (dialog-state rule): a casual
+			    dismiss keeps the form draft; only a committed create resets it. */}
+			<ClientFormSheet
+				open={createOpen}
+				onClose={(): void => setCreateOpen(false)}
+				onSecretRevealed={(secret): void => {
+					setSecretDialogTitle('Client Secret Created');
+					setRevealedSecret(secret);
+				}}
+			/>
+			<ClientFormSheet
+				open={editOpen}
+				onClose={(): void => setEditOpen(false)}
+				client={editTarget}
+			/>
+			<ClientDetailSheet
+				client={detailTarget}
+				open={detailOpen}
+				onClose={(): void => setDetailOpen(false)}
+				onEdit={openEdit}
+				onRotate={setRotateTarget}
+				onDeactivate={setDeactivateTarget}
+			/>
 
-			{deleteTarget != null && (
-				<Dialog
+			{/* Stateless confirms — conditional mounting is fine here. */}
+			{deactivateTarget != null && (
+				<DeactivateConfirmDialog
 					open
-					onClose={(): void => setDeleteTarget(null)}
-					title="Deactivate OAuth Client?"
-					footer={
-						<>
-							<Button variant="outline" onClick={(): void => setDeleteTarget(null)}>
-								Cancel
-							</Button>
-							<Button
-								variant="danger"
-								onClick={(): void => void handleDeactivate()}
-								disabled={deactivateMutation.isPending}
-							>
-								{deactivateMutation.isPending ? 'Deactivating...' : 'Deactivate'}
-							</Button>
-						</>
-					}
-				>
-					<p className="text-muted-foreground">
-						This will prevent <strong>{deleteTarget.name}</strong> from initiating new
-						authorization flows. Existing sessions are not affected. You can reactivate
-						the client later if needed.
-					</p>
-					{deactivateMutation.error && (
-						<p className="text-destructive mt-2 text-sm">
-							{deactivateMutation.error instanceof Error
-								? deactivateMutation.error.message
-								: 'An error occurred'}
-						</p>
-					)}
-				</Dialog>
+					onClose={(): void => setDeactivateTarget(null)}
+					onConfirm={(): void => void handleDeactivate()}
+					isPending={deactivateMutation.isPending}
+					clientName={deactivateTarget.name}
+					error={deactivateMutation.error}
+				/>
 			)}
-
 			{rotateTarget != null && (
 				<RotateConfirmDialog
 					open
@@ -1030,7 +288,7 @@ export function OAuthClientsSection() {
 					clientName={rotateTarget.name}
 				/>
 			)}
-
+			{/* Sensitive-data exception: unmounting on close wipes the secret. */}
 			{revealedSecret != null && (
 				<SecretDialog
 					open

--- a/ui/src/modules/settings/pages/OAuthClientsSection.tsx
+++ b/ui/src/modules/settings/pages/OAuthClientsSection.tsx
@@ -7,18 +7,18 @@
  * and the section-level confirm/secret dialogs. Data wiring stays in
  * `settings/api/hooks.ts`.
  *
- * The active tab lives in `?tab=` so the agent rail's "Review" action on an
- * `oauth_client.registered` alert can deep-link straight to the queue; the
- * queue's pending/denied filter is lifted here so a denied roster row's
- * "Review in queue" verb lands directly on the Denied slice.
+ * The page chrome — header, "Add client", PageHelp, and the Clients/Queue
+ * TabNav — lives one level UP in `SettingsPage` (flattened per review: one
+ * tab bar, no double headers). This component is a controlled panel: the
+ * page passes the active tab down and the create-sheet open state is lifted
+ * so the header action can open it; the queue's pending/denied filter stays
+ * here so a denied roster row's "Review in queue" verb lands directly on the
+ * Denied slice.
  */
 import { useState } from 'react';
-import { useSearchParams } from 'react-router';
-import { KeyRound, Plus, ShieldQuestion } from 'lucide-react';
-import { Button, PageHelp, TabNav, toast, type TabNavOption } from '@/shared/ui';
+import { toast } from '@/shared/ui';
 import {
 	useDeactivateOAuthClient,
-	useOAuthClientQueue,
 	useOAuthClients,
 	useReactivateOAuthClient,
 	useRotateOAuthClientSecret,
@@ -34,33 +34,30 @@ import {
 	SecretDialog,
 } from '@/modules/settings/components/ClientLifecycleDialogs';
 
-const SECTION_TABS = ['clients', 'queue'] as const;
-type SectionTab = (typeof SECTION_TABS)[number];
+export const SECTION_TABS = ['clients', 'queue'] as const;
+export type SectionTab = (typeof SECTION_TABS)[number];
 
-function isSectionTab(value: string | null): value is SectionTab {
+export function isSectionTab(value: string | null): value is SectionTab {
 	return SECTION_TABS.includes(value as SectionTab);
 }
 
-export function OAuthClientsSection() {
-	const [searchParams, setSearchParams] = useSearchParams();
-	const tabParam = searchParams.get('tab');
-	const activeTab: SectionTab = isSectionTab(tabParam) ? tabParam : 'clients';
-	// Fetched at section level so the queue tab label can carry the pending
-	// count even while the clients tab is active.
-	const { data: pendingClients } = useOAuthClientQueue('pending');
-	const [queueFilter, setQueueFilter] = useState<QueueFilter>('pending');
+export interface OAuthClientsSectionProps {
+	/** The page-owned tab (mirrors `?tab=`; see SettingsPage). */
+	activeTab: SectionTab;
+	/** Page-owned tab setter — "Review in queue" retargets through it. */
+	onTabChange: (tab: SectionTab) => void;
+	/** Lifted create-sheet state so the header's "Add client" can open it. */
+	createOpen: boolean;
+	onCreateOpenChange: (open: boolean) => void;
+}
 
-	const setTab = (tab: SectionTab): void => {
-		setSearchParams(
-			(prev) => {
-				const next = new URLSearchParams(prev);
-				if (tab === 'clients') next.delete('tab');
-				else next.set('tab', tab);
-				return next;
-			},
-			{ replace: false },
-		);
-	};
+export function OAuthClientsSection({
+	activeTab,
+	onTabChange,
+	createOpen,
+	onCreateOpenChange,
+}: OAuthClientsSectionProps) {
+	const [queueFilter, setQueueFilter] = useState<QueueFilter>('pending');
 
 	// One include_inactive read backs the roster: the status segments partition
 	// the joint (approval_status, active) state client-side — including the
@@ -68,8 +65,8 @@ export function OAuthClientsSection() {
 	const clientsQuery = useOAuthClients(true);
 
 	// Sheet/dialog targets. Target + open are separate for the sheets so a
-	// dismissal keeps the mounted component (and any draft) alive.
-	const [createOpen, setCreateOpen] = useState(false);
+	// dismissal keeps the mounted component (and any draft) alive. (The
+	// create sheet's open state is the lifted `createOpen` prop.)
 	const [editTarget, setEditTarget] = useState<OAuthClient | null>(null);
 	const [editOpen, setEditOpen] = useState(false);
 	const [detailTarget, setDetailTarget] = useState<OAuthClient | null>(null);
@@ -131,7 +128,7 @@ export function OAuthClientsSection() {
 				break;
 			case 'review-in-queue':
 				setQueueFilter('denied');
-				setTab('queue');
+				onTabChange('queue');
 				break;
 		}
 	};
@@ -167,65 +164,8 @@ export function OAuthClientsSection() {
 		}
 	};
 
-	const tabOptions: TabNavOption<SectionTab>[] = [
-		{ value: 'clients', label: 'Clients', icon: <KeyRound className="h-4 w-4" /> },
-		{
-			value: 'queue',
-			label: 'Approval queue',
-			icon: <ShieldQuestion className="h-4 w-4" />,
-			count: pendingClients?.length || undefined,
-		},
-	];
-
 	return (
 		<section>
-			<div className="mb-6 flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
-				<div className="min-w-0 flex-1">
-					<h2 className="text-foreground text-lg font-semibold tracking-tight">
-						OAuth Clients
-					</h2>
-					<p className="text-muted-foreground mt-0.5 text-sm">
-						Manage third-party applications that can authenticate users via Jentic One.
-					</p>
-				</div>
-				<div className="flex shrink-0 items-center gap-2 self-center">
-					<Button onClick={(): void => setCreateOpen(true)}>
-						<Plus className="h-4 w-4" />
-						Add client
-					</Button>
-					<PageHelp
-						title="About OAuth Clients"
-						intro="OAuth clients are third-party applications that use Jentic One for user authentication."
-						sections={[
-							{
-								heading: 'Client ID',
-								body: 'The client_id is a public identifier used in OAuth flows. Configure it in the third-party application.',
-							},
-							{
-								heading: 'Client Secret',
-								body: 'The client secret is shown once at creation and after rotation. Store it securely — it cannot be retrieved later.',
-							},
-							{
-								heading: 'Redirect URIs',
-								body: 'OAuth callbacks are only allowed to URLs in this list. Include all environments (dev, staging, prod).',
-							},
-							{
-								heading: 'Approval queue',
-								body: 'Clients that register themselves (DCR) wait in the queue until an admin approves them. Judge a registration by its redirect-URI origins — the name is self-reported.',
-							},
-						]}
-					/>
-				</div>
-			</div>
-
-			<TabNav<SectionTab>
-				options={tabOptions}
-				value={activeTab}
-				onChange={setTab}
-				ariaLabel="OAuth client sections"
-				className="mb-4"
-			/>
-
 			{activeTab === 'queue' && (
 				<ApprovalQueue filter={queueFilter} onFilterChange={setQueueFilter} />
 			)}
@@ -239,7 +179,7 @@ export function OAuthClientsSection() {
 					onRefresh={(): void => void clientsQuery.refetch()}
 					onOpenDetail={openDetail}
 					onAction={handleAction}
-					onCreate={(): void => setCreateOpen(true)}
+					onCreate={(): void => onCreateOpenChange(true)}
 					pendingId={pendingId}
 				/>
 			)}
@@ -248,7 +188,7 @@ export function OAuthClientsSection() {
 			    dismiss keeps the form draft; only a committed create resets it. */}
 			<ClientFormSheet
 				open={createOpen}
-				onClose={(): void => setCreateOpen(false)}
+				onClose={(): void => onCreateOpenChange(false)}
 				onSecretRevealed={(secret): void => {
 					setSecretDialogTitle('Client Secret Created');
 					setRevealedSecret(secret);

--- a/ui/src/modules/settings/pages/SettingsPage.tsx
+++ b/ui/src/modules/settings/pages/SettingsPage.tsx
@@ -1,41 +1,96 @@
+/**
+ * SettingsPage — the settings surface shell: a section nav + the active
+ * section's content.
+ *
+ * Layout: the shell is a flex COLUMN with a min-height filling the Layout's
+ * content area (100dvh minus the fixed h-12 TopNavbar and `<main>`'s bottom
+ * padding — `pb-20` under the mobile BottomNavbar, `md:pb-12` on desktop), so
+ * the section row can `flex-1`-stretch and the sidebar's `border-r` runs to
+ * the bottom of the viewport even when the content is short. It's a
+ * MIN-height, not a height: long content (the OAuth clients roster) grows
+ * past it and the DOCUMENT scrolls — no nested scroll container.
+ *
+ * Responsive: the persistent side column is a desktop (`md+`) grammar. On
+ * phones the section nav collapses to the platform's horizontal `TabNav`
+ * above the content — a hard `w-56` column would eat half of a 375px screen.
+ */
 import { useState } from 'react';
 import { Code2 } from 'lucide-react';
-import { PageHeader, PageShell } from '@/shared/ui';
+import { Button, PageHeader, PageShell, TabNav, type TabNavOption } from '@/shared/ui';
+import { cn } from '@/shared/lib/utils';
 import { OAuthClientsSection } from './OAuthClientsSection';
 
 type SettingsSection = 'developer';
 
+const SECTIONS: { id: SettingsSection; label: string }[] = [
+	{ id: 'developer', label: 'Developer Settings' },
+];
+
+const SECTION_ICONS: Record<SettingsSection, React.ReactNode> = {
+	developer: <Code2 className="h-4 w-4" aria-hidden="true" />,
+};
+
 export function SettingsPage() {
 	const [activeSection, setActiveSection] = useState<SettingsSection>('developer');
 
+	const tabOptions: TabNavOption<SettingsSection>[] = SECTIONS.map((s) => ({
+		value: s.id,
+		label: s.label,
+		icon: SECTION_ICONS[s.id],
+	}));
+
 	return (
-		<PageShell spacing="space-y-0">
+		<PageShell
+			spacing="space-y-0"
+			// pb-0: the shell's own bottom padding would stop the sidebar
+			// border short of the bottom edge; the content column carries its
+			// own py instead.
+			className="flex min-h-[calc(100dvh-8rem)] flex-col pb-0 md:min-h-[calc(100dvh-6rem)]"
+		>
 			<PageHeader
 				title="Settings"
 				subtitle="Manage your organization's configuration and integrations."
 			/>
 
-			<div className="flex min-h-0 flex-1">
-				{/* Sidebar */}
-				<nav className="border-border w-56 shrink-0 border-r p-4">
+			{/* Phone grammar: horizontal section tabs above the content. */}
+			<TabNav<SettingsSection>
+				options={tabOptions}
+				value={activeSection}
+				onChange={setActiveSection}
+				ariaLabel="Settings sections"
+				className="mt-2 md:hidden"
+			/>
+
+			<div className="flex min-h-0 flex-1 flex-col md:flex-row">
+				{/* Desktop grammar: persistent side column. */}
+				<nav
+					aria-label="Settings sections"
+					className="border-border hidden w-56 shrink-0 border-r py-6 pr-4 md:block"
+				>
 					<div className="space-y-1">
-						<button
-							type="button"
-							onClick={(): void => setActiveSection('developer')}
-							className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm ${
-								activeSection === 'developer'
-									? 'bg-accent text-foreground'
-									: 'text-muted-foreground hover:bg-accent/50'
-							}`}
-						>
-							<Code2 className="h-4 w-4" />
-							Developer Settings
-						</button>
+						{SECTIONS.map((section) => (
+							<Button
+								key={section.id}
+								variant="ghost"
+								size="sm"
+								onClick={(): void => setActiveSection(section.id)}
+								aria-current={activeSection === section.id ? 'page' : undefined}
+								className={cn(
+									'w-full justify-start gap-2',
+									activeSection === section.id && 'bg-accent text-foreground',
+								)}
+							>
+								{SECTION_ICONS[section.id]}
+								{section.label}
+							</Button>
+						))}
 					</div>
 				</nav>
 
-				{/* Content */}
-				<div className="min-h-0 flex-1 overflow-y-auto p-6">
+				{/* Content flows with the document (no nested scroll container —
+				    the old overflow-y-auto sat in an unbounded column and never
+				    actually scrolled; the roster scrolls with the page). */}
+				<div className="min-w-0 flex-1 py-6 md:pl-6">
 					{activeSection === 'developer' && <OAuthClientsSection />}
 				</div>
 			</div>

--- a/ui/src/modules/settings/pages/SettingsPage.tsx
+++ b/ui/src/modules/settings/pages/SettingsPage.tsx
@@ -1,99 +1,109 @@
 /**
- * SettingsPage — the settings surface shell: a section nav + the active
- * section's content.
+ * SettingsPage — the flat settings surface (platform page grammar).
  *
- * Layout: the shell is a flex COLUMN with a min-height filling the Layout's
- * content area (100dvh minus the fixed h-12 TopNavbar and `<main>`'s bottom
- * padding — `pb-20` under the mobile BottomNavbar, `md:pb-12` on desktop), so
- * the section row can `flex-1`-stretch and the sidebar's `border-r` runs to
- * the bottom of the viewport even when the content is short. It's a
- * MIN-height, not a height: long content (the OAuth clients roster) grows
- * past it and the DOCUMENT scrolls — no nested scroll container.
+ * Flattened per review: the old left sidebar was the only left-sidebar nav in
+ * the SPA (every other multi-section surface uses TabNav), had exactly one
+ * destination ("Developer Settings"), and triple-nested navigation (sidebar →
+ * section header → the section's own TabNav). Now it's a standard page in the
+ * AgentsPage shape: PageShell + PageHeader (Add client + PageHelp in the
+ * actions slot) + ONE page-level TabNav for the OAuth surface's two tabs.
  *
- * Responsive: the persistent side column is a desktop (`md+`) grammar. On
- * phones the section nav collapses to the platform's horizontal `TabNav`
- * above the content — a hard `w-56` column would eat half of a 375px screen.
+ * The active tab lives in `?tab=` so the agent rail's "Review" action on an
+ * `oauth_client.registered` alert (and the backend approval-pending page) can
+ * deep-link straight to the queue via /app/settings?tab=queue. The pending
+ * count is fetched here so the queue tab label carries the badge even while
+ * the clients tab is active. `OAuthClientsSection` keeps owning data wiring,
+ * tables, sheets, and dialogs.
  */
 import { useState } from 'react';
-import { Code2 } from 'lucide-react';
-import { Button, PageHeader, PageShell, TabNav, type TabNavOption } from '@/shared/ui';
-import { cn } from '@/shared/lib/utils';
-import { OAuthClientsSection } from './OAuthClientsSection';
-
-type SettingsSection = 'developer';
-
-const SECTIONS: { id: SettingsSection; label: string }[] = [
-	{ id: 'developer', label: 'Developer Settings' },
-];
-
-const SECTION_ICONS: Record<SettingsSection, React.ReactNode> = {
-	developer: <Code2 className="h-4 w-4" aria-hidden="true" />,
-};
+import { useSearchParams } from 'react-router';
+import { KeyRound, Plus, ShieldQuestion } from 'lucide-react';
+import { Button, PageHeader, PageHelp, PageShell, TabNav, type TabNavOption } from '@/shared/ui';
+import { useOAuthClientQueue } from '@/modules/settings/api/hooks';
+import { isSectionTab, OAuthClientsSection, type SectionTab } from './OAuthClientsSection';
 
 export function SettingsPage() {
-	const [activeSection, setActiveSection] = useState<SettingsSection>('developer');
+	const [searchParams, setSearchParams] = useSearchParams();
+	const tabParam = searchParams.get('tab');
+	const activeTab: SectionTab = isSectionTab(tabParam) ? tabParam : 'clients';
+	// Fetched at page level so the queue tab label can carry the pending
+	// count even while the clients tab is active.
+	const { data: pendingClients } = useOAuthClientQueue('pending');
+	// Lifted so the header's "Add client" opens the section-owned form sheet.
+	const [createOpen, setCreateOpen] = useState(false);
 
-	const tabOptions: TabNavOption<SettingsSection>[] = SECTIONS.map((s) => ({
-		value: s.id,
-		label: s.label,
-		icon: SECTION_ICONS[s.id],
-	}));
+	const setTab = (tab: SectionTab): void => {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				if (tab === 'clients') next.delete('tab');
+				else next.set('tab', tab);
+				return next;
+			},
+			{ replace: false },
+		);
+	};
+
+	const tabOptions: TabNavOption<SectionTab>[] = [
+		{ value: 'clients', label: 'Clients', icon: <KeyRound className="h-4 w-4" /> },
+		{
+			value: 'queue',
+			label: 'Approval queue',
+			icon: <ShieldQuestion className="h-4 w-4" />,
+			count: pendingClients?.length || undefined,
+		},
+	];
 
 	return (
-		<PageShell
-			spacing="space-y-0"
-			// pb-0: the shell's own bottom padding would stop the sidebar
-			// border short of the bottom edge; the content column carries its
-			// own py instead.
-			className="flex min-h-[calc(100dvh-8rem)] flex-col pb-0 md:min-h-[calc(100dvh-6rem)]"
-		>
+		<PageShell>
 			<PageHeader
 				title="Settings"
-				subtitle="Manage your organization's configuration and integrations."
-			/>
-
-			{/* Phone grammar: horizontal section tabs above the content. */}
-			<TabNav<SettingsSection>
-				options={tabOptions}
-				value={activeSection}
-				onChange={setActiveSection}
-				ariaLabel="Settings sections"
-				className="mt-2 md:hidden"
-			/>
-
-			<div className="flex min-h-0 flex-1 flex-col md:flex-row">
-				{/* Desktop grammar: persistent side column. */}
-				<nav
-					aria-label="Settings sections"
-					className="border-border hidden w-56 shrink-0 border-r py-6 pr-4 md:block"
-				>
-					<div className="space-y-1">
-						{SECTIONS.map((section) => (
-							<Button
-								key={section.id}
-								variant="ghost"
-								size="sm"
-								onClick={(): void => setActiveSection(section.id)}
-								aria-current={activeSection === section.id ? 'page' : undefined}
-								className={cn(
-									'w-full justify-start gap-2',
-									activeSection === section.id && 'bg-accent text-foreground',
-								)}
-							>
-								{SECTION_ICONS[section.id]}
-								{section.label}
-							</Button>
-						))}
+				subtitle="Manage the OAuth clients that authenticate users via Jentic One."
+				actions={
+					<div className="flex items-center gap-2">
+						<Button onClick={(): void => setCreateOpen(true)}>
+							<Plus className="h-4 w-4" />
+							Add client
+						</Button>
+						<PageHelp
+							title="About OAuth Clients"
+							intro="OAuth clients are third-party applications that use Jentic One for user authentication."
+							sections={[
+								{
+									heading: 'Client ID',
+									body: 'The client_id is a public identifier used in OAuth flows. Configure it in the third-party application.',
+								},
+								{
+									heading: 'Client Secret',
+									body: 'The client secret is shown once at creation and after rotation. Store it securely — it cannot be retrieved later.',
+								},
+								{
+									heading: 'Redirect URIs',
+									body: 'OAuth callbacks are only allowed to URLs in this list. Include all environments (dev, staging, prod).',
+								},
+								{
+									heading: 'Approval queue',
+									body: 'Clients that register themselves (DCR) wait in the queue until an admin approves them. Judge a registration by its redirect-URI origins — the name is self-reported.',
+								},
+							]}
+						/>
 					</div>
-				</nav>
+				}
+			/>
 
-				{/* Content flows with the document (no nested scroll container —
-				    the old overflow-y-auto sat in an unbounded column and never
-				    actually scrolled; the roster scrolls with the page). */}
-				<div className="min-w-0 flex-1 py-6 md:pl-6">
-					{activeSection === 'developer' && <OAuthClientsSection />}
-				</div>
-			</div>
+			<TabNav<SectionTab>
+				options={tabOptions}
+				value={activeTab}
+				onChange={setTab}
+				ariaLabel="Settings sections"
+			/>
+
+			<OAuthClientsSection
+				activeTab={activeTab}
+				onTabChange={setTab}
+				createOpen={createOpen}
+				onCreateOpenChange={setCreateOpen}
+			/>
 		</PageShell>
 	);
 }

--- a/ui/src/shared/api/index.ts
+++ b/ui/src/shared/api/index.ts
@@ -257,7 +257,9 @@ export type { VersionResponse } from '@/shared/api/generated/models/VersionRespo
 
 // OAuth client management (third-party application registrations). Append-only.
 export { OAuthClientsService } from '@/shared/api/generated/services/OAuthClientsService';
-export type { OAuthClientCreateRequest } from '@/shared/api/generated/models/OAuthClientCreateRequest';
+// Value export (not type-only): the create request carries enum namespaces
+// (`consent_model`, `token_endpoint_auth_method`) the form sheet needs.
+export { OAuthClientCreateRequest } from '@/shared/api/generated/models/OAuthClientCreateRequest';
 export type { OAuthClientCreateResponse } from '@/shared/api/generated/models/OAuthClientCreateResponse';
 export type { OAuthClientResponse } from '@/shared/api/generated/models/OAuthClientResponse';
 export type { OAuthClientRotateSecretResponse } from '@/shared/api/generated/models/OAuthClientRotateSecretResponse';
@@ -285,3 +287,7 @@ export type { IdpDescriptor } from '@/shared/api/idp';
 export { OAuthService } from '@/shared/api/generated/services/OAuthService';
 export type { OAuthGrantResponse } from '@/shared/api/generated/models/OAuthGrantResponse';
 export type { OAuthGrantListResponse } from '@/shared/api/generated/models/OAuthGrantListResponse';
+// Admin cross-view rows (`GET /admin/oauth-grants`) — the per-client grants
+// panel in the OAuth-clients detail sheet. Append-only, like the rest.
+export type { OAuthGrantAdminResponse } from '@/shared/api/generated/models/OAuthGrantAdminResponse';
+export type { OAuthGrantAdminListResponse } from '@/shared/api/generated/models/OAuthGrantAdminListResponse';

--- a/ui/src/shared/ui/SegmentedToggle.tsx
+++ b/ui/src/shared/ui/SegmentedToggle.tsx
@@ -74,7 +74,10 @@ export function SegmentedToggle<T extends string = string>({
 
 	// Measure the active button's box relative to the container after layout,
 	// and re-measure on resize. `useLayoutEffect` so the pill is positioned
-	// before paint (no first-frame flash at 0,0).
+	// before paint (no first-frame flash at 0,0). Both the container AND the
+	// active button are observed: a segment can resize without the container
+	// telling the whole story (e.g. a count in its label ticking over),
+	// which would otherwise leave the pill on a stale rect.
 	useLayoutEffect(() => {
 		function measure() {
 			const container = containerRef.current;
@@ -85,6 +88,8 @@ export function SegmentedToggle<T extends string = string>({
 		measure();
 		const ro = new ResizeObserver(measure);
 		if (containerRef.current) ro.observe(containerRef.current);
+		const activeBtn = btnRefs.current.get(value);
+		if (activeBtn) ro.observe(activeBtn);
 		return () => ro.disconnect();
 	}, [value, options]);
 
@@ -114,7 +119,11 @@ export function SegmentedToggle<T extends string = string>({
 			role={isTabs ? 'tablist' : ariaLabel ? 'group' : undefined}
 			aria-label={ariaLabel}
 			className={cn(
-				'border-border bg-muted/50 relative flex rounded-lg border p-0.5',
+				// Structural backstop for the invariant above: even if a stale
+				// rect ever slipped through, overflow past the control's border
+				// never becomes visible or scrollable. The pill is inset
+				// (top-0.5/bottom-0.5, within p-0.5), so nothing is cut at rest.
+				'border-border bg-muted/50 relative flex overflow-x-clip rounded-lg border p-0.5',
 				className,
 			)}
 		>
@@ -124,7 +133,20 @@ export function SegmentedToggle<T extends string = string>({
 					className="bg-foreground/10 ring-border/50 pointer-events-none absolute top-0.5 bottom-0.5 rounded-md shadow-sm ring-1"
 					initial={false}
 					animate={{ left: pill.left, width: pill.width }}
-					transition={{ type: 'spring', stiffness: 500, damping: 35 }}
+					// INVARIANT: the pill must never extend past the control's own
+					// bounds. At rest the measurement guarantees it (offsetLeft/
+					// offsetWidth are relative to the same padding box the pill
+					// positions against); mid-animation it holds because this
+					// spring is critically damped (damping ≥ 2·√stiffness ≈ 44.7):
+					// `left` and `width` approach their targets monotonically, so
+					// `left + width` stays inside the endpoints' envelope. The
+					// underdamped original (damping 35) overshot proportionally to
+					// the jump size, which inside an `overflow-x-auto` wrapper
+					// (phone toolbars) could poke the pill's right edge past the
+					// content width and blip a horizontal scrollbar. The root's
+					// overflow-x-clip is the structural backstop for the same
+					// invariant. Pinned by the bounds test in SegmentedToggle.test.
+					transition={{ type: 'spring', stiffness: 500, damping: 45 }}
 				/>
 			)}
 			{options.map((option) => {

--- a/ui/src/shared/ui/__tests__/SegmentedToggle.test.tsx
+++ b/ui/src/shared/ui/__tests__/SegmentedToggle.test.tsx
@@ -43,4 +43,52 @@ describe('SegmentedToggle', () => {
 		);
 		await checkA11y(container);
 	});
+
+	it('keeps the sliding pill inside the control bounds for the whole animation', async () => {
+		// INVARIANT (see the transition comment in SegmentedToggle): the pill
+		// must never extend past the control's own bounds — an overshooting
+		// spring transiently poked its right edge past the content width and
+		// blipped a horizontal scrollbar in overflow-x-auto toolbar wrappers.
+		// Sample the pill's rect against the root's on every animation frame
+		// while switching to the far segment. Spring overshoot scales with the
+		// step size, so the segments are deliberately wide and asymmetric
+		// (worst case: a long jump onto a wide segment, like count labels).
+		const user = userEvent.setup();
+		const wide = [
+			{ value: 'a', label: 'A 1' },
+			{ value: 'b', label: 'B 12' },
+			{ value: 'c', label: `C ${'1234567890'.repeat(4)}` },
+		];
+		function Harness() {
+			const [value, setValue] = useState('a');
+			return <SegmentedToggle options={wide} value={value} onChange={setValue} />;
+		}
+		const { container } = renderWithProviders(<Harness />);
+		const root = container.querySelector('.overflow-x-clip') as HTMLElement;
+		const pill = root?.querySelector('[aria-hidden="true"]') as HTMLElement;
+		expect(root).not.toBeNull();
+		expect(pill).not.toBeNull();
+
+		await user.click(screen.getByRole('button', { name: wide[2].label }));
+
+		const maxBleed = await new Promise<number>((resolve) => {
+			let worst = -Infinity;
+			const start = performance.now();
+			function sample() {
+				const rootRect = root.getBoundingClientRect();
+				const pillRect = pill.getBoundingClientRect();
+				worst = Math.max(
+					worst,
+					pillRect.right - rootRect.right,
+					rootRect.left - pillRect.left,
+				);
+				if (performance.now() - start < 600) requestAnimationFrame(sample);
+				else resolve(worst);
+			}
+			requestAnimationFrame(sample);
+		});
+		// The pill sits inside the root's 1px border + 2px padding; it must
+		// never even reach the border box edge, let alone poke past it.
+		expect(maxBleed).toBeLessThanOrEqual(0);
+	});
 });


### PR DESCRIPTION
## Summary

The OAuth clients settings surface was a 1,047-line monolith with hand-rolled list rows, dialog-only flows, and several operator hazards (a Reactivate verb that success-toasted denied clients into a still-bricked state, approved+inactive "zombies" invisible to every filter, deny reasons captured but never shown). This rebuilds it into the platform's standard grammar — DataTable roster, origins-first approval queue, detail sheet, form sheet — per the design plan in `jentic-one-plans/themes/local-mcp/oauth-clients-ui-redesign.md`. UI-only; no backend or generated-client changes.

## Changes

- **`ui` settings module, decomposition**: `OAuthClientsSection.tsx` shrinks to ~290 lines of orchestration; the surface now lives in focused components under `modules/settings/components/`.
- **Roster (`ClientsTable.tsx`)**: DataTable with identity cell (name → detail sheet, mono client_id + copy), derived redirect-URI origins, type chips (Public / DCR / Agent consent), single-sourced status badges, active-grant count, registered timeAgo, and a per-row kebab. Toolbar has a filter input plus status segments with live counts — the **Inactive** segment finally surfaces approved+deactivated zombies. Mobile falls back to stacked cards.
- **Approval queue (`ApprovalQueue.tsx`)**: rows lead with the *verifiable* signal (redirect-URI origins + `software_id`); the attacker-chosen name is demoted to labelled "Self-reported name" secondary text. Denied filter re-offers Approve only (the denied→active recovery path); deny-reason draft survives casual dismissal.
- **Detail sheet (`ClientDetailSheet.tsx`)**: full metadata, the per-client grants panel (admin cross-view, status filter, revoke honouring `can_revoke` with an explanatory tooltip), a client-scoped audit trail that finally surfaces deny reasons, and a danger zone (deactivate / rotate).
- **Form sheet (`ClientFormSheet.tsx`)**: persistent-mount create/edit with draft preservation; exposes the previously-hidden create-only `consent_model` and `token_endpoint_auth_method` (public/PKCE) API fields; allowed scopes use the shared grouped `ScopePicker` plus a custom-scope affordance.
- **Hazard fixes**: Reactivate is only offered on approved+inactive rows (denied rows route to the queue instead); deactivate confirm copy explains the DCR re-queue behaviour; status vocabulary single-sourced in `clientStatus.ts`.
- **Hooks (`settings/api/hooks.ts`)**: new `useOAuthClient`, `useOAuthClientGrants` (cursor-paginated), `useRevokeOAuthClientGrant`, `useOAuthClientAudit` (403→empty).
- **Mocks**: settings MSW store extended with grants + audit fixtures and an approved+inactive seed; decision verbs append audit rows; the agents module's revoke handler now falls through for unknown grant ids instead of 404ing (it shadowed the settings handler).
- **Out of scope**: backend changes, generated API client changes, the consent screen itself, and the agents module's "Connected clients" panel (already correct).

## Risk & rollback

- Low risk: UI-only. The one cross-module touch is the agents MSW mock fall-through (test infrastructure, not product code) and two append-only export additions in `shared/api/index.ts`.
- Revert the squash commit to roll back.

## Test plan

- `npm run lint` / `npm run lint:fix` — clean.
- `npm run build` — clean.
- `npm run test:run` — full browser-mode suite green (129 files, 1195 tests), including the rewritten `OAuthClientsSection.test.tsx` (19 specs): default-roster scoping, live segment counts + zombie surfacing, no-Reactivate-on-denied, review-in-queue deep link, origins-first queue rows, approve/deny lifecycle incl. rail settle mirror and draft preservation, detail-sheet metadata/grants/`can_revoke`/audit-with-deny-reason, public+agent-consent create round-trip, one-time secret wipe, form draft survival, and axe checks on both tabs.

## Review guide

- Start with `clientStatus.ts` (the status vocabulary and the reactivation guard) and `OAuthClientsSection.tsx` (the orchestration shape); the components read top-down from there. The MSW store rewrite mirrors the backend state machine and is best read next to the tests.

Made with [Cursor](https://cursor.com)