### PR TITLE
fix(mcp): drop dangling next_tool pointers on the HTTP lane

### DIFF
--- a/src/jentic_one/mcp/envelopes.py
+++ b/src/jentic_one/mcp/envelopes.py
@@ -142,6 +142,12 @@ def soft_error_result(ctx: Context, err: ToolError) -> mcp_types.CallToolResult:
     if next_tool in SERVED_TOOLS:
         payload["next_tool"] = next_tool
     for key, value in (err.extra or {}).items():
+        # The same lane filter guards the ``extra`` pass-through: without it a
+        # call site could smuggle a dangling pointer past the seam via
+        # ``extra={"next_tool": …}`` (``setdefault`` would insert it whenever
+        # the filter above dropped the field).
+        if key == "next_tool" and value not in SERVED_TOOLS:
+            continue
         payload.setdefault(key, value)
     payload["instance"] = instance_stamp(ctx)
     return _text_result(payload, is_error=True)

--- a/src/jentic_one/mcp/envelopes.py
+++ b/src/jentic_one/mcp/envelopes.py
@@ -27,6 +27,7 @@ from typing import Any
 
 import mcp.types as mcp_types
 
+from jentic_one.mcp.spec import SERVED_TOOLS
 from jentic_one.shared.context import Context
 from jentic_one.shared.web.instance_identity import resolve_instance_identity
 
@@ -43,13 +44,21 @@ CODE_TRANSPORT_ERROR = "TRANSPORT_ERROR"
 CODE_INTERNAL_ERROR = "INTERNAL_ERROR"
 
 #: error codes whose default recovery pointer is ``get_started`` (Go:
-#: ``softErrorExtra``'s code-keyed mapping). ``get_started`` is not served by
-#: this mount yet (it queues behind this PR with the other CLI-flavoured
-#: tools), but the pointer strings are part of the shared envelope contract —
-#: they must match the stdio server byte-for-byte.
+#: ``softErrorExtra``'s code-keyed mapping). The pointer *spellings* stay the
+#: shared envelope contract (byte-for-byte with the stdio server, which
+#: serves all ten tools), but this mount serves only ``SERVED_TOOLS`` —
+#: :func:`soft_error_result` drops any pointer that does not resolve in this
+#: lane's ``tools/list`` (#1254): a recovery pointer at a tool the caller
+#: cannot discover or call is a dead end, worse than no pointer.
 _DEFAULT_NEXT_TOOL_CODES = frozenset(
     {CODE_NOT_AUTHENTICATED, CODE_PENDING_APPROVAL, CODE_RESOLVE_FAILED}
 )
+
+#: the code-keyed default pointer (Go: ``softErrorExtra``). Not served on
+#: this lane, so today the default never reaches a rendered envelope — it is
+#: kept so serving ``get_started`` later restores the stdio behaviour with no
+#: further change here.
+_DEFAULT_NEXT_TOOL = "get_started"
 
 
 class ToolError(Exception):
@@ -124,8 +133,13 @@ def soft_error_result(ctx: Context, err: ToolError) -> mcp_types.CallToolResult:
         payload["details"] = err.details
     next_tool = err.next_tool
     if not next_tool and err.code in _DEFAULT_NEXT_TOOL_CODES:
-        next_tool = "get_started"
-    if next_tool:
+        next_tool = _DEFAULT_NEXT_TOOL
+    # Lane-aware pointer filter (#1254): only emit a ``next_tool`` the caller
+    # can actually see in THIS mount's ``tools/list``. Handlers keep raising
+    # the shared stdio pointer spellings (``get_started``, ``request_access``,
+    # …) so the contract never forks — the projection onto the served subset
+    # happens here, at the one seam every soft error renders through.
+    if next_tool in SERVED_TOOLS:
         payload["next_tool"] = next_tool
     for key, value in (err.extra or {}).items():
         payload.setdefault(key, value)

--- a/tests/unit/mcp/test_envelopes.py
+++ b/tests/unit/mcp/test_envelopes.py
@@ -83,3 +83,15 @@ def test_every_emittable_pointer_resolves_in_the_served_surface() -> None:
             payload = _payload(soft_error_result(_ctx(), err))
             emitted = payload.get("next_tool")
             assert emitted is None or emitted in SERVED_TOOLS
+
+
+def test_extra_carried_pointers_cannot_bypass_the_lane_filter() -> None:
+    """The ``extra`` pass-through is also an emission path: a call site
+    passing ``extra={"next_tool": …}`` must hit the same SERVED_TOOLS
+    projection, or the invariant above is only true for the ``next_tool``
+    keyword. Unserved pointers are dropped; served ones still ride."""
+    dangling = ToolError(CODE_TRANSPORT_ERROR, "boom", extra={"next_tool": "get_started"})
+    assert "next_tool" not in _payload(soft_error_result(_ctx(), dangling))
+
+    served = ToolError(CODE_TRANSPORT_ERROR, "boom", extra={"next_tool": "whoami"})
+    assert _payload(soft_error_result(_ctx(), served))["next_tool"] == "whoami"

--- a/tests/unit/mcp/test_envelopes.py
+++ b/tests/unit/mcp/test_envelopes.py
@@ -1,0 +1,85 @@
+"""Lane-aware ``next_tool`` rendering — the #1254 regression guard.
+
+The HTTP mount serves the :data:`jentic_one.mcp.spec.SERVED_TOOLS` subset of
+the pinned surface, but the coded soft errors carry the stdio lane's shared
+pointer spellings (``get_started``, ``request_access``, …). A pointer at a
+tool absent from this lane's ``tools/list`` is an unactionable dead end, so
+:func:`soft_error_result` — the one seam every soft error renders through —
+must drop any ``next_tool`` that does not resolve in ``SERVED_TOOLS``.
+
+These tests pin that projection for every pointer the pinned spec knows
+about, so serving (or unserving) a tool consciously changes which envelopes
+carry pointers. The stdio lane is untouched: the Go server serves all ten
+tools, and its envelope bytes stay pinned by ``mcp_golden_test.go``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from jentic_one.mcp.envelopes import (
+    _DEFAULT_NEXT_TOOL_CODES,
+    CODE_TRANSPORT_ERROR,
+    ToolError,
+    soft_error_result,
+)
+from jentic_one.mcp.spec import SERVED_TOOLS, load_spec
+from jentic_one.shared.config import AuthConfig, ServerConfig
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.config.auth = AuthConfig(canonical_base_url="https://auth.example.com")
+    ctx.config.server = ServerConfig()
+    ctx.instance_id = None
+    return ctx
+
+
+def _payload(result: Any) -> dict[str, Any]:
+    (content,) = result.content
+    decoded = json.loads(content.text)
+    assert isinstance(decoded, dict)
+    return decoded
+
+
+@pytest.mark.parametrize("code", sorted(_DEFAULT_NEXT_TOOL_CODES))
+def test_default_get_started_pointer_is_dropped_on_this_lane(code: str) -> None:
+    """The code-keyed stdio default (``get_started``) never reaches a rendered
+    envelope while the tool stays unserved here — no pointer beats a dangling
+    one."""
+    payload = _payload(soft_error_result(_ctx(), ToolError(code, "boom")))
+    assert "next_tool" not in payload
+
+
+@pytest.mark.parametrize("pointer", [*sorted(set(load_spec()) - set(SERVED_TOOLS)), "made_up_tool"])
+def test_unserved_explicit_pointers_are_dropped_on_this_lane(pointer: str) -> None:
+    """An explicit pointer at a tool outside SERVED_TOOLS (the stdio-only
+    trio today, or anything unknown) is stripped at render time."""
+    err = ToolError(CODE_TRANSPORT_ERROR, "boom", next_tool=pointer)
+    payload = _payload(soft_error_result(_ctx(), err))
+    assert "next_tool" not in payload
+
+
+@pytest.mark.parametrize("pointer", sorted(SERVED_TOOLS))
+def test_served_pointers_ride_the_envelope_unchanged(pointer: str) -> None:
+    """Pointers that resolve in this lane's tools/list pass through verbatim
+    (whoami on broker denials, search_apis on inspect 404s, …)."""
+    err = ToolError(CODE_TRANSPORT_ERROR, "boom", next_tool=pointer)
+    payload = _payload(soft_error_result(_ctx(), err))
+    assert payload["next_tool"] == pointer
+
+
+def test_every_emittable_pointer_resolves_in_the_served_surface() -> None:
+    """The #1254 invariant, as a property of the rendering seam: whatever
+    pointer a handler raises — every spec-declared name and a garbage one —
+    the rendered envelope's ``next_tool`` is always in SERVED_TOOLS."""
+    for pointer in [*load_spec(), "made_up_tool", ""]:
+        for code in ["NOT_AUTHENTICATED", "PENDING_APPROVAL", "RESOLVE_FAILED", "TRANSPORT_ERROR"]:
+            err = ToolError(code, "boom", next_tool=pointer)
+            payload = _payload(soft_error_result(_ctx(), err))
+            emitted = payload.get("next_tool")
+            assert emitted is None or emitted in SERVED_TOOLS

--- a/tests/unit/mcp/test_execute_golden.py
+++ b/tests/unit/mcp/test_execute_golden.py
@@ -335,3 +335,23 @@ async def test_ipv6_loopback_broker_stays_allowed(broker) -> None:
     env = make_env("http://[::1]:8100")
     result = await dispatch_tool_call(env, "execute", {"operation_id": "GET:/v1/pets"})
     assert not result.is_error, result.content
+
+
+async def test_unreachable_broker_envelope_carries_no_dangling_pointer(broker) -> None:
+    """#1254: with the broker down, the TRANSPORT_ERROR envelope must not
+    point at ``get_started`` — that tool is absent from this lane's
+    tools/list, so the pointer was an undiscoverable dead end exactly when
+    the model was looking for recovery. The retryable hint still rides."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("All connection attempts failed")
+
+    broker(handler)
+    env = make_env("http://127.0.0.1:8100")
+    result = await dispatch_tool_call(env, "execute", {"operation_id": "GET:/v1/pets"})
+    assert result.is_error
+
+    payload = decode_tool_json(result)
+    assert payload["error_code"] == "TRANSPORT_ERROR"
+    assert payload["retryable"] is True
+    assert "next_tool" not in payload

--- a/tests/unit/mcp/test_scopes.py
+++ b/tests/unit/mcp/test_scopes.py
@@ -90,7 +90,12 @@ async def test_scope_failure_renders_not_authenticated(
     assert result.is_error
     payload = _payload(result)
     assert payload["error_code"] == "NOT_AUTHENTICATED"
-    assert payload["next_tool"] == "get_started"
+    # The code-keyed stdio default pointer is get_started, which this mount
+    # does not serve — the lane-aware filter (#1254) drops it rather than
+    # pointing the model at a tool absent from tools/list. The get_started
+    # spelling still rides the actionable prose (shared contract).
+    assert "next_tool" not in payload
+    assert "get_started" in payload["actionable_step"]
 
 
 async def test_search_catalog_scope_failure_is_the_agent_fixable_special_case() -> None:
@@ -101,7 +106,10 @@ async def test_search_catalog_scope_failure_is_the_agent_fixable_special_case() 
     assert result.is_error
     payload = _payload(result)
     assert payload["error_code"] == "BROKER_DENIED"
-    assert payload["next_tool"] == "request_access"
+    # request_access stays stdio-only, so the pointer is dropped on this lane
+    # (#1254); the actionable prose still names it (shared contract spelling).
+    assert "next_tool" not in payload
+    assert "request_access" in payload["actionable_step"]
     assert "capabilities:read" in payload["error"]
     prefix, _, tail = payload["error"].partition("scope: ")
     assert prefix == "reading the catalog requires the capabilities:read "


### PR DESCRIPTION
## Summary

On the daemon-native HTTP `/mcp` lane, runtime error envelopes pointed the model at recovery tools this lane does not serve: `_DEFAULT_NEXT_TOOL_CODES` defaulted `NOT_AUTHENTICATED`/`PENDING_APPROVAL`/`RESOLVE_FAILED` to `next_tool: "get_started"`, the execute transport errors set it explicitly, and `search_catalog`'s scope failure pointed at `request_access` — all three tools are stdio-only (`SERVED_TOOLS` in `src/jentic_one/mcp/spec.py`), so the recommended recovery action was a tool absent from this lane's `tools/list`, discoverable only by calling it and failing. This makes the pointers lane-aware: the rendered envelope only carries a `next_tool` that resolves in `SERVED_TOOLS`.

## Changes

- `src/jentic_one/mcp/envelopes.py` (control-plane MCP mount): `soft_error_result` — the one seam every soft error renders through — drops any `next_tool` not in `SERVED_TOOLS`. Handlers keep raising the shared stdio pointer spellings, so the cross-implementation envelope contract never forks; the projection onto the served subset happens at render time. Served pointers (`whoami`, `search_apis`, `get_execution_result`) pass through unchanged.
- No pointer is emitted (rather than remapped) when the target is unserved: for `TRANSPORT_ERROR` the actionable step is "check the broker is reachable", which no served tool addresses, and for the auth codes `whoami` would fail with the same credential — omitting is the only honest option (issue's suggested fix 1).
- Deliberately out of scope: the pinned tool *descriptions* that mention `get_started`/`import_api` (`whoami`, `search_catalog`). They are pinned byte-for-byte to the Go stdio server's `toolSpecs()` and drift-tested; rewording them per lane is a contract change that needs its own pass. Same for the `actionable_step` prose, which still names the stdio tools — those strings are the shared taxonomy.
- The stdio lane is untouched: it is the Go server (`cli/internal/cli/api`), which serves all ten tools, so `get_started` pointers resolve there; no Go code changed and the shared goldens still pass byte-identical.

## Risk & rollback

Low risk: the change removes an unactionable field from error envelopes on one lane; no success-path envelope changes (the shared golden replays are untouched). Revert the squash commit to restore the old pointers.

## Test plan

- New `tests/unit/mcp/test_envelopes.py`: pins that the code-keyed `get_started` default and every unserved explicit pointer are dropped, that every served pointer rides unchanged, and the regression guard from the issue — every emittable pointer resolves in `SERVED_TOOLS` (parametrized over the full pinned spec).
- New test in `tests/unit/mcp/test_execute_golden.py`: the issue's exact repro — broker unreachable → `TRANSPORT_ERROR` envelope keeps `retryable: true` but carries no dangling `next_tool`.
- Adjusted `tests/unit/mcp/test_scopes.py`: the two envelopes previously pinned to `get_started`/`request_access` now pin the pointer's absence on this lane.
- Ran `make fmt lint typecheck` and `uv run pytest tests/unit/mcp/` (128 passed).

Closes #1254

Made with [Cursor](https://cursor.com)