### PR TITLE
feat(mcp): serve the skill set as resources on the /mcp mount

### DIFF
--- a/src/jentic_one/mcp/app.py
+++ b/src/jentic_one/mcp/app.py
@@ -103,10 +103,11 @@ MCP_PRM_PATH = "/.well-known/oauth-protected-resource/mcp"
 #: defense hold that property (``tests/unit/mcp/test_resources.py``):
 #:
 #: 1. **Resolver characterization (the proof)** — ``read_skill_resource`` is
-#:    unit-characterized as two-armed by construction: every URI outside
-#:    ``skill://<shipped name>`` + ``skill://index`` raises -32002, and no
-#:    branch of it can see a credential (it never reads identity), so its
-#:    behavior is structurally identical pre- and post-auth.
+#:    unit-characterized as three-armed by construction: every URI outside
+#:    ``skill://<shipped name>`` + ``skill://<shipped name>/references/<file>``
+#:    (lane-filtered: never a ``CLI_ONLY_REFERENCES`` file) + ``skill://index``
+#:    raises -32002, and no branch of it can see a credential (it never reads
+#:    identity), so its behavior is structurally identical pre- and post-auth.
 #: 2. **Delegation pin (the structural lock)** — ``on_read_resource`` below
 #:    is pinned to be a bare delegation to ``read_skill_resource``, so this
 #:    module cannot grow a bypass arm without failing a test.
@@ -365,10 +366,10 @@ def build_mcp_server(ctx: Context) -> Server[Any]:
     Tools come from the pinned tool-surface spec (``jentic_one.mcp.spec``);
     ``tools/list`` is connection-independent (stateless — the same list for
     every caller). Resources are the public ``skill://`` surface
-    (``jentic_one.mcp.resources``): the shipped skill set plus the index,
-    listed and read identically for every caller — ``on_read_resource`` is a
-    bare delegation to the two-armed resolver (pinned; see the
-    ``PRE_AUTH_METHODS`` comment for the layered defense).
+    (``jentic_one.mcp.resources``): the shipped skill set, its lane-filtered
+    references, and the index, listed and read identically for every caller —
+    ``on_read_resource`` is a bare delegation to the three-armed resolver
+    (pinned; see the ``PRE_AUTH_METHODS`` comment for the layered defense).
     """
 
     async def on_list_tools(
@@ -396,7 +397,7 @@ def build_mcp_server(ctx: Context) -> Server[Any]:
         sctx: ServerRequestContext[Any, Any],
         params: mcp_types.ReadResourceRequestParams,
     ) -> mcp_types.ReadResourceResult:
-        # A BARE delegation to the two-armed resolver — pinned structurally
+        # A BARE delegation to the three-armed resolver — pinned structurally
         # (test_resources.py) so no bypass arm can appear here unnoticed.
         return read_skill_resource(params.uri, _request_base_url(ctx, sctx))
 
@@ -422,8 +423,9 @@ def build_mcp_server(ctx: Context) -> Server[Any]:
             "from. The flow is whoami → search_apis → inspect_operation → execute; "
             "never execute an operation just to probe whether you have access. "
             "The skill://jentic resource is the canonical guide to the whole flow "
-            "(skill://index lists every skill document); read it when unsure how "
-            "the pieces fit together."
+            "(skill://index lists every skill document, and "
+            "skill://jentic/references/mcp.md carries the MCP-lane detail); "
+            "read it when unsure how the pieces fit together."
         ),
         on_list_tools=on_list_tools,
         on_call_tool=on_call_tool,

--- a/src/jentic_one/mcp/app.py
+++ b/src/jentic_one/mcp/app.py
@@ -44,8 +44,10 @@ that owns everything the platform — not the SDK — must decide:
   a garbage one) keeps the challenge contract on every method.
 - **The pre-auth whitelist**: ``tools/list``, the SDK's legacy ``initialize``
   fallback (+ ``notifications/initialized``), ``ping``, and the public
-  resource listings are served without a credential — a client can always
-  discover the tool surface before authenticating. Everything else
+  ``skill://`` resource surface (listings AND reads — the same documents
+  ``GET /skills/*`` serves without a credential) are served without a
+  credential — a client can always discover the tool surface and read the
+  skill set before authenticating. Everything else
   requires a resolved identity.
 - **Session telemetry**: each authenticated POST feeds the
   windowed ``mcp.session_started`` emit — key = (agent identity x ``_meta``
@@ -75,6 +77,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.types import Receive, Scope, Send
 
+from jentic_one.mcp.resources import read_skill_resource, skill_resources
 from jentic_one.mcp.spec import served_tools
 from jentic_one.mcp.tools import CallEnv, dispatch_tool_call
 from jentic_one.shared.auth.identity import Identity
@@ -93,11 +96,29 @@ MCP_PRM_PATH = "/.well-known/oauth-protected-resource/mcp"
 
 #: JSON-RPC methods served WITHOUT a credential: discovery of the tool
 #: surface, the spec's ping, the legacy-``initialize`` fallback pair, and the
-#: public resource listings. ``resources/read`` is deliberately NOT here: no
-#: resources are served yet, so pre-declaring it would hand a future resource
-#: registration a pre-auth ride nobody re-reviewed — when the public skill
-#: resources land, add it back alongside a pin that the readable set
-#: stays public-only.
+#: public skill-resource surface (listings + reads). ``resources/read`` is
+#: pre-auth because the readable set is the public skill set and NOTHING
+#: else — the same documents ``GET /skills/*`` already serves without a
+#: credential, so the pre-auth read adds zero new exposure. Three layers of
+#: defense hold that property (``tests/unit/mcp/test_resources.py``):
+#:
+#: 1. **Resolver characterization (the proof)** — ``read_skill_resource`` is
+#:    unit-characterized as two-armed by construction: every URI outside
+#:    ``skill://<shipped name>`` + ``skill://index`` raises -32002, and no
+#:    branch of it can see a credential (it never reads identity), so its
+#:    behavior is structurally identical pre- and post-auth.
+#: 2. **Delegation pin (the structural lock)** — ``on_read_resource`` below
+#:    is pinned to be a bare delegation to ``read_skill_resource``, so this
+#:    module cannot grow a bypass arm without failing a test.
+#: 3. **Probe battery (the tripwire)** — a mount-level battery of hostile
+#:    URIs answers -32002 twice, credential-less and with a valid bearer.
+#:
+#: In SDK 2.1.1 every ``resources/read`` dispatches to the ONE handler
+#: (there is no per-resource routing), so a future non-public resource would
+#: need a NEW handler arm here — no finite probe battery can prove such an
+#: arm doesn't exist, so a new arm is exactly what code review plus this
+#: comment must catch: if you are adding one, take ``resources/read`` back
+#: OFF this whitelist first and re-review the pre-auth door.
 PRE_AUTH_METHODS = frozenset(
     {
         "initialize",
@@ -105,6 +126,7 @@ PRE_AUTH_METHODS = frozenset(
         "ping",
         "tools/list",
         "resources/list",
+        "resources/read",
         "resources/templates/list",
     }
 )
@@ -311,13 +333,34 @@ def _auth_required_error() -> Exception:
     return MCPError(-32001, "authentication required")
 
 
+def _request_base_url(ctx: Context, sctx: ServerRequestContext[Any, Any]) -> str:
+    """The deployment base URL for one handler's request, auth or not.
+
+    The base-URL seam for the pre-auth index read: ``_stash_call_state`` only
+    runs on the authenticated branch, so a pre-auth request has no
+    ``mcp_base_url`` in ``scope["state"]``. Computed at the source instead —
+    ``deployment_base_url`` over the SDK-attached Starlette request — the same
+    function, same config inputs as the HTTP route's manifest, so the two
+    manifests stamp identical URLs for identical requests. A request-less
+    call is structurally unreachable on the mount; fall back to ``""``-based
+    relative URLs rather than raising (the ``CallEnv.base_url`` default).
+    """
+    request = sctx.request
+    if request is None:  # pragma: no cover - the transport always attaches it
+        return ""
+    return deployment_base_url(ctx.config.auth, request)
+
+
 def build_mcp_server(ctx: Context) -> Server[Any]:
     """Assemble the low-level SDK server for this deployment.
 
     Tools come from the pinned tool-surface spec (``jentic_one.mcp.spec``);
     ``tools/list`` is connection-independent (stateless — the same list for
-    every caller). Resource listings are served empty until the
-    skill-resources slice lands.
+    every caller). Resources are the public ``skill://`` surface
+    (``jentic_one.mcp.resources``): the shipped skill set plus the index,
+    listed and read identically for every caller — ``on_read_resource`` is a
+    bare delegation to the two-armed resolver (pinned; see the
+    ``PRE_AUTH_METHODS`` comment for the layered defense).
     """
 
     async def on_list_tools(
@@ -337,12 +380,25 @@ def build_mcp_server(ctx: Context) -> Server[Any]:
         sctx: ServerRequestContext[Any, Any],
         params: mcp_types.PaginatedRequestParams | None,
     ) -> mcp_types.ListResourcesResult:
-        return mcp_types.ListResourcesResult(resources=[])
+        # Pagination: none — params are accepted and ignored, no nextCursor is
+        # ever emitted (the served set is the shipped skills plus the index).
+        return mcp_types.ListResourcesResult(resources=skill_resources())
+
+    async def on_read_resource(
+        sctx: ServerRequestContext[Any, Any],
+        params: mcp_types.ReadResourceRequestParams,
+    ) -> mcp_types.ReadResourceResult:
+        # A BARE delegation to the two-armed resolver — pinned structurally
+        # (test_resources.py) so no bypass arm can appear here unnoticed.
+        return read_skill_resource(params.uri, _request_base_url(ctx, sctx))
 
     async def on_list_resource_templates(
         sctx: ServerRequestContext[Any, Any],
         params: mcp_types.PaginatedRequestParams | None,
     ) -> mcp_types.ListResourceTemplatesResult:
+        # Deliberately empty: ``skill://<name>`` is a closed, enumerable set
+        # fully described by resources/list — a URI template would advertise
+        # an open namespace this server deliberately does not have.
         return mcp_types.ListResourceTemplatesResult(resource_templates=[])
 
     version = _package_version()
@@ -356,11 +412,15 @@ def build_mcp_server(ctx: Context) -> Server[Any]:
             "requesting access or executing operations. Every tool result carries a "
             "top-level `instance` key identifying the Jentic One instance it came "
             "from. The flow is whoami → search_apis → inspect_operation → execute; "
-            "never execute an operation just to probe whether you have access."
+            "never execute an operation just to probe whether you have access. "
+            "The skill://jentic resource is the canonical guide to the whole flow "
+            "(skill://index lists every skill document); read it when unsure how "
+            "the pieces fit together."
         ),
         on_list_tools=on_list_tools,
         on_call_tool=on_call_tool,
         on_list_resources=on_list_resources,
+        on_read_resource=on_read_resource,
         on_list_resource_templates=on_list_resource_templates,
     )
 

--- a/src/jentic_one/mcp/app.py
+++ b/src/jentic_one/mcp/app.py
@@ -115,10 +115,18 @@ MCP_PRM_PATH = "/.well-known/oauth-protected-resource/mcp"
 #:
 #: In SDK 2.1.1 every ``resources/read`` dispatches to the ONE handler
 #: (there is no per-resource routing), so a future non-public resource would
-#: need a NEW handler arm here — no finite probe battery can prove such an
-#: arm doesn't exist, so a new arm is exactly what code review plus this
-#: comment must catch: if you are adding one, take ``resources/read`` back
-#: OFF this whitelist first and re-review the pre-auth door.
+#: need a NEW handler arm — no finite probe battery can prove such an arm
+#: doesn't exist, so a new arm is exactly what code review plus this comment
+#: must catch: if you are adding one, take ``resources/read`` back OFF this
+#: whitelist first and re-review the pre-auth door. The arm has THREE doors,
+#: not one: here in ``build_mcp_server`` (the delegation pin catches that),
+#: inside ``read_skill_resource`` itself (``resources.py`` — a third resolver
+#: arm passes both the pin and every probe, so review must watch that module
+#: with the same eyes), or via the SDK's
+#: ``Server.add_request_handler("resources/read", …)``, which replaces the
+#: registered handler after ``build_mcp_server`` returns and bypasses this
+#: module entirely (``tests/arch/test_mcp_handler_registration.py`` pins that
+#: nothing under ``src/`` calls it).
 PRE_AUTH_METHODS = frozenset(
     {
         "initialize",

--- a/src/jentic_one/mcp/resources.py
+++ b/src/jentic_one/mcp/resources.py
@@ -22,7 +22,11 @@ mislead. The mount refuses to read what it does not list (listed set ==
 readable set, the D11 invariant); the Go stdio server applies the SAME
 filter (``skillgen.CLIOnlyReference``). This is a serving decision, not a
 secret: the HTTP routes are the raw neutral channel and serve every
-reference, ``cli.md`` included.
+reference, ``cli.md`` included. Note the filter governs the ``skill://``
+door only — a ``skill://index`` read, being the HTTP manifest verbatim,
+still NAMES the CLI-lane references and their HTTP URLs in its
+``references`` rows; it advertises where the neutral channel serves them,
+it does not make them readable here.
 
 Kept as a sibling of ``app.py`` (the ``access_compose.py`` precedent:
 handlers-adjacent logic lives next to the handlers, keeping ``app.py``

--- a/src/jentic_one/mcp/resources.py
+++ b/src/jentic_one/mcp/resources.py
@@ -2,15 +2,27 @@
 
 Serves the shipped skill set as MCP resources — ``skill://<name>`` for every
 skill in :func:`jentic_one.shared.web.agent_discovery.shipped_skill_names`,
-plus ``skill://index`` (the set manifest) — mirroring the Go stdio server's
-surface (``cli/internal/cli/api/mcp_resources.go``) **minus its
-hosted-vs-bundled machinery**: the CLI prefers the connected backend's copy
-and falls back to its embed because it is a *client* of a backend; the daemon
-**is** the backend. There is exactly one source — the wheel-shipped package
-data ``agent_discovery`` already globs — so this module mints no new copy and
+``skill://<name>/references/<file>`` for every shipped reference OUTSIDE the
+CLI lane (decision D11 — see below), plus ``skill://index`` (the set
+manifest) — mirroring the Go stdio server's surface
+(``cli/internal/cli/api/mcp_resources.go``) **minus its hosted-vs-bundled
+machinery**: the CLI prefers the connected backend's copy and falls back to
+its embed because it is a *client* of a backend; the daemon **is** the
+backend. There is exactly one source — the wheel-shipped package data
+``agent_discovery`` already globs — so this module mints no new copy and
 adds no fourth corner to the drift triangle: the mount consumes the same
 allowlist and manifest helper the HTTP routes consume
 (``tests/arch/test_skill_drift.py`` covers it transitively).
+
+The lane filter (decision D11 of the plan): a reference named in
+:data:`~jentic_one.shared.web.agent_discovery.CLI_ONLY_REFERENCES`
+(``cli.md``) is never listed and never readable on this mount — an MCP
+session has no ``jentic`` CLI, so serving it the CLI lane would only
+mislead. The mount refuses to read what it does not list (listed set ==
+readable set, the D11 invariant); the Go stdio server applies the SAME
+filter (``skillgen.CLIOnlyReference``). This is a serving decision, not a
+secret: the HTTP routes are the raw neutral channel and serve every
+reference, ``cli.md`` included.
 
 Kept as a sibling of ``app.py`` (the ``access_compose.py`` precedent:
 handlers-adjacent logic lives next to the handlers, keeping ``app.py``
@@ -37,11 +49,15 @@ import mcp.types as mcp_types
 from mcp.shared.exceptions import MCPError
 
 from jentic_one.shared.web.agent_discovery import (
+    CLI_ONLY_REFERENCES,
     MARKDOWN_MEDIA_TYPE,
+    REFERENCE_STEM_RE,
     SKILL_NAME_RE,
     _parse_frontmatter,
     load_skill_markdown,
+    load_skill_reference,
     shipped_skill_names,
+    shipped_skill_references,
     skills_index_rows,
 )
 
@@ -51,6 +67,13 @@ from jentic_one.shared.web.agent_discovery import (
 #: one skill document; ``skill://index`` serves the set manifest.
 SKILL_URI_SCHEME = "skill://"
 SKILL_INDEX_URI = SKILL_URI_SCHEME + "index"
+
+#: The path infix separating a skill name from one of its reference files in
+#: a resource URI: ``skill://<name>/references/<file>`` — byte-parallel to
+#: the Go server's reference URIs (``registerResources`` builds
+#: ``skillURIScheme + name + "/references/" + ref``) and to the HTTP route
+#: ``GET /skills/<name>/references/<file>``.
+REFERENCES_INFIX = "/references/"
 
 #: ``_meta`` keys carrying the provenance on every read result — byte-equal to
 #: the Go constants (``skillMetaSource``/``skillMetaVersion``), namespaced per
@@ -100,31 +123,52 @@ _INDEX_DESCRIPTION = (
 
 
 def skill_resources() -> list[mcp_types.Resource]:
-    """The ``resources/list`` payload: the shipped skill set plus the index.
+    """The ``resources/list`` payload: skills + lane-filtered references + index.
 
-    Derived from the same glob the HTTP routes serve
-    (:func:`shipped_skill_names` — cached wheel package data), never a second
-    hand-maintained list, so listing and reading cannot drift. Listing fields
-    mirror the Go server's (``registerResources``): ``name``/``title`` per
-    skill, the frontmatter description plus the daemon provenance note, and
-    Go-identical MIME types.
+    Derived from the same globs the HTTP routes serve
+    (:func:`shipped_skill_names` / :func:`shipped_skill_references` — cached
+    wheel package data), never a second hand-maintained list, so listing and
+    reading cannot drift. Listing fields mirror the Go server's
+    (``registerResources``): ``name``/``title`` per skill and per reference
+    (``<name>/references/<file>`` / ``Jentic skill reference: <name>/<file>``
+    — the same vocabulary on both doors), the frontmatter description plus
+    the daemon provenance note, and Go-identical MIME types.
 
-    No pagination: the served set is the shipped skills plus the index
-    (currently four resources) — the SDK's ``PaginatedRequestParams`` is
+    The lane filter (D11): references named in :data:`CLI_ONLY_REFERENCES`
+    are skipped — never listed here, never readable in
+    :func:`read_skill_resource` — matching the Go stdio server's filter
+    (``skillgen.CLIOnlyReference``). Skills without references contribute no
+    reference rows.
+
+    No pagination: the served set is the shipped skills, their MCP-visible
+    references, and the index — the SDK's ``PaginatedRequestParams`` is
     accepted and ignored by the handler and no ``nextCursor`` is ever
     emitted, exactly what the Go server does. Revisit if the served set ever
     grows past dozens.
     """
-    resources = [
-        mcp_types.Resource(
-            uri=SKILL_URI_SCHEME + name,
-            name=name,
-            title="Jentic skill: " + name,
-            description=_skill_frontmatter(name).get("description", "") + SKILL_PROVENANCE_NOTE,
-            mime_type=MARKDOWN_MEDIA_TYPE,
+    resources: list[mcp_types.Resource] = []
+    for name in shipped_skill_names():
+        resources.append(
+            mcp_types.Resource(
+                uri=SKILL_URI_SCHEME + name,
+                name=name,
+                title="Jentic skill: " + name,
+                description=_skill_frontmatter(name).get("description", "") + SKILL_PROVENANCE_NOTE,
+                mime_type=MARKDOWN_MEDIA_TYPE,
+            )
         )
-        for name in shipped_skill_names()
-    ]
+        for file in shipped_skill_references(name):
+            if file in CLI_ONLY_REFERENCES:
+                continue
+            resources.append(
+                mcp_types.Resource(
+                    uri=SKILL_URI_SCHEME + name + REFERENCES_INFIX + file,
+                    name=name + "/references/" + file,
+                    title="Jentic skill reference: " + name + "/" + file,
+                    description=_reference_description(name, file),
+                    mime_type=MARKDOWN_MEDIA_TYPE,
+                )
+            )
     resources.append(
         mcp_types.Resource(
             uri=SKILL_INDEX_URI,
@@ -137,10 +181,31 @@ def skill_resources() -> list[mcp_types.Resource]:
     return resources
 
 
+def _reference_description(name: str, file: str) -> str:
+    """One reference resource's listing description.
+
+    The first sentence is the Go server's reference description verbatim
+    (``registerResources`` — the two doors share the vocabulary); the
+    provenance sentence is the daemon's own (same honest divergence as
+    :data:`SKILL_PROVENANCE_NOTE`: nothing here is "embedded in this
+    binary" — there is exactly one source, the shipped package data).
+    """
+    return (
+        f"A level-3 reference document of the {name} skill (read the skill first; "
+        "it points at this file when the material applies). Served from this "
+        "deployment's shipped package data (the same bytes as "
+        f"GET /skills/{name}/references/{file}); the read result's _meta carries "
+        + META_SOURCE_KEY
+        + " and "
+        + META_VERSION_KEY
+        + "."
+    )
+
+
 def read_skill_resource(uri: str, base: str) -> mcp_types.ReadResourceResult:
     """Resolve one ``resources/read`` URI — the entire pre-auth read seam.
 
-    Exactly two arms, both public by construction, and **no identity read
+    Exactly three arms, all public by construction, and **no identity read
     anywhere** — the resolver never sees a credential, so its behavior is
     *structurally* identical pre-auth and post-auth:
 
@@ -154,12 +219,23 @@ def read_skill_resource(uri: str, base: str) -> mcp_types.ReadResourceResult:
       :func:`shipped_skill_names` allowlist → the RAW package-data bytes
       verbatim (no BaseURL interpolation — render-time is CLI-only), with
       ``_meta`` = source + the frontmatter version (default ``"1"``).
+    - ``skill://<name>/references/<file>`` (D11) where ``<name>`` passes the
+      document arm's grammar+allowlist AND ``<file>`` passes the reference
+      grammar (:data:`REFERENCE_STEM_RE` + ``.md``) + the
+      :func:`shipped_skill_references` allowlist AND is NOT in
+      :data:`CLI_ONLY_REFERENCES` → the reference's raw bytes verbatim,
+      markdown MIME, ``_meta`` = source + the OWNING skill's frontmatter
+      version (a reference has no frontmatter of its own). The lane filter
+      is read-side too: the mount must refuse to read what it does not list
+      (listed set == readable set), so ``cli.md`` is RESOURCE_NOT_FOUND here
+      while the same bytes stay public over HTTP.
 
     **Everything else** — unknown scheme, ``skill://`` with a name that fails
     the grammar or the allowlist (including ``init-design``, which lives in
-    ``skills/`` but is deliberately un-served), empty name, traversal junk —
-    raises :data:`RESOURCE_NOT_FOUND`: the same layered, fail-closed
-    validation as the HTTP route's 404.
+    ``skills/`` but is deliberately un-served), a reference that fails the
+    grammar, the per-skill allowlist, or the lane filter, empty name or file,
+    traversal junk — raises :data:`RESOURCE_NOT_FOUND`: the same layered,
+    fail-closed validation as the HTTP route's 404.
     """
     if uri == SKILL_INDEX_URI:
         # Serialize with the JSONResponse separators so the read is
@@ -169,15 +245,31 @@ def read_skill_resource(uri: str, base: str) -> mcp_types.ReadResourceResult:
         text = json.dumps(skills_index_rows(base), separators=(",", ":"), ensure_ascii=False)
         return _read_result(uri, SKILL_INDEX_MIME, text, {META_SOURCE_KEY: SOURCE_HOSTED})
     if uri.startswith(SKILL_URI_SCHEME):
-        name = uri[len(SKILL_URI_SCHEME) :]
+        # ``partition`` splits on the FIRST infix, so a second ``/references/``
+        # inside ``file`` survives into the filename and fails the grammar.
+        name, infix, file = uri[len(SKILL_URI_SCHEME) :].partition(REFERENCES_INFIX)
         if SKILL_NAME_RE.fullmatch(name) and name in shipped_skill_names():
-            text = load_skill_markdown(name)
-            meta = {
-                META_SOURCE_KEY: SOURCE_HOSTED,
-                META_VERSION_KEY: _parse_frontmatter(text).get("version") or "1",
-            }
-            return _read_result(uri, MARKDOWN_MEDIA_TYPE, text, meta)
+            if not infix:
+                text = load_skill_markdown(name)
+                return _read_result(uri, MARKDOWN_MEDIA_TYPE, text, _document_meta(text))
+            if (
+                file.endswith(".md")
+                and REFERENCE_STEM_RE.fullmatch(file[: -len(".md")])
+                and file in shipped_skill_references(name)
+                and file not in CLI_ONLY_REFERENCES
+            ):
+                meta = _document_meta(load_skill_markdown(name))  # the OWNING skill's version
+                text = load_skill_reference(name, file)
+                return _read_result(uri, MARKDOWN_MEDIA_TYPE, text, meta)
     raise MCPError(RESOURCE_NOT_FOUND, "resource not found")
+
+
+def _document_meta(skill_text: str) -> dict[str, str]:
+    """The provenance ``_meta`` stamped from one skill document's frontmatter."""
+    return {
+        META_SOURCE_KEY: SOURCE_HOSTED,
+        META_VERSION_KEY: _parse_frontmatter(skill_text).get("version") or "1",
+    }
 
 
 def _skill_frontmatter(name: str) -> dict[str, str]:
@@ -200,6 +292,7 @@ def _read_result(
 __all__ = [
     "META_SOURCE_KEY",
     "META_VERSION_KEY",
+    "REFERENCES_INFIX",
     "RESOURCE_NOT_FOUND",
     "SKILL_INDEX_MIME",
     "SKILL_INDEX_URI",

--- a/src/jentic_one/mcp/resources.py
+++ b/src/jentic_one/mcp/resources.py
@@ -1,0 +1,211 @@
+"""The ``skill://`` resource surface served on the ``/mcp`` mount.
+
+Serves the shipped skill set as MCP resources — ``skill://<name>`` for every
+skill in :func:`jentic_one.shared.web.agent_discovery.shipped_skill_names`,
+plus ``skill://index`` (the set manifest) — mirroring the Go stdio server's
+surface (``cli/internal/cli/api/mcp_resources.go``) **minus its
+hosted-vs-bundled machinery**: the CLI prefers the connected backend's copy
+and falls back to its embed because it is a *client* of a backend; the daemon
+**is** the backend. There is exactly one source — the wheel-shipped package
+data ``agent_discovery`` already globs — so this module mints no new copy and
+adds no fourth corner to the drift triangle: the mount consumes the same
+allowlist and manifest helper the HTTP routes consume
+(``tests/arch/test_skill_drift.py`` covers it transitively).
+
+Kept as a sibling of ``app.py`` (the ``access_compose.py`` precedent:
+handlers-adjacent logic lives next to the handlers, keeping ``app.py``
+gate-focused). ``app.py``'s ``on_read_resource`` is a bare delegation to
+:func:`read_skill_resource` — pinned structurally by
+``tests/unit/mcp/test_resources.py`` — so this resolver is the entire
+pre-auth enforcement seam for ``resources/read``.
+
+Provenance (decision D3 of the plan): every read stamps
+``one.jentic/source: "hosted"`` — the Go vocabulary's (``skillgen.Source``)
+"the connected backend's copy, the session's source of truth", which is
+exactly what a client reading from the mount gets. ``hosted`` is the ONLY
+value this mount ever stamps (nothing client-side is embedded, so ``bundled``
+would be a lie, and a third value would distinguish nothing), which makes the
+Go index description's index-vs-document source-mismatch caveat structurally
+impossible here — its prose is dropped from the index description accordingly.
+"""
+
+from __future__ import annotations
+
+import json
+
+import mcp.types as mcp_types
+from mcp.shared.exceptions import MCPError
+
+from jentic_one.shared.web.agent_discovery import (
+    MARKDOWN_MEDIA_TYPE,
+    SKILL_NAME_RE,
+    _parse_frontmatter,
+    load_skill_markdown,
+    shipped_skill_names,
+    skills_index_rows,
+)
+
+#: Resource URI scheme — byte-equal to the Go constants
+#: (``skillURIScheme``/``skillIndexURI``), so a model that learned the
+#: vocabulary on one door reuses it on the other. ``skill://<name>`` serves
+#: one skill document; ``skill://index`` serves the set manifest.
+SKILL_URI_SCHEME = "skill://"
+SKILL_INDEX_URI = SKILL_URI_SCHEME + "index"
+
+#: ``_meta`` keys carrying the provenance on every read result — byte-equal to
+#: the Go constants (``skillMetaSource``/``skillMetaVersion``), namespaced per
+#: the MCP general-fields guidance.
+META_SOURCE_KEY = "one.jentic/source"
+META_VERSION_KEY = "one.jentic/version"
+
+#: The one source value this mount ever stamps (see the module docstring).
+SOURCE_HOSTED = "hosted"
+
+#: MIME type for the index manifest — the same string the Go constant
+#: (``skillIndexMIME``) mirrors and ``GET /skills/index.json`` serves.
+#: Documents reuse ``MARKDOWN_MEDIA_TYPE`` (= Go's ``skillMarkdownMIME``).
+SKILL_INDEX_MIME = "application/json"
+
+#: The MCP spec's resource-not-found JSON-RPC error code. The installed SDK
+#: (2.1.1) leaves unmapped codes at HTTP 200, so the refusal rides in-band as
+#: a JSON-RPC error — like every other handler error on the mount.
+RESOURCE_NOT_FOUND = -32002
+
+#: Appended to every resource description so a client (and its model) knows
+#: where the bytes come from and how to read the provenance stamp.
+#: Deliberately NOT the Go ``skillProvenanceNote`` verbatim: that note
+#: promises "falling back to the copy embedded in this binary offline", which
+#: is false here — the daemon serves one source. Honest divergence in prose,
+#: identical ``_meta`` keys on the wire.
+SKILL_PROVENANCE_NOTE = (
+    " Served from this deployment's shipped package data (the same bytes as"
+    " GET /skills/<name>.md); the read result's _meta carries "
+    + META_SOURCE_KEY
+    + " and "
+    + META_VERSION_KEY
+    + "."
+)
+
+#: The index resource's listing description: the Go server's manifest sentence
+#: with the source-mismatch caveat dropped (structurally impossible here — see
+#: the module docstring) and the url-vs-uri tell replaced by the daemon truth:
+#: rows are always the hosted shape, locating each document by absolute
+#: ``url`` (the strongest parity claim — the HTTP manifest verbatim).
+_INDEX_DESCRIPTION = (
+    "Manifest of the served skill set: name, description, version, and the sha256 of each "
+    "document's raw bytes, so a client can pick and verify skills without reading them all. "
+    "Rows locate each document with an absolute `url` — the same manifest "
+    "GET /skills/index.json serves." + SKILL_PROVENANCE_NOTE
+)
+
+
+def skill_resources() -> list[mcp_types.Resource]:
+    """The ``resources/list`` payload: the shipped skill set plus the index.
+
+    Derived from the same glob the HTTP routes serve
+    (:func:`shipped_skill_names` — cached wheel package data), never a second
+    hand-maintained list, so listing and reading cannot drift. Listing fields
+    mirror the Go server's (``registerResources``): ``name``/``title`` per
+    skill, the frontmatter description plus the daemon provenance note, and
+    Go-identical MIME types.
+
+    No pagination: the served set is the shipped skills plus the index
+    (currently four resources) — the SDK's ``PaginatedRequestParams`` is
+    accepted and ignored by the handler and no ``nextCursor`` is ever
+    emitted, exactly what the Go server does. Revisit if the served set ever
+    grows past dozens.
+    """
+    resources = [
+        mcp_types.Resource(
+            uri=SKILL_URI_SCHEME + name,
+            name=name,
+            title="Jentic skill: " + name,
+            description=_skill_frontmatter(name).get("description", "") + SKILL_PROVENANCE_NOTE,
+            mime_type=MARKDOWN_MEDIA_TYPE,
+        )
+        for name in shipped_skill_names()
+    ]
+    resources.append(
+        mcp_types.Resource(
+            uri=SKILL_INDEX_URI,
+            name="index",
+            title="Jentic skill index",
+            description=_INDEX_DESCRIPTION,
+            mime_type=SKILL_INDEX_MIME,
+        )
+    )
+    return resources
+
+
+def read_skill_resource(uri: str, base: str) -> mcp_types.ReadResourceResult:
+    """Resolve one ``resources/read`` URI — the entire pre-auth read seam.
+
+    Exactly two arms, both public by construction, and **no identity read
+    anywhere** — the resolver never sees a credential, so its behavior is
+    *structurally* identical pre-auth and post-auth:
+
+    - ``skill://index`` → the SAME manifest rows ``GET /skills/index.json``
+      serves, produced by the SAME function (:func:`skills_index_rows`), so
+      sha256 parity with the HTTP manifest is structural, not tested into
+      existence. ``base`` is only used by this arm (absolute ``url`` rows).
+      ``_meta`` carries the source only — Go parity: the index carries
+      per-row versions, so ``skillReadResult`` omits the top-level stamp.
+    - ``skill://<name>`` where ``<name>`` passes :data:`SKILL_NAME_RE` AND the
+      :func:`shipped_skill_names` allowlist → the RAW package-data bytes
+      verbatim (no BaseURL interpolation — render-time is CLI-only), with
+      ``_meta`` = source + the frontmatter version (default ``"1"``).
+
+    **Everything else** — unknown scheme, ``skill://`` with a name that fails
+    the grammar or the allowlist (including ``init-design``, which lives in
+    ``skills/`` but is deliberately un-served), empty name, traversal junk —
+    raises :data:`RESOURCE_NOT_FOUND`: the same layered, fail-closed
+    validation as the HTTP route's 404.
+    """
+    if uri == SKILL_INDEX_URI:
+        # Serialize with the JSONResponse separators so the read is
+        # byte-identical to what ``GET /skills/index.json`` serves at the
+        # same base — the manifest sha256s cover documents, and byte parity
+        # here means one wire shape for clients to cache and compare.
+        text = json.dumps(skills_index_rows(base), separators=(",", ":"), ensure_ascii=False)
+        return _read_result(uri, SKILL_INDEX_MIME, text, {META_SOURCE_KEY: SOURCE_HOSTED})
+    if uri.startswith(SKILL_URI_SCHEME):
+        name = uri[len(SKILL_URI_SCHEME) :]
+        if SKILL_NAME_RE.fullmatch(name) and name in shipped_skill_names():
+            text = load_skill_markdown(name)
+            meta = {
+                META_SOURCE_KEY: SOURCE_HOSTED,
+                META_VERSION_KEY: _parse_frontmatter(text).get("version") or "1",
+            }
+            return _read_result(uri, MARKDOWN_MEDIA_TYPE, text, meta)
+    raise MCPError(RESOURCE_NOT_FOUND, "resource not found")
+
+
+def _skill_frontmatter(name: str) -> dict[str, str]:
+    """Parsed frontmatter scalars for one shipped skill."""
+    return _parse_frontmatter(load_skill_markdown(name))
+
+
+def _read_result(
+    uri: str, mime_type: str, text: str, meta: dict[str, str]
+) -> mcp_types.ReadResourceResult:
+    """The one read-result shape both arms return: the document bytes VERBATIM
+    with the provenance stamped into the contents' ``_meta`` (wire alias)."""
+    return mcp_types.ReadResourceResult(
+        contents=[
+            mcp_types.TextResourceContents(uri=uri, mime_type=mime_type, text=text, _meta=meta)
+        ]
+    )
+
+
+__all__ = [
+    "META_SOURCE_KEY",
+    "META_VERSION_KEY",
+    "RESOURCE_NOT_FOUND",
+    "SKILL_INDEX_MIME",
+    "SKILL_INDEX_URI",
+    "SKILL_PROVENANCE_NOTE",
+    "SKILL_URI_SCHEME",
+    "SOURCE_HOSTED",
+    "read_skill_resource",
+    "skill_resources",
+]

--- a/src/jentic_one/shared/web/agent_discovery.py
+++ b/src/jentic_one/shared/web/agent_discovery.py
@@ -67,9 +67,12 @@ ONBOARDING_SKILL = "jentic"
 MARKDOWN_MEDIA_TYPE = "text/markdown; charset=utf-8"
 
 #: Agent Skills ``name`` grammar (Anthropic spec): 1-64 chars, lowercase
-#: alphanumerics and single interior hyphens, no leading/trailing hyphen. Kept
-#: as an independent constant here (not imported from ``tools``) so the runtime
-#: backend has no dependency on the un-shipped repo-root ``tools`` package.
+#: alphanumerics and interior hyphens, no leading/trailing hyphen. The regex
+#: does permit consecutive interior hyphens (``a--b``) — that's fine: the
+#: grammar only pre-filters shapes, and the ``shipped_skill_names()``
+#: allowlist is the real serving gate. Kept as an independent constant here
+#: (not imported from ``tools``) so the runtime backend has no dependency on
+#: the un-shipped repo-root ``tools`` package.
 SKILL_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$")
 
 #: Reference-file *stem* grammar (the filename minus ``.md``): the skill-name

--- a/src/jentic_one/shared/web/agent_discovery.py
+++ b/src/jentic_one/shared/web/agent_discovery.py
@@ -298,7 +298,9 @@ with `Authorization: Bearer <agent API key or access token>`. Alternatively,
 the local `jentic mcp` stdio server — available in the `jentic` CLI from the
 next release; check `jentic mcp --help` — spawns on the agent machine and
 talks to this deployment with the agent's registered identity. Both expose
-the same discover → execute loop as the CLI tools. Stdio-only MCP runtimes
+the same discover → execute loop as the CLI tools. The endpoint also serves
+the shipped skill set as MCP resources (`skill://<name>`; `skill://index` is
+the manifest). Stdio-only MCP runtimes
 can reach {base}/mcp through a stdio↔HTTP bridge such as `mcp-remote` or
 `mcp-proxy` — exact entries in the
 [MCP endpoint guide](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/mcp-http-endpoint.md).

--- a/tests/arch/test_mcp_handler_registration.py
+++ b/tests/arch/test_mcp_handler_registration.py
@@ -2,7 +2,7 @@
 
 The ``/mcp`` mount's pre-auth ``resources/read`` door is held closed by a
 layered defense (see the ``PRE_AUTH_METHODS`` comment in
-``jentic_one/mcp/app.py``): the resolver is characterized as two-armed, and
+``jentic_one/mcp/app.py``): the resolver is characterized as three-armed, and
 ``build_mcp_server``'s ``on_read_resource`` is pinned to be a bare delegation
 to it. Both pins inspect **source that exists today** — the SDK's
 ``Server.add_request_handler`` / ``add_notification_handler`` would replace a

--- a/tests/arch/test_mcp_handler_registration.py
+++ b/tests/arch/test_mcp_handler_registration.py
@@ -1,0 +1,55 @@
+"""Forbid post-build MCP handler registration in application code.
+
+The ``/mcp`` mount's pre-auth ``resources/read`` door is held closed by a
+layered defense (see the ``PRE_AUTH_METHODS`` comment in
+``jentic_one/mcp/app.py``): the resolver is characterized as two-armed, and
+``build_mcp_server``'s ``on_read_resource`` is pinned to be a bare delegation
+to it. Both pins inspect **source that exists today** — the SDK's
+``Server.add_request_handler`` / ``add_notification_handler`` would replace a
+registered handler *after* ``build_mcp_server`` returns (from the installer,
+or anywhere else holding the ``Server`` instance), bypassing both pins without
+touching the pinned code. Nothing in the platform needs post-build
+registration: every handler is wired declaratively in ``build_mcp_server``.
+This test keeps it that way — any attribute reference to either method (call
+or alias) under ``src/`` is a violation.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from .conftest import SRC_ROOT, python_files_in
+
+_FORBIDDEN_ATTRS = frozenset({"add_request_handler", "add_notification_handler"})
+
+
+def _check_file(filepath: Path) -> list[str]:
+    """Return violations for post-build MCP handler registration."""
+    source = filepath.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(filepath))
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in _FORBIDDEN_ATTRS:
+            violations.append(
+                f"{filepath}:{node.lineno} — '{node.attr}' replaces an MCP handler "
+                f"after build_mcp_server returns, bypassing the pre-auth delegation "
+                f"pins; wire handlers declaratively in build_mcp_server instead"
+            )
+
+    return violations
+
+
+@pytest.mark.arch
+def test_no_post_build_mcp_handler_registration() -> None:
+    """No module under ``src/`` registers MCP handlers outside ``build_mcp_server``."""
+    violations: list[str] = []
+    for py_file in python_files_in(SRC_ROOT):
+        violations.extend(_check_file(py_file))
+    assert not violations, (
+        "Post-build MCP handler registration bypasses the pre-auth delegation pins:\n"
+        + "\n".join(violations)
+    )

--- a/tests/unit/mcp/test_mount_gate.py
+++ b/tests/unit/mcp/test_mount_gate.py
@@ -206,20 +206,40 @@ def test_enabled_credential_less_tools_call_is_challenged() -> None:
         assert resp.headers["www-authenticate"] == _CHALLENGE
 
 
-def test_credential_less_resources_read_is_challenged() -> None:
-    """resources/read stays OFF the pre-auth whitelist until resources are
-    actually served — a future registration must not land pre-auth by default
-    (the listings stay whitelisted; they are empty and connection-independent)."""
+def test_credential_less_resources_read_of_a_skill_is_served() -> None:
+    """The skill-resources slice's flip of the old 401 pin: ``resources/read``
+    is on the pre-auth whitelist and a credential-less read of a shipped
+    skill serves the document (the same bytes ``GET /skills/*`` already
+    serves without a credential — zero new exposure). The readable set stays
+    public-only, pinned three-layered in ``test_resources.py``."""
     with make_client(oauth_enabled=True) as client:
         read = client.post(
             "/mcp",
             json=_rpc("resources/read", {"uri": "skill://jentic"}),
             headers=_ACCEPT,
         )
-        assert read.status_code == 401
-        assert read.headers["www-authenticate"] == _CHALLENGE
+        assert read.status_code == 200
+        body = read.json()
+        assert "error" not in body
+        contents = body["result"]["contents"]
+        assert contents[0]["text"].strip()
+        assert contents[0]["mimeType"] == "text/markdown; charset=utf-8"
         listing = client.post("/mcp", json=_rpc("resources/list"), headers=_ACCEPT)
         assert listing.status_code == 200
+
+
+def test_batch_mixing_resources_read_with_tools_call_still_requires_credential() -> None:
+    """The batched-body rule survives the whitelist widening: pre-auth only
+    when ALL methods in a batch are whitelisted — ``resources/read`` cannot
+    smuggle a ``tools/call`` past the gate."""
+    with make_client(oauth_enabled=True) as client:
+        batch = [
+            _rpc("resources/read", {"uri": "skill://jentic"}, id_=1),
+            _rpc("tools/call", {"name": "whoami", "arguments": {}}, id_=2),
+        ]
+        resp = client.post("/mcp", content=json.dumps(batch), headers=_ACCEPT)
+        assert resp.status_code == 401
+        assert resp.headers["www-authenticate"] == _CHALLENGE
 
 
 def test_authenticated_get_is_405_and_never_reaches_the_sse_arm() -> None:

--- a/tests/unit/mcp/test_resources.py
+++ b/tests/unit/mcp/test_resources.py
@@ -233,6 +233,20 @@ def test_resource_templates_stay_empty() -> None:
         assert resp.json()["result"]["resourceTemplates"] == []
 
 
+def test_listing_cursor_is_accepted_and_ignored() -> None:
+    """Pagination params are accepted and ignored (the served set is small by
+    design): a listing with a cursor still returns the full set, and no
+    ``nextCursor`` is ever emitted — exactly the Go server's posture."""
+    with make_client() as client:
+        resp = client.post(
+            "/mcp", json=_rpc("resources/list", {"cursor": "opaque-cursor"}), headers=_ACCEPT
+        )
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert {r["uri"] for r in result["resources"]} == _SERVED_URIS
+        assert "nextCursor" not in result
+
+
 def test_index_never_enters_the_shipped_set() -> None:
     """``skill://index`` is minted by the resources module, never shipped as a
     document: ``read_skill_resource`` matches ``SKILL_INDEX_URI`` before the
@@ -451,6 +465,19 @@ def test_probe_battery_answers_resource_not_found_pre_and_post_auth(uri: str) ->
         assert anon.json()["error"]["code"] == RESOURCE_NOT_FOUND
         assert authed.status_code == 200
         assert anon.content == authed.content
+
+
+@pytest.mark.parametrize("uri", _PROBES)
+def test_probe_battery_stays_in_band_under_oauth(uri: str) -> None:
+    """The OAuth arm must not convert a hostile pre-auth read into the 401
+    discovery challenge: ``resources/read`` rides the pre-auth whitelist, so
+    the refusal stays the in-band JSON-RPC -32002 (HTTP 200) with
+    ``server.mcp.oauth.enabled`` on, exactly as on the oauth-off arm."""
+    with make_client(oauth_enabled=True) as client:
+        resp = client.post("/mcp", json=_rpc("resources/read", {"uri": uri}), headers=_ACCEPT)
+        assert resp.status_code != 401, uri
+        assert resp.status_code == 200, uri
+        assert resp.json()["error"]["code"] == RESOURCE_NOT_FOUND
 
 
 def test_every_listed_resource_reads_identically_pre_and_post_auth() -> None:

--- a/tests/unit/mcp/test_resources.py
+++ b/tests/unit/mcp/test_resources.py
@@ -1,22 +1,33 @@
 """The ``skill://`` resource surface on the mounted ``/mcp`` app.
 
 Pins the wire contract of the skill-resources slice (plan:
-``jentic-one-plans/themes/local-mcp/mcp-skill-resources.md``, PR A):
+``jentic-one-plans/themes/local-mcp/mcp-skill-resources.md``, reshaped PR A —
+rev 2's PR A mechanics plus the rev 3 D11 reference arm):
 
-- ``resources/list`` = the shipped skill set + ``skill://index``, derived from
-  the same glob the HTTP routes serve (``shipped_skill_names()``) — the pins
-  parametrize over it, so they survive a fourth skill;
+- ``resources/list`` = the shipped skill set + its lane-filtered references
+  (``skill://<name>/references/<file>`` for every shipped reference OUTSIDE
+  ``CLI_ONLY_REFERENCES``) + ``skill://index``, derived from the same globs
+  the HTTP routes serve (``shipped_skill_names()`` /
+  ``shipped_skill_references()``) — the pins parametrize over them, so they
+  survive a fourth skill or a new reference;
 - ``resources/read skill://<name>`` serves the raw package-data bytes
   (identical to ``GET /skills/<name>.md``) with the ``one.jentic/*``
-  provenance ``_meta``; ``skill://index`` serves the SAME manifest
+  provenance ``_meta``; reference reads serve the raw reference bytes
+  (identical to ``GET /skills/<name>/references/<file>``) stamped with the
+  OWNING skill's version; ``skill://index`` serves the SAME manifest
   ``GET /skills/index.json`` serves (one function computes both);
+- the D11 lane filter holds on BOTH sides: ``cli.md`` is never listed and
+  never readable on the mount (RESOURCE_NOT_FOUND) while staying public over
+  HTTP — and the listed set == the readable set as a general invariant (the
+  strongest pin for D11: the mount refuses to read what it does not list);
 - the D4 three-layer defense on the pre-auth read seam: the resolver is
-  provably two-armed (unit characterization), ``on_read_resource`` is a bare
-  delegation to it (structural lock), and a hostile-URI probe battery answers
-  -32002 twice — credential-less and with a valid bearer (tripwire);
-- ``initialize.instructions`` point at ``skill://jentic``/``skill://index``
-  (Go-parity sentence — a resource surface nobody is told about is the
-  original bug in miniature).
+  provably three-armed (unit characterization), ``on_read_resource`` is a
+  bare delegation to it (structural lock), and a hostile-URI probe battery —
+  extended with reference shapes — answers -32002 twice — credential-less
+  and with a valid bearer (tripwire);
+- ``initialize.instructions`` point at ``skill://jentic``/``skill://index``/
+  ``skill://jentic/references/mcp.md`` (Go-parity sentence — a resource
+  surface nobody is told about is the original bug in miniature).
 """
 
 from __future__ import annotations
@@ -38,6 +49,7 @@ from jentic_one.mcp.app import PRE_AUTH_METHODS, build_mcp_server
 from jentic_one.mcp.resources import (
     META_SOURCE_KEY,
     META_VERSION_KEY,
+    REFERENCES_INFIX,
     RESOURCE_NOT_FOUND,
     SKILL_INDEX_MIME,
     SKILL_INDEX_URI,
@@ -45,13 +57,17 @@ from jentic_one.mcp.resources import (
     SKILL_URI_SCHEME,
     SOURCE_HOSTED,
     read_skill_resource,
+    skill_resources,
 )
 from jentic_one.shared.web.agent_discovery import (
+    CLI_ONLY_REFERENCES,
     MARKDOWN_MEDIA_TYPE,
     _parse_frontmatter,
     get_agent_discovery_router,
     load_skill_markdown,
+    load_skill_reference,
     shipped_skill_names,
+    shipped_skill_references,
     skills_index_rows,
 )
 
@@ -59,13 +75,33 @@ from .test_mount_gate import _ACCEPT, _BASE, _GOOD_BEARER, _rpc, make_client
 
 _AUTH = {**_ACCEPT, "Authorization": f"Bearer {_GOOD_BEARER}"}
 
-#: Every URI the mount serves: the shipped set + the index (currently four).
-_SERVED_URIS = {SKILL_URI_SCHEME + name for name in shipped_skill_names()} | {SKILL_INDEX_URI}
+#: The MCP-visible reference URIs: every shipped reference outside the CLI
+#: lane (D11) — derived from the same glob the resolver consumes.
+_REFERENCE_URIS = {
+    SKILL_URI_SCHEME + name + REFERENCES_INFIX + file
+    for name in shipped_skill_names()
+    for file in shipped_skill_references(name)
+    if file not in CLI_ONLY_REFERENCES
+}
+
+#: Every URI the mount serves: the shipped set + lane-filtered references +
+#: the index.
+_SERVED_URIS = (
+    {SKILL_URI_SCHEME + name for name in shipped_skill_names()}
+    | _REFERENCE_URIS
+    | {SKILL_INDEX_URI}
+)
 
 #: The D4 probe battery: unknown schemes, grammar violations, traversal junk,
-#: unknown names, and ``init-design`` (lives in ``skills/`` but is
-#: deliberately un-served — the allowlist is the shipped wheel glob, not the
-#: repo tree). Every one answers -32002, pre- and post-auth alike.
+#: unknown names, ``init-design`` (lives in ``skills/`` but is deliberately
+#: un-served — the allowlist is the shipped wheel glob, not the repo tree),
+#: and the D11 reference shapes: the lane-filtered ``cli.md``, unknown files,
+#: traversal (raw and percent-encoded — the resolver sees the raw URI string,
+#: so an encoded dot-segment is just grammar junk), a reference on a skill
+#: that ships none, references of unknown/unserved skills, the bare
+#: ``references/`` stem, and index collisions
+#: (``skill://index/references/…`` — ``index`` is minted, never a skill).
+#: Every one answers -32002, pre- and post-auth alike.
 _PROBES = (
     "config://x",
     "file:///etc/passwd",
@@ -77,6 +113,20 @@ _PROBES = (
     "skill://",
     "skill",
     "",
+    "skill://jentic/references/cli.md",  # lane-filtered (D11): listed nowhere, readable nowhere
+    "skill://jentic/references/unknown.md",
+    "skill://jentic/references/../SKILL.md",
+    "skill://jentic/references/%2e%2e/SKILL.md",
+    "skill://jentic/references/%2e%2e%2fSKILL.md",
+    "skill://jentic/references/mcp",  # missing .md
+    "skill://jentic/references/MCP.md",  # grammar: uppercase stem
+    "skill://jentic/references/",  # bare — empty filename
+    "skill://jentic/references",  # no trailing slash — not a document name either
+    "skill://contribute-spec-fix/references/mcp.md",  # skill ships no references
+    "skill://unknown/references/mcp.md",
+    "skill://init-design/references/mcp.md",
+    "skill://index/references/mcp.md",  # index is minted, never a skill with references
+    "skill://jentic/references/mcp.md/references/mcp.md",
 )
 
 
@@ -104,7 +154,7 @@ def _read_contents(client: TestClient, uri: str) -> dict[str, Any]:
 # --- resources/list: the shipped set + index, from the HTTP routes' glob -----
 
 
-def test_resources_list_is_the_shipped_set_plus_index() -> None:
+def test_resources_list_is_the_shipped_set_plus_references_plus_index() -> None:
     with make_client() as client:
         resp = client.post("/mcp", json=_rpc("resources/list"), headers=_ACCEPT)
         assert resp.status_code == 200
@@ -125,6 +175,22 @@ def test_resources_list_is_the_shipped_set_plus_index() -> None:
             description = _parse_frontmatter(load_skill_markdown(name)).get("description", "")
             assert row["description"] == description + SKILL_PROVENANCE_NOTE
 
+            for file in shipped_skill_references(name):
+                if file in CLI_ONLY_REFERENCES:
+                    continue
+                # The Go stdio server's reference vocabulary, byte-parallel
+                # (``registerResources``): name ``<name>/references/<file>``,
+                # title ``Jentic skill reference: <name>/<file>`` — the lane
+                # is obvious from the filename on both doors.
+                ref = listed[SKILL_URI_SCHEME + name + REFERENCES_INFIX + file]
+                assert ref["name"] == f"{name}/references/{file}"
+                assert ref["title"] == f"Jentic skill reference: {name}/{file}"
+                assert ref["mimeType"] == MARKDOWN_MEDIA_TYPE
+                assert f"reference document of the {name} skill" in ref["description"]
+                # The daemon provenance note: package data + the _meta keys.
+                assert f"GET /skills/{name}/references/{file}" in ref["description"]
+                assert META_SOURCE_KEY in ref["description"]
+
         index = listed[SKILL_INDEX_URI]
         assert index["name"] == "index"
         assert index["title"] == "Jentic skill index"
@@ -133,6 +199,29 @@ def test_resources_list_is_the_shipped_set_plus_index() -> None:
         # D3: the mount stamps one source, so the Go description's
         # source-mismatch caveat must not be parroted here.
         assert "same one.jentic/source as the index read" not in index["description"]
+
+
+def test_listing_lane_filter_and_reference_rows() -> None:
+    """The D11 lane filter on the listing, pinned concretely: the ``jentic``
+    skill's MCP-visible references (``mcp.md``, ``recovery.md``) are listed,
+    the CLI-lane ``cli.md`` is NOT — even though it ships in the package data
+    and stays public over HTTP — and single-file skills contribute no
+    reference rows at all."""
+    listed = {str(r.uri) for r in skill_resources()}
+
+    # Grounded against the actual shipped set, not hardcoded wholesale: the
+    # jentic skill must ship all three lanes for the filter to mean anything.
+    assert {"cli.md", "mcp.md", "recovery.md"} <= set(shipped_skill_references("jentic"))
+    assert SKILL_URI_SCHEME + "jentic" + REFERENCES_INFIX + "mcp.md" in listed
+    assert SKILL_URI_SCHEME + "jentic" + REFERENCES_INFIX + "recovery.md" in listed
+    assert SKILL_URI_SCHEME + "jentic" + REFERENCES_INFIX + "cli.md" not in listed
+
+    for name in shipped_skill_names():
+        if shipped_skill_references(name):
+            continue
+        assert not any(
+            uri.startswith(SKILL_URI_SCHEME + name + REFERENCES_INFIX) for uri in listed
+        ), f"single-file skill {name} must contribute no reference rows"
 
 
 def test_resource_templates_stay_empty() -> None:
@@ -175,6 +264,36 @@ def test_read_skill_documents_match_the_http_route_bytes() -> None:
             }
 
 
+def test_read_references_match_the_http_route_bytes() -> None:
+    """Each listed ``skill://<name>/references/<file>`` read serves the RAW
+    reference bytes — identical to ``load_skill_reference`` AND to
+    ``GET /skills/<name>/references/<file>`` (same package data, so parity is
+    structural) — markdown MIME, ``_meta`` = source + the OWNING skill's
+    frontmatter version (a reference has no frontmatter of its own). The
+    lane-filtered ``cli.md`` meanwhile stays public over HTTP while the mount
+    refuses it: the filter is a serving decision, not a secret."""
+    with make_resource_client() as client:
+        for name in shipped_skill_names():
+            version = _parse_frontmatter(load_skill_markdown(name)).get("version") or "1"
+            for file in shipped_skill_references(name):
+                http = client.get(f"/skills/{name}/references/{file}")
+                assert http.status_code == 200, (name, file)  # HTTP: the neutral channel
+                if file in CLI_ONLY_REFERENCES:
+                    read = _read(client, SKILL_URI_SCHEME + name + REFERENCES_INFIX + file)
+                    assert read["error"]["code"] == RESOURCE_NOT_FOUND  # the mount: filtered
+                    continue
+                uri = SKILL_URI_SCHEME + name + REFERENCES_INFIX + file
+                contents = _read_contents(client, uri)
+                assert contents["uri"] == uri
+                assert contents["mimeType"] == MARKDOWN_MEDIA_TYPE
+                assert contents["text"] == load_skill_reference(name, file)
+                assert contents["text"] == http.text
+                assert contents["_meta"] == {
+                    META_SOURCE_KEY: SOURCE_HOSTED,
+                    META_VERSION_KEY: version,
+                }
+
+
 def test_read_index_is_the_http_manifest_at_the_same_base() -> None:
     """``skill://index`` serves the SAME manifest ``GET /skills/index.json``
     serves at the same deployment base — parity is structural (one function,
@@ -195,8 +314,11 @@ def test_read_index_is_the_http_manifest_at_the_same_base() -> None:
 
         for row in rows:
             # Hosted-manifest shape: absolute `url`, never `uri` (the Go
-            # server's documented tell for backend-produced rows).
-            assert set(row) == {"name", "description", "version", "sha256", "url"}
+            # server's documented tell for backend-produced rows). Rows for
+            # skills that ship references carry a `references` array; rows
+            # without omit the key (never null/empty).
+            assert set(row) <= {"name", "description", "version", "sha256", "url", "references"}
+            assert {"name", "description", "version", "sha256", "url"} <= set(row)
             assert row["url"] == f"{_BASE}/skills/{row['name']}.md"
             doc = _read_contents(client, SKILL_URI_SCHEME + row["name"])
             digest = hashlib.sha256(doc["text"].encode("utf-8")).hexdigest()
@@ -206,6 +328,21 @@ def test_read_index_is_the_http_manifest_at_the_same_base() -> None:
             # (``skills_index_rows`` / ``read_skill_resource``) — cross-pin
             # them so neither default can drift from the other.
             assert doc["_meta"][META_VERSION_KEY] == row["version"]
+
+            has_references = "references" in row
+            assert has_references == bool(shipped_skill_references(row["name"]))
+            for ref in row.get("references", []):
+                assert set(ref) == {"name", "sha256", "url"}
+                assert ref["url"] == f"{_BASE}/skills/{row['name']}/references/{ref['name']}"
+                if ref["name"] in CLI_ONLY_REFERENCES:
+                    continue  # verifiable over HTTP only — the mount won't read it
+                # The manifest's per-reference sha256 verifies against the
+                # corresponding resource read — the client-side loop the
+                # manifest exists for, extended to the reference rows.
+                ref_doc = _read_contents(
+                    client, SKILL_URI_SCHEME + row["name"] + REFERENCES_INFIX + ref["name"]
+                )
+                assert ref["sha256"] == hashlib.sha256(ref_doc["text"].encode("utf-8")).hexdigest()
 
 
 # --- D4 layer 1: resolver characterization (the proof) -----------------------
@@ -220,18 +357,46 @@ def test_resolver_first_arm_rejects_every_non_skill_uri(uri: str) -> None:
     assert exc.value.code == RESOURCE_NOT_FOUND
 
 
-def test_resolver_skill_arm_serves_exactly_the_shipped_set_plus_index() -> None:
-    """The ``skill://`` arm serves exactly ``shipped_skill_names() | {index}``
-    — provably two-armed: the readable set is derived from the same glob as
+def test_resolver_skill_arm_serves_exactly_the_listed_set() -> None:
+    """The ``skill://`` arms serve exactly the listed set —
+    ``shipped_skill_names()`` + their lane-filtered references + ``index`` —
+    provably three-armed: the readable set is derived from the same globs as
     the listing (never a second hand-maintained list), and every other
-    ``skill://``-prefixed string (grammar or allowlist miss) raises -32002."""
+    ``skill://``-prefixed string (grammar, allowlist, or lane-filter miss)
+    raises -32002."""
     for uri in _SERVED_URIS:
         result = read_skill_resource(uri, _BASE)
-        assert result.contents[0].uri == uri
+        assert str(result.contents[0].uri) == uri
     for uri in (u for u in _PROBES if u.startswith(SKILL_URI_SCHEME)):
         with pytest.raises(MCPError) as exc:
             read_skill_resource(uri, _BASE)
         assert exc.value.code == RESOURCE_NOT_FOUND, uri
+
+
+def test_listed_set_equals_readable_set() -> None:
+    """The D11 invariant, asserted generally: every listed URI reads, and the
+    readable set is exactly the listed set — the mount refuses to read what
+    it does not list (the lane filter can never be listing-only), and it
+    never lists what it cannot read. The readable side's exhaustiveness over
+    an infinite URI space is carried by the resolver characterization above
+    (three arms by construction, each allowlisted from the same globs the
+    listing derives from); this test pins the two derivations to each other."""
+    listed = {str(r.uri) for r in skill_resources()}
+    assert listed == _SERVED_URIS
+    for uri in listed:
+        result = read_skill_resource(uri, _BASE)  # every listed URI reads
+        assert str(result.contents[0].uri) == uri
+    # No listed URI is CLI-lane, and every lane-filtered URI is unreadable.
+    for name in shipped_skill_names():
+        for file in shipped_skill_references(name):
+            uri = SKILL_URI_SCHEME + name + REFERENCES_INFIX + file
+            if file in CLI_ONLY_REFERENCES:
+                assert uri not in listed
+                with pytest.raises(MCPError) as exc:
+                    read_skill_resource(uri, _BASE)
+                assert exc.value.code == RESOURCE_NOT_FOUND
+            else:
+                assert uri in listed
 
 
 # --- D4 layer 2: delegation pin (the structural lock) ------------------------
@@ -318,13 +483,17 @@ def test_resources_read_is_pre_auth_whitelisted() -> None:
 
 def test_instructions_point_at_the_skill_resources() -> None:
     """The mount's ``initialize.instructions`` carry the Go server's
-    skill-pointer sentence verbatim — HTTP clients have no other in-handshake
-    pointer at the resource surface."""
+    skill-pointer sentence verbatim — naming ``skill://jentic``,
+    ``skill://index``, AND the MCP-session guide
+    ``skill://jentic/references/mcp.md`` (the D11 instructions update,
+    mirroring the Go stdio server's) — HTTP clients have no other
+    in-handshake pointer at the resource surface."""
     server = build_mcp_server(MagicMock())
     instructions = server.instructions
     assert instructions is not None
     assert (
         "The skill://jentic resource is the canonical guide to the whole flow "
-        "(skill://index lists every skill document); read it when unsure how "
-        "the pieces fit together." in instructions
+        "(skill://index lists every skill document, and "
+        "skill://jentic/references/mcp.md carries the MCP-lane detail); "
+        "read it when unsure how the pieces fit together." in instructions
     )

--- a/tests/unit/mcp/test_resources.py
+++ b/tests/unit/mcp/test_resources.py
@@ -1,0 +1,306 @@
+"""The ``skill://`` resource surface on the mounted ``/mcp`` app.
+
+Pins the wire contract of the skill-resources slice (plan:
+``jentic-one-plans/themes/local-mcp/mcp-skill-resources.md``, PR A):
+
+- ``resources/list`` = the shipped skill set + ``skill://index``, derived from
+  the same glob the HTTP routes serve (``shipped_skill_names()``) — the pins
+  parametrize over it, so they survive a fourth skill;
+- ``resources/read skill://<name>`` serves the raw package-data bytes
+  (identical to ``GET /skills/<name>.md``) with the ``one.jentic/*``
+  provenance ``_meta``; ``skill://index`` serves the SAME manifest
+  ``GET /skills/index.json`` serves (one function computes both);
+- the D4 three-layer defense on the pre-auth read seam: the resolver is
+  provably two-armed (unit characterization), ``on_read_resource`` is a bare
+  delegation to it (structural lock), and a hostile-URI probe battery answers
+  -32002 twice — credential-less and with a valid bearer (tripwire);
+- ``initialize.instructions`` point at ``skill://jentic``/``skill://index``
+  (Go-parity sentence — a resource surface nobody is told about is the
+  original bug in miniature).
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+import json
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from mcp.shared.exceptions import MCPError
+
+import jentic_one.mcp.app as mcp_app
+from jentic_one.mcp.app import PRE_AUTH_METHODS, build_mcp_server
+from jentic_one.mcp.resources import (
+    META_SOURCE_KEY,
+    META_VERSION_KEY,
+    RESOURCE_NOT_FOUND,
+    SKILL_INDEX_MIME,
+    SKILL_INDEX_URI,
+    SKILL_PROVENANCE_NOTE,
+    SKILL_URI_SCHEME,
+    SOURCE_HOSTED,
+    read_skill_resource,
+)
+from jentic_one.shared.web.agent_discovery import (
+    MARKDOWN_MEDIA_TYPE,
+    _parse_frontmatter,
+    get_agent_discovery_router,
+    load_skill_markdown,
+    shipped_skill_names,
+    skills_index_rows,
+)
+
+from .test_mount_gate import _ACCEPT, _BASE, _GOOD_BEARER, _rpc, make_client
+
+_AUTH = {**_ACCEPT, "Authorization": f"Bearer {_GOOD_BEARER}"}
+
+#: Every URI the mount serves: the shipped set + the index (currently four).
+_SERVED_URIS = {SKILL_URI_SCHEME + name for name in shipped_skill_names()} | {SKILL_INDEX_URI}
+
+#: The D4 probe battery: unknown schemes, grammar violations, traversal junk,
+#: unknown names, and ``init-design`` (lives in ``skills/`` but is
+#: deliberately un-served — the allowlist is the shipped wheel glob, not the
+#: repo tree). Every one answers -32002, pre- and post-auth alike.
+_PROBES = (
+    "config://x",
+    "file:///etc/passwd",
+    "https://example.com/skills/jentic.md",
+    "skill://../../x",
+    "skill://Jentic",
+    "skill://unknown",
+    "skill://init-design",
+    "skill://",
+    "skill",
+    "",
+)
+
+
+def make_resource_client(**kwargs: Any) -> TestClient:
+    """The mount-gate client plus the agent-discovery HTTP routes, so the
+    mount's reads can be pinned against the HTTP documents at the same base."""
+    client = make_client(**kwargs)
+    cast(FastAPI, client.app).include_router(get_agent_discovery_router())
+    return client
+
+
+def _read(client: TestClient, uri: str, headers: dict[str, str] = _ACCEPT) -> dict[str, Any]:
+    resp = client.post("/mcp", json=_rpc("resources/read", {"uri": uri}), headers=headers)
+    assert resp.status_code == 200, uri
+    return cast(dict[str, Any], resp.json())
+
+
+def _read_contents(client: TestClient, uri: str) -> dict[str, Any]:
+    body = _read(client, uri)
+    contents = body["result"]["contents"]
+    assert len(contents) == 1
+    return cast(dict[str, Any], contents[0])
+
+
+# --- resources/list: the shipped set + index, from the HTTP routes' glob -----
+
+
+def test_resources_list_is_the_shipped_set_plus_index() -> None:
+    with make_client() as client:
+        resp = client.post("/mcp", json=_rpc("resources/list"), headers=_ACCEPT)
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert "nextCursor" not in result  # no pagination, ever
+        listed = {r["uri"]: r for r in result["resources"]}
+        assert set(listed) == _SERVED_URIS
+
+        for name in shipped_skill_names():
+            row = listed[SKILL_URI_SCHEME + name]
+            assert row["name"] == name
+            assert row["title"] == f"Jentic skill: {name}"
+            assert row["mimeType"] == MARKDOWN_MEDIA_TYPE
+            description = _parse_frontmatter(load_skill_markdown(name)).get("description", "")
+            assert row["description"] == description + SKILL_PROVENANCE_NOTE
+
+        index = listed[SKILL_INDEX_URI]
+        assert index["name"] == "index"
+        assert index["title"] == "Jentic skill index"
+        assert index["mimeType"] == SKILL_INDEX_MIME
+        assert index["description"].endswith(SKILL_PROVENANCE_NOTE)
+        # D3: the mount stamps one source, so the Go description's
+        # source-mismatch caveat must not be parroted here.
+        assert "same one.jentic/source as the index read" not in index["description"]
+
+
+def test_resource_templates_stay_empty() -> None:
+    """D2: ``skill://<name>`` is a closed, enumerable set fully described by
+    resources/list — no URI template advertises an open namespace."""
+    with make_client() as client:
+        resp = client.post("/mcp", json=_rpc("resources/templates/list"), headers=_ACCEPT)
+        assert resp.status_code == 200
+        assert resp.json()["result"]["resourceTemplates"] == []
+
+
+# --- resources/read: documents (bytes + provenance, HTTP-route parity) -------
+
+
+def test_read_skill_documents_match_the_http_route_bytes() -> None:
+    """Each ``skill://<name>`` read serves the RAW package-data bytes —
+    identical to ``load_skill_markdown`` AND to ``GET /skills/<name>.md`` —
+    with the Go-parity MIME type and the D3 provenance ``_meta``."""
+    with make_resource_client() as client:
+        for name in shipped_skill_names():
+            contents = _read_contents(client, SKILL_URI_SCHEME + name)
+            raw = load_skill_markdown(name)
+            assert contents["uri"] == SKILL_URI_SCHEME + name
+            assert contents["mimeType"] == MARKDOWN_MEDIA_TYPE
+            assert contents["text"] == raw
+            assert contents["text"] == client.get(f"/skills/{name}.md").text
+            version = _parse_frontmatter(raw).get("version") or "1"
+            assert contents["_meta"] == {
+                META_SOURCE_KEY: SOURCE_HOSTED,
+                META_VERSION_KEY: version,
+            }
+
+
+def test_read_index_is_the_http_manifest_at_the_same_base() -> None:
+    """``skill://index`` serves the SAME manifest ``GET /skills/index.json``
+    serves at the same deployment base — parity is structural (one function,
+    ``skills_index_rows``, computes both) and pinned byte-level anyway. The
+    ``_meta`` carries the source only (Go parity: versions ride per row), and
+    each row's sha256 verifies the corresponding document read — the
+    client-side loop the manifest exists for."""
+    with make_resource_client() as client:
+        contents = _read_contents(client, SKILL_INDEX_URI)
+        assert contents["mimeType"] == SKILL_INDEX_MIME
+        assert contents["_meta"] == {META_SOURCE_KEY: SOURCE_HOSTED}
+
+        http = client.get("/skills/index.json")
+        assert contents["text"] == http.text  # byte parity, same base
+        rows = json.loads(contents["text"])
+        assert rows == skills_index_rows(_BASE)
+        assert [row["name"] for row in rows] == sorted(shipped_skill_names())
+
+        for row in rows:
+            # Hosted-manifest shape: absolute `url`, never `uri` (the Go
+            # server's documented tell for backend-produced rows).
+            assert set(row) == {"name", "description", "version", "sha256", "url"}
+            assert row["url"] == f"{_BASE}/skills/{row['name']}.md"
+            doc = _read_contents(client, SKILL_URI_SCHEME + row["name"])
+            digest = hashlib.sha256(doc["text"].encode("utf-8")).hexdigest()
+            assert row["sha256"] == digest
+
+
+# --- D4 layer 1: resolver characterization (the proof) -----------------------
+
+
+@pytest.mark.parametrize("uri", [u for u in _PROBES if not u.startswith(SKILL_URI_SCHEME)])
+def test_resolver_first_arm_rejects_every_non_skill_uri(uri: str) -> None:
+    """Every string not prefixed ``skill://`` raises -32002 — the resolver's
+    first arm is scheme-closed by construction."""
+    with pytest.raises(MCPError) as exc:
+        read_skill_resource(uri, _BASE)
+    assert exc.value.code == RESOURCE_NOT_FOUND
+
+
+def test_resolver_skill_arm_serves_exactly_the_shipped_set_plus_index() -> None:
+    """The ``skill://`` arm serves exactly ``shipped_skill_names() | {index}``
+    — provably two-armed: the readable set is derived from the same glob as
+    the listing (never a second hand-maintained list), and every other
+    ``skill://``-prefixed string (grammar or allowlist miss) raises -32002."""
+    for uri in _SERVED_URIS:
+        result = read_skill_resource(uri, _BASE)
+        assert result.contents[0].uri == uri
+    for uri in (u for u in _PROBES if u.startswith(SKILL_URI_SCHEME)):
+        with pytest.raises(MCPError) as exc:
+            read_skill_resource(uri, _BASE)
+        assert exc.value.code == RESOURCE_NOT_FOUND, uri
+
+
+# --- D4 layer 2: delegation pin (the structural lock) ------------------------
+
+
+def test_on_read_resource_is_a_bare_delegation_to_the_resolver() -> None:
+    """``build_mcp_server``'s ``on_read_resource`` body is a single ``return``
+    of a ``read_skill_resource(...)`` call — the app layer provably routes
+    every read through the characterized resolver, so a bypass arm cannot
+    appear in ``app.py`` without failing this test. (In SDK 2.1.1 there is no
+    per-resource routing: the one handler is the entire seam.)"""
+    tree = ast.parse(inspect.getsource(mcp_app))
+    build = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "build_mcp_server"
+    )
+    handler = next(
+        node
+        for node in ast.walk(build)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "on_read_resource"
+    )
+    assert len(handler.body) == 1, "on_read_resource must be a single statement"
+    ret = handler.body[0]
+    assert isinstance(ret, ast.Return)
+    call = ret.value
+    assert isinstance(call, ast.Call)
+    assert isinstance(call.func, ast.Name)
+    assert call.func.id == "read_skill_resource"
+
+
+# --- D4 layer 3: the probe battery, credential-less AND with a bearer --------
+
+
+@pytest.mark.parametrize("uri", _PROBES)
+def test_probe_battery_answers_resource_not_found_pre_and_post_auth(uri: str) -> None:
+    """Hostile URIs answer JSON-RPC -32002 in-band (the SDK leaves unmapped
+    codes at HTTP 200) — asserted twice, credential-less and with a valid
+    bearer, byte-equal: pre/post-auth equality is pinned on the probed URIs
+    rather than assumed (layers 1+2 carry the exhaustiveness a finite battery
+    can't)."""
+    with make_client() as client:
+        anon = client.post("/mcp", json=_rpc("resources/read", {"uri": uri}), headers=_ACCEPT)
+        authed = client.post("/mcp", json=_rpc("resources/read", {"uri": uri}), headers=_AUTH)
+        assert anon.status_code == 200
+        assert anon.json()["error"]["code"] == RESOURCE_NOT_FOUND
+        assert authed.status_code == 200
+        assert anon.content == authed.content
+
+
+def test_every_listed_resource_reads_identically_pre_and_post_auth() -> None:
+    """The whole listed surface reads without a credential, and an
+    authenticated read returns byte-identical results — the handler never
+    reads identity, so the pre-auth door serves exactly the post-auth set."""
+    with make_client() as client:
+        listing = client.post("/mcp", json=_rpc("resources/list"), headers=_ACCEPT)
+        uris = [r["uri"] for r in listing.json()["result"]["resources"]]
+        assert set(uris) == _SERVED_URIS
+        for uri in uris:
+            anon = client.post("/mcp", json=_rpc("resources/read", {"uri": uri}), headers=_ACCEPT)
+            authed = client.post("/mcp", json=_rpc("resources/read", {"uri": uri}), headers=_AUTH)
+            assert anon.status_code == 200, uri
+            assert "error" not in anon.json(), uri
+            assert anon.content == authed.content, uri
+
+
+def test_resources_read_is_pre_auth_whitelisted() -> None:
+    """The D4 flip this slice makes: ``resources/read`` rides the pre-auth
+    whitelist, alongside the listings it was reserved to join."""
+    assert "resources/read" in PRE_AUTH_METHODS
+    assert "resources/list" in PRE_AUTH_METHODS
+    assert "resources/templates/list" in PRE_AUTH_METHODS
+    assert "tools/call" not in PRE_AUTH_METHODS
+
+
+# --- D5: the instructions point at the skills --------------------------------
+
+
+def test_instructions_point_at_the_skill_resources() -> None:
+    """The mount's ``initialize.instructions`` carry the Go server's
+    skill-pointer sentence verbatim — HTTP clients have no other in-handshake
+    pointer at the resource surface."""
+    server = build_mcp_server(MagicMock())
+    instructions = server.instructions
+    assert instructions is not None
+    assert (
+        "The skill://jentic resource is the canonical guide to the whole flow "
+        "(skill://index lists every skill document); read it when unsure how "
+        "the pieces fit together." in instructions
+    )

--- a/tests/unit/mcp/test_resources.py
+++ b/tests/unit/mcp/test_resources.py
@@ -110,6 +110,10 @@ def test_resources_list_is_the_shipped_set_plus_index() -> None:
         assert resp.status_code == 200
         result = resp.json()["result"]
         assert "nextCursor" not in result  # no pagination, ever
+        uris = [r["uri"] for r in result["resources"]]
+        # Keying by URI below would silently dedupe — assert no duplicates
+        # first (a shipped ``index.md`` would list ``skill://index`` twice).
+        assert len(uris) == len(set(uris))
         listed = {r["uri"]: r for r in result["resources"]}
         assert set(listed) == _SERVED_URIS
 
@@ -138,6 +142,15 @@ def test_resource_templates_stay_empty() -> None:
         resp = client.post("/mcp", json=_rpc("resources/templates/list"), headers=_ACCEPT)
         assert resp.status_code == 200
         assert resp.json()["result"]["resourceTemplates"] == []
+
+
+def test_index_never_enters_the_shipped_set() -> None:
+    """``skill://index`` is minted by the resources module, never shipped as a
+    document: ``read_skill_resource`` matches ``SKILL_INDEX_URI`` before the
+    name arm, so a future ``content/index.md`` would be listed as a document
+    yet silently shadowed by the manifest on every read. Fail loudly here
+    instead — rename any such document before shipping it."""
+    assert "index" not in shipped_skill_names()
 
 
 # --- resources/read: documents (bytes + provenance, HTTP-route parity) -------
@@ -188,6 +201,11 @@ def test_read_index_is_the_http_manifest_at_the_same_base() -> None:
             doc = _read_contents(client, SKILL_URI_SCHEME + row["name"])
             digest = hashlib.sha256(doc["text"].encode("utf-8")).hexdigest()
             assert row["sha256"] == digest
+            # The row's version and the document read's ``_meta`` version are
+            # computed by two independent ``get("version") or "1"`` copies
+            # (``skills_index_rows`` / ``read_skill_resource``) — cross-pin
+            # them so neither default can drift from the other.
+            assert doc["_meta"][META_VERSION_KEY] == row["version"]
 
 
 # --- D4 layer 1: resolver characterization (the proof) -----------------------
@@ -243,6 +261,12 @@ def test_on_read_resource_is_a_bare_delegation_to_the_resolver() -> None:
     assert isinstance(call, ast.Call)
     assert isinstance(call.func, ast.Name)
     assert call.func.id == "read_skill_resource"
+    # The delegated argument is pinned too: the first argument must be the
+    # request's own ``params.uri`` — a hardcoded URI (or anything else) would
+    # otherwise pass the "bare delegation" pin while routing reads elsewhere.
+    uri_arg = call.args[0]
+    assert isinstance(uri_arg, ast.Attribute) and uri_arg.attr == "uri"
+    assert isinstance(uri_arg.value, ast.Name) and uri_arg.value.id == "params"
 
 
 # --- D4 layer 3: the probe battery, credential-less AND with a bearer --------

--- a/tests/unit/shared/web/test_agent_discovery.py
+++ b/tests/unit/shared/web/test_agent_discovery.py
@@ -424,6 +424,10 @@ def test_llms_txt_advertises_http_endpoint_only_when_enabled(
     assert "mcp-remote" in body
     assert "mcp-proxy" in body
     assert "docs/mcp-http-endpoint.md" in body
+    # The skill-resources sentence: the endpoint serves the set as resources.
+    assert "skill set as MCP resources" in body
+    assert "`skill://<name>`" in body
+    assert "`skill://index`" in body
     # The routing paragraph (§3.5) is arm-independent.
     assert "prefer them" in body
     assert "`backend`/`host`" in body
@@ -503,7 +507,9 @@ with `Authorization: Bearer <agent API key or access token>`. Alternatively,
 the local `jentic mcp` stdio server — available in the `jentic` CLI from the
 next release; check `jentic mcp --help` — spawns on the agent machine and
 talks to this deployment with the agent's registered identity. Both expose
-the same discover → execute loop as the CLI tools. Stdio-only MCP runtimes
+the same discover → execute loop as the CLI tools. The endpoint also serves
+the shipped skill set as MCP resources (`skill://<name>`; `skill://index` is
+the manifest). Stdio-only MCP runtimes
 can reach {base}/mcp through a stdio↔HTTP bridge such as `mcp-remote` or
 `mcp-proxy` — exact entries in the
 [MCP endpoint guide](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/mcp-http-endpoint.md).

--- a/tests/unit/shared/web/test_agent_discovery.py
+++ b/tests/unit/shared/web/test_agent_discovery.py
@@ -449,6 +449,9 @@ def test_llms_txt_config_only_enablement_does_not_advertise(
 
     assert "http://testserver/mcp" not in body
     assert "Streamable HTTP endpoint" not in body
+    # The skill-resources sentence rides the enabled arm only — this app
+    # serves no resource surface to advertise.
+    assert "skill set as MCP resources" not in body
     assert "serves no MCP server today" in body
 
 
@@ -470,6 +473,7 @@ def test_llms_txt_auth_standalone_never_advertises_the_endpoint(
     assert "http://testserver/mcp" not in body
     assert "Streamable HTTP endpoint" not in body
     assert "mcp-remote" not in body
+    assert "skill set as MCP resources" not in body
     # The disabled arm's probe-misdiagnosis wording stays.
     assert "serves no MCP server today" in body
 
@@ -477,11 +481,13 @@ def test_llms_txt_auth_standalone_never_advertises_the_endpoint(
 def test_llms_txt_disabled_arm_never_mentions_the_endpoint_url(client: TestClient) -> None:
     """The disabled arm is silent about the endpoint: no URL-shaped `/mcp`
     advertisement an agent could wire an entry to (the path only appears in
-    the probe-misdiagnosis explanation)."""
+    the probe-misdiagnosis explanation), and no skill-resources sentence for
+    a resource surface this arm does not serve."""
     body = client.get(LLMS_TXT_PATH).text
     assert "http://testserver/mcp" not in body
     assert "Streamable HTTP endpoint" not in body
     assert "mcp-remote" not in body
+    assert "skill set as MCP resources" not in body
 
 
 #: The pre-phase-3 MCP paragraph, verbatim from the base branch's


### PR DESCRIPTION
## Summary

An HTTP-only MCP client against `/mcp` learns the surface from `tools/list` + `initialize.instructions` and never sees the skills: `resources/list` was served empty and `resources/read` was deliberately off the pre-auth whitelist. This PR serves the shipped skill set — and, per rev 3's D11, each skill's **lane-filtered references** — as MCP resources on the mount (the same documents `GET /skills/*` already serves publicly) and points the handshake at them. Reshaped PR A of #1333; plan: `jentic-one-plans/themes/local-mcp/mcp-skill-resources.md` (rev 3).

**Stacked on #1336** (`feat/jentic-skill-transport-aware`), which lands first: it holds the `skills/jentic` router+references split, the reference mirroring pipeline, the HTTP reference routes/manifest rows, and the helpers this PR consumes (`shipped_skill_references`, `CLI_ONLY_REFERENCES`, public `skills_index_rows`) plus the Go stdio server's matching reference resources. This PR stays **Python-only**.

## Changes

- **`src/jentic_one/mcp/resources.py` (new, control/mcp)** — the wire contract:
  - `resources/list`: one resource per skill in `shipped_skill_names()` (`uri=skill://<name>`, `title="Jentic skill: <name>"`, frontmatter description + a daemon-appropriate provenance note), **one per MCP-visible reference** (`skill://<name>/references/<file>` for every file in `shipped_skill_references(name)` **except** `CLI_ONLY_REFERENCES` — name `<name>/references/<file>`, title `Jentic skill reference: <name>/<file>`, the Go stdio server's vocabulary byte-parallel), plus `skill://index`. Constants (`skill://`, `one.jentic/source`, `one.jentic/version`, MIME types) byte-equal to the Go server's (`cli/internal/cli/api/mcp_resources.go`). No pagination, no templates (closed set).
  - `resources/read skill://<name>`: the RAW package-data bytes verbatim, `_meta = {"one.jentic/source": "hosted", "one.jentic/version": <frontmatter, default "1">}`, `text/markdown; charset=utf-8`.
  - `resources/read skill://<name>/references/<file>` (**D11, new arm**): the reference's raw bytes verbatim, markdown MIME, `_meta` source + the **owning skill's** frontmatter version (references have no frontmatter). `<name>` passes the document arm's grammar+allowlist; `<file>` passes the reference grammar + `shipped_skill_references(name)` + the lane filter. **`cli.md` is never listed and never readable here** — the mount refuses to read what it does not list — while the same bytes stay public over HTTP (a serving decision, not a secret). The resolver stays identity-free.
  - `resources/read skill://index`: the SAME manifest rows `GET /skills/index.json` serves (now including the per-row `references` arrays from #1336) — produced by the same function, serialized with the same separators, so sha256 parity with the HTTP manifest is **structural**. Rows keep the hosted-shape absolute `url` (never `uri`). `_meta` is source-only (Go parity: versions ride per row).
  - Everything else — unknown scheme, grammar/allowlist miss (incl. `init-design`), lane-filtered or unknown references, traversal junk — answers JSON-RPC `-32002`.
- **`src/jentic_one/mcp/app.py` (control/mcp)** — `resources/read` joins `PRE_AUTH_METHODS`; the comment block names the three defense layers (below). Handlers: `on_list_resources` serves the listing, `on_read_resource` is a **bare delegation** to the resolver, templates stay empty. The pre-auth base-URL seam: the index arm's base comes from `deployment_base_url(ctx.config.auth, sctx.request)` directly (pre-auth requests never run `_stash_call_state`). `initialize.instructions` carry the Go server's updated sentence: "The skill://jentic resource is the canonical guide to the whole flow (skill://index lists every skill document, and **skill://jentic/references/mcp.md carries the MCP-lane detail**); read it when unsure how the pieces fit together."
- **`src/jentic_one/shared/web/agent_discovery.py` (shared/web)** — the enabled-arm llms.txt paragraph gains one sentence advertising the resource surface (the `skills_index_rows` export now lands in #1336; this PR only consumes it).
- **Out of scope**: skill content and the reference pipeline (#1336), the Go stdio server's identical lane filter (#1336 — this PR has **no Go changes**), `get_started`/10th tool/pinned-spec changes, resource subscriptions and templates content, new config knobs (the surface rides `server.mcp.enabled`).

## Risk & rollback

- **This widens the pre-auth door** — the security-sensitive change the old `PRE_AUTH_METHODS` comment reserved for this slice. Net new exposure is **zero**: the identical bytes are already served unauthenticated over plain HTTP (`GET /skills/*` is public by design), so no scope, `_require_db`, or extra rate limiting is added — deliberately matching the HTTP door.
- The guarantee "the pre-auth door serves the public skill set and nothing else" is held by **three layers** (SDK 2.1.1 routes every `resources/read` to the one handler, so the handler is the whole seam):
  1. **Resolver characterization (proof)** — `read_skill_resource` is unit-characterized as three-armed by construction (index / document / lane-filtered reference); it never reads identity, so pre/post-auth equality is structural, not policy.
  2. **Delegation pin (structural lock)** — an AST test pins `on_read_resource` to a single `return read_skill_resource(...)`, so `app.py` can't grow a bypass arm without failing a test.
  3. **Probe battery (tripwire)** — hostile URIs (now including the reference shapes: `cli.md`, unknown files, raw and percent-encoded traversal, references of skills that ship none, index collisions) answer `-32002`, asserted byte-equal credential-less and with a valid bearer.
- **Listed set == readable set** is now asserted as a general invariant (the strongest pin for D11): every listed URI reads, and the readable set is derived from the same globs as the listing — the lane filter can never be listing-only, and listing/reading/HTTP cannot drift (`tests/arch/test_skill_drift.py` covers the mount transitively).
- Rollback: revert the squash commit (no migrations, no config, no spec changes).

## Go-parity points

- URIs, `_meta` keys, MIME types, listing `name`/`title` shapes — for skills AND references — byte-parallel to `mcp_resources.go`; the instructions sentence matches `mcp_server.go`'s updated one; the lane filter is the same one-constant convention on both sides (`CLI_ONLY_REFERENCES` / `skillgen.CLIOnlyReference`).
- Deliberate prose divergences (documented in code): the provenance notes don't promise a bundled fallback (false here — the daemon is the backend), and the index description drops the source-mismatch caveat (`hosted` is the only value this mount ever stamps).

## Test plan

- `tests/unit/mcp/test_resources.py`: listing = shipped set + lane-filtered references + index (parametrized over `shipped_skill_names()`/`shipped_skill_references()`, survives a fourth skill or new reference); `jentic` lists `mcp.md`+`recovery.md` and never `cli.md`, single-file skills contribute no reference rows; document AND reference reads byte-equal to the HTTP routes (with `cli.md` pinned HTTP-200/mount-refused side by side); index read byte-equal to `GET /skills/index.json` at the same base with per-row sha256 — including the `references` rows — verified against the resource reads; the three defense layers above with the extended probe battery run pre- and post-auth; the `listed == readable` invariant; templates-stay-empty pin; instructions pin.
- `tests/unit/mcp/test_mount_gate.py`: credential-less `resources/read skill://jentic` serves the document; a `[resources/read, tools/call]` batch still 401s.
- `tests/unit/shared/web/test_agent_discovery.py`: enabled-arm llms.txt golden extended with the resources sentence.
- Gates run locally at 44033958: `uv run pytest tests/unit/mcp/ tests/arch/ -q` (605 passed), `uv run pytest tests/unit/ -q` (3610 passed, coverage 80.76%), `uv run ruff check` + `uv run ruff format --check` (clean), `uv run mypy src` (clean, 651 files).

Part A of #1333 (reshaped per rev 3, stacked on #1336).
Plan: `jentic-one-plans/themes/local-mcp/mcp-skill-resources.md`

Made with [Cursor](https://cursor.com)