### PR TITLE
feat(instance): expose the MCP broker URL via /instance and both MCP UIs

### DIFF
--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -1916,6 +1916,9 @@ type InstanceIdentityResponse struct {
 	// Backend Operator-declared backend locality (server.backend): 'local' for a self-hosted install on the operator's own machine/network, 'remote' for a hosted install run elsewhere. A hint, not an authorization signal; defaults to 'local'.
 	Backend InstanceIdentityResponseBackend `json:"backend"`
 
+	// BrokerUrl The broker (data plane) base URL a client should send `execute` traffic to, as configured by the operator (server.mcp.broker_url), with any userinfo stripped. Null when the platform cannot honestly advertise one: on a 'remote' backend a loopback-host value (the config default) describes the control plane's own machine, not an address any client can dial, so it is withheld rather than published as misleading guidance. Deployment metadata, not a secret — the broker URL is handed to every client expected to call it (issue #1249).
+	BrokerUrl *string `json:"broker_url,omitempty"`
+
 	// CanonicalBaseUrl The instance's own canonical base URL (auth.canonical_base_url), with any userinfo stripped; '' if unset.
 	CanonicalBaseUrl string `json:"canonical_base_url"`
 

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -2593,6 +2593,12 @@ components:
           - remote
           title: Backend
           type: string
+        broker_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: 'The broker (data plane) base URL a client should send `execute` traffic to, as configured by the operator (server.mcp.broker_url), with any userinfo stripped. Null when the platform cannot honestly advertise one: on a ''remote'' backend a loopback-host value (the config default) describes the control plane''s own machine, not an address any client can dial, so it is withheld rather than published as misleading guidance. Deployment metadata, not a secret — the broker URL is handed to every client expected to call it (issue #1249).'
+          title: Broker Url
         canonical_base_url:
           description: The instance's own canonical base URL (auth.canonical_base_url), with any userinfo stripped; '' if unset.
           title: Canonical Base Url

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -356,8 +356,10 @@ jentic api GET /instance   # reads the connected backend's identity (auth attach
 ```
 
 The unauthenticated `/instance` response reports `backend` (`local` / `remote` —
-the install's declared `server.backend`), `canonical_base_url`, `host`, and an
-opaque `instance_id` (null when telemetry is off). If it's not the backend you
+the install's declared `server.backend`), `canonical_base_url`, `host`, an
+opaque `instance_id` (null when telemetry is off), and `broker_url` (the broker
+/ data-plane base URL for `execute`, when the backend can advertise one — null
+otherwise). If it's not the backend you
 meant to use (e.g. an MCP server still on a remote backend while you imported
 locally), repoint that client at the right base URL rather than
 importing/searching again.
@@ -423,8 +425,9 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   refuses up front (it never dials the local default for a remote control
   plane). This means the environment was onboarded without a broker: set it
   with `jentic register --url <URL> --broker-url <broker URL>` (or
-  `JENTIC_BROKER_URL` in file-less mode) — ask the operator for the broker
-  URL; do **not** assume a local broker.
+  `JENTIC_BROKER_URL` in file-less mode). Read the broker URL from the
+  unauthenticated `GET /instance` on the control plane (`broker_url`); if
+  that reports null, ask the operator — do **not** assume a local broker.
 
 - **Stopped instance (connection refused on a local target).** If the target
   is already local (`127.0.0.1` / `localhost`) and the connection is

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -2593,6 +2593,12 @@ components:
           - remote
           title: Backend
           type: string
+        broker_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: 'The broker (data plane) base URL a client should send `execute` traffic to, as configured by the operator (server.mcp.broker_url), with any userinfo stripped. Null when the platform cannot honestly advertise one: on a ''remote'' backend a loopback-host value (the config default) describes the control plane''s own machine, not an address any client can dial, so it is withheld rather than published as misleading guidance. Deployment metadata, not a secret — the broker URL is handed to every client expected to call it (issue #1249).'
+          title: Broker Url
         canonical_base_url:
           description: The instance's own canonical base URL (auth.canonical_base_url), with any userinfo stripped; '' if unset.
           title: Canonical Base Url

--- a/skills/jentic/SKILL.md
+++ b/skills/jentic/SKILL.md
@@ -356,8 +356,10 @@ jentic api GET /instance   # reads the connected backend's identity (auth attach
 ```
 
 The unauthenticated `/instance` response reports `backend` (`local` / `remote` —
-the install's declared `server.backend`), `canonical_base_url`, `host`, and an
-opaque `instance_id` (null when telemetry is off). If it's not the backend you
+the install's declared `server.backend`), `canonical_base_url`, `host`, an
+opaque `instance_id` (null when telemetry is off), and `broker_url` (the broker
+/ data-plane base URL for `execute`, when the backend can advertise one — null
+otherwise). If it's not the backend you
 meant to use (e.g. an MCP server still on a remote backend while you imported
 locally), repoint that client at the right base URL rather than
 importing/searching again.
@@ -423,8 +425,9 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   refuses up front (it never dials the local default for a remote control
   plane). This means the environment was onboarded without a broker: set it
   with `jentic register --url <URL> --broker-url <broker URL>` (or
-  `JENTIC_BROKER_URL` in file-less mode) — ask the operator for the broker
-  URL; do **not** assume a local broker.
+  `JENTIC_BROKER_URL` in file-less mode). Read the broker URL from the
+  unauthenticated `GET /instance` on the control plane (`broker_url`); if
+  that reports null, ask the operator — do **not** assume a local broker.
 
 - **Stopped instance (connection refused on a local target).** If the target
   is already local (`127.0.0.1` / `localhost`) and the connection is

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -356,8 +356,10 @@ jentic api GET /instance   # reads the connected backend's identity (auth attach
 ```
 
 The unauthenticated `/instance` response reports `backend` (`local` / `remote` —
-the install's declared `server.backend`), `canonical_base_url`, `host`, and an
-opaque `instance_id` (null when telemetry is off). If it's not the backend you
+the install's declared `server.backend`), `canonical_base_url`, `host`, an
+opaque `instance_id` (null when telemetry is off), and `broker_url` (the broker
+/ data-plane base URL for `execute`, when the backend can advertise one — null
+otherwise). If it's not the backend you
 meant to use (e.g. an MCP server still on a remote backend while you imported
 locally), repoint that client at the right base URL rather than
 importing/searching again.
@@ -423,8 +425,9 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   refuses up front (it never dials the local default for a remote control
   plane). This means the environment was onboarded without a broker: set it
   with `jentic register --url <URL> --broker-url <broker URL>` (or
-  `JENTIC_BROKER_URL` in file-less mode) — ask the operator for the broker
-  URL; do **not** assume a local broker.
+  `JENTIC_BROKER_URL` in file-less mode). Read the broker URL from the
+  unauthenticated `GET /instance` on the control plane (`broker_url`); if
+  that reports null, ask the operator — do **not** assume a local broker.
 
 - **Stopped instance (connection refused on a local target).** If the target
   is already local (`127.0.0.1` / `localhost`) and the connection is

--- a/src/jentic_one/shared/web/instance_identity.py
+++ b/src/jentic_one/shared/web/instance_identity.py
@@ -10,17 +10,21 @@ backends.
 This endpoint gives any client a cheap, unauthenticated way to read the
 identity of the backend it is talking to, so it can label its responses and a
 human/agent can tell local from remote at a glance. It intentionally exposes
-only non-sensitive identity metadata: the operator-declared ``backend`` locality
-(``server.backend``) and the instance's own canonical base URL / host (from
-``auth.canonical_base_url``, with any userinfo stripped before echoing). The
-``instance_id`` is a one-way digest *derived from* the telemetry instance id —
-distinct installs get distinct values, but the durable telemetry identifier
-itself is never published.
+only non-sensitive identity/deployment metadata: the operator-declared
+``backend`` locality (``server.backend``), the instance's own canonical base
+URL / host (from ``auth.canonical_base_url``, with any userinfo stripped before
+echoing), whether the ``/mcp`` endpoint is served, and the broker (data plane)
+URL clients need for ``execute`` (``server.mcp.broker_url``, when honestly
+advertisable — see ``_advertised_broker_url``). The ``instance_id`` is a
+one-way digest *derived from* the telemetry instance id — distinct installs get
+distinct values, but the durable telemetry identifier itself is never
+published.
 """
 
 from __future__ import annotations
 
 import hashlib
+from ipaddress import ip_address
 from typing import Literal
 from urllib.parse import urlsplit, urlunsplit
 
@@ -84,6 +88,19 @@ class InstanceIdentityResponse(BaseModel):
             "anyway."
         ),
     )
+    broker_url: str | None = Field(
+        default=None,
+        description=(
+            "The broker (data plane) base URL a client should send `execute` traffic "
+            "to, as configured by the operator (server.mcp.broker_url), with any "
+            "userinfo stripped. Null when the platform cannot honestly advertise "
+            "one: on a 'remote' backend a loopback-host value (the config default) "
+            "describes the control plane's own machine, not an address any client "
+            "can dial, so it is withheld rather than published as misleading "
+            "guidance. Deployment metadata, not a secret — the broker URL is handed "
+            "to every client expected to call it (issue #1249)."
+        ),
+    )
 
 
 def _public_instance_id(instance_id: str | None) -> str | None:
@@ -112,6 +129,47 @@ def _sanitized_url_parts(canonical_base_url: str) -> tuple[str, str]:
     return canonical_base_url, host
 
 
+def _is_loopback_host(hostname: str | None) -> bool:
+    """``localhost`` or a literal loopback IP — parsed, never prefix-matched.
+
+    Same semantics as the MCP execute proxy's guard (``mcp/execute.py``) and the
+    Go client's ``isLoopbackHost``; kept local because ``shared.web`` must not
+    import from the ``mcp`` module (shared is imported by every module).
+    """
+    if hostname is None:
+        return False
+    name = hostname.lower()
+    if name == "localhost":
+        return True
+    try:
+        return ip_address(name).is_loopback
+    except ValueError:
+        return False
+
+
+def _advertised_broker_url(config_broker_url: str, backend: str) -> str | None:
+    """The broker URL ``/instance`` may honestly advertise, or ``None``.
+
+    ``server.mcp.broker_url`` is the address the CONTROL PLANE dials for its
+    server-side execute proxy hop. It is the best broker pointer the platform
+    has, so it is republished for clients (issue #1249) — except when doing so
+    would mislead: on a ``remote`` backend a loopback host (notably the config
+    default ``http://127.0.0.1:8100``) names the control plane's own machine,
+    which no remote client can dial, so ``None`` (→ the UI keeps its
+    ``<broker-url>`` placeholder + "ask your operator" fallback). On a
+    ``local`` backend the loopback default is exactly the address a client on
+    that machine should use. Userinfo is stripped before echoing, mirroring
+    ``canonical_base_url``.
+    """
+    if not config_broker_url:
+        return None
+    parts = urlsplit(config_broker_url)
+    if backend == "remote" and _is_loopback_host(parts.hostname):
+        return None
+    sanitized, _host = _sanitized_url_parts(config_broker_url)
+    return sanitized
+
+
 def resolve_instance_identity(ctx: Context) -> InstanceIdentityResponse:
     """Build the backend-identity payload from the live application ``Context``."""
     canonical_base_url = ctx.config.auth.canonical_base_url or ""
@@ -124,6 +182,9 @@ def resolve_instance_identity(ctx: Context) -> InstanceIdentityResponse:
         host=host,
         instance_id=_public_instance_id(ctx.instance_id),
         mcp_enabled=ctx.config.server.mcp.enabled,
+        broker_url=_advertised_broker_url(
+            ctx.config.server.mcp.broker_url, ctx.config.server.backend
+        ),
     )
 
 

--- a/tests/unit/shared/test_instance_identity.py
+++ b/tests/unit/shared/test_instance_identity.py
@@ -30,11 +30,17 @@ def _ctx(
     canonical_base_url: str = "http://127.0.0.1:8000",
     *,
     backend: str | None = None,
+    broker_url: str | None = None,
 ) -> Context:
     cfg = dict(sample_config_dict)
     cfg["auth"] = {**cfg.get("auth", {}), "canonical_base_url": canonical_base_url}
+    server = dict(cfg.get("server", {}))
     if backend is not None:
-        cfg["server"] = {**cfg.get("server", {}), "backend": backend}
+        server["backend"] = backend
+    if broker_url is not None:
+        server["mcp"] = {**server.get("mcp", {}), "broker_url": broker_url}
+    if server:
+        cfg["server"] = server
     return Context(AppConfig.model_validate(cfg))
 
 
@@ -127,7 +133,14 @@ def test_instance_endpoint_response_has_exactly_the_documented_fields(
 
     data = client.get("/instance").json()
 
-    assert set(data) == {"backend", "canonical_base_url", "host", "instance_id", "mcp_enabled"}
+    assert set(data) == {
+        "backend",
+        "canonical_base_url",
+        "host",
+        "instance_id",
+        "mcp_enabled",
+        "broker_url",
+    }
 
 
 def test_instance_endpoint_schema_visible_and_public(sample_config_dict: dict[str, Any]) -> None:
@@ -171,3 +184,88 @@ def test_resolve_instance_identity_strips_userinfo(sample_config_dict: dict[str,
     assert identity.host == "jentic.acme.example:8443"
     assert "secret" not in identity.canonical_base_url
     assert "user" not in identity.host
+
+
+# ---------------------------------------------------------------------------
+# broker_url (issue #1249): the one backend field both UI consumers (the agent
+# MCP snippet and the Settings "Connect an MCP client" card) and CLI/agent
+# self-onboarding read the broker (data plane) URL from.
+# ---------------------------------------------------------------------------
+
+
+def test_instance_endpoint_reports_configured_broker_url_on_remote(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    """A remote install with a real (non-loopback) broker URL advertises it."""
+    ctx = _ctx(
+        sample_config_dict,
+        "https://app.jentic.example",
+        backend="remote",
+        broker_url="https://broker.jentic.example",
+    )
+    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
+
+    data = client.get("/instance").json()
+
+    assert data["broker_url"] == "https://broker.jentic.example"
+
+
+def test_instance_endpoint_reports_loopback_broker_url_on_local(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    """On a local install the loopback config default IS the client's broker address."""
+    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
+
+    data = client.get("/instance").json()
+
+    # sample config leaves server.mcp.broker_url at its default.
+    assert data["broker_url"] == "http://127.0.0.1:8100"
+
+
+def test_instance_endpoint_withholds_loopback_broker_url_on_remote(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    """A remote backend must not advertise a loopback broker (unreachable for clients).
+
+    The config default names the control plane's own machine — publishing it
+    would send every remote client to its own loopback. Null keeps the UI on
+    its ``<broker-url>`` placeholder + "ask your operator" fallback.
+    """
+    ctx = _ctx(sample_config_dict, "https://app.jentic.example", backend="remote")
+    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
+
+    data = client.get("/instance").json()
+
+    assert data["broker_url"] is None
+
+
+def test_resolve_instance_identity_withholds_localhost_broker_on_remote(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    """``localhost`` (not just literal loopback IPs) is withheld on remote too."""
+    identity = resolve_instance_identity(
+        _ctx(
+            sample_config_dict,
+            "https://app.jentic.example",
+            backend="remote",
+            broker_url="http://localhost:8100",
+        )
+    )
+    assert identity.broker_url is None
+
+
+def test_resolve_instance_identity_strips_broker_url_userinfo(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    """Credentials embedded in the configured broker URL are never echoed back."""
+    identity = resolve_instance_identity(
+        _ctx(
+            sample_config_dict,
+            "https://app.jentic.example",
+            backend="remote",
+            broker_url="https://user:secret@broker.jentic.example:8443",
+        )
+    )
+    assert identity.broker_url == "https://broker.jentic.example:8443"
+    assert "secret" not in (identity.broker_url or "")

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -4039,6 +4039,18 @@
             "title": "Backend",
             "type": "string"
           },
+          "broker_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The broker (data plane) base URL a client should send `execute` traffic to, as configured by the operator (server.mcp.broker_url), with any userinfo stripped. Null when the platform cannot honestly advertise one: on a 'remote' backend a loopback-host value (the config default) describes the control plane's own machine, not an address any client can dial, so it is withheld rather than published as misleading guidance. Deployment metadata, not a secret — the broker URL is handed to every client expected to call it (issue #1249).",
+            "title": "Broker Url"
+          },
           "canonical_base_url": {
             "description": "The instance's own canonical base URL (auth.canonical_base_url), with any userinfo stripped; '' if unset.",
             "title": "Canonical Base Url",

--- a/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
@@ -813,6 +813,42 @@ describe('AgentDetailPage', () => {
 			),
 		).toBeInTheDocument();
 		expect(screen.getByText(/fail-closes/)).toBeInTheDocument();
+		// The placeholder arm keeps sending the operator to a human — the
+		// backend reported no broker URL, so the UI must not guess one.
+		expect(screen.getByText(/Ask your operator/)).toBeInTheDocument();
+	});
+
+	it('renders the real broker URL in the register snippet when the instance reports one (#1249)', async () => {
+		const user = userEvent.setup();
+		worker.use(
+			http.get('/instance', () =>
+				HttpResponse.json({
+					backend: 'remote',
+					canonical_base_url: 'https://jentic.example.test',
+					host: 'jentic.example.test',
+					instance_id: 'inst_digest_1',
+					broker_url: 'https://broker.jentic.example.test',
+				}),
+			),
+		);
+		renderDetail('agnt_active_1');
+		await screen.findByRole('heading', { name: 'support-agent' });
+
+		await user.click(screen.getByRole('tab', { name: 'MCP' }));
+		await screen.findByText('Connect via MCP');
+
+		// The backend advertises server.mcp.broker_url via GET /instance, so
+		// the snippet is copy-paste complete — no placeholder, no "ask your
+		// operator" dead end.
+		expect(
+			await screen.findByText(
+				'jentic register --url "https://jentic.example.test" --broker-url "https://broker.jentic.example.test"',
+			),
+		).toBeInTheDocument();
+		expect(screen.queryByText(/Ask your operator/)).not.toBeInTheDocument();
+		// The operator-facing meta row shows the data plane address too.
+		expect(screen.getByText('Broker URL')).toBeInTheDocument();
+		expect(screen.getByText('https://broker.jentic.example.test')).toBeInTheDocument();
 	});
 
 	// --- #607: agent-side bind / unbind toolkit ---------------------------

--- a/ui/src/modules/agents/api/client.ts
+++ b/ui/src/modules/agents/api/client.ts
@@ -928,6 +928,10 @@ export async function fetchInstanceIdentity(): Promise<InstanceIdentityEntity> {
 			// Older backends predate the field; absent means the endpoint
 			// doesn't exist there either, so hiding the HTTP variant is right.
 			mcpEnabled: res.mcp_enabled ?? false,
+			// Absent (older backend) and null (backend withholds a loopback
+			// broker on a remote install) both mean "unknown" — the snippet
+			// keeps its placeholder either way.
+			brokerUrl: res.broker_url ?? null,
 		};
 	} catch (error) {
 		throw toAgentsError(error, 'Failed to load the instance identity.');

--- a/ui/src/modules/agents/api/types.ts
+++ b/ui/src/modules/agents/api/types.ts
@@ -256,6 +256,15 @@ export interface InstanceIdentityEntity {
 	 * variant so the UI never advertises a transport that 404s.
 	 */
 	mcpEnabled: boolean;
+	/**
+	 * The broker (data plane) base URL the backend advertises
+	 * (`server.mcp.broker_url` via `GET /instance`, #1249). Null when the
+	 * backend cannot honestly report one — older backends predate the field,
+	 * and a remote install whose configured broker is loopback withholds it —
+	 * in which case the register snippet keeps its `<broker-url>` placeholder
+	 * and the "ask your operator" help text.
+	 */
+	brokerUrl: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/src/modules/agents/components/detail/McpPanel.tsx
+++ b/ui/src/modules/agents/components/detail/McpPanel.tsx
@@ -93,9 +93,13 @@ export function McpConfigCard({ agentName }: { agentName: string }) {
 	const instanceHost = identity.data?.host || safeHost(instanceUrl);
 	// On a remote install the broker lives on its own host and is never derived
 	// from the control-plane URL — without --broker-url the environment has no
-	// broker and `jentic execute` fail-closes (register.go). The UI can't know
-	// the broker URL, so the snippet carries an explicit placeholder.
+	// broker and `jentic execute` fail-closes (register.go). The instance
+	// endpoint reports the operator-configured broker URL when it can honestly
+	// advertise one (#1249); when it can't (older backend, or a loopback-only
+	// broker on a remote install) the snippet keeps an explicit placeholder
+	// and the help text sends the operator to whoever deployed the instance.
 	const isRemote = identity.data?.backend === 'remote';
+	const brokerUrl = identity.data?.brokerUrl ?? null;
 
 	// §3.10 one-agent-per-runtime: the context name is whatever binding the
 	// operator created on the agent machine — the agent's name is the
@@ -103,7 +107,7 @@ export function McpConfigCard({ agentName }: { agentName: string }) {
 	const context = shellArg(agentName);
 	const command = `jentic mcp --context ${context}`;
 	const registerCommand = `jentic register --url ${shellArg(instanceUrl)}${
-		isRemote ? ' --broker-url <broker-url>' : ''
+		isRemote ? ` --broker-url ${brokerUrl ? shellArg(brokerUrl) : '<broker-url>'}` : ''
 	}`;
 	const jsonConfig = JSON.stringify(
 		{ mcpServers: { jentic: { command: 'jentic', args: ['mcp', '--context', agentName] } } },
@@ -135,7 +139,7 @@ export function McpConfigCard({ agentName }: { agentName: string }) {
 				<code className="font-mono text-xs">{registerCommand}</code> on the{' '}
 				<strong>agent machine</strong> — or{' '}
 				<code className="font-mono text-xs">jentic setup</code> for the guided path.
-				{isRemote && (
+				{isRemote && !brokerUrl && (
 					<>
 						{' '}
 						On a remote install <code className="font-mono text-xs">
@@ -144,6 +148,17 @@ export function McpConfigCard({ agentName }: { agentName: string }) {
 						is required — without it{' '}
 						<code className="font-mono text-xs">jentic execute</code> fail-closes. Ask
 						your operator for the broker (data plane) URL.
+					</>
+				)}
+				{isRemote && brokerUrl && (
+					<>
+						{' '}
+						On a remote install <code className="font-mono text-xs">
+							--broker-url
+						</code>{' '}
+						is required — without it{' '}
+						<code className="font-mono text-xs">jentic execute</code> fail-closes. The
+						snippet carries this instance's broker (data plane) URL.
 					</>
 				)}
 			</p>
@@ -183,6 +198,14 @@ export function McpConfigCard({ agentName }: { agentName: string }) {
 				/>
 				{identity.data?.backend && (
 					<MetaItem label="Backend" value={identity.data.backend} />
+				)}
+				{/* Operator-facing lookup for the data plane address (#1249):
+				    rendered only when the backend reports one — never a guess. */}
+				{brokerUrl && (
+					<MetaItem
+						label="Broker URL"
+						value={<span className="font-mono">{brokerUrl}</span>}
+					/>
 				)}
 			</dl>
 		</DetailSection>

--- a/ui/src/modules/settings/__tests__/McpConnectCard.test.tsx
+++ b/ui/src/modules/settings/__tests__/McpConnectCard.test.tsx
@@ -72,6 +72,52 @@ describe('McpConnectCard', () => {
 
 		expect(await screen.findByText(`${window.location.origin}/mcp`)).toBeInTheDocument();
 	});
+
+	it('shows the broker (data plane) URL when the backend reports one (#1249)', async () => {
+		useInstanceHandler({
+			backend: 'remote',
+			canonical_base_url: 'https://jentic.example.test',
+			host: 'jentic.example.test',
+			mcp_enabled: true,
+			broker_url: 'https://broker.jentic.example.test',
+		});
+		const { container } = renderWithProviders(<McpConnectCard />);
+
+		expect(await screen.findByText('Broker (data plane) URL')).toBeInTheDocument();
+		expect(screen.getByText('https://broker.jentic.example.test')).toBeInTheDocument();
+		expect(screen.getByText(/jentic register --broker-url/)).toBeInTheDocument();
+		await checkA11y(container);
+	});
+
+	it('renders the broker row in the MCP-disabled arm too — the broker serves stdio execute', async () => {
+		useInstanceHandler({
+			backend: 'remote',
+			canonical_base_url: 'https://jentic.example.test',
+			host: 'jentic.example.test',
+			mcp_enabled: false,
+			broker_url: 'https://broker.jentic.example.test',
+		});
+		renderWithProviders(<McpConnectCard />);
+
+		expect(await screen.findByText(/does not serve the HTTP MCP endpoint/)).toBeInTheDocument();
+		expect(screen.getByText('https://broker.jentic.example.test')).toBeInTheDocument();
+	});
+
+	it('omits the broker row when the backend reports null or predates the field', async () => {
+		// Null = the backend withholds a loopback broker on a remote install;
+		// absent = an older backend. Either way, no guess is rendered.
+		useInstanceHandler({
+			backend: 'remote',
+			canonical_base_url: 'https://jentic.example.test',
+			host: 'jentic.example.test',
+			mcp_enabled: true,
+			broker_url: null,
+		});
+		renderWithProviders(<McpConnectCard />);
+
+		expect(await screen.findByText('https://jentic.example.test/mcp')).toBeInTheDocument();
+		expect(screen.queryByText('Broker (data plane) URL')).not.toBeInTheDocument();
+	});
 });
 
 describe('mcpEndpointUrl', () => {

--- a/ui/src/modules/settings/components/McpConnectCard.tsx
+++ b/ui/src/modules/settings/components/McpConnectCard.tsx
@@ -16,10 +16,11 @@
  *     mirroring McpPanel's gate: advertising the URL unconditionally would
  *     show an endpoint that 404s on default installs, so the disabled arm
  *     says so instead.
- *
- * The broker (data plane) URL — the other half of #1249 — is deliberately
- * NOT shown: no HTTP surface exposes `server.mcp.broker_url`, so the SPA
- * cannot know it; surfacing it needs a backend change first.
+ *   - The broker (data plane) URL — the other half of #1249 — when the
+ *     backend reports one (`broker_url` on `GET /instance`, sourced from
+ *     `server.mcp.broker_url`). Null means the backend can't honestly
+ *     advertise it (older backend, or a remote install whose configured
+ *     broker is loopback), so the row simply doesn't render — never a guess.
  */
 import { Plug } from 'lucide-react';
 import { Card, CardBody, CardTitle, CodeSnippet } from '@/shared/ui';
@@ -42,6 +43,10 @@ export function McpConnectCard() {
 	if (!identity.data) return null;
 
 	const enabled = identity.data.mcp_enabled === true;
+	// Older backends predate the field; the backend also nulls it when the
+	// configured broker is loopback on a remote install (unreachable for any
+	// client) — either way there is nothing honest to show.
+	const brokerUrl = identity.data.broker_url ?? null;
 
 	return (
 		<Card>
@@ -71,6 +76,20 @@ export function McpConnectCard() {
 						<code className="font-mono text-xs">jentic</code> CLI — see an agent's MCP
 						tab.
 					</p>
+				)}
+				{/* #1249: the deployment-level broker (data plane) pointer.
+				    Rendered in BOTH arms — the broker serves `jentic execute`
+				    over stdio too, independent of the HTTP MCP endpoint. */}
+				{brokerUrl && (
+					<>
+						<CodeSnippet label="Broker (data plane) URL" code={brokerUrl} />
+						<p className="text-muted-foreground text-sm">
+							The data plane that executes API calls. On a remote install, pass it to{' '}
+							<code className="font-mono text-xs">jentic register --broker-url</code>{' '}
+							on the agent machine — without it{' '}
+							<code className="font-mono text-xs">jentic execute</code> fail-closes.
+						</p>
+					</>
 				)}
 			</CardBody>
 		</Card>

--- a/ui/src/shared/api/generated/models/InstanceIdentityResponse.ts
+++ b/ui/src/shared/api/generated/models/InstanceIdentityResponse.ts
@@ -15,6 +15,10 @@ export type InstanceIdentityResponse = {
      */
     backend: InstanceIdentityResponse.backend;
     /**
+     * The broker (data plane) base URL a client should send `execute` traffic to, as configured by the operator (server.mcp.broker_url), with any userinfo stripped. Null when the platform cannot honestly advertise one: on a 'remote' backend a loopback-host value (the config default) describes the control plane's own machine, not an address any client can dial, so it is withheld rather than published as misleading guidance. Deployment metadata, not a secret — the broker URL is handed to every client expected to call it (issue #1249).
+     */
+    broker_url?: (string | null);
+    /**
      * The instance's own canonical base URL (auth.canonical_base_url), with any userinfo stripped; '' if unset.
      */
     canonical_base_url: string;


### PR DESCRIPTION
Closes #1249

## Problem

The broker (data-plane) URL was pure tribal knowledge. `server.mcp.broker_url` existed in config, but no API or UI surface exposed it:

- The agent-detail **McpPanel** rendered a literal `<broker-url>` placeholder in the `jentic register` snippet (`ui/src/modules/agents/components/detail/McpPanel.tsx`) and told users to "ask your operator".
- The Settings **"Connect an MCP client"** card (#1330) showed the MCP endpoint but nothing about the broker.
- An agent holding only a control-plane base URL + token had no machine-readable way to discover where `execute` lives; operators DNS-guessed.

## Design decision (researched, per the issue's open question)

**Both surfaces, fed by one backend field on `GET /instance`.** Rationale:

- `/instance` is already the self-describing, **unauthenticated** identity endpoint that #1330 used to expose `mcp_enabled` for exactly this kind of client-onboarding UI — deployment metadata like this has precedent there, and one nullable field serves every consumer (UI, CLI, agents, scripts) without a new discovery mechanism.
- The broker URL is **not a secret**: it is handed to every MCP client expected to call it, and the broker authenticates every request itself. Gating it would only re-create the discoverability problem.
- A machine-only surface (`.well-known`/llms.txt) would leave the two human touchpoints (McpPanel snippet, Settings card) broken, and a UI-only fix would leave agents/CLI blind. The served `jentic.md` skill (the llms.txt-style self-onboarding surface from #809) is updated to point at `GET /instance` → `broker_url`, so a dedicated `.well-known` addition is **deliberately deferred** — noted below.

One wrinkle handled: on a **remote** backend whose `broker_url` still points at the compiled-in loopback default, the field is withheld (`null`) — advertising `http://127.0.0.1:8081` to a remote client would be actively misleading. Loopback URLs are advertised as-is on `backend=local` installs, where they are correct. Userinfo, if ever configured, is stripped before advertising.

## Fix

- `GET /instance` (`shared/web/instance_identity.py`): new nullable `broker_url` field sourced from `server.mcp.broker_url`, with the loopback-on-remote withholding rule above.
- **McpPanel** (agent detail): renders the real broker URL in the register snippet and as a "Broker URL" meta item when reported; keeps the `<broker-url>` placeholder + "ask your operator" help text as the fallback.
- **Settings "Connect an MCP client" card**: shows a "Broker (data plane) URL" row when reported — including when the HTTP MCP endpoint is disabled, since the broker is a separate concern.
- Served **jentic skill** (`skills/jentic/SKILL.md`, mirrored by `make skills`): documents the field and tells agents to read it from `/instance` before falling back to the operator.
- Codegen: `make openapi`, UI codegen, Go client regen all committed.

## Tests

- Backend (`tests/unit/shared/test_instance_identity.py`): field-set/unset arms, loopback-on-local advertised, loopback-on-remote withheld (IP and `localhost` spellings), userinfo stripping, exact response-shape pin updated.
- UI: `McpConnectCard` (shown when reported, shown even with MCP disabled, omitted when null/absent) and `AgentDetailPage`/McpPanel (real URL in snippet + placeholder/fallback text gone; placeholder retained when null). Full UI suite: 131 files / 1211 tests green, including the existing axe checks on both touched pages.
- Gates: backend fmt/lint/typecheck + full unit/arch suites green; `go build` + client tests green after regen.

## Deliberately not done

- No `.well-known/oauth-*`-style or llms.txt file addition — the served skill + `/instance` field satisfy machine discovery; a dedicated `.well-known` document can follow if a standard emerges worth tracking.
- No CLI behaviour change: `jentic register --broker-url` semantics are untouched (the UI snippet now fills the value in).

Made with [Cursor](https://cursor.com)