### PR TITLE
fix(cli): refuse --token-file with --allow-unauthenticated on jentic mcp --http

### DIFF
--- a/cli/internal/cli/api/mcp.go
+++ b/cli/internal/cli/api/mcp.go
@@ -107,7 +107,7 @@ func newMCPCmd(app *app) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.http.allowNonLoopback, "allow-non-loopback", false,
 		"explicitly allow a non-loopback --listen bind (still refuses without --tls-cert/--tls-key and --token-file)")
 	cmd.Flags().BoolVar(&opts.http.allowUnauthenticated, "allow-unauthenticated", false,
-		"serve loopback --listen without a token — every local user may then act as this context; loopback-only")
+		"serve loopback --listen without a token — every local user may then act as this context; loopback-only, mutually exclusive with --token-file")
 	cmd.Flags().StringSliceVar(&opts.http.allowOrigins, "allow-origin", nil,
 		"Origin values allowed on --http requests besides loopback (repeatable); anything else is refused with 403")
 	cmd.Flags().IntSliceVar(&opts.http.allowUIDs, "allow-uid", nil,

--- a/cli/internal/cli/api/mcp_http.go
+++ b/cli/internal/cli/api/mcp_http.go
@@ -18,7 +18,8 @@ package api
 //     the client side — this is the §3.7.5 credential-less posture.
 //   - TCP loopback (--listen 127.0.0.1:…): no peer identity exists on TCP,
 //     so a bearer token is REQUIRED (--token-file); --allow-unauthenticated
-//     is the explicit, loopback-only opt-out.
+//     is the explicit, loopback-only opt-out (mutually exclusive with
+//     --token-file — the pair is a refused contradiction).
 //   - TCP non-loopback: refused unless --allow-non-loopback AND TLS
 //     (--tls-cert/--tls-key) AND a token are all present (phase acceptance).
 //
@@ -155,7 +156,13 @@ func resolveMCPBindPosture(opts *mcpHTTPOptions) (*mcpBindPosture, error) {
 
 	// Loopback TCP: no peer identity exists, so require the token unless the
 	// operator explicitly accepts that every local uid may use this
-	// context's keys (the documented single-user-machine trade-off).
+	// context's keys (the documented single-user-machine trade-off). The two
+	// flags contradict each other — one configures the bearer gate, the
+	// other disables it — so presenting both is refused rather than letting
+	// either silently win (#1242).
+	if opts.tokenFile != "" && opts.allowUnauthenticated {
+		return nil, errors.New("--token-file and --allow-unauthenticated are contradictory: the token file configures the bearer gate and --allow-unauthenticated disables it — pass exactly one")
+	}
 	if len(token) == 0 && !opts.allowUnauthenticated {
 		return nil, fmt.Errorf("refusing the loopback bind %q without auth: TCP has no peer identity, so provide --token-file (or pass --allow-unauthenticated to accept that every local user may act as this context)", opts.listen)
 	}

--- a/cli/internal/cli/api/mcp_http_posture_test.go
+++ b/cli/internal/cli/api/mcp_http_posture_test.go
@@ -53,6 +53,7 @@ func TestResolveMCPBindPosture(t *testing.T) {
 		{"loopback without token refuses", mcpHTTPOptions{listen: "127.0.0.1:9999"}, "--token-file"},
 		{"loopback with token serves", mcpHTTPOptions{listen: "127.0.0.1:9999", tokenFile: token}, ""},
 		{"loopback opt-out serves tokenless", mcpHTTPOptions{listen: "localhost:9999", allowUnauthenticated: true}, ""},
+		{"loopback token + opt-out is a refused contradiction", mcpHTTPOptions{listen: "127.0.0.1:9999", tokenFile: token, allowUnauthenticated: true}, "contradictory"},
 		{"non-loopback never serves unauthenticated", mcpHTTPOptions{listen: "10.0.0.5:9999", allowNonLoopback: true, tlsCert: "c.pem", tlsKey: "k.pem", tokenFile: token, allowUnauthenticated: true}, "loopback-only"},
 		{"half a TLS pair refuses", mcpHTTPOptions{listen: "127.0.0.1:9999", tokenFile: token, tlsCert: "c.pem"}, "together"},
 		{"unix socket serves credential-less", mcpHTTPOptions{socket: "/tmp/x.sock"}, ""},

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -2809,7 +2809,7 @@
               "name": "allow-unauthenticated",
               "type": "bool",
               "default": "false",
-              "usage": "serve loopback --listen without a token — every local user may then act as this context; loopback-only"
+              "usage": "serve loopback --listen without a token — every local user may then act as this context; loopback-only, mutually exclusive with --token-file"
             },
             {
               "name": "bearer-file",


### PR DESCRIPTION
## Summary

On a loopback `--listen`, `jentic mcp --http` silently accepted `--token-file` together with `--allow-unauthenticated`. The flags are contradictory — one configures the bearer gate, the other disables it — and in practice the token silently won, so the operator's `--allow-unauthenticated` intent was dropped without a word. `resolveMCPBindPosture` now refuses the pair with an explicit error, matching the precision of the daemon's other posture-refusal arms.

## Changes

- `cli/internal/cli/api/mcp_http.go` (cli): new refusal arm in the loopback branch of `resolveMCPBindPosture` — `--token-file` + `--allow-unauthenticated` errors with "the token file configures the bearer gate and --allow-unauthenticated disables it — pass exactly one". The non-loopback and unix-socket arms already refuse `--allow-unauthenticated` with their own specific messages, so loopback TCP was the only silent gap.
- `--allow-unauthenticated`'s flag help now names the mutual exclusion; `ui/public/cli-reference.json` regenerated via `clidocs` (drift-gated).
- File-header posture comment updated to document the exclusion.

## Risk & rollback

Low risk: a previously-accepted (but ambiguous) flag combination now fails fast at startup with an actionable message; no serving behaviour changes for valid flag sets. Revert the squash commit.

## Test plan

- New case in the table-driven `TestResolveMCPBindPosture` (`mcp_http_posture_test.go`): loopback + token + opt-out → refusal mentioning "contradictory". Existing cases pin that each flag alone keeps working and that the non-loopback "loopback-only" refusal is untouched.
- Ran `gofmt -l` (clean), `go vet ./...`, and `go test ./...` in `cli/` (all pass; run with `GOWORK=off` — the workspace `go.work` is stale against the modules' go 1.25.7 requirement, unrelated to this change). `golangci-lint` is not installed locally; CI's lint job covers it.

Closes #1242

Made with [Cursor](https://cursor.com)