### PR TITLE
feat(mcp): serve import_api on the daemon-native /mcp mount

### DIFF
--- a/src/jentic_one/mcp/envelopes.py
+++ b/src/jentic_one/mcp/envelopes.py
@@ -43,10 +43,11 @@ CODE_TRANSPORT_ERROR = "TRANSPORT_ERROR"
 CODE_INTERNAL_ERROR = "INTERNAL_ERROR"
 
 #: error codes whose default recovery pointer is ``get_started`` (Go:
-#: ``softErrorExtra``'s code-keyed mapping). ``get_started`` is not served by
-#: this mount yet (it queues behind this PR with the other CLI-flavoured
-#: tools), but the pointer strings are part of the shared envelope contract —
-#: they must match the stdio server byte-for-byte.
+#: ``softErrorExtra``'s code-keyed mapping). ``get_started`` never ports to
+#: this mount (it diagnoses *the local machine's* CLI setup — over HTTP there
+#: is no local machine; see ``spec.py``), but the pointer strings are part of
+#: the shared envelope contract — they must match the stdio server
+#: byte-for-byte.
 _DEFAULT_NEXT_TOOL_CODES = frozenset(
     {CODE_NOT_AUTHENTICATED, CODE_PENDING_APPROVAL, CODE_RESOLVE_FAILED}
 )

--- a/src/jentic_one/mcp/spec.py
+++ b/src/jentic_one/mcp/spec.py
@@ -23,11 +23,12 @@ from typing import Any
 import mcp.types as mcp_types
 
 #: The tools this mount serves — the subset of the pinned surface whose
-#: dispatch is clean in-process (registry search/inspect/catalog, admin jobs,
-#: auth whoami) or a server-side broker proxy (the execute family).
-#: ``get_started`` (CLI setup diagnosis), ``import_api`` (job tracking +
-#: promotion loop), and ``request_access`` (token re-mint semantics) stay
-#: stdio-only for now.
+#: dispatch is clean in-process (registry search/inspect/catalog + the catalog
+#: import loop, admin jobs, auth whoami) or a server-side broker proxy (the
+#: execute family). ``get_started`` never ports — it diagnoses *the local
+#: machine's* CLI setup, and over HTTP there is no local machine; and
+#: ``request_access`` (access-request filing + polling) queues behind this
+#: wave's PR B. Both stay stdio-only until then.
 SERVED_TOOLS: tuple[str, ...] = (
     "whoami",
     "search_apis",
@@ -36,6 +37,7 @@ SERVED_TOOLS: tuple[str, ...] = (
     "execute_read",
     "get_execution_result",
     "search_catalog",
+    "import_api",
 )
 
 

--- a/src/jentic_one/mcp/tools.py
+++ b/src/jentic_one/mcp/tools.py
@@ -21,7 +21,9 @@ agent can fix itself (BROKER_DENIED + request_access, the Go special case).
 
 from __future__ import annotations
 
+import asyncio
 import json
+import time
 import uuid as uuid_mod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -34,6 +36,7 @@ from mcp.shared.exceptions import MCPError
 from jentic_one.admin.services.errors import JobNotFoundError
 from jentic_one.admin.services.job_result_service import JobResultService
 from jentic_one.admin.services.job_service import JobService
+from jentic_one.admin.services.schemas.jobs import JobView
 from jentic_one.admin.services.user_service import UserService
 from jentic_one.auth.services.agent_service import AgentService
 from jentic_one.auth.services.service_account_service import ServiceAccountService
@@ -56,16 +59,21 @@ from jentic_one.mcp.envelopes import (
 from jentic_one.registry.services.catalog.service import CatalogService
 from jentic_one.registry.services.errors import (
     ArchivedRevisionPinError,
+    CatalogEntryNotFoundError,
+    CatalogUnavailableError,
     InvalidApiFilterError,
     OperationNotFoundError,
+    OverlaySupersedeForbiddenError,
     SearchUnavailableError,
 )
 from jentic_one.registry.services.inspect.models import SUMMARY_LOAD_OPTIONS
 from jentic_one.registry.services.inspect.service import InspectService
 from jentic_one.registry.services.inspect.url_lookup import URLLookupService
+from jentic_one.registry.services.revision_service import RevisionService
 from jentic_one.registry.services.search_service import SearchService
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.auth.permission_catalog import compute_effective
+from jentic_one.shared.auth.permissions import has_effective_permission
 from jentic_one.shared.context import Context
 from jentic_one.shared.pagination import InvalidCursorError, InvalidSearchCursorError
 
@@ -515,6 +523,272 @@ async def handle_search_catalog(
     return tool_result(env.ctx, payload)
 
 
+# ── import_api ────────────────────────────────────────────────────────────────
+
+_IMPORT_API_PARAMS = [ParamSpec("api_id", "string", ("id", "api"))]
+
+#: How long import_api tracks the import job in-process before handing the
+#: still-running job back to the model (Go: ``defaultImportWaitBudget``). The
+#: mount applies no per-call deadline of its own, so this constant also bounds
+#: how long the blocking handler holds the ASGI request open — sized inside
+#: typical MCP client tool timeouts. A plain module constant beside
+#: ``_EXECUTE_TIMEOUT_SECONDS``'s pattern (tests inject via monkeypatch, like
+#: the Go side's ``importWaitBudget``); no config knob until someone needs one.
+_IMPORT_WAIT_BUDGET_SECONDS = 15.0
+
+#: In-process poll cadence for the job tracker: the first poll is immediate,
+#: then back off from the step to the max (Go: ``App.PollCadence``).
+_IMPORT_POLL_STEP_SECONDS = 0.25
+_IMPORT_POLL_MAX_SECONDS = 2.0
+
+#: The stable leading fragment of ``DuplicateRevisionError``'s message
+#: (``registry/ingest/exc.py`` — also what the worker's IntegrityError
+#: translation mints for a lost one-active race, ``import_service.py``).
+#: ``job.error`` is truncated to 128 chars after a ~42-char wrapper prefix, so
+#: only the message head survives: match this fragment, never the full message.
+_DUPLICATE_CONTENT_FRAGMENT = "identical content already exists"
+
+#: Job statuses that end the tracking loop (Go: ``catJobCompleted`` /
+#: ``catJobFailed`` / ``catJobCancelled`` / ``catJobDeadLetter`` — dead_letter
+#: IS terminal: the worker's retry-backoff ladder parks poison jobs there).
+_JOB_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "dead_letter"})
+
+#: the job kind the catalog import loop rides (``JobKind.IMPORT``).
+_JOB_KIND_IMPORT = "import"
+
+
+def validate_api_id(api_id: str) -> None:
+    """Syntactic guard on the catalog entry id (Go: ``validateAPIID``).
+
+    The Go client splices the api_id into the ``{api_id:path}`` route verbatim,
+    so it rejects traversal shapes before the wire. In-process there is no
+    route to rewrite, but the error contract must not differ: the same shapes
+    are refused as the same correctable protocol error.
+    """
+    if api_id.startswith("/"):
+        raise invalid_params(
+            f'invalid api_id {api_id!r}: a leading "/" is not allowed — pass the api_id '
+            "from a search_catalog hit verbatim"
+        )
+    for segment in api_id.split("/"):
+        if segment in ("", ".", ".."):
+            raise invalid_params(
+                f'invalid api_id {api_id!r}: empty, ".", or ".." path segments are not '
+                "allowed — pass the api_id from a search_catalog hit verbatim"
+            )
+
+
+def _already_imported_payload(job_id: str) -> dict[str, Any]:
+    """The duplicate-content short-circuit envelope (import_api + the job poll).
+
+    The wording says "already present", never "you imported this before": the
+    same ``job.error`` fragment also covers a lost concurrent-import race
+    (the ``ix_api_revisions_one_active`` collision), where "already imported"
+    means "another import just won" — the recovery (search_apis) is identical
+    either way. This mapping is what keeps the pinned description's
+    "re-importing converges (idempotent)" true on this backend.
+    """
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "job_id": job_id,
+        "status": "already_imported",
+        "note": "a revision with identical content is already present in the registry "
+        "(imported earlier, or a concurrent import just won the race) — nothing new was "
+        "imported and nothing needs promoting; find the API's operations with search_apis",
+        "next_tool": "search_apis",
+    }
+
+
+async def _track_import_job(ctx: Context, job_id: str) -> tuple[JobView, bool]:
+    """Poll the import job briefly; returns ``(job, duplicate_content)``.
+
+    Mirrors Go's ``trackImportJob`` three-outcome contract: a terminal job
+    returns with its terminal status, a budget lapse returns the last
+    non-terminal status (the caller renders both from ``job.status``), and a
+    failing poll PROPAGATES — the job's state is then unknown, and the caller
+    must surface that as a failure, never as a clean "still running" result.
+
+    The duplicate-content check runs on EVERY poll, including non-terminal
+    requeued states: the worker treats a duplicate ingest as retryable
+    (exponential backoff to a terminal DEAD_LETTER, ~30s+ total), so waiting
+    for a terminal status would burn the whole wait budget on a job that can
+    never succeed. ``job.error`` is populated while requeued, which is what
+    makes the early exit possible.
+    """
+    svc = JobService(ctx)
+    deadline = time.monotonic() + _IMPORT_WAIT_BUDGET_SECONDS
+    delay = _IMPORT_POLL_STEP_SECONDS  # the first poll is immediate; back off from the step
+    while True:
+        job = await svc.get_by_id(job_id)
+        if job.error and _DUPLICATE_CONTENT_FRAGMENT in job.error:
+            return job, True
+        if job.status in _JOB_TERMINAL_STATUSES or time.monotonic() >= deadline:
+            return job, False
+        await asyncio.sleep(delay)
+        delay = min(delay + _IMPORT_POLL_STEP_SECONDS, _IMPORT_POLL_MAX_SECONDS)
+
+
+async def _promote_revisions(env: CallEnv, revisions: list[Any]) -> dict[str, str]:
+    """Promote each imported draft revision live, softly (Go: ``promoteRevisions``).
+
+    Catalog imports normally land ``IMPORTED`` (already live/searchable), so
+    this loop is usually a runtime no-op — non-draft revisions map to their
+    state verbatim, exactly like Go. For a genuine draft:
+    ``RevisionService.promote`` enforces NO scopes in-process (the
+    ``apis:write`` gate lives only on the REST route), so the handler
+    soft-checks the scope itself — an unguarded call would let a default agent
+    actually promote, a capability escalation over REST. The check is
+    ``has_effective_permission`` (implication-map expansion), never a literal
+    membership test: grants arrive unexpanded and ``org:admin`` implies
+    ``apis:write`` only via the implication map. Every failure becomes a
+    per-revision ``"promote failed: …"`` entry — never a hard error.
+    """
+    promoted: dict[str, str] = {}
+    can_write = has_effective_permission(env.identity.permissions, "apis:write")
+    for rev in revisions:
+        if not isinstance(rev, dict):
+            continue
+        revision_id = str(rev.get("revision_id") or "")
+        if not revision_id:
+            continue
+        state = str(rev.get("state") or "")
+        if state != "draft":
+            promoted[revision_id] = state
+            continue
+        if not can_write:
+            promoted[revision_id] = "promote failed: missing apis:write scope"
+            continue
+        api = rev.get("api") or {}
+        try:
+            await RevisionService(env.ctx).promote(
+                str(api.get("vendor") or ""),
+                str(api.get("name") or ""),
+                str(api.get("version") or ""),
+                revision_id,
+                identity=env.identity,
+            )
+        except Exception as exc:  # per-revision softness — mirror Go's posture
+            promoted[revision_id] = f"promote failed: {exc}"
+            continue
+        promoted[revision_id] = "live"
+    return promoted
+
+
+async def handle_import_api(env: CallEnv, arguments: dict[str, Any]) -> mcp_types.CallToolResult:
+    """POST /catalog/{api_id}:import + the track-and-promote loop, in-process
+    (Go: ``handleImportAPI`` + ``trackImportJob`` + ``promoteRevisions``)."""
+    args = normalize_tool_args(arguments, _IMPORT_API_PARAMS)
+    api_id = args.get("api_id", "")
+    if not api_id:
+        raise invalid_params(
+            'import_api requires "api_id" (aliases: "id", "api"): a catalog entry id '
+            'from a search_catalog hit, e.g. "googleapis.com/sheets"'
+        )
+    validate_api_id(api_id)
+    try:
+        require_scopes(env.identity, ["catalog:import"])
+    except ToolError as exc:
+        # The Go special case (importAPIError's 403 arm): a 403 on THIS route
+        # is the missing catalog:import scope — an access gap the agent can
+        # close itself via request_access, not a revoked identity.
+        raise ToolError(
+            CODE_BROKER_DENIED,
+            f"importing a cataloged API requires the catalog:import scope: {exc}",
+            actionable='Request the scope with request_access, e.g. {"scopes": '
+            '["catalog:import"], "reason": "import the API needed for this task"}, wait '
+            "for your operator's approval, then retry import_api.",
+            next_tool="request_access",
+        ) from None
+    _require_db(env.ctx, "registry", "the catalog")
+    _require_db(env.ctx, "admin", "import job tracking")
+
+    try:
+        job_id = await CatalogService(env.ctx).import_entry(api_id, env.identity)
+    except CatalogEntryNotFoundError:
+        raise ToolError(
+            CODE_RESOLVE_FAILED,
+            f"catalog entry {api_id!r} not found",
+            actionable="Call search_catalog with a keyword for the API you need and use "
+            "the api_id from one of its hits.",
+            next_tool="search_catalog",
+        ) from None
+    except OverlaySupersedeForbiddenError as exc:
+        # An arm Go never sees distinctly: re-importing would supersede an
+        # operator's confirmed overlay, which requires overlays:confirm.
+        # Mapped honestly, never folded into a generic "import failed".
+        raise ToolError(
+            CODE_BROKER_DENIED,
+            str(exc),
+            actionable="Relay this to your human operator: superseding a confirmed "
+            "overlay is an operator decision (overlays:confirm), not a scope an agent "
+            "should request for itself.",
+        ) from None
+    except CatalogUnavailableError as exc:
+        raise ToolError(CODE_INTERNAL_ERROR, f"catalog not available: {exc}") from None
+
+    try:
+        job, duplicate_content = await _track_import_job(env.ctx, job_id)
+    except Exception as exc:
+        # Go's poll-failure arm: a failing job poll is UNKNOWN state — never a
+        # clean "still running" result (which would send the model into a
+        # re-import loop against a backend that de-duplicates nothing).
+        # Surface the failure with the job_id so the model keeps watching
+        # THIS job instead of filing another.
+        raise ToolError(
+            CODE_INTERNAL_ERROR,
+            f"import of {api_id} was filed as job {job_id}, but polling the job failed: {exc}",
+            actionable="The job's state is unknown — do not re-import; poll this job "
+            "with get_execution_result using the job_id in this result.",
+            next_tool="get_execution_result",
+            extra={"job_id": job_id},
+        ) from exc
+    if duplicate_content:
+        # Identical content already present (or a concurrent import just won
+        # the one-active race): short-circuit honestly instead of letting the
+        # job burn its retry backoff to DEAD_LETTER inside the wait budget.
+        return tool_result(env.ctx, _already_imported_payload(job_id))
+    if job.status not in _JOB_TERMINAL_STATUSES:
+        # Budget lapsed with the job still running: a normal result — the
+        # model converges by re-calling import_api (idempotent) or watches
+        # the job with get_execution_result. Never block out the call.
+        return tool_result(
+            env.ctx,
+            {"schema_version": SCHEMA_VERSION, "job_id": job_id, "status": job.status},
+        )
+    if job.status != _JOB_COMPLETED:
+        raise ToolError(
+            CODE_INTERNAL_ERROR,
+            f"import of {api_id} {job.status}: {job.error or 'no detail'}",
+            actionable="Re-check the api_id against a search_catalog hit and retry "
+            "import_api; if the import keeps failing, relay this error to your operator.",
+            next_tool="search_catalog",
+            extra={"job_id": job_id, "job_status": job.status},
+        )
+
+    try:
+        view = await JobResultService(env.ctx).get(job_id)
+    except Exception as exc:
+        raise ToolError(
+            CODE_INTERNAL_ERROR,
+            f"import job {job_id} completed but its result could not be fetched: {exc}",
+            actionable="Poll this job with get_execution_result using the job_id in this result.",
+            next_tool="get_execution_result",
+            extra={"job_id": job_id},
+        ) from exc
+    revisions = view.body.get("revisions", []) if isinstance(view.body, dict) else []
+    promoted = await _promote_revisions(env, revisions)
+    return tool_result(
+        env.ctx,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "job_id": job_id,
+            "status": job.status,
+            "revisions": revisions,
+            "promoted": promoted,
+        },
+    )
+
+
 # ── execute / execute_read ────────────────────────────────────────────────────
 
 _EXECUTE_PARAMS = [
@@ -662,6 +936,13 @@ async def handle_get_execution_result(
             next_tool="get_execution_result",
         ) from None
 
+    if job.kind == _JOB_KIND_IMPORT and job.error and _DUPLICATE_CONTENT_FRAGMENT in job.error:
+        # The same duplicate-content short-circuit import_api makes: a
+        # duplicate import job polled here reports already_imported (the
+        # content is present — possibly a lost concurrent race), never a
+        # scary dead_letter after the worker burns its retry backoff.
+        return tool_result(env.ctx, _already_imported_payload(job.id))
+
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "job_id": job.id,
@@ -714,6 +995,7 @@ HANDLERS: dict[str, Handler] = {
     "search_apis": handle_search_apis,
     "inspect_operation": handle_inspect_operation,
     "search_catalog": handle_search_catalog,
+    "import_api": handle_import_api,
     "execute": handle_execute,
     "execute_read": handle_execute_read,
     "get_execution_result": handle_get_execution_result,

--- a/src/jentic_one/mcp/tools.py
+++ b/src/jentic_one/mcp/tools.py
@@ -15,8 +15,9 @@ Scope enforcement mirrors the REST routes fronted: the same
 identity through the same ``compute_effective`` expansion + ``org:admin``
 bypass ``get_current_identity`` applies. A scope failure maps exactly like the
 Go client's wire 403 (``mcpCoded``): NOT_AUTHENTICATED with the get_started
-pointer — except ``search_catalog``, whose 403 is a missing-scope fact the
-agent can fix itself (BROKER_DENIED + request_access, the Go special case).
+pointer — except ``search_catalog`` and ``import_api``, whose 403s are
+missing-scope facts the agent can fix itself (BROKER_DENIED + request_access,
+the Go special case).
 """
 
 from __future__ import annotations
@@ -536,6 +537,13 @@ _IMPORT_API_PARAMS = [ParamSpec("api_id", "string", ("id", "api"))]
 #: the Go side's ``importWaitBudget``); no config knob until someone needs one.
 _IMPORT_WAIT_BUDGET_SECONDS = 15.0
 
+#: Grace on top of the wait budget for the hard per-leg ceiling
+#: (``asyncio.timeout`` around the whole track-and-promote tail). The budget
+#: alone only gates BETWEEN polls — a single hung poll / result fetch /
+#: promote would hold the ASGI request open indefinitely; the ceiling turns
+#: that into the poll-failure arm (unknown state, never "still running").
+_IMPORT_WAIT_GRACE_SECONDS = 5.0
+
 #: In-process poll cadence for the job tracker: the first poll is immediate,
 #: then back off from the step to the max (Go: ``App.PollCadence``).
 _IMPORT_POLL_STEP_SECONDS = 0.25
@@ -613,14 +621,18 @@ async def _track_import_job(ctx: Context, job_id: str) -> tuple[JobView, bool]:
     (exponential backoff to a terminal DEAD_LETTER, ~30s+ total), so waiting
     for a terminal status would burn the whole wait budget on a job that can
     never succeed. ``job.error`` is populated while requeued, which is what
-    makes the early exit possible.
+    makes the early exit possible. A COMPLETED job is exempt: the worker never
+    clears ``job.error`` (requeue writes it; neither claim nor completion
+    resets it), so a job that failed once with the duplicate message and
+    succeeded on a later attempt carries the stale fragment forever — its
+    completed result is always more honest than its residual error.
     """
     svc = JobService(ctx)
     deadline = time.monotonic() + _IMPORT_WAIT_BUDGET_SECONDS
     delay = _IMPORT_POLL_STEP_SECONDS  # the first poll is immediate; back off from the step
     while True:
         job = await svc.get_by_id(job_id)
-        if job.error and _DUPLICATE_CONTENT_FRAGMENT in job.error:
+        if job.status != _JOB_COMPLETED and job.error and _DUPLICATE_CONTENT_FRAGMENT in job.error:
             return job, True
         if job.status in _JOB_TERMINAL_STATUSES or time.monotonic() >= deadline:
             return job, False
@@ -641,15 +653,19 @@ async def _promote_revisions(env: CallEnv, revisions: list[Any]) -> dict[str, st
     ``has_effective_permission`` (implication-map expansion), never a literal
     membership test: grants arrive unexpanded and ``org:admin`` implies
     ``apis:write`` only via the implication map. Every failure becomes a
-    per-revision ``"promote failed: …"`` entry — never a hard error.
+    per-revision ``"promote failed: …"`` entry — never a hard error; a
+    malformed row (non-dict, or no ``revision_id``) gets an explicit
+    index-keyed entry rather than vanishing silently.
     """
     promoted: dict[str, str] = {}
     can_write = has_effective_permission(env.identity.permissions, "apis:write")
-    for rev in revisions:
+    for idx, rev in enumerate(revisions):
         if not isinstance(rev, dict):
+            promoted[f"revision[{idx}]"] = "promote failed: malformed revision entry"
             continue
         revision_id = str(rev.get("revision_id") or "")
         if not revision_id:
+            promoted[f"revision[{idx}]"] = "promote failed: malformed revision entry"
             continue
         state = str(rev.get("state") or "")
         if state != "draft":
@@ -726,6 +742,41 @@ async def handle_import_api(env: CallEnv, arguments: dict[str, Any]) -> mcp_type
     except CatalogUnavailableError as exc:
         raise ToolError(CODE_INTERNAL_ERROR, f"catalog not available: {exc}") from None
 
+    try:
+        require_scopes(env.identity, ["jobs:read"])
+    except ToolError:
+        # In-process tracking rides the same jobs:read gate the Go client's
+        # poll leg does (GET /jobs/{id}). Absent the scope, degrade to the
+        # filed-{job_id, status} envelope — NOT an error: the filing
+        # succeeded, only the courtesy tracking is off the table (REST
+        # parity: the poll would have been refused, the import would not).
+        # Both scopes ride DEFAULT_AGENT_SCOPES, so defaults are unaffected.
+        return tool_result(
+            env.ctx,
+            {"schema_version": SCHEMA_VERSION, "job_id": job_id, "status": "queued"},
+        )
+
+    try:
+        # The hard per-leg ceiling: the wait budget only gates BETWEEN polls —
+        # a hung poll / result fetch / promote inside the tail would hold the
+        # ASGI request open indefinitely without it.
+        async with asyncio.timeout(_IMPORT_WAIT_BUDGET_SECONDS + _IMPORT_WAIT_GRACE_SECONDS):
+            return await _finish_import(env, api_id, job_id)
+    except TimeoutError as exc:
+        # The ceiling lapse maps to the poll-failure arm: the job's state is
+        # UNKNOWN (a leg hung mid-flight) — never a clean "still running".
+        raise ToolError(
+            CODE_INTERNAL_ERROR,
+            f"import of {api_id} was filed as job {job_id}, but tracking it timed out mid-poll",
+            actionable="The job's state is unknown — do not re-import; poll this job "
+            "with get_execution_result using the job_id in this result.",
+            next_tool="get_execution_result",
+            extra={"job_id": job_id},
+        ) from exc
+
+
+async def _finish_import(env: CallEnv, api_id: str, job_id: str) -> mcp_types.CallToolResult:
+    """The track-and-promote tail of import_api (runs under the hard ceiling)."""
     try:
         job, duplicate_content = await _track_import_job(env.ctx, job_id)
     except Exception as exc:
@@ -936,11 +987,20 @@ async def handle_get_execution_result(
             next_tool="get_execution_result",
         ) from None
 
-    if job.kind == _JOB_KIND_IMPORT and job.error and _DUPLICATE_CONTENT_FRAGMENT in job.error:
+    if (
+        job.kind == _JOB_KIND_IMPORT
+        and job.status != _JOB_COMPLETED
+        and job.error
+        and _DUPLICATE_CONTENT_FRAGMENT in job.error
+    ):
         # The same duplicate-content short-circuit import_api makes: a
         # duplicate import job polled here reports already_imported (the
         # content is present — possibly a lost concurrent race), never a
         # scary dead_letter after the worker burns its retry backoff.
+        # COMPLETED jobs are exempt: the worker never clears job.error, so a
+        # job that failed once with the duplicate message and succeeded on a
+        # later attempt carries the stale fragment — its completed result is
+        # always more honest than its residual error.
         return tool_result(env.ctx, _already_imported_payload(job.id))
 
     payload: dict[str, Any] = {

--- a/src/jentic_one/mcp/tools.py
+++ b/src/jentic_one/mcp/tools.py
@@ -52,6 +52,7 @@ from jentic_one.mcp.envelopes import (
     CODE_INTERNAL_ERROR,
     CODE_NOT_AUTHENTICATED,
     CODE_RESOLVE_FAILED,
+    CODE_TRANSPORT_ERROR,
     SCHEMA_VERSION,
     ToolError,
     soft_error_result,
@@ -66,6 +67,10 @@ from jentic_one.registry.services.errors import (
     OperationNotFoundError,
     OverlaySupersedeForbiddenError,
     SearchUnavailableError,
+)
+from jentic_one.registry.services.import_service import (
+    ALL_SOURCES_FAILED_PREFIX_TEMPLATE,
+    SOURCE_FAILURE_PREFIX_TEMPLATE,
 )
 from jentic_one.registry.services.inspect.models import SUMMARY_LOAD_OPTIONS
 from jentic_one.registry.services.inspect.service import InspectService
@@ -538,10 +543,12 @@ _IMPORT_API_PARAMS = [ParamSpec("api_id", "string", ("id", "api"))]
 _IMPORT_WAIT_BUDGET_SECONDS = 15.0
 
 #: Grace on top of the wait budget for the hard per-leg ceiling
-#: (``asyncio.timeout`` around the whole track-and-promote tail). The budget
-#: alone only gates BETWEEN polls — a single hung poll / result fetch /
-#: promote would hold the ASGI request open indefinitely; the ceiling turns
-#: that into the poll-failure arm (unknown state, never "still running").
+#: (``asyncio.timeout`` around the filing call + the whole track-and-promote
+#: tail). The budget alone only gates BETWEEN polls — a single hung poll /
+#: result fetch / promote would hold the ASGI request open indefinitely — and
+#: the filing leg's catalog read can lazily refresh the upstream manifest
+#: (bounded only by ``ingest.fetch_timeout_s``, ~30s default). The ceiling
+#: turns either into a soft error (unknown state, never "still running").
 _IMPORT_WAIT_GRACE_SECONDS = 5.0
 
 #: In-process poll cadence for the job tracker: the first poll is immediate,
@@ -556,10 +563,28 @@ _IMPORT_POLL_MAX_SECONDS = 2.0
 #: only the message head survives: match this fragment, never the full message.
 _DUPLICATE_CONTENT_FRAGMENT = "identical content already exists"
 
+#: The exact ``job.error`` head of a SINGLE-source import whose one source
+#: failed (``ImportHandler``'s wrapper templates rendered for one source):
+#: ``"all 1 import source(s) failed: source[0]: "``. The duplicate-content
+#: remap keys on it because only a job whose ENTIRE failure is the duplicate
+#: may report ``already_imported``: ``POST /apis`` enqueues multi-source
+#: ``JobKind.IMPORT`` jobs, and on those a duplicate source[0] must never mask
+#: a genuine source[1] failure. ``CatalogService.import_entry`` (import_api's
+#: filing leg) always files exactly one source, so the import_api tracker can
+#: never see a multi-source job — the gate rides there too as defense in depth.
+_SINGLE_SOURCE_IMPORT_FAILURE_PREFIX = ALL_SOURCES_FAILED_PREFIX_TEMPLATE.format(
+    count=1
+) + SOURCE_FAILURE_PREFIX_TEMPLATE.format(index=0)
+
 #: Job statuses that end the tracking loop (Go: ``catJobCompleted`` /
 #: ``catJobFailed`` / ``catJobCancelled`` / ``catJobDeadLetter`` — dead_letter
 #: IS terminal: the worker's retry-backoff ladder parks poison jobs there).
 _JOB_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "dead_letter"})
+
+#: the one non-failure terminal status: its result document rides the poll
+#: payload, and its residual ``job.error`` (never cleared by the worker) is
+#: exempt from the duplicate-content remap.
+_JOB_COMPLETED = "completed"
 
 #: the job kind the catalog import loop rides (``JobKind.IMPORT``).
 _JOB_KIND_IMPORT = "import"
@@ -607,6 +632,25 @@ def _already_imported_payload(job_id: str) -> dict[str, Any]:
     }
 
 
+def _is_single_source_duplicate_failure(error: str | None) -> bool:
+    """True when a job's ENTIRE failure is the duplicate-content collision.
+
+    Keys on the single-source wrapper head (``all 1 import source(s) failed:
+    source[0]: ``) AND the duplicate fragment: a multi-source job (``POST
+    /apis`` enqueues those) whose source[0] hit the duplicate can still carry a
+    genuine source[1] failure inside the truncated ``job.error`` — remapping it
+    to ``already_imported`` would mask that failure, so only the single-source
+    rendering qualifies. Both halves survive the worker's 128-char truncation
+    (the wrapper is ~43 chars, the fragment heads the duplicate message —
+    pinned end-to-end by the fragment test).
+    """
+    return bool(
+        error
+        and error.startswith(_SINGLE_SOURCE_IMPORT_FAILURE_PREFIX)
+        and _DUPLICATE_CONTENT_FRAGMENT in error
+    )
+
+
 async def _track_import_job(ctx: Context, job_id: str) -> tuple[JobView, bool]:
     """Poll the import job briefly; returns ``(job, duplicate_content)``.
 
@@ -632,7 +676,7 @@ async def _track_import_job(ctx: Context, job_id: str) -> tuple[JobView, bool]:
     delay = _IMPORT_POLL_STEP_SECONDS  # the first poll is immediate; back off from the step
     while True:
         job = await svc.get_by_id(job_id)
-        if job.status != _JOB_COMPLETED and job.error and _DUPLICATE_CONTENT_FRAGMENT in job.error:
+        if job.status != _JOB_COMPLETED and _is_single_source_duplicate_failure(job.error):
             return job, True
         if job.status in _JOB_TERMINAL_STATUSES or time.monotonic() >= deadline:
             return job, False
@@ -718,8 +762,75 @@ async def handle_import_api(env: CallEnv, arguments: dict[str, Any]) -> mcp_type
     _require_db(env.ctx, "registry", "the catalog")
     _require_db(env.ctx, "admin", "import job tracking")
 
+    job_id: str | None = None
     try:
-        job_id = await CatalogService(env.ctx).import_entry(api_id, env.identity)
+        # The hard per-leg ceiling, from the filing call onward. Two legs need
+        # it: the filing leg's catalog read can lazily refresh the upstream
+        # manifest (bounded only by ``ingest.fetch_timeout_s``, ~30s default),
+        # and the wait budget in the tail only gates BETWEEN polls — a hung
+        # poll / result fetch / promote would hold the ASGI request open
+        # indefinitely. One ceiling over both bounds the whole request inside
+        # typical MCP client tool timeouts.
+        async with asyncio.timeout(_IMPORT_WAIT_BUDGET_SECONDS + _IMPORT_WAIT_GRACE_SECONDS):
+            job_id = await _file_import(env, api_id)
+
+            try:
+                require_scopes(env.identity, ["jobs:read"])
+            except ToolError:
+                # In-process tracking rides the same jobs:read gate the Go
+                # client's poll leg does (GET /jobs/{id}). Absent the scope,
+                # degrade to the filed-{job_id, status} envelope — NOT an
+                # error: the filing succeeded, only the courtesy tracking is
+                # off the table (REST parity: the poll would have been
+                # refused, the import would not). Both scopes ride
+                # DEFAULT_AGENT_SCOPES, so defaults are unaffected.
+                return tool_result(
+                    env.ctx,
+                    {"schema_version": SCHEMA_VERSION, "job_id": job_id, "status": "queued"},
+                )
+
+            return await _finish_import(env, api_id, job_id)
+    except TimeoutError as exc:
+        if job_id is None:
+            # The ceiling lapsed inside the FILING leg: whether the enqueue
+            # committed is unknowable from here (the lapse may have hit the
+            # lazy manifest refresh before it, or the enqueue itself). A
+            # re-import converges either way — the backend de-duplicates
+            # identical content — so this is a retryable transport-class
+            # lapse (Go's transportSoftError posture), never "stop, bug".
+            raise ToolError(
+                CODE_TRANSPORT_ERROR,
+                f"filing the import of {api_id} timed out — the import may or may not "
+                "have been filed",
+                actionable="Re-calling import_api with the same api_id is safe "
+                "(re-importing converges), or re-check the entry with search_catalog "
+                "first.",
+                next_tool="search_catalog",
+                extra={"retryable": True},
+            ) from exc
+        # The ceiling lapsed in the tracking tail: maps to the poll-failure
+        # arm — the job's state is UNKNOWN (a leg hung mid-flight), never a
+        # clean "still running".
+        raise ToolError(
+            CODE_INTERNAL_ERROR,
+            f"import of {api_id} was filed as job {job_id}, but tracking it timed out mid-poll",
+            actionable="The job's state is unknown — prefer polling this job with "
+            "get_execution_result (using the job_id in this result) over re-importing "
+            "(a re-import of the same api_id converges, but files a fresh job).",
+            next_tool="get_execution_result",
+            extra={"job_id": job_id},
+        ) from exc
+
+
+async def _file_import(env: CallEnv, api_id: str) -> str:
+    """The filing leg: POST /catalog/{api_id}:import in-process, error-mapped.
+
+    Runs under the caller's hard ceiling — ``import_entry``'s catalog read can
+    lazily refresh the upstream manifest (``_refresh_if_stale``), a fetch
+    bounded only by ``ingest.fetch_timeout_s``.
+    """
+    try:
+        return await CatalogService(env.ctx).import_entry(api_id, env.identity)
     except CatalogEntryNotFoundError:
         raise ToolError(
             CODE_RESOLVE_FAILED,
@@ -742,38 +853,6 @@ async def handle_import_api(env: CallEnv, arguments: dict[str, Any]) -> mcp_type
     except CatalogUnavailableError as exc:
         raise ToolError(CODE_INTERNAL_ERROR, f"catalog not available: {exc}") from None
 
-    try:
-        require_scopes(env.identity, ["jobs:read"])
-    except ToolError:
-        # In-process tracking rides the same jobs:read gate the Go client's
-        # poll leg does (GET /jobs/{id}). Absent the scope, degrade to the
-        # filed-{job_id, status} envelope — NOT an error: the filing
-        # succeeded, only the courtesy tracking is off the table (REST
-        # parity: the poll would have been refused, the import would not).
-        # Both scopes ride DEFAULT_AGENT_SCOPES, so defaults are unaffected.
-        return tool_result(
-            env.ctx,
-            {"schema_version": SCHEMA_VERSION, "job_id": job_id, "status": "queued"},
-        )
-
-    try:
-        # The hard per-leg ceiling: the wait budget only gates BETWEEN polls —
-        # a hung poll / result fetch / promote inside the tail would hold the
-        # ASGI request open indefinitely without it.
-        async with asyncio.timeout(_IMPORT_WAIT_BUDGET_SECONDS + _IMPORT_WAIT_GRACE_SECONDS):
-            return await _finish_import(env, api_id, job_id)
-    except TimeoutError as exc:
-        # The ceiling lapse maps to the poll-failure arm: the job's state is
-        # UNKNOWN (a leg hung mid-flight) — never a clean "still running".
-        raise ToolError(
-            CODE_INTERNAL_ERROR,
-            f"import of {api_id} was filed as job {job_id}, but tracking it timed out mid-poll",
-            actionable="The job's state is unknown — do not re-import; poll this job "
-            "with get_execution_result using the job_id in this result.",
-            next_tool="get_execution_result",
-            extra={"job_id": job_id},
-        ) from exc
-
 
 async def _finish_import(env: CallEnv, api_id: str, job_id: str) -> mcp_types.CallToolResult:
     """The track-and-promote tail of import_api (runs under the hard ceiling)."""
@@ -788,8 +867,9 @@ async def _finish_import(env: CallEnv, api_id: str, job_id: str) -> mcp_types.Ca
         raise ToolError(
             CODE_INTERNAL_ERROR,
             f"import of {api_id} was filed as job {job_id}, but polling the job failed: {exc}",
-            actionable="The job's state is unknown — do not re-import; poll this job "
-            "with get_execution_result using the job_id in this result.",
+            actionable="The job's state is unknown — prefer polling this job with "
+            "get_execution_result (using the job_id in this result) over re-importing "
+            "(a re-import of the same api_id converges, but files a fresh job).",
             next_tool="get_execution_result",
             extra={"job_id": job_id},
         ) from exc
@@ -958,9 +1038,6 @@ def _header_kvs(obj: dict[str, Any] | None) -> list[tuple[str, str]]:
 
 _GET_EXECUTION_RESULT_PARAMS = [ParamSpec("job_id", "string", ("id", "job"))]
 
-#: the terminal state whose result document rides the poll payload.
-_JOB_COMPLETED = "completed"
-
 
 async def handle_get_execution_result(
     env: CallEnv, arguments: dict[str, Any]
@@ -990,13 +1067,15 @@ async def handle_get_execution_result(
     if (
         job.kind == _JOB_KIND_IMPORT
         and job.status != _JOB_COMPLETED
-        and job.error
-        and _DUPLICATE_CONTENT_FRAGMENT in job.error
+        and _is_single_source_duplicate_failure(job.error)
     ):
         # The same duplicate-content short-circuit import_api makes: a
         # duplicate import job polled here reports already_imported (the
         # content is present — possibly a lost concurrent race), never a
         # scary dead_letter after the worker burns its retry backoff.
+        # Gated on the single-source wrapper: a multi-source job (POST /apis)
+        # whose failure is only PARTLY the duplicate keeps its honest
+        # dead-letter payload — see _is_single_source_duplicate_failure.
         # COMPLETED jobs are exempt: the worker never clears job.error, so a
         # job that failed once with the duplicate message and succeeded on a
         # later attempt carries the stale fragment — its completed result is

--- a/src/jentic_one/registry/services/import_service.py
+++ b/src/jentic_one/registry/services/import_service.py
@@ -51,6 +51,18 @@ _source_adapter: TypeAdapter[IngestSource] = TypeAdapter(IngestSource)
 _DIGEST_CONSTRAINT = "uq_api_revisions_api_id_spec_digest"
 _ONE_ACTIVE_CONSTRAINT = "ix_api_revisions_one_active"
 
+# The job-error wrapper an all-sources-failed import rides (``IngestJobError``):
+# ``ALL_SOURCES_FAILED_PREFIX_TEMPLATE`` heads the whole message and
+# ``SOURCE_FAILURE_PREFIX_TEMPLATE`` heads each per-source entry. Named (rather
+# than inline f-strings) because the rendering is a cross-module contract: the
+# /mcp mount's duplicate-content detection (``jentic_one.mcp.tools``) keys on
+# the single-source rendering surviving the worker's 128-char ``job.error``
+# truncation, and its tests build fixtures from these exact templates. Keep the
+# rendering byte-identical when touching them — a wrapper that grows can push
+# the duplicate fragment past the truncation point in production.
+SOURCE_FAILURE_PREFIX_TEMPLATE = "source[{index}]: "
+ALL_SOURCES_FAILED_PREFIX_TEMPLATE = "all {count} import source(s) failed: "
+
 
 def _readable_source_error(exc: Exception) -> str:
     """Map a source-level ingest failure to a message safe to show a user.
@@ -137,7 +149,10 @@ class ImportHandler:
                     )
                 except Exception as exc:
                     logger.exception("import_source_failed", source_index=idx, job_id=job_id)
-                    failures.append(f"source[{idx}]: {_readable_source_error(exc)}")
+                    failures.append(
+                        SOURCE_FAILURE_PREFIX_TEMPLATE.format(index=idx)
+                        + _readable_source_error(exc)
+                    )
 
             logger.info(
                 "import_handler_complete",
@@ -248,7 +263,8 @@ class ImportHandler:
                 and not recovered_supersede
             ):
                 raise IngestJobError(
-                    f"all {len(sources)} import source(s) failed: " + "; ".join(failures)
+                    ALL_SOURCES_FAILED_PREFIX_TEMPLATE.format(count=len(sources))
+                    + "; ".join(failures)
                 )
 
             return JobResultPayload(

--- a/tests/unit/mcp/test_tool_surface.py
+++ b/tests/unit/mcp/test_tool_surface.py
@@ -81,8 +81,10 @@ def test_handlers_cover_served_tools_exactly() -> None:
 
 
 def test_unserved_phase1_tools_stay_stdio_only_for_now() -> None:
-    """The CLI-flavoured tools queue behind this PR (their dispatch is not
-    clean in-process yet) — pinned so serving one is a conscious decision."""
+    """``get_started`` never ports (it diagnoses the local machine's CLI
+    setup — over HTTP there is no local machine) and ``request_access``
+    queues behind the import_api PR — pinned so serving one is a conscious
+    decision."""
     specs = load_spec()
     deferred = set(specs) - set(SERVED_TOOLS)
-    assert deferred == {"get_started", "import_api", "request_access"}
+    assert deferred == {"get_started", "request_access"}

--- a/tests/unit/mcp/test_tools_import_api.py
+++ b/tests/unit/mcp/test_tools_import_api.py
@@ -1,0 +1,451 @@
+"""import_api on the mount — the Go table tests, replayed against the port.
+
+Mirrors ``cli/internal/cli/api/mcp_access_test.go``'s import coverage
+(validation arms, scope gate, three-outcome tracking, failed-job arm) plus the
+arms only the in-process port has: the duplicate-content short-circuit (the
+worker requeues a duplicate ingest with backoff and dead-letters it, so the
+handler matches ``job.error`` on every poll — including via
+get_execution_result), and the promote-leg softness (``RevisionService.promote``
+enforces no scopes in-process, so the handler soft-checks ``apis:write``
+itself; every promote failure is a per-revision map entry, never a hard error).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any, ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+from mcp.shared.exceptions import MCPError
+
+import jentic_one.mcp.tools as tools_mod
+from jentic_one.admin.services.schemas.jobs import JobResultView, JobView
+from jentic_one.mcp.tools import CallEnv, dispatch_tool_call, validate_api_id
+from jentic_one.registry.services.errors import (
+    CatalogEntryNotFoundError,
+    OverlaySupersedeForbiddenError,
+    RevisionStateConflictError,
+)
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.config import AuthConfig, ServerConfig
+from jentic_one.shared.models import ActorType
+
+_NOW = datetime(2026, 9, 10, tzinfo=UTC)
+
+#: the import-job result body the worker writes for one draft revision
+#: (``import_service.py`` — ``{"revisions": [...]}``); the Go fixture's twin.
+_DRAFT_REVISION = {
+    "api": {"vendor": "googleapis.com", "name": "sheets", "version": "v4"},
+    "revision_id": "rev_1",
+    "superseded_revision_id": None,
+    "state": "draft",
+}
+
+
+def _env(permissions: list[str]) -> CallEnv:
+    ctx = MagicMock()
+    ctx.config.auth = AuthConfig(canonical_base_url="https://auth.example.com")
+    ctx.config.server = ServerConfig()
+    ctx.instance_id = None
+    return CallEnv(
+        ctx=ctx,
+        identity=Identity(sub="agnt_1", permissions=permissions, actor_type=ActorType.AGENT),
+        credential="jak_test",
+        base_url="https://auth.example.com",
+        session_id=None,
+    )
+
+
+def _payload(result: Any) -> dict[str, Any]:
+    (content,) = result.content
+    decoded = json.loads(content.text)
+    assert isinstance(decoded, dict)
+    return decoded
+
+
+def _job(status: str, *, error: str | None = None, kind: str = "import") -> JobView:
+    return JobView(
+        id="job_9", kind=kind, status=status, error=error, created_at=_NOW, updated_at=_NOW
+    )
+
+
+class _FakeCatalogService:
+    """CatalogService stand-in: ``import_entry`` enqueues job_9 (or raises)."""
+
+    filed: ClassVar[list[str]] = []
+    import_error: ClassVar[Exception | None] = None
+
+    def __init__(self, ctx: Any) -> None:
+        self._ctx = ctx
+
+    async def import_entry(self, api_id: str, identity: Identity) -> str:
+        if _FakeCatalogService.import_error is not None:
+            raise _FakeCatalogService.import_error
+        _FakeCatalogService.filed.append(api_id)
+        return "job_9"
+
+
+class _FakeJobService:
+    """JobService stand-in: serves a scripted status sequence for job_9."""
+
+    statuses: ClassVar[list[JobView]] = []
+    polls: ClassVar[int] = 0
+    poll_error: ClassVar[Exception | None] = None
+
+    def __init__(self, ctx: Any) -> None:
+        self._ctx = ctx
+
+    async def get_by_id(self, job_id: str) -> JobView:
+        assert job_id == "job_9"
+        if _FakeJobService.poll_error is not None:
+            raise _FakeJobService.poll_error
+        idx = min(_FakeJobService.polls, len(_FakeJobService.statuses) - 1)
+        _FakeJobService.polls += 1
+        return _FakeJobService.statuses[idx]
+
+
+class _FakeJobResultService:
+    """JobResultService stand-in: serves the import job's result body."""
+
+    body: ClassVar[dict[str, Any]] = {}
+    error: ClassVar[Exception | None] = None
+
+    def __init__(self, ctx: Any) -> None:
+        self._ctx = ctx
+
+    async def get(self, job_id: str) -> JobResultView:
+        if _FakeJobResultService.error is not None:
+            raise _FakeJobResultService.error
+        return JobResultView(
+            id="jr_1",
+            job_id=job_id,
+            kind="import",
+            body=_FakeJobResultService.body,
+            created_at=_NOW,
+        )
+
+
+class _FakeRevisionService:
+    """RevisionService stand-in: records promote calls (or raises)."""
+
+    promotes: ClassVar[list[tuple[str, str, str, str]]] = []
+    promote_error: ClassVar[Exception | None] = None
+
+    def __init__(self, ctx: Any) -> None:
+        self._ctx = ctx
+
+    async def promote(
+        self, vendor: str, name: str, version: str, revision_id: str, *, identity: Identity
+    ) -> Any:
+        if _FakeRevisionService.promote_error is not None:
+            raise _FakeRevisionService.promote_error
+        _FakeRevisionService.promotes.append((vendor, name, version, revision_id))
+        return MagicMock()
+
+
+@pytest.fixture()
+def services(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wire the four service seams to fresh fakes and shrink the poll cadence."""
+    _FakeCatalogService.filed = []
+    _FakeCatalogService.import_error = None
+    _FakeJobService.statuses = []
+    _FakeJobService.polls = 0
+    _FakeJobService.poll_error = None
+    _FakeJobResultService.body = {"revisions": [dict(_DRAFT_REVISION)]}
+    _FakeJobResultService.error = None
+    _FakeRevisionService.promotes = []
+    _FakeRevisionService.promote_error = None
+    monkeypatch.setattr(tools_mod, "CatalogService", _FakeCatalogService)
+    monkeypatch.setattr(tools_mod, "JobService", _FakeJobService)
+    monkeypatch.setattr(tools_mod, "JobResultService", _FakeJobResultService)
+    monkeypatch.setattr(tools_mod, "RevisionService", _FakeRevisionService)
+    monkeypatch.setattr(tools_mod, "_IMPORT_POLL_STEP_SECONDS", 0.001)
+    monkeypatch.setattr(tools_mod, "_IMPORT_POLL_MAX_SECONDS", 0.002)
+
+
+# ── validation arms (Go: MissingAPIID / TraversalAPIID) ──────────────────────
+
+
+async def test_missing_api_id_is_invalid_params(services: None) -> None:
+    with pytest.raises(MCPError) as err:
+        await tools_mod.handle_import_api(_env(["catalog:import"]), {})
+    assert "api_id" in str(err.value)
+    assert "search_catalog" in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "../access-requests",
+        "/catalog/x",
+        "a//b",
+        "a/./b",
+        "googleapis.com/sheets/..",
+        "googleapis.com/",
+    ],
+)
+async def test_traversal_api_id_is_invalid_params(services: None, bad: str) -> None:
+    """The Go ``validateAPIID`` contract: traversal-shaped ids are refused as
+    a correctable protocol error before any service call."""
+    with pytest.raises(MCPError) as err:
+        await tools_mod.handle_import_api(_env(["catalog:import"]), {"api_id": bad})
+    assert "search_catalog" in str(err.value)
+    assert _FakeCatalogService.filed == []
+
+
+def test_umbrella_api_id_with_literal_slash_stays_accepted() -> None:
+    validate_api_id("googleapis.com/sheets")  # must not raise
+
+
+# ── scope gate (Go: 403PointsAtRequestAccessForScope) ────────────────────────
+
+
+async def test_missing_scope_is_broker_denied_pointing_at_request_access(
+    services: None,
+) -> None:
+    """The same gate as POST /catalog/{api_id}:import (catalog:import); the
+    403 points at request_access even though PR B hasn't landed yet — the
+    pinned description already does, and the pointer is the contract."""
+    result = await dispatch_tool_call(_env([]), "import_api", {"api_id": "googleapis.com/sheets"})
+    assert result.is_error
+    payload = _payload(result)
+    assert payload["error_code"] == "BROKER_DENIED"
+    assert payload["next_tool"] == "request_access"
+    assert "catalog:import" in payload["error"]
+    assert "catalog:import" in payload["actionable_step"]
+    assert _FakeCatalogService.filed == []
+
+
+# ── three-outcome tracking (Go: CompletesAndPromotes / StillRunning / PollFailure) ──
+
+
+async def test_completed_import_promotes_and_returns_the_go_envelope(services: None) -> None:
+    """The happy path: track to completion, fetch the result, promote the
+    draft revision live — {schema_version, job_id, status, revisions,
+    promoted} with the instance stamp joined. Uses the ``id`` alias and an
+    umbrella api_id with its literal slash, like the Go test."""
+    _FakeJobService.statuses = [_job("running"), _job("completed")]
+    env = _env(["catalog:import", "apis:write"])
+    result = await dispatch_tool_call(env, "import_api", {"id": "googleapis.com/sheets"})
+    assert not result.is_error, result.content
+    payload = _payload(result)
+    assert payload["schema_version"] == "1"
+    assert payload["job_id"] == "job_9"
+    assert payload["status"] == "completed"
+    assert payload["revisions"] == [_DRAFT_REVISION]
+    assert payload["promoted"] == {"rev_1": "live"}
+    assert _FakeCatalogService.filed == ["googleapis.com/sheets"]
+    assert _FakeRevisionService.promotes == [("googleapis.com", "sheets", "v4", "rev_1")]
+    assert "instance" in payload
+
+
+async def test_budget_lapse_returns_the_running_job_as_a_normal_result(
+    services: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A slow import is not an error — the model converges by re-calling
+    import_api (idempotent) or watching the job with get_execution_result."""
+    monkeypatch.setattr(tools_mod, "_IMPORT_WAIT_BUDGET_SECONDS", 0.0)
+    _FakeJobService.statuses = [_job("running")]
+    env = _env(["catalog:import"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert not result.is_error, result.content
+    payload = _payload(result)
+    assert payload["job_id"] == "job_9"
+    assert payload["status"] == "running"
+    assert "promoted" not in payload, "nothing completed, nothing may claim promotion"
+    assert "revisions" not in payload
+
+
+async def test_job_poll_failure_is_a_soft_error_never_still_running(services: None) -> None:
+    """A failing poll is UNKNOWN state: reporting it as a clean non-terminal
+    result would send the model into a re-import loop against a backend that
+    de-duplicates nothing. The job_id rides the extras so the model can keep
+    watching THIS job."""
+    _FakeJobService.poll_error = RuntimeError("job store down")
+    env = _env(["catalog:import"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert result.is_error, "a job-poll failure must never look like still-running"
+    payload = _payload(result)
+    assert payload["error_code"] == "INTERNAL_ERROR"
+    assert payload["job_id"] == "job_9"
+    assert payload["next_tool"] == "get_execution_result"
+    assert "job store down" in payload["error"]
+
+
+# ── failed-job arm (Go: FailedJobIsSoftError; DEAD_LETTER is terminal) ───────
+
+
+@pytest.mark.parametrize("terminal", ["failed", "dead_letter", "cancelled"])
+async def test_failed_job_is_internal_error_with_job_extras(services: None, terminal: str) -> None:
+    _FakeJobService.statuses = [_job(terminal, error="spec fetch failed")]
+    env = _env(["catalog:import"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert result.is_error
+    payload = _payload(result)
+    assert payload["error_code"] == "INTERNAL_ERROR"
+    assert "spec fetch failed" in payload["error"]
+    assert payload["job_id"] == "job_9"
+    assert payload["job_status"] == terminal
+    assert payload["next_tool"] == "search_catalog"
+
+
+# ── duplicate-content short-circuit ──────────────────────────────────────────
+
+
+async def test_duplicate_content_short_circuits_on_a_non_terminal_requeued_job(
+    services: None,
+) -> None:
+    """The worker treats a duplicate ingest as retryable (backoff to
+    DEAD_LETTER, ~30s+), so the handler matches the stable leading fragment of
+    ``job.error`` on EVERY poll — including a non-terminal requeued state —
+    and short-circuits instead of burning the wait budget."""
+    duplicate_error = (
+        "attempt 1/5 failed: all 1 import source(s) failed: source[0]: A revision with "
+        "identical content already exists for this API"  # truncated at 128 chars
+    )
+    _FakeJobService.statuses = [_job("queued", error=duplicate_error)]
+    env = _env(["catalog:import"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert not result.is_error, "already-present content is a convergence, not a failure"
+    payload = _payload(result)
+    assert payload["schema_version"] == "1"
+    assert payload["job_id"] == "job_9"
+    assert payload["status"] == "already_imported"
+    assert "already present" in payload["note"]
+    assert payload["next_tool"] == "search_apis"
+    assert _FakeJobService.polls == 1, "the short-circuit must not keep polling"
+
+
+async def test_duplicate_content_dead_letter_via_get_execution_result(services: None) -> None:
+    """A duplicate import job polled later reports already_imported, never a
+    scary dead_letter — the same detection, placed before the generic payload
+    assembly in handle_get_execution_result."""
+    _FakeJobService.statuses = [
+        _job("dead_letter", error="… A revision with identical content already exists for …")
+    ]
+    env = _env(["jobs:read"])
+    result = await dispatch_tool_call(env, "get_execution_result", {"job_id": "job_9"})
+    assert not result.is_error
+    payload = _payload(result)
+    assert payload["status"] == "already_imported"
+    assert payload["job_id"] == "job_9"
+    assert payload["next_tool"] == "search_apis"
+
+
+async def test_execution_jobs_never_trip_the_duplicate_detection(services: None) -> None:
+    """The short-circuit is keyed on kind=import: an execution job whose error
+    happens to carry the fragment keeps the generic poll payload."""
+    _FakeJobService.statuses = [
+        _job("failed", error="identical content already exists", kind="execution")
+    ]
+    env = _env(["jobs:read"])
+    result = await dispatch_tool_call(env, "get_execution_result", {"job_id": "job_9"})
+    assert not result.is_error
+    payload = _payload(result)
+    assert payload["status"] == "failed"
+    assert payload["kind"] == "execution"
+
+
+# ── promote-leg softness ─────────────────────────────────────────────────────
+
+
+async def test_promote_without_apis_write_soft_fails_without_calling_the_service(
+    services: None,
+) -> None:
+    """``RevisionService.promote`` enforces no scopes in-process — an
+    unguarded call would be a capability escalation over REST. Missing
+    ``apis:write`` becomes a per-revision map entry, and the service is never
+    touched; the import itself still succeeds."""
+    _FakeJobService.statuses = [_job("completed")]
+    env = _env(["catalog:import"])  # no apis:write
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert not result.is_error, "a promote failure is never a hard error"
+    payload = _payload(result)
+    assert payload["promoted"] == {"rev_1": "promote failed: missing apis:write scope"}
+    assert _FakeRevisionService.promotes == []
+
+
+async def test_org_admin_implies_apis_write_via_the_implication_map(services: None) -> None:
+    """The soft-check is ``has_effective_permission``, not a literal
+    membership test: org:admin holders promote even though the literal scope
+    string is absent from their grants."""
+    _FakeJobService.statuses = [_job("completed")]
+    env = _env(["org:admin"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert not result.is_error, result.content
+    assert _payload(result)["promoted"] == {"rev_1": "live"}
+
+
+async def test_promote_state_conflict_is_a_soft_map_entry(services: None) -> None:
+    """A typed promote error (e.g. the revision is no longer DRAFT — the
+    parity no-op path) degrades to a "promote failed: …" entry, never a hard
+    error on the import result."""
+    _FakeJobService.statuses = [_job("completed")]
+    _FakeRevisionService.promote_error = RevisionStateConflictError(
+        "rev_1", "imported", ["draft"], "promote"
+    )
+    env = _env(["catalog:import", "apis:write"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert not result.is_error
+    promoted = _payload(result)["promoted"]
+    assert promoted["rev_1"].startswith("promote failed: ")
+    assert "promote" in promoted["rev_1"]
+
+
+async def test_non_draft_revisions_map_to_their_state_verbatim(services: None) -> None:
+    """Catalog imports land IMPORTED (already live) on this backend — the
+    promote leg is a runtime no-op that reports the state, exactly like Go's
+    ``promoteRevisions`` skip."""
+    _FakeJobService.statuses = [_job("completed")]
+    _FakeJobResultService.body = {"revisions": [{**_DRAFT_REVISION, "state": "imported"}]}
+    env = _env(["catalog:import", "apis:write"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert not result.is_error
+    assert _payload(result)["promoted"] == {"rev_1": "imported"}
+    assert _FakeRevisionService.promotes == []
+
+
+# ── filing-time error arms ───────────────────────────────────────────────────
+
+
+async def test_unknown_catalog_entry_is_resolve_failed(services: None) -> None:
+    _FakeCatalogService.import_error = CatalogEntryNotFoundError("nope/nothing")
+    env = _env(["catalog:import"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "nope/nothing"})
+    assert result.is_error
+    payload = _payload(result)
+    assert payload["error_code"] == "RESOLVE_FAILED"
+    assert payload["next_tool"] == "search_catalog"
+    assert "nope/nothing" in payload["error"]
+
+
+async def test_overlay_supersede_refusal_maps_to_broker_denied(services: None) -> None:
+    """The in-process arm Go never sees distinctly: superseding a confirmed
+    overlay needs overlays:confirm — mapped honestly, not folded into a
+    generic import failure."""
+    _FakeCatalogService.import_error = OverlaySupersedeForbiddenError(
+        "googleapis.com/sheets", "ovl_1"
+    )
+    env = _env(["catalog:import"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert result.is_error
+    payload = _payload(result)
+    assert payload["error_code"] == "BROKER_DENIED"
+    assert "overlays:confirm" in payload["error"]
+    assert "operator" in payload["actionable_step"]
+
+
+async def test_result_fetch_failure_points_at_the_job_poll(services: None) -> None:
+    """A completed job whose result fetch fails surfaces with the job_id —
+    the model polls get_execution_result rather than re-importing blind."""
+    _FakeJobService.statuses = [_job("completed")]
+    _FakeJobResultService.error = RuntimeError("result store down")
+    env = _env(["catalog:import", "apis:write"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert result.is_error
+    payload = _payload(result)
+    assert payload["error_code"] == "INTERNAL_ERROR"
+    assert payload["job_id"] == "job_9"
+    assert payload["next_tool"] == "get_execution_result"

--- a/tests/unit/mcp/test_tools_import_api.py
+++ b/tests/unit/mcp/test_tools_import_api.py
@@ -12,9 +12,10 @@ itself; every promote failure is a per-revision map entry, never a hard error).
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import UTC, datetime
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,6 +24,7 @@ from mcp.shared.exceptions import MCPError
 import jentic_one.mcp.tools as tools_mod
 from jentic_one.admin.services.schemas.jobs import JobResultView, JobView
 from jentic_one.mcp.tools import CallEnv, dispatch_tool_call, validate_api_id
+from jentic_one.registry.ingest.exc import DuplicateRevisionError
 from jentic_one.registry.services.errors import (
     CatalogEntryNotFoundError,
     OverlaySupersedeForbiddenError,
@@ -30,9 +32,25 @@ from jentic_one.registry.services.errors import (
 )
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.config import AuthConfig, ServerConfig
+from jentic_one.shared.jobs.worker import _ERROR_MAX_LEN
 from jentic_one.shared.models import ActorType
 
 _NOW = datetime(2026, 9, 10, tzinfo=UTC)
+
+
+def _real_duplicate_job_error() -> str:
+    """``job.error`` exactly as the worker writes it for a duplicate ingest.
+
+    The construction is the real pipeline, end to end: ``ImportHandler``
+    wraps the per-source failure as ``IngestJobError("all 1 import source(s)
+    failed: source[0]: " + DuplicateRevisionError().message)``
+    (``import_service.py``), and the worker's requeue/terminal writes truncate
+    it to ``_ERROR_MAX_LEN`` (``worker.py``). Fixtures use this — never a
+    hand-crafted string — so a reword on either side breaks the tests.
+    """
+    wrapped = "all 1 import source(s) failed: source[0]: " + DuplicateRevisionError().message
+    return wrapped[:_ERROR_MAX_LEN]
+
 
 #: the import-job result body the worker writes for one draft revision
 #: (``import_service.py`` — ``{"revisions": [...]}``); the Go fixture's twin.
@@ -170,7 +188,7 @@ def services(monkeypatch: pytest.MonkeyPatch) -> None:
 
 async def test_missing_api_id_is_invalid_params(services: None) -> None:
     with pytest.raises(MCPError) as err:
-        await tools_mod.handle_import_api(_env(["catalog:import"]), {})
+        await tools_mod.handle_import_api(_env(["catalog:import", "jobs:read"]), {})
     assert "api_id" in str(err.value)
     assert "search_catalog" in str(err.value)
 
@@ -190,7 +208,7 @@ async def test_traversal_api_id_is_invalid_params(services: None, bad: str) -> N
     """The Go ``validateAPIID`` contract: traversal-shaped ids are refused as
     a correctable protocol error before any service call."""
     with pytest.raises(MCPError) as err:
-        await tools_mod.handle_import_api(_env(["catalog:import"]), {"api_id": bad})
+        await tools_mod.handle_import_api(_env(["catalog:import", "jobs:read"]), {"api_id": bad})
     assert "search_catalog" in str(err.value)
     assert _FakeCatalogService.filed == []
 
@@ -218,6 +236,27 @@ async def test_missing_scope_is_broker_denied_pointing_at_request_access(
     assert _FakeCatalogService.filed == []
 
 
+async def test_missing_jobs_read_degrades_to_the_filed_envelope_without_polling(
+    services: None,
+) -> None:
+    """In-process tracking rides the same jobs:read gate the Go client's poll
+    leg does (GET /jobs/{id}). An identity with catalog:import but not
+    jobs:read files successfully and gets the queued envelope — NOT an error
+    (the filing succeeded) — and the job service is never touched. Both
+    scopes ride DEFAULT_AGENT_SCOPES, so defaults are unaffected."""
+    env = _env(["catalog:import"])  # no jobs:read
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert not result.is_error, "a missing poll scope degrades; the filing still succeeded"
+    payload = _payload(result)
+    assert payload["schema_version"] == "1"
+    assert payload["job_id"] == "job_9"
+    assert payload["status"] == "queued"
+    assert "revisions" not in payload
+    assert "promoted" not in payload
+    assert _FakeCatalogService.filed == ["googleapis.com/sheets"]
+    assert _FakeJobService.polls == 0, "no jobs:read → no job polling"
+
+
 # ── three-outcome tracking (Go: CompletesAndPromotes / StillRunning / PollFailure) ──
 
 
@@ -227,7 +266,7 @@ async def test_completed_import_promotes_and_returns_the_go_envelope(services: N
     promoted} with the instance stamp joined. Uses the ``id`` alias and an
     umbrella api_id with its literal slash, like the Go test."""
     _FakeJobService.statuses = [_job("running"), _job("completed")]
-    env = _env(["catalog:import", "apis:write"])
+    env = _env(["catalog:import", "jobs:read", "apis:write"])
     result = await dispatch_tool_call(env, "import_api", {"id": "googleapis.com/sheets"})
     assert not result.is_error, result.content
     payload = _payload(result)
@@ -248,7 +287,7 @@ async def test_budget_lapse_returns_the_running_job_as_a_normal_result(
     import_api (idempotent) or watching the job with get_execution_result."""
     monkeypatch.setattr(tools_mod, "_IMPORT_WAIT_BUDGET_SECONDS", 0.0)
     _FakeJobService.statuses = [_job("running")]
-    env = _env(["catalog:import"])
+    env = _env(["catalog:import", "jobs:read"])
     result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
     assert not result.is_error, result.content
     payload = _payload(result)
@@ -264,7 +303,7 @@ async def test_job_poll_failure_is_a_soft_error_never_still_running(services: No
     de-duplicates nothing. The job_id rides the extras so the model can keep
     watching THIS job."""
     _FakeJobService.poll_error = RuntimeError("job store down")
-    env = _env(["catalog:import"])
+    env = _env(["catalog:import", "jobs:read"])
     result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
     assert result.is_error, "a job-poll failure must never look like still-running"
     payload = _payload(result)
@@ -274,13 +313,38 @@ async def test_job_poll_failure_is_a_soft_error_never_still_running(services: No
     assert "job store down" in payload["error"]
 
 
+async def test_hung_poll_trips_the_hard_ceiling_and_maps_to_the_poll_failure_arm(
+    services: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wait budget only gates BETWEEN polls — a single hung poll would
+    hold the ASGI request open indefinitely without the ``asyncio.timeout``
+    ceiling. The lapse is UNKNOWN state: INTERNAL_ERROR with the job_id,
+    never a clean "still running"."""
+    monkeypatch.setattr(tools_mod, "_IMPORT_WAIT_BUDGET_SECONDS", 0.01)
+    monkeypatch.setattr(tools_mod, "_IMPORT_WAIT_GRACE_SECONDS", 0.02)
+
+    async def _hang(self: Any, job_id: str) -> JobView:
+        await asyncio.Event().wait()  # never set — a poll that never returns
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(_FakeJobService, "get_by_id", _hang)
+    env = _env(["catalog:import", "jobs:read"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert result.is_error, "a ceiling lapse must never look like still-running"
+    payload = _payload(result)
+    assert payload["error_code"] == "INTERNAL_ERROR"
+    assert payload["job_id"] == "job_9"
+    assert payload["next_tool"] == "get_execution_result"
+    assert "timed out" in payload["error"]
+
+
 # ── failed-job arm (Go: FailedJobIsSoftError; DEAD_LETTER is terminal) ───────
 
 
 @pytest.mark.parametrize("terminal", ["failed", "dead_letter", "cancelled"])
 async def test_failed_job_is_internal_error_with_job_extras(services: None, terminal: str) -> None:
     _FakeJobService.statuses = [_job(terminal, error="spec fetch failed")]
-    env = _env(["catalog:import"])
+    env = _env(["catalog:import", "jobs:read"])
     result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
     assert result.is_error
     payload = _payload(result)
@@ -294,19 +358,24 @@ async def test_failed_job_is_internal_error_with_job_extras(services: None, term
 # ── duplicate-content short-circuit ──────────────────────────────────────────
 
 
+def test_duplicate_fragment_pins_the_real_worker_error_message() -> None:
+    """Couples ``_DUPLICATE_CONTENT_FRAGMENT`` to the real ``job.error``: the
+    ``ImportHandler`` wrapper around ``DuplicateRevisionError().message``,
+    truncated to the worker's ``_ERROR_MAX_LEN``. A reword of the exception
+    message (or a wrapper change that pushes the fragment past the truncation
+    point) fails here first, not in production."""
+    assert tools_mod._DUPLICATE_CONTENT_FRAGMENT in _real_duplicate_job_error()
+
+
 async def test_duplicate_content_short_circuits_on_a_non_terminal_requeued_job(
     services: None,
 ) -> None:
     """The worker treats a duplicate ingest as retryable (backoff to
     DEAD_LETTER, ~30s+), so the handler matches the stable leading fragment of
-    ``job.error`` on EVERY poll — including a non-terminal requeued state —
-    and short-circuits instead of burning the wait budget."""
-    duplicate_error = (
-        "attempt 1/5 failed: all 1 import source(s) failed: source[0]: A revision with "
-        "identical content already exists for this API"  # truncated at 128 chars
-    )
-    _FakeJobService.statuses = [_job("queued", error=duplicate_error)]
-    env = _env(["catalog:import"])
+    ``job.error`` on EVERY non-completed poll — including a non-terminal
+    requeued state — and short-circuits instead of burning the wait budget."""
+    _FakeJobService.statuses = [_job("queued", error=_real_duplicate_job_error())]
+    env = _env(["catalog:import", "jobs:read"])
     result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
     assert not result.is_error, "already-present content is a convergence, not a failure"
     payload = _payload(result)
@@ -318,13 +387,31 @@ async def test_duplicate_content_short_circuits_on_a_non_terminal_requeued_job(
     assert _FakeJobService.polls == 1, "the short-circuit must not keep polling"
 
 
+async def test_completed_job_with_stale_duplicate_error_reports_the_completed_result(
+    services: None,
+) -> None:
+    """The worker never clears ``job.error`` (requeue writes it; neither claim
+    nor completion resets it), so an import that failed once with the
+    duplicate message and succeeded on a later attempt carries the stale
+    fragment forever. A COMPLETED job's result is always more honest than its
+    residual error: the normal completed envelope — revisions AND the promote
+    leg — never already_imported."""
+    _FakeJobService.statuses = [_job("completed", error=_real_duplicate_job_error())]
+    env = _env(["catalog:import", "jobs:read", "apis:write"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert not result.is_error, result.content
+    payload = _payload(result)
+    assert payload["status"] == "completed", "a stale requeue error must not mask completion"
+    assert payload["revisions"] == [_DRAFT_REVISION]
+    assert payload["promoted"] == {"rev_1": "live"}
+    assert _FakeRevisionService.promotes == [("googleapis.com", "sheets", "v4", "rev_1")]
+
+
 async def test_duplicate_content_dead_letter_via_get_execution_result(services: None) -> None:
     """A duplicate import job polled later reports already_imported, never a
     scary dead_letter — the same detection, placed before the generic payload
     assembly in handle_get_execution_result."""
-    _FakeJobService.statuses = [
-        _job("dead_letter", error="… A revision with identical content already exists for …")
-    ]
+    _FakeJobService.statuses = [_job("dead_letter", error=_real_duplicate_job_error())]
     env = _env(["jobs:read"])
     result = await dispatch_tool_call(env, "get_execution_result", {"job_id": "job_9"})
     assert not result.is_error
@@ -332,6 +419,20 @@ async def test_duplicate_content_dead_letter_via_get_execution_result(services: 
     assert payload["status"] == "already_imported"
     assert payload["job_id"] == "job_9"
     assert payload["next_tool"] == "search_apis"
+
+
+async def test_completed_job_with_stale_duplicate_error_polls_normally(services: None) -> None:
+    """The COMPLETED exemption, on the poll side: a completed import job whose
+    ``job.error`` still carries the duplicate fragment reports its normal
+    completed payload (result attached), never already_imported."""
+    _FakeJobService.statuses = [_job("completed", error=_real_duplicate_job_error())]
+    env = _env(["jobs:read"])
+    result = await dispatch_tool_call(env, "get_execution_result", {"job_id": "job_9"})
+    assert not result.is_error
+    payload = _payload(result)
+    assert payload["status"] == "completed", "a stale requeue error must not mask completion"
+    assert payload["kind"] == "import"
+    assert payload["result"] == {"revisions": [_DRAFT_REVISION]}
 
 
 async def test_execution_jobs_never_trip_the_duplicate_detection(services: None) -> None:
@@ -359,7 +460,7 @@ async def test_promote_without_apis_write_soft_fails_without_calling_the_service
     ``apis:write`` becomes a per-revision map entry, and the service is never
     touched; the import itself still succeeds."""
     _FakeJobService.statuses = [_job("completed")]
-    env = _env(["catalog:import"])  # no apis:write
+    env = _env(["catalog:import", "jobs:read"])  # no apis:write
     result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
     assert not result.is_error, "a promote failure is never a hard error"
     payload = _payload(result)
@@ -386,7 +487,7 @@ async def test_promote_state_conflict_is_a_soft_map_entry(services: None) -> Non
     _FakeRevisionService.promote_error = RevisionStateConflictError(
         "rev_1", "imported", ["draft"], "promote"
     )
-    env = _env(["catalog:import", "apis:write"])
+    env = _env(["catalog:import", "jobs:read", "apis:write"])
     result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
     assert not result.is_error
     promoted = _payload(result)["promoted"]
@@ -400,11 +501,47 @@ async def test_non_draft_revisions_map_to_their_state_verbatim(services: None) -
     ``promoteRevisions`` skip."""
     _FakeJobService.statuses = [_job("completed")]
     _FakeJobResultService.body = {"revisions": [{**_DRAFT_REVISION, "state": "imported"}]}
-    env = _env(["catalog:import", "apis:write"])
+    env = _env(["catalog:import", "jobs:read", "apis:write"])
     result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
     assert not result.is_error
     assert _payload(result)["promoted"] == {"rev_1": "imported"}
     assert _FakeRevisionService.promotes == []
+
+
+async def test_malformed_revision_entries_get_explicit_promote_failures(services: None) -> None:
+    """A non-dict row or a revision_id-less dict never vanishes silently —
+    each gets an explicit index-keyed "promote failed: malformed revision
+    entry" map entry, and the promote service is never called for it."""
+    _FakeJobService.statuses = [_job("completed")]
+    _FakeJobResultService.body = {"revisions": ["not-a-dict", {"state": "draft"}]}
+    env = _env(["catalog:import", "jobs:read", "apis:write"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert not result.is_error
+    assert _payload(result)["promoted"] == {
+        "revision[0]": "promote failed: malformed revision entry",
+        "revision[1]": "promote failed: malformed revision entry",
+    }
+    assert _FakeRevisionService.promotes == []
+
+
+# ── DB-gate refusal ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("blocked", ["registry", "admin"])
+async def test_db_gate_refusal_is_a_soft_internal_error(services: None, blocked: str) -> None:
+    """import_api needs BOTH the registry DB (the catalog) and the admin DB
+    (the job rides it): a deployment shape missing either refuses softly —
+    INTERNAL_ERROR, before any filing — never an unhandled crash. (The
+    happy-path fixtures never exercise this arm: a MagicMock ctx is always
+    truthy.)"""
+    env = _env(["catalog:import", "jobs:read"])
+    cast(MagicMock, env.ctx).is_db_allowed.side_effect = lambda db: db != blocked
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert result.is_error
+    payload = _payload(result)
+    assert payload["error_code"] == "INTERNAL_ERROR"
+    assert "not available on this deployment" in payload["error"]
+    assert _FakeCatalogService.filed == [], "the DB gate must refuse before filing"
 
 
 # ── filing-time error arms ───────────────────────────────────────────────────
@@ -412,7 +549,7 @@ async def test_non_draft_revisions_map_to_their_state_verbatim(services: None) -
 
 async def test_unknown_catalog_entry_is_resolve_failed(services: None) -> None:
     _FakeCatalogService.import_error = CatalogEntryNotFoundError("nope/nothing")
-    env = _env(["catalog:import"])
+    env = _env(["catalog:import", "jobs:read"])
     result = await dispatch_tool_call(env, "import_api", {"api_id": "nope/nothing"})
     assert result.is_error
     payload = _payload(result)
@@ -428,7 +565,7 @@ async def test_overlay_supersede_refusal_maps_to_broker_denied(services: None) -
     _FakeCatalogService.import_error = OverlaySupersedeForbiddenError(
         "googleapis.com/sheets", "ovl_1"
     )
-    env = _env(["catalog:import"])
+    env = _env(["catalog:import", "jobs:read"])
     result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
     assert result.is_error
     payload = _payload(result)
@@ -442,7 +579,7 @@ async def test_result_fetch_failure_points_at_the_job_poll(services: None) -> No
     the model polls get_execution_result rather than re-importing blind."""
     _FakeJobService.statuses = [_job("completed")]
     _FakeJobResultService.error = RuntimeError("result store down")
-    env = _env(["catalog:import", "apis:write"])
+    env = _env(["catalog:import", "jobs:read", "apis:write"])
     result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
     assert result.is_error
     payload = _payload(result)

--- a/tests/unit/mcp/test_tools_import_api.py
+++ b/tests/unit/mcp/test_tools_import_api.py
@@ -30,6 +30,10 @@ from jentic_one.registry.services.errors import (
     OverlaySupersedeForbiddenError,
     RevisionStateConflictError,
 )
+from jentic_one.registry.services.import_service import (
+    ALL_SOURCES_FAILED_PREFIX_TEMPLATE,
+    SOURCE_FAILURE_PREFIX_TEMPLATE,
+)
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.config import AuthConfig, ServerConfig
 from jentic_one.shared.jobs.worker import _ERROR_MAX_LEN
@@ -41,14 +45,39 @@ _NOW = datetime(2026, 9, 10, tzinfo=UTC)
 def _real_duplicate_job_error() -> str:
     """``job.error`` exactly as the worker writes it for a duplicate ingest.
 
-    The construction is the real pipeline, end to end: ``ImportHandler``
-    wraps the per-source failure as ``IngestJobError("all 1 import source(s)
-    failed: source[0]: " + DuplicateRevisionError().message)``
+    The construction is the real pipeline, end to end: ``ImportHandler`` wraps
+    the per-source failure with its own (imported, never hand-copied) wrapper
+    templates around ``DuplicateRevisionError().message``
     (``import_service.py``), and the worker's requeue/terminal writes truncate
     it to ``_ERROR_MAX_LEN`` (``worker.py``). Fixtures use this — never a
-    hand-crafted string — so a reword on either side breaks the tests.
+    hand-crafted string — so a reword on either side (or a wrapper that grows
+    past the truncation point) breaks the tests.
     """
-    wrapped = "all 1 import source(s) failed: source[0]: " + DuplicateRevisionError().message
+    wrapped = (
+        ALL_SOURCES_FAILED_PREFIX_TEMPLATE.format(count=1)
+        + SOURCE_FAILURE_PREFIX_TEMPLATE.format(index=0)
+        + DuplicateRevisionError().message
+    )
+    return wrapped[:_ERROR_MAX_LEN]
+
+
+def _multi_source_duplicate_job_error() -> str:
+    """A MULTI-source ``job.error``: source[0] duplicate, source[1] genuine.
+
+    ``POST /apis`` enqueues multi-source ``JobKind.IMPORT`` jobs; when one
+    source hits the duplicate but another genuinely fails, the whole job
+    dead-letters with the duplicate fragment inside the truncated error. The
+    remap must NOT fire on it — reporting already_imported would mask
+    source[1]'s failure.
+    """
+    wrapped = (
+        ALL_SOURCES_FAILED_PREFIX_TEMPLATE.format(count=2)
+        + SOURCE_FAILURE_PREFIX_TEMPLATE.format(index=0)
+        + DuplicateRevisionError().message
+        + "; "
+        + SOURCE_FAILURE_PREFIX_TEMPLATE.format(index=1)
+        + "spec fetch failed"
+    )
     return wrapped[:_ERROR_MAX_LEN]
 
 
@@ -342,6 +371,34 @@ async def test_hung_poll_trips_the_hard_ceiling_and_maps_to_the_poll_failure_arm
     assert "timed out" in payload["error"]
 
 
+async def test_hung_filing_trips_the_hard_ceiling_as_a_retryable_transport_lapse(
+    services: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ceiling wraps the FILING leg too (its catalog read can lazily
+    refresh the upstream manifest, bounded only by ingest.fetch_timeout_s).
+    A lapse there has no job_id yet and whether the enqueue committed is
+    unknowable: a retryable TRANSPORT_ERROR ("may or may not have been
+    filed") — a re-import converges, so retrying is safe — never the
+    INTERNAL_ERROR mid-poll arm and never a job_id it does not have."""
+    monkeypatch.setattr(tools_mod, "_IMPORT_WAIT_BUDGET_SECONDS", 0.01)
+    monkeypatch.setattr(tools_mod, "_IMPORT_WAIT_GRACE_SECONDS", 0.02)
+
+    async def _hang(self: Any, api_id: str, identity: Identity) -> str:
+        await asyncio.Event().wait()  # never set — a filing that never returns
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(_FakeCatalogService, "import_entry", _hang)
+    env = _env(["catalog:import", "jobs:read"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert result.is_error, "a filing lapse must never look like a clean filing"
+    payload = _payload(result)
+    assert payload["error_code"] == "TRANSPORT_ERROR"
+    assert "may or may not have been filed" in payload["error"]
+    assert payload["retryable"] is True
+    assert payload["next_tool"] == "search_catalog"
+    assert "job_id" not in payload, "no job_id exists at filing time"
+
+
 # ── failed-job arm (Go: FailedJobIsSoftError; DEAD_LETTER is terminal) ───────
 
 
@@ -363,12 +420,15 @@ async def test_failed_job_is_internal_error_with_job_extras(services: None, term
 
 
 def test_duplicate_fragment_pins_the_real_worker_error_message() -> None:
-    """Couples ``_DUPLICATE_CONTENT_FRAGMENT`` to the real ``job.error``: the
-    ``ImportHandler`` wrapper around ``DuplicateRevisionError().message``,
-    truncated to the worker's ``_ERROR_MAX_LEN``. A reword of the exception
-    message (or a wrapper change that pushes the fragment past the truncation
-    point) fails here first, not in production."""
-    assert tools_mod._DUPLICATE_CONTENT_FRAGMENT in _real_duplicate_job_error()
+    """Couples the remap's two keys to the real ``job.error``: the
+    ``ImportHandler`` wrapper templates around
+    ``DuplicateRevisionError().message``, truncated to the worker's
+    ``_ERROR_MAX_LEN``. A reword of the exception message, a wrapper change
+    that pushes the fragment past the truncation point, or a prefix drift
+    that unkeys the single-source gate fails here first, not in production."""
+    error = _real_duplicate_job_error()
+    assert tools_mod._DUPLICATE_CONTENT_FRAGMENT in error
+    assert error.startswith(tools_mod._SINGLE_SOURCE_IMPORT_FAILURE_PREFIX)
 
 
 async def test_duplicate_content_short_circuits_on_a_non_terminal_requeued_job(
@@ -453,6 +513,45 @@ async def test_execution_jobs_never_trip_the_duplicate_detection(services: None)
     assert payload["kind"] == "execution"
 
 
+async def test_multi_source_dead_letter_keeps_its_generic_payload_on_the_poll_side(
+    services: None,
+) -> None:
+    """A 2-source import (POST /apis files those) where source[0] hit the
+    duplicate but source[1] genuinely failed must NOT be remapped to
+    already_imported — the remap is gated on the single-source wrapper, so
+    the honest dead-letter payload (with source[1]'s failure) survives."""
+    error = _multi_source_duplicate_job_error()
+    assert tools_mod._DUPLICATE_CONTENT_FRAGMENT in error, "the masking premise"
+    _FakeJobService.statuses = [_job("dead_letter", error=error)]
+    env = _env(["jobs:read"])
+    result = await dispatch_tool_call(env, "get_execution_result", {"job_id": "job_9"})
+    assert not result.is_error
+    payload = _payload(result)
+    assert payload["status"] == "dead_letter", "a partial duplicate must not mask the failure"
+    assert payload["error"] == error
+    assert "note" not in payload
+
+
+async def test_multi_source_dead_letter_never_short_circuits_the_import_tracker(
+    services: None,
+) -> None:
+    """Defense in depth on import_api's own tracker: its filing leg
+    (CatalogService.import_entry) always enqueues exactly one source, so a
+    multi-source error should be unreachable there — but the same
+    single-source gate rides the tracker, so a future multi-source filing
+    would surface the honest failed-job arm, never already_imported."""
+    _FakeJobService.statuses = [_job("dead_letter", error=_multi_source_duplicate_job_error())]
+    env = _env(["catalog:import", "jobs:read"])
+    result = await dispatch_tool_call(env, "import_api", {"api_id": "googleapis.com/sheets"})
+    assert result.is_error, "a partial duplicate is a failure, not a convergence"
+    payload = _payload(result)
+    assert payload["error_code"] == "INTERNAL_ERROR"
+    assert payload["job_status"] == "dead_letter"
+    # source[1]'s own text sits past the 128-char truncation point; what must
+    # survive is the honest multi-source failure, never an already_imported remap.
+    assert ALL_SOURCES_FAILED_PREFIX_TEMPLATE.format(count=2) in payload["error"]
+
+
 # ── promote-leg softness ─────────────────────────────────────────────────────
 
 
@@ -496,7 +595,8 @@ async def test_promote_state_conflict_is_a_soft_map_entry(services: None) -> Non
     assert not result.is_error
     promoted = _payload(result)["promoted"]
     assert promoted["rev_1"].startswith("promote failed: ")
-    assert "promote" in promoted["rev_1"]
+    assert "imported" in promoted["rev_1"], "the conflict's actual state must reach the map"
+    assert "draft" in promoted["rev_1"], "…and the state promote expected"
 
 
 async def test_non_draft_revisions_map_to_their_state_verbatim(services: None) -> None:


### PR DESCRIPTION
## Summary

PR A of the HTTP tool parity wave for #1323: the daemon-native `/mcp` mount now serves `import_api`, closing the catalog dead-end for OAuth-connected clients — an agent that finds an unimported API in `search_catalog` can now import it in the same session instead of waiting for a human with a CLI. The Go stdio server's `handleImportAPI` + `trackImportJob` + `promoteRevisions` is the behavioral spec, with the CLI's client-side track-and-promote loop moved in-process. Plan: `jentic-one-plans/themes/local-mcp/http-tool-parity.md` (rev 6). PR B (`request_access`) follows separately.

## Changes

- **`handle_import_api`** (`src/jentic_one/mcp/tools.py`): api_id validation (Go `validateAPIID` parity — aliases `id`/`api`, leading `/` and empty/`.`/`..` segments are `invalid_params`), `catalog:import` scope gate (403 → `BROKER_DENIED` pointing at `request_access` — the pinned description already does, and PR B lands next), `_require_db` on both `registry` and `admin`, filing via `CatalogService.import_entry` in-process.
- **Three-outcome tracking** via `JobService.get_by_id` against `_IMPORT_WAIT_BUDGET_SECONDS` (15s plain module constant, test-injected via monkeypatch): terminal / budget-lapse (a normal `{schema_version, job_id, status}` result — the model converges by re-calling) / poll-failure (unknown state — surfaced as a failure with `job_id`, never "still running"). `dead_letter` is terminal.
- **Duplicate-content short-circuit**: the worker requeues a duplicate ingest with backoff and dead-letters it (~30s+), and `job.error` is truncated to 128 chars — so the handler substring-matches the stable fragment `"identical content already exists"` on **every** poll, including non-terminal requeued states, and returns `{schema_version, job_id, status: already_imported, note, next_tool: search_apis}`. The note says "already present" (it also covers a lost concurrent-import race). **`handle_get_execution_result` gained the same detection**, placed before its generic payload assembly and keyed on `kind=import`, so a duplicate job polled later reports `already_imported`, not a scary `dead_letter`.
- **Promote leg** with an in-process capability guard: `RevisionService.promote` enforces no scopes itself, so the handler soft-checks `has_effective_permission(identity.permissions, "apis:write")` per draft revision — absent → `"promote failed: missing apis:write scope"` map entry without calling the service; present → promote, soft-catching failures (e.g. `RevisionStateConflictError`) into `"promote failed: …"` entries. Never a hard error; non-draft revisions map to their state verbatim (catalog imports land `IMPORTED`, so the leg is normally a runtime no-op — kept deliberately).
- **Distinct in-process arms**: `CatalogEntryNotFoundError` → `RESOLVE_FAILED` + `search_catalog`; `OverlaySupersedeForbiddenError` → `BROKER_DENIED` (an operator decision, never folded into a generic import failure); other failed jobs → `INTERNAL_ERROR` with the job's error, `job_id`/`job_status` extras, and the `search_catalog` re-check pointer.
- **Wiring**: `import_api` added to `SERVED_TOOLS` (`spec.py`, module comment rewritten) and `HANDLERS`; the pinned drift assertions in `tests/unit/mcp/test_tool_surface.py` updated (deferred set is now `{get_started, request_access}`).
- Out of scope: PR B (`request_access`), the tasks-extension adoption (#1324), and any change to the pinned spec (`docs/reference/mcp-tools.json` is untouched — the mount consumes it).

## Risk & rollback

- Permission surface: the promote leg's in-process `apis:write` soft-check is what prevents a capability escalation over REST (the service enforces nothing); pinned by tests. The scope gate mirrors `POST /catalog/{api_id:path}:import` exactly.
- No migrations, no config knobs, no OpenAPI impact (`/mcp` is `include_in_schema=False`). Rollback: revert the squash commit.

## Test plan

- `tests/unit/mcp/test_tools_import_api.py` (19 tests) mirroring the Go table tests (`mcp_access_test.go`): validation arms, scope gate, three-outcome tracking, duplicate short-circuit (incl. a non-terminal requeued job, via `get_execution_result`, and the execution-kind guard), promote softness (missing scope never calls the service; `org:admin` implies via the implication map; state conflict degrades to a map entry), failed/dead-letter arm, budget lapse, filing-time error arms.
- No integration test: there is no existing integration seam for the mount (`tests/integration/` has no mcp suite), so the full catalog-loop test (search_catalog → import_api → search_apis) is noted here rather than built ad-hoc.
- Gates run locally: `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run pytest tests/unit/ tests/arch/` — 3708 passed, coverage 80.24%.

Part of #1323

Made with [Cursor](https://cursor.com)