### PR TITLE
fix(ui): agent rail scrolls away on short pages (phantom scroll from sr-only escapees)

### DIFF
--- a/ui/src/shared/app/rail/AgentRail.tsx
+++ b/ui/src/shared/app/rail/AgentRail.tsx
@@ -259,7 +259,7 @@ export function AgentRail() {
 
 	if (collapsed) {
 		return (
-			<aside className="bg-muted border-border hidden w-10 shrink-0 flex-col items-center border-l xl:flex">
+			<aside className="bg-muted border-border relative hidden w-10 shrink-0 flex-col items-center border-l xl:flex">
 				<Button
 					variant="ghost"
 					size="icon"
@@ -329,7 +329,16 @@ export function AgentRail() {
 	return (
 		<aside
 			aria-label="Agent rail"
-			className="bg-muted border-border hidden w-72 shrink-0 flex-col overflow-hidden border-l xl:flex"
+			// `relative` is load-bearing: feed rows carry `sr-only` (absolutely
+			// positioned) spans, and absolute boxes are only clipped by ancestors
+			// in their CONTAINING-BLOCK chain — the static `overflow-hidden` here
+			// and the feed's `overflow-y-auto` don't qualify. Without a positioned
+			// ancestor those spans escaped to the sticky wrapper, adding ~240px of
+			// phantom document scroll on short pages, which in turn dragged the
+			// whole rail up with the scroll (the sticky wrapper is clamped to its
+			// row, and the row only grows with real `main` content). See #1318
+			// review follow-up: rail scrolled away on Settings/Toolkits.
+			className="bg-muted border-border relative hidden w-72 shrink-0 flex-col overflow-hidden border-l xl:flex"
 			onMouseEnter={() => setHoverFrozen(true)}
 			onMouseLeave={() => setHoverFrozen(false)}
 		>

--- a/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
@@ -610,6 +610,34 @@ describe('AgentRail — shell-mounted live surface', () => {
 		).toBeInTheDocument();
 	});
 
+	it('is a containing block, so sr-only descendants cannot leak scroll height (phantom-scroll pin)', async () => {
+		// Regression pin: feed rows carry `sr-only` spans (position: absolute).
+		// Absolute boxes are clipped only by CONTAINING-BLOCK ancestors — the
+		// aside's static `overflow-hidden` didn't qualify, so those spans
+		// escaped to the shell's sticky wrapper and added ~240px of phantom
+		// document scroll on short pages, dragging the whole rail up with the
+		// scroll (seen on Settings/Toolkits; Workspace masked it with tall
+		// content). The aside must be `position: relative`, which both clips
+		// the escapees and keeps them out of the document's scroll overflow.
+		// The shell caps the rail at viewport height; reproduce that constraint
+		// here — an unconstrained aside would grow to fit and pass vacuously.
+		renderRail(
+			<div style={{ display: 'flex', height: '320px' }}>
+				<AgentRail />
+			</div>,
+		);
+		const aside = await screen.findByRole('complementary', { name: 'Agent rail' });
+		await screen.findByText(/Execution failed: slack\.postMessage/i);
+		expect(getComputedStyle(aside).position).toBe('relative');
+		// And the observable consequence: a 320px-tall rail must not give the
+		// DOCUMENT any scroll height beyond the viewport. Without `relative`,
+		// the sr-only boxes anchor to the initial containing block and extend
+		// the page's scrollable overflow (the phantom scroll from the bug).
+		// (In-flow feed rows may have rects past the aside — they're inside the
+		// feed's own scroll container — so we pin the document, not the rects.)
+		expect(document.documentElement.scrollHeight).toBeLessThanOrEqual(window.innerHeight);
+	});
+
 	it('collapses and persists the collapsed state to localStorage', async () => {
 		const user = userEvent.setup();
 		renderRail(<AgentRail />);


### PR DESCRIPTION
## Problem

On pages whose content fits the viewport (Settings, Toolkits, Credentials), the page could scroll ~240px into blank space and the agent rail scrolled away with it — its top vanishing behind the navbar. Workspace looked fine only because its content is genuinely tall.

## Root cause

Feed rows contain `sr-only` spans, which Tailwind implements as `position: absolute`. Absolute boxes are clipped only by ancestors in their **containing-block chain**. The rail's `aside` (`overflow-hidden`) and the feed (`overflow-y-auto`) are both `position: static`, so neither qualified — the spans escaped to the shell's sticky wrapper, extending the document's scrollable overflow by ~240px of invisible space. Scrolling that phantom range moved the rail because the sticky wrapper is clamped to its flex row, which only grows with real `main` content.

Diagnosed empirically with a headless-browser probe against the live app: document scrollHeight 1138 vs. tallest real content 900 on Settings/Toolkits; forcing `position: relative` on the aside collapsed it to 900 (Workspace unaffected).

## Fix

`position: relative` on the rail aside (expanded and collapsed variants) makes it the containing block: the sr-only boxes are clipped by its `overflow-hidden` and no longer contribute to document scroll overflow.

## Test

New regression pin renders the rail in a bounded-height shell and asserts (a) the aside is a containing block and (b) the document gains no scroll height. Verified red without the fix (`expected 'static' to be 'relative'`), green with it. Full AgentRail suite: 57/57.

Made with [Cursor](https://cursor.com)