### PR TITLE
fix(auth): advertise revocation auth method none in the root RFC 8414 doc

### DIFF
--- a/src/jentic_one/auth/web/routers/discovery.py
+++ b/src/jentic_one/auth/web/routers/discovery.py
@@ -69,6 +69,11 @@ async def oauth_authorization_server(
         "token_endpoint": f"{issuer}/oauth/token",
         "registration_endpoint": f"{issuer}/register",
         "revocation_endpoint": f"{issuer}/oauth/revoke",
+        # RFC 8414 §2's implicit default for the auth-methods member is
+        # client_secret_basic, which mis-describes /oauth/revoke's public arm
+        # (RFC 7009 auth method "none", G11) — so the member must be explicit
+        # and agree with the /mcp-scoped document below (#1244).
+        "revocation_endpoint_auth_methods_supported": ["none"],
         "introspection_endpoint": f"{issuer}/oauth/introspect",
         "jwks_uri": f"{issuer}/.well-known/jwks.json",
         "grant_types_supported": [

--- a/src/jentic_one/auth/web/routers/discovery.py
+++ b/src/jentic_one/auth/web/routers/discovery.py
@@ -72,7 +72,11 @@ async def oauth_authorization_server(
         # RFC 8414 §2's implicit default for the auth-methods member is
         # client_secret_basic, which mis-describes /oauth/revoke's public arm
         # (RFC 7009 auth method "none", G11) — so the member must be explicit
-        # and agree with the /mcp-scoped document below (#1244).
+        # and agree with the /mcp-scoped document below (#1244). The member is
+        # deliberately gate-independent even though the "none" (form-encoded)
+        # arm 404s while server.mcp.oauth.enabled is off: this document is
+        # pinned byte-identical in both gate arms (gate unobservability), and
+        # no RFC 8414 value describes the ungated bearer-JSON arm anyway.
         "revocation_endpoint_auth_methods_supported": ["none"],
         "introspection_endpoint": f"{issuer}/oauth/introspect",
         "jwks_uri": f"{issuer}/.well-known/jwks.json",

--- a/tests/unit/auth/web/test_discovery.py
+++ b/tests/unit/auth/web/test_discovery.py
@@ -62,6 +62,16 @@ def test_discovery_contains_grant_types_and_auth_methods(client: TestClient) -> 
     assert "private_key_jwt" in data["token_endpoint_auth_methods_supported"]
 
 
+def test_discovery_revocation_auth_methods_describe_the_public_arm(client: TestClient) -> None:
+    """#1244: without the member, RFC 8414's implicit default
+    (client_secret_basic) mis-described /oauth/revoke's public arm — the
+    root doc must advertise auth method "none" explicitly, like the
+    /mcp-scoped document."""
+    resp = client.get("/.well-known/oauth-authorization-server")
+    data = resp.json()
+    assert data["revocation_endpoint_auth_methods_supported"] == ["none"]
+
+
 def test_discovery_response_types_supported_includes_code(client: TestClient) -> None:
     resp = client.get("/.well-known/oauth-authorization-server")
     data = resp.json()

--- a/tests/unit/auth/web/test_mcp_discovery.py
+++ b/tests/unit/auth/web/test_mcp_discovery.py
@@ -53,6 +53,7 @@ _ROOT_AS_GOLDEN = (
     b'"token_endpoint":"https://auth.example.com/oauth/token",'
     b'"registration_endpoint":"https://auth.example.com/register",'
     b'"revocation_endpoint":"https://auth.example.com/oauth/revoke",'
+    b'"revocation_endpoint_auth_methods_supported":["none"],'
     b'"introspection_endpoint":"https://auth.example.com/oauth/introspect",'
     b'"jwks_uri":"https://auth.example.com/.well-known/jwks.json",'
     b'"grant_types_supported":["authorization_code",'
@@ -382,3 +383,18 @@ def test_root_as_document_is_byte_identical_golden(oauth_enabled: bool) -> None:
 def test_root_as_document_still_advertises_agent_register(enabled_client: TestClient) -> None:
     data = enabled_client.get("/.well-known/oauth-authorization-server").json()
     assert data["registration_endpoint"] == f"{_BASE}/register"
+
+
+def test_root_and_mcp_docs_agree_on_revocation_auth_methods(enabled_client: TestClient) -> None:
+    """#1244: both RFC 8414 documents describe the same /oauth/revoke public
+    arm, so their auth-methods members must agree — the root doc used to omit
+    it, letting the spec's implicit client_secret_basic default mis-describe
+    an endpoint whose public arm is auth method "none"."""
+    root = enabled_client.get("/.well-known/oauth-authorization-server").json()
+    scoped = enabled_client.get("/.well-known/oauth-authorization-server/mcp").json()
+    assert root["revocation_endpoint"] == scoped["revocation_endpoint"]
+    assert (
+        root["revocation_endpoint_auth_methods_supported"]
+        == scoped["revocation_endpoint_auth_methods_supported"]
+        == ["none"]
+    )


### PR DESCRIPTION
## Summary

The root `/.well-known/oauth-authorization-server` document advertises `revocation_endpoint` without `revocation_endpoint_auth_methods_supported`, so RFC 8414's implicit default (`client_secret_basic`) mis-describes an endpoint whose public arm is auth method `none` (the RFC 7009-conformant arm G11 added). The `/mcp`-scoped document already carries the member; this mirrors it into the root doc so the two documents agree about the same `/oauth/revoke` endpoint.

## Changes

- `src/jentic_one/auth/web/routers/discovery.py` (auth surface): add `revocation_endpoint_auth_methods_supported: ["none"]` to the root RFC 8414 document, with a comment tying it to the /mcp-scoped doc. The two documents build their bodies inline (no shared-values helper exists in this file), so the member is mirrored rather than extracted — consistent with how every other shared value (e.g. `revocation_endpoint` itself) is handled there.
- Update the byte-identical `_ROOT_AS_GOLDEN` regression pin (`tests/unit/auth/web/test_mcp_discovery.py`) — this golden exists precisely so a root-doc change is a conscious diff; this PR is that conscious change. Its real payload (the agent `/register` registration_endpoint) is untouched.
- OpenAPI: verified unaffected — the discovery handlers return untyped `dict[str, Any]` bodies, and `make openapi` regenerates byte-identical spec files (no generated files in this diff).

## Risk & rollback

Low risk: additive metadata member on an unauthenticated discovery document; live endpoint behaviour is unchanged (it already accepts auth method `none` on the public arm). Revert the squash commit.

## Test plan

- New `test_discovery_revocation_auth_methods_describe_the_public_arm` pins the member in the root doc.
- New `test_root_and_mcp_docs_agree_on_revocation_auth_methods` pins the cross-document agreement the issue asks for.
- Updated `_ROOT_AS_GOLDEN` keeps pinning the full root body byte-for-byte in both gate arms.
- Ran `make openapi` (no diff), `make fmt lint typecheck`, and `uv run pytest tests/unit/auth/web/` (309 passed).

Closes #1244

Made with [Cursor](https://cursor.com)