### PR TITLE
fix(auth): speak RFC 6749 §5.2 errors on the token endpoint

### DIFF
--- a/cli/client/auth/bearer_test.go
+++ b/cli/client/auth/bearer_test.go
@@ -165,10 +165,12 @@ func TestClassifyTokenError_PendingShapes(t *testing.T) {
 
 // TestClassifyTokenError_Rfc6749DistinctCodes pins the #1252 backend dialect:
 // the token endpoint now names conditions with their proper RFC 6749 §5.2 /
-// RFC 8628 codes (invalid_client, unsupported_grant_type, slow_down) instead
-// of a blanket invalid_grant. None of these are a pending approval — they
-// must classify as hard errors carrying the code AND the description, so the
-// register wait loop never polls a condition that can't clear.
+// RFC 8628 codes (invalid_request, invalid_client, unsupported_grant_type,
+// slow_down) instead of a blanket invalid_grant — including the §5.2 401 arm
+// for a client whose HTTP-Basic authentication failed. None of these are a
+// pending approval — they must classify as hard errors carrying the code AND
+// the description, so the register wait loop never polls a condition that
+// can't clear.
 func TestClassifyTokenError_Rfc6749DistinctCodes(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -178,8 +180,24 @@ func TestClassifyTokenError_Rfc6749DistinctCodes(t *testing.T) {
 		desc   string
 	}{
 		{
+			name:   "invalid_request",
+			status: http.StatusBadRequest,
+			body:   `{"error":"invalid_request","error_description":"request body is required"}`,
+			code:   "invalid_request",
+			desc:   "request body is required",
+		},
+		{
 			name:   "invalid_client",
 			status: http.StatusBadRequest,
+			body:   `{"error":"invalid_client","error_description":"client authentication failed"}`,
+			code:   "invalid_client",
+			desc:   "client authentication failed",
+		},
+		{
+			// §5.2: failed HTTP-Basic client authentication answers 401
+			// (+ WWW-Authenticate) with the same dialect body.
+			name:   "invalid_client_basic_401",
+			status: http.StatusUnauthorized,
 			body:   `{"error":"invalid_client","error_description":"client authentication failed"}`,
 			code:   "invalid_client",
 			desc:   "client authentication failed",

--- a/cli/client/auth/bearer_test.go
+++ b/cli/client/auth/bearer_test.go
@@ -121,9 +121,10 @@ func TestRefreshBearerToken_StaticCredentialsPassThrough(t *testing.T) {
 }
 
 // TestClassifyTokenError_PendingShapes pins that BOTH wire shapes of a pending
-// 400 classify as *PendingError: the RFC 7807 problem-details the shipped
-// backend actually emits ({"type": "invalid_grant"} — auth/web/errors.py), and
-// the RFC 6749 OAuth shape ({"error": "invalid_grant"}). The V2 port
+// 400 classify as *PendingError: the RFC 6749 OAuth shape the shipped backend's
+// token endpoint now emits ({"error": "invalid_grant"} — the #1252 §5.2
+// dialect reshaping), and the RFC 7807 problem-details shape older backends
+// emitted ({"type": "invalid_grant"} — auth/web/errors.py). The V2 port
 // originally read only the OAuth key, so a real pending agent surfaced as a
 // hard "token exchange failed (status 400)" instead of the approval wait.
 func TestClassifyTokenError_PendingShapes(t *testing.T) {
@@ -159,6 +160,59 @@ func TestClassifyTokenError_PendingShapes(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "actor_not_found") {
 		t.Errorf("error should carry the code: %v", err)
+	}
+}
+
+// TestClassifyTokenError_Rfc6749DistinctCodes pins the #1252 backend dialect:
+// the token endpoint now names conditions with their proper RFC 6749 §5.2 /
+// RFC 8628 codes (invalid_client, unsupported_grant_type, slow_down) instead
+// of a blanket invalid_grant. None of these are a pending approval — they
+// must classify as hard errors carrying the code AND the description, so the
+// register wait loop never polls a condition that can't clear.
+func TestClassifyTokenError_Rfc6749DistinctCodes(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		code   string
+		desc   string
+	}{
+		{
+			name:   "invalid_client",
+			status: http.StatusBadRequest,
+			body:   `{"error":"invalid_client","error_description":"client authentication failed"}`,
+			code:   "invalid_client",
+			desc:   "client authentication failed",
+		},
+		{
+			name:   "unsupported_grant_type",
+			status: http.StatusBadRequest,
+			body:   `{"error":"unsupported_grant_type","error_description":"unsupported grant_type: password"}`,
+			code:   "unsupported_grant_type",
+			desc:   "unsupported grant_type: password",
+		},
+		{
+			name:   "slow_down",
+			status: http.StatusTooManyRequests,
+			body:   `{"error":"slow_down","error_description":"rate limit exceeded, retry later"}`,
+			code:   "slow_down",
+			desc:   "rate limit exceeded, retry later",
+		},
+	}
+	for _, tc := range cases {
+		resp := &http.Response{
+			StatusCode: tc.status,
+			Body:       io.NopCloser(strings.NewReader(tc.body)),
+		}
+		err := classifyTokenError(resp)
+		var pending *PendingError
+		if errors.As(err, &pending) {
+			t.Errorf("%s: classified as pending — only 400 invalid_grant may pend", tc.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.code) || !strings.Contains(err.Error(), tc.desc) {
+			t.Errorf("%s: error should carry code %q and description %q: %v", tc.name, tc.code, tc.desc, err)
+		}
 	}
 }
 

--- a/cli/client/auth/oauth.go
+++ b/cli/client/auth/oauth.go
@@ -283,11 +283,12 @@ func performOAuthExchange(creds Credentials) (*TokenSet, error) {
 
 // classifyTokenError decodes the error body of a non-200 token response.
 // A 400 invalid_grant means the identity is unapproved -> *PendingError; anything
-// else is wrapped with the status and error code. The shipped backend emits
-// RFC 7807 problem-details ({"type": "invalid_grant", "detail": ...} — see
-// auth/web/errors.py), which is what the V1 client parsed; the RFC 6749 OAuth
-// shape ({"error": ..., "error_description": ...}) is also accepted so an
-// RFC-compliant server classifies identically.
+// else is wrapped with the status and error code. The shipped backend's token
+// endpoint emits the RFC 6749 §5.2 OAuth shape ({"error": ...,
+// "error_description": ...} — reshaped by _TokenRoute in
+// auth/web/routers/oauth.py, #1252); the RFC 7807 problem-details shape
+// ({"type": "invalid_grant", "detail": ...}) that older backends emitted is
+// still accepted so this client classifies identically against them.
 func classifyTokenError(resp *http.Response) error {
 	// #1207: redirects are never followed on auth calls (noFollowRedirects), so
 	// a 3xx lands here as the final response. Name it explicitly — "token

--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -34390,8 +34390,6 @@ type TokenEndpointHTTPResp struct {
 	HTTPResponse *http.Response
 	// JSON200 the response for an HTTP 200 `application/json` response
 	JSON200 *TokenResponse
-	// ApplicationproblemJSON422 the response for an HTTP 422 `application/problem+json` response
-	ApplicationproblemJSON422 *ProblemDetail
 	// ApplicationproblemJSON500 the response for an HTTP 500 `application/problem+json` response
 	ApplicationproblemJSON500 *ProblemDetail
 	// ApplicationproblemJSON503 the response for an HTTP 503 `application/problem+json` response
@@ -34401,11 +34399,6 @@ type TokenEndpointHTTPResp struct {
 // GetJSON200 returns the response for an HTTP 200 `application/json` response
 func (r TokenEndpointHTTPResp) GetJSON200() *TokenResponse {
 	return r.JSON200
-}
-
-// GetApplicationproblemJSON422 returns the response for an HTTP 422 `application/problem+json` response
-func (r TokenEndpointHTTPResp) GetApplicationproblemJSON422() *ProblemDetail {
-	return r.ApplicationproblemJSON422
 }
 
 // GetApplicationproblemJSON500 returns the response for an HTTP 500 `application/problem+json` response
@@ -51069,13 +51062,6 @@ func ParseTokenEndpointHTTPResp(rsp *http.Response) (*TokenEndpointHTTPResp, err
 
 	case rsp.StatusCode == 400:
 		break // No content-type
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest ProblemDetail
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.ApplicationproblemJSON422 = &dest
 
 	case rsp.StatusCode == 429:
 		break // No content-type

--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -6698,7 +6698,10 @@ type ClientInterface interface {
 	//
 	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
 	// ``error_description``), NOT platform Problem Details — reshaped by
-	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;
+	// failed client authentication answers ``invalid_client`` (status 401 with a
+	// ``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,
+	// 400 otherwise). On the refresh arm, a revoked consent grant answers
 	// ``invalid_grant`` with ``error_description: "consent grant has been
 	// revoked"`` — terminal; restart the authorization flow.
 	//
@@ -6713,7 +6716,10 @@ type ClientInterface interface {
 	//
 	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
 	// ``error_description``), NOT platform Problem Details — reshaped by
-	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;
+	// failed client authentication answers ``invalid_client`` (status 401 with a
+	// ``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,
+	// 400 otherwise). On the refresh arm, a revoked consent grant answers
 	// ``invalid_grant`` with ``error_description: "consent grant has been
 	// revoked"`` — terminal; restart the authorization flow.
 	//
@@ -6728,7 +6734,10 @@ type ClientInterface interface {
 	//
 	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
 	// ``error_description``), NOT platform Problem Details — reshaped by
-	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;
+	// failed client authentication answers ``invalid_client`` (status 401 with a
+	// ``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,
+	// 400 otherwise). On the refresh arm, a revoked consent grant answers
 	// ``invalid_grant`` with ``error_description: "consent grant has been
 	// revoked"`` — terminal; restart the authorization flow.
 	//
@@ -10892,7 +10901,10 @@ func (c *Client) SessionContinueEndpoint(ctx context.Context, body SessionContin
 //
 // Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
 // “error_description“), NOT platform Problem Details — reshaped by
-// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “_TokenRoute“. Malformed/missing parameters answer “invalid_request“;
+// failed client authentication answers “invalid_client“ (status 401 with a
+// “WWW-Authenticate: Basic“ challenge when the client attempted HTTP Basic,
+// 400 otherwise). On the refresh arm, a revoked consent grant answers
 // “invalid_grant“ with “error_description: "consent grant has been
 // revoked"“ — terminal; restart the authorization flow.
 //
@@ -10917,7 +10929,10 @@ func (c *Client) TokenEndpointWithBody(ctx context.Context, contentType string, 
 //
 // Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
 // “error_description“), NOT platform Problem Details — reshaped by
-// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “_TokenRoute“. Malformed/missing parameters answer “invalid_request“;
+// failed client authentication answers “invalid_client“ (status 401 with a
+// “WWW-Authenticate: Basic“ challenge when the client attempted HTTP Basic,
+// 400 otherwise). On the refresh arm, a revoked consent grant answers
 // “invalid_grant“ with “error_description: "consent grant has been
 // revoked"“ — terminal; restart the authorization flow.
 //
@@ -10942,7 +10957,10 @@ func (c *Client) TokenEndpoint(ctx context.Context, body TokenEndpointJSONReques
 //
 // Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
 // “error_description“), NOT platform Problem Details — reshaped by
-// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “_TokenRoute“. Malformed/missing parameters answer “invalid_request“;
+// failed client authentication answers “invalid_client“ (status 401 with a
+// “WWW-Authenticate: Basic“ challenge when the client attempted HTTP Basic,
+// 400 otherwise). On the refresh arm, a revoked consent grant answers
 // “invalid_grant“ with “error_description: "consent grant has been
 // revoked"“ — terminal; restart the authorization flow.
 //
@@ -23423,7 +23441,10 @@ type ClientWithResponsesInterface interface {
 	//
 	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
 	// ``error_description``), NOT platform Problem Details — reshaped by
-	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;
+	// failed client authentication answers ``invalid_client`` (status 401 with a
+	// ``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,
+	// 400 otherwise). On the refresh arm, a revoked consent grant answers
 	// ``invalid_grant`` with ``error_description: "consent grant has been
 	// revoked"`` — terminal; restart the authorization flow.
 	//
@@ -23438,7 +23459,10 @@ type ClientWithResponsesInterface interface {
 	//
 	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
 	// ``error_description``), NOT platform Problem Details — reshaped by
-	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;
+	// failed client authentication answers ``invalid_client`` (status 401 with a
+	// ``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,
+	// 400 otherwise). On the refresh arm, a revoked consent grant answers
 	// ``invalid_grant`` with ``error_description: "consent grant has been
 	// revoked"`` — terminal; restart the authorization flow.
 	//
@@ -23453,7 +23477,10 @@ type ClientWithResponsesInterface interface {
 	//
 	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
 	// ``error_description``), NOT platform Problem Details — reshaped by
-	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;
+	// failed client authentication answers ``invalid_client`` (status 401 with a
+	// ``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,
+	// 400 otherwise). On the refresh arm, a revoked consent grant answers
 	// ``invalid_grant`` with ``error_description: "consent grant has been
 	// revoked"`` — terminal; restart the authorization flow.
 	//
@@ -41504,7 +41531,10 @@ func (c *ClientWithResponses) SessionContinueEndpointWithResponse(ctx context.Co
 //
 // Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
 // “error_description“), NOT platform Problem Details — reshaped by
-// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “_TokenRoute“. Malformed/missing parameters answer “invalid_request“;
+// failed client authentication answers “invalid_client“ (status 401 with a
+// “WWW-Authenticate: Basic“ challenge when the client attempted HTTP Basic,
+// 400 otherwise). On the refresh arm, a revoked consent grant answers
 // “invalid_grant“ with “error_description: "consent grant has been
 // revoked"“ — terminal; restart the authorization flow.
 //
@@ -41525,7 +41555,10 @@ func (c *ClientWithResponses) TokenEndpointWithBodyWithResponse(ctx context.Cont
 //
 // Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
 // “error_description“), NOT platform Problem Details — reshaped by
-// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “_TokenRoute“. Malformed/missing parameters answer “invalid_request“;
+// failed client authentication answers “invalid_client“ (status 401 with a
+// “WWW-Authenticate: Basic“ challenge when the client attempted HTTP Basic,
+// 400 otherwise). On the refresh arm, a revoked consent grant answers
 // “invalid_grant“ with “error_description: "consent grant has been
 // revoked"“ — terminal; restart the authorization flow.
 //
@@ -41546,7 +41579,10 @@ func (c *ClientWithResponses) TokenEndpointWithResponse(ctx context.Context, bod
 //
 // Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
 // “error_description“), NOT platform Problem Details — reshaped by
-// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “_TokenRoute“. Malformed/missing parameters answer “invalid_request“;
+// failed client authentication answers “invalid_client“ (status 401 with a
+// “WWW-Authenticate: Basic“ challenge when the client attempted HTTP Basic,
+// 400 otherwise). On the refresh arm, a revoked consent grant answers
 // “invalid_grant“ with “error_description: "consent grant has been
 // revoked"“ — terminal; restart the authorization flow.
 //

--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -6696,6 +6696,12 @@ type ClientInterface interface {
 	//
 	// Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
 	//
+	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
+	// ``error_description``), NOT platform Problem Details — reshaped by
+	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``invalid_grant`` with ``error_description: "consent grant has been
+	// revoked"`` — terminal; restart the authorization flow.
+	//
 	// Takes any type of body and a specified content type.
 	//
 	// Corresponds with POST /oauth/token (the `TokenEndpoint` operationId).
@@ -6705,6 +6711,12 @@ type ClientInterface interface {
 	//
 	// Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
 	//
+	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
+	// ``error_description``), NOT platform Problem Details — reshaped by
+	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``invalid_grant`` with ``error_description: "consent grant has been
+	// revoked"`` — terminal; restart the authorization flow.
+	//
 	// Takes a body of the `application/json` content type.
 	//
 	// Corresponds with POST /oauth/token (the `TokenEndpoint` operationId).
@@ -6713,6 +6725,12 @@ type ClientInterface interface {
 	// TokenEndpointWithFormdataBody Token Endpoint
 	//
 	// Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
+	//
+	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
+	// ``error_description``), NOT platform Problem Details — reshaped by
+	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``invalid_grant`` with ``error_description: "consent grant has been
+	// revoked"`` — terminal; restart the authorization flow.
 	//
 	// Takes a body of the `application/x-www-form-urlencoded` content type.
 	//
@@ -10872,6 +10890,12 @@ func (c *Client) SessionContinueEndpoint(ctx context.Context, body SessionContin
 //
 // Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
 //
+// Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
+// “error_description“), NOT platform Problem Details — reshaped by
+// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “invalid_grant“ with “error_description: "consent grant has been
+// revoked"“ — terminal; restart the authorization flow.
+//
 // Takes any type of body and a specified content type.
 //
 // Corresponds with POST /oauth/token (the `TokenEndpoint` operationId).
@@ -10891,6 +10915,12 @@ func (c *Client) TokenEndpointWithBody(ctx context.Context, contentType string, 
 //
 // Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
 //
+// Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
+// “error_description“), NOT platform Problem Details — reshaped by
+// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “invalid_grant“ with “error_description: "consent grant has been
+// revoked"“ — terminal; restart the authorization flow.
+//
 // Takes a body of the `application/json` content type.
 //
 // Corresponds with POST /oauth/token (the `TokenEndpoint` operationId).
@@ -10909,6 +10939,12 @@ func (c *Client) TokenEndpoint(ctx context.Context, body TokenEndpointJSONReques
 // TokenEndpointWithFormdataBody Token Endpoint
 //
 // Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
+//
+// Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
+// “error_description“), NOT platform Problem Details — reshaped by
+// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “invalid_grant“ with “error_description: "consent grant has been
+// revoked"“ — terminal; restart the authorization flow.
 //
 // Takes a body of the `application/x-www-form-urlencoded` content type.
 //
@@ -23385,6 +23421,12 @@ type ClientWithResponsesInterface interface {
 	//
 	// Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
 	//
+	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
+	// ``error_description``), NOT platform Problem Details — reshaped by
+	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``invalid_grant`` with ``error_description: "consent grant has been
+	// revoked"`` — terminal; restart the authorization flow.
+	//
 	// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
 	//
 	// Corresponds with POST /oauth/token (the `TokenEndpoint` operationId).
@@ -23394,6 +23436,12 @@ type ClientWithResponsesInterface interface {
 	//
 	// Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
 	//
+	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
+	// ``error_description``), NOT platform Problem Details — reshaped by
+	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``invalid_grant`` with ``error_description: "consent grant has been
+	// revoked"`` — terminal; restart the authorization flow.
+	//
 	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
 	//
 	// Corresponds with POST /oauth/token (the `TokenEndpoint` operationId).
@@ -23402,6 +23450,12 @@ type ClientWithResponsesInterface interface {
 	// TokenEndpointWithFormdataBodyWithResponse Token Endpoint
 	//
 	// Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
+	//
+	// Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
+	// ``error_description``), NOT platform Problem Details — reshaped by
+	// ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+	// ``invalid_grant`` with ``error_description: "consent grant has been
+	// revoked"`` — terminal; restart the authorization flow.
 	//
 	// Takes a body of the `application/x-www-form-urlencoded` content type, and returns a wrapper object for the known response body format(s).
 	//
@@ -34309,8 +34363,6 @@ type TokenEndpointHTTPResp struct {
 	HTTPResponse *http.Response
 	// JSON200 the response for an HTTP 200 `application/json` response
 	JSON200 *TokenResponse
-	// ApplicationproblemJSON400 the response for an HTTP 400 `application/problem+json` response
-	ApplicationproblemJSON400 *ProblemDetail
 	// ApplicationproblemJSON422 the response for an HTTP 422 `application/problem+json` response
 	ApplicationproblemJSON422 *ProblemDetail
 	// ApplicationproblemJSON500 the response for an HTTP 500 `application/problem+json` response
@@ -34322,11 +34374,6 @@ type TokenEndpointHTTPResp struct {
 // GetJSON200 returns the response for an HTTP 200 `application/json` response
 func (r TokenEndpointHTTPResp) GetJSON200() *TokenResponse {
 	return r.JSON200
-}
-
-// GetApplicationproblemJSON400 returns the response for an HTTP 400 `application/problem+json` response
-func (r TokenEndpointHTTPResp) GetApplicationproblemJSON400() *ProblemDetail {
-	return r.ApplicationproblemJSON400
 }
 
 // GetApplicationproblemJSON422 returns the response for an HTTP 422 `application/problem+json` response
@@ -41455,6 +41502,12 @@ func (c *ClientWithResponses) SessionContinueEndpointWithResponse(ctx context.Co
 //
 // Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
 //
+// Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
+// “error_description“), NOT platform Problem Details — reshaped by
+// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “invalid_grant“ with “error_description: "consent grant has been
+// revoked"“ — terminal; restart the authorization flow.
+//
 // Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
 //
 // Corresponds with POST /oauth/token (the `TokenEndpoint` operationId).
@@ -41470,6 +41523,12 @@ func (c *ClientWithResponses) TokenEndpointWithBodyWithResponse(ctx context.Cont
 //
 // Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
 //
+// Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
+// “error_description“), NOT platform Problem Details — reshaped by
+// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “invalid_grant“ with “error_description: "consent grant has been
+// revoked"“ — terminal; restart the authorization flow.
+//
 // Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
 //
 // Corresponds with POST /oauth/token (the `TokenEndpoint` operationId).
@@ -41484,6 +41543,12 @@ func (c *ClientWithResponses) TokenEndpointWithResponse(ctx context.Context, bod
 // TokenEndpointWithFormdataBodyWithResponse Token Endpoint
 //
 // Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
+//
+// Error responses speak the RFC 6749 §5.2 dialect (top-level “error“ +
+// “error_description“), NOT platform Problem Details — reshaped by
+// “_TokenRoute“. On the refresh arm, a revoked consent grant answers
+// “invalid_grant“ with “error_description: "consent grant has been
+// revoked"“ — terminal; restart the authorization flow.
 //
 // Takes a body of the `application/x-www-form-urlencoded` content type, and returns a wrapper object for the known response body format(s).
 //
@@ -50966,12 +51031,8 @@ func ParseTokenEndpointHTTPResp(rsp *http.Response) (*TokenEndpointHTTPResp, err
 		}
 		response.JSON200 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
-		var dest ProblemDetail
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.ApplicationproblemJSON400 = &dest
+	case rsp.StatusCode == 400:
+		break // No content-type
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest ProblemDetail
@@ -50979,6 +51040,9 @@ func ParseTokenEndpointHTTPResp(rsp *http.Response) (*TokenEndpointHTTPResp, err
 			return nil, err
 		}
 		response.ApplicationproblemJSON422 = &dest
+
+	case rsp.StatusCode == 429:
+		break // No content-type
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ProblemDetail

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -16617,7 +16617,10 @@ paths:
 
         Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
         ``error_description``), NOT platform Problem Details — reshaped by
-        ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+        ``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;
+        failed client authentication answers ``invalid_client`` (status 401 with a
+        ``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,
+        400 otherwise). On the refresh arm, a revoked consent grant answers
         ``invalid_grant`` with ``error_description: "consent grant has been
         revoked"`` — terminal; restart the authorization flow.
       operationId: tokenEndpoint
@@ -16730,7 +16733,7 @@ paths:
                 $ref: '#/components/schemas/TokenResponse'
           description: Successful Response
         '400':
-          description: 'RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{"error": "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}`. A revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: "consent grant has been revoked"` — clients should treat it as terminal and restart the authorization flow.'
+          description: 'RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{"error": "invalid_request" | "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}`. `invalid_request` covers malformed/missing parameters; a revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: "consent grant has been revoked"` — clients should treat it as terminal and restart the authorization flow. A client whose authentication fails after attempting HTTP Basic (`Authorization` header, RFC 6749 §2.3.1) gets the same `invalid_client` dialect body with status 401 and a `WWW-Authenticate: Basic` challenge, per §5.2.'
         '422':
           content:
             application/problem+json:

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -16734,13 +16734,6 @@ paths:
           description: Successful Response
         '400':
           description: 'RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{"error": "invalid_request" | "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}`. `invalid_request` covers malformed/missing parameters; a revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: "consent grant has been revoked"` — clients should treat it as terminal and restart the authorization flow. A client whose authentication fails after attempting HTTP Basic (`Authorization` header, RFC 6749 §2.3.1) gets the same `invalid_client` dialect body with status 401 and a `WWW-Authenticate: Basic` challenge, per §5.2.'
-        '422':
-          content:
-            application/problem+json:
-              example: *id002
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-          description: Unprocessable Entity
         '429':
           description: Per-client+IP rate limit exceeded (`Retry-After` header set; RFC 6749 §5.2 dialect body, `error=slow_down` per RFC 8628 §3.5).
         '500':

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -16612,7 +16612,14 @@ paths:
       - OAuth
   /oauth/token:
     post:
-      description: Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
+      description: |-
+        Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
+
+        Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
+        ``error_description``), NOT platform Problem Details — reshaped by
+        ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+        ``invalid_grant`` with ``error_description: "consent grant has been
+        revoked"`` — terminal; restart the authorization flow.
       operationId: tokenEndpoint
       requestBody:
         content:
@@ -16723,12 +16730,7 @@ paths:
                 $ref: '#/components/schemas/TokenResponse'
           description: Successful Response
         '400':
-          content:
-            application/problem+json:
-              example: *id001
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-          description: Bad Request
+          description: 'RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{"error": "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}`. A revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: "consent grant has been revoked"` — clients should treat it as terminal and restart the authorization flow.'
         '422':
           content:
             application/problem+json:
@@ -16736,6 +16738,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Unprocessable Entity
+        '429':
+          description: Per-client+IP rate limit exceeded (`Retry-After` header set; RFC 6749 §5.2 dialect body, `error=slow_down` per RFC 8628 §3.5).
         '500':
           content:
             application/problem+json:

--- a/cli/internal/cli/api/register_test.go
+++ b/cli/internal/cli/api/register_test.go
@@ -167,10 +167,11 @@ func TestRegister_ClaimPending_AssertionInvalidIsNotFatal(t *testing.T) {
 			_, _ = w.Write([]byte(`{"client_id":"agnt_boot","status":"pending","claim_token":"` + claimTok + `"}`))
 		case "/oauth/token":
 			// Not-yet-claimed/approved agent: the backend's approval gate fires
-			// before signature/audience validation and returns this exact string.
+			// before signature/audience validation and returns this exact string
+			// (RFC 6749 §5.2 dialect — the shipped token endpoint shape, #1252).
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"type":"invalid_grant","status":400,"detail":"Assertion is invalid","instance":"/oauth/token"}`))
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Assertion is invalid"}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -373,7 +374,7 @@ func TestRegister_ContextCancelExitsPromptly(t *testing.T) {
 			polls.Add(1) // always pending → the loop never exits on its own
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"type":"invalid_grant","status":400,"detail":"agent pending approval","instance":"/oauth/token"}`))
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"agent pending approval"}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -424,7 +425,7 @@ func TestRegister_AssertionInvalidNoClaimIsFatal(t *testing.T) {
 			polls.Add(1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"type":"invalid_grant","status":400,"detail":"Assertion is invalid","instance":"/oauth/token"}`))
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Assertion is invalid"}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/cli/internal/cli/api/setup_test.go
+++ b/cli/internal/cli/api/setup_test.go
@@ -34,9 +34,10 @@ func setupServer(t *testing.T, pendingPolls int32) (*httptest.Server, *atomic.In
 			if polls.Add(1) <= pendingPolls {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
-				// RFC 7807 problem-details — the REAL backend error shape
-				// (auth/web/errors.py), which pending-classification must parse.
-				_, _ = w.Write([]byte(`{"type":"invalid_grant","status":400,"detail":"agent pending approval","instance":"/oauth/token"}`))
+				// RFC 6749 §5.2 dialect — the REAL backend token-endpoint
+				// error shape (#1252; the legacy RFC 7807 shape stays
+				// covered by client/auth's classifier table tests).
+				_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"agent pending approval"}`))
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -16617,7 +16617,10 @@ paths:
 
         Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
         ``error_description``), NOT platform Problem Details — reshaped by
-        ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+        ``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;
+        failed client authentication answers ``invalid_client`` (status 401 with a
+        ``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,
+        400 otherwise). On the refresh arm, a revoked consent grant answers
         ``invalid_grant`` with ``error_description: "consent grant has been
         revoked"`` — terminal; restart the authorization flow.
       operationId: tokenEndpoint
@@ -16730,7 +16733,7 @@ paths:
                 $ref: '#/components/schemas/TokenResponse'
           description: Successful Response
         '400':
-          description: 'RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{"error": "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}`. A revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: "consent grant has been revoked"` — clients should treat it as terminal and restart the authorization flow.'
+          description: 'RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{"error": "invalid_request" | "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}`. `invalid_request` covers malformed/missing parameters; a revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: "consent grant has been revoked"` — clients should treat it as terminal and restart the authorization flow. A client whose authentication fails after attempting HTTP Basic (`Authorization` header, RFC 6749 §2.3.1) gets the same `invalid_client` dialect body with status 401 and a `WWW-Authenticate: Basic` challenge, per §5.2.'
         '422':
           content:
             application/problem+json:

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -16734,13 +16734,6 @@ paths:
           description: Successful Response
         '400':
           description: 'RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{"error": "invalid_request" | "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}`. `invalid_request` covers malformed/missing parameters; a revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: "consent grant has been revoked"` — clients should treat it as terminal and restart the authorization flow. A client whose authentication fails after attempting HTTP Basic (`Authorization` header, RFC 6749 §2.3.1) gets the same `invalid_client` dialect body with status 401 and a `WWW-Authenticate: Basic` challenge, per §5.2.'
-        '422':
-          content:
-            application/problem+json:
-              example: *id002
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-          description: Unprocessable Entity
         '429':
           description: Per-client+IP rate limit exceeded (`Retry-After` header set; RFC 6749 §5.2 dialect body, `error=slow_down` per RFC 8628 §3.5).
         '500':

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -16612,7 +16612,14 @@ paths:
       - OAuth
   /oauth/token:
     post:
-      description: Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
+      description: |-
+        Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
+
+        Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
+        ``error_description``), NOT platform Problem Details — reshaped by
+        ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+        ``invalid_grant`` with ``error_description: "consent grant has been
+        revoked"`` — terminal; restart the authorization flow.
       operationId: tokenEndpoint
       requestBody:
         content:
@@ -16723,12 +16730,7 @@ paths:
                 $ref: '#/components/schemas/TokenResponse'
           description: Successful Response
         '400':
-          content:
-            application/problem+json:
-              example: *id001
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-          description: Bad Request
+          description: 'RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{"error": "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}`. A revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: "consent grant has been revoked"` — clients should treat it as terminal and restart the authorization flow.'
         '422':
           content:
             application/problem+json:
@@ -16736,6 +16738,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Unprocessable Entity
+        '429':
+          description: Per-client+IP rate limit exceeded (`Retry-After` header set; RFC 6749 §5.2 dialect body, `error=slow_down` per RFC 8628 §3.5).
         '500':
           content:
             application/problem+json:

--- a/src/jentic_one/auth/services/errors.py
+++ b/src/jentic_one/auth/services/errors.py
@@ -51,7 +51,8 @@ class InvalidGrantError(AuthServiceError):
     ``oauth_error_code`` is the RFC 6749 §5.2 error code the token endpoint's
     dialect reshaping (``_TokenRoute`` in ``auth/web/routers/oauth.py``) emits
     as the top-level ``error`` member. It defaults to ``invalid_grant``; raise
-    sites whose condition §5.2 names differently (``invalid_client``,
+    sites whose condition §5.2 names differently (``invalid_request`` for
+    malformed/missing parameters, ``invalid_client``,
     ``unsupported_grant_type``) override it. The platform Problem Details
     handler ignores it (every subclass instance still maps to
     ``type=invalid_grant`` there).

--- a/src/jentic_one/auth/services/errors.py
+++ b/src/jentic_one/auth/services/errors.py
@@ -46,11 +46,23 @@ class ToolkitBindingNotFoundError(AuthServiceError):
 
 
 class InvalidGrantError(AuthServiceError):
-    """Raised when a token grant is invalid (expired, consumed, or not found)."""
+    """Raised when a token grant is invalid (expired, consumed, or not found).
 
-    def __init__(self, reason: str = "invalid_grant") -> None:
+    ``oauth_error_code`` is the RFC 6749 §5.2 error code the token endpoint's
+    dialect reshaping (``_TokenRoute`` in ``auth/web/routers/oauth.py``) emits
+    as the top-level ``error`` member. It defaults to ``invalid_grant``; raise
+    sites whose condition §5.2 names differently (``invalid_client``,
+    ``unsupported_grant_type``) override it. The platform Problem Details
+    handler ignores it (every subclass instance still maps to
+    ``type=invalid_grant`` there).
+    """
+
+    def __init__(
+        self, reason: str = "invalid_grant", *, oauth_error_code: str = "invalid_grant"
+    ) -> None:
         super().__init__(reason)
         self.reason = reason
+        self.oauth_error_code = oauth_error_code
 
 
 class UserNotAdmittedError(AuthServiceError):

--- a/src/jentic_one/auth/services/service_account_auth_service.py
+++ b/src/jentic_one/auth/services/service_account_auth_service.py
@@ -118,21 +118,29 @@ class ServiceAccountAuthService:
         service account's live ``actor_scope_grants`` set stamped on the
         minted pair, returned so the token endpoint can report the effective
         scope per RFC 6749 §5.1.
-        Raises InvalidGrantError on authentication failure.
+        Raises InvalidGrantError (§5.2 code ``invalid_client`` — one
+        indistinguishable message for unknown/non-active/secret-less/wrong-secret,
+        no oracle for probing client ids) on authentication failure.
         """
         async with self._ctx.admin_db.session() as session:
             sa = await ServiceAccountRepository.get_by_id(session, client_id)
             if sa is None or sa.status != ActorStatus.ACTIVE:
-                raise InvalidGrantError("invalid_client")
+                raise InvalidGrantError(
+                    "client authentication failed", oauth_error_code="invalid_client"
+                )
 
             cred = await ServiceAccountCredentialRepository.get_by_service_account_id(
                 session, client_id
             )
             if cred is None or cred.client_secret_hash is None:
-                raise InvalidGrantError("invalid_client")
+                raise InvalidGrantError(
+                    "client authentication failed", oauth_error_code="invalid_client"
+                )
 
             if not hmac.compare_digest(hash_secret(client_secret), cred.client_secret_hash):
-                raise InvalidGrantError("invalid_client")
+                raise InvalidGrantError(
+                    "client authentication failed", oauth_error_code="invalid_client"
+                )
 
             grants = await ActorScopeGrantRepository.list_for_actor(
                 session, client_id, actor_type=ActorType.SERVICE_ACCOUNT

--- a/src/jentic_one/auth/web/routers/oauth.py
+++ b/src/jentic_one/auth/web/routers/oauth.py
@@ -240,10 +240,75 @@ _TOKEN_REQUEST_BODY: dict[str, object] = {
 }
 
 
-@router.post(
+class _TokenRoute(APIRoute):
+    """Route class making ``POST /oauth/token`` errors speak RFC 6749 §5.2.
+
+    §5.2 REQUIRES the token endpoint's error body to be a top-level
+    ``{"error": …, "error_description": …}`` object. The platform-wide
+    handlers emit RFC 9457 Problem Details (``{"type": …, "detail": …}``)
+    instead, which real MCP clients (mcp-remote's zod schema, Cursor's MCP
+    SDK) do not parse — a revoked-grant client sees an opaque 400 rather than
+    ``invalid_grant`` and keeps replaying its dead refresh token instead of
+    restarting authorization (#1252). The reshaping wraps the framework's
+    whole route handler, so errors raised by the endpoint body AND by its
+    dependencies (``_parse_token_request``, ``_check_token_rate_limit``) are
+    covered. Same posture as the RFC 7009 form arm below and the DCR door's
+    RFC 7591 §3.2.2 reshaping: spec-facing doors speak their spec's dialect;
+    everything else stays Problem Details.
+    """
+
+    def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+        original = super().get_route_handler()
+
+        async def handler(request: Request) -> Response:
+            try:
+                return await original(request)
+            except InvalidGrantError as exc:
+                # §5.2 error code chosen at the raise site (invalid_grant
+                # unless the condition is named differently — invalid_client,
+                # unsupported_grant_type); the exception reason becomes
+                # error_description.
+                response = _rfc6749_error(400, str(exc), error_code=exc.oauth_error_code)
+            except RateLimitExceededError as exc:
+                # Mirrors the RFC 7009 form arm: §5.2 defines no rate-limit
+                # code, so `slow_down` (RFC 8628 §3.5) is the registered
+                # token-endpoint error code for "back off".
+                record_rate_limited_request(request.url.path)
+                response = _rfc6749_error(
+                    429, "rate limit exceeded, retry later", error_code="slow_down"
+                )
+                response.headers["Retry-After"] = str(max(1, math.ceil(exc.retry_after)))
+            # §5.2's error responses carry the same no-store posture as §5.1
+            # success responses (the endpoint handler sets these on success).
+            response.headers["Cache-Control"] = "no-store"
+            response.headers["Pragma"] = "no-cache"
+            return response
+
+        return handler
+
+
+token_router = APIRouter(route_class=_TokenRoute)
+
+
+@token_router.post(
     "/oauth/token",
     dependencies=[Depends(_check_token_rate_limit)],
     openapi_extra=_TOKEN_REQUEST_BODY,
+    responses={
+        400: {
+            "description": "RFC 6749 §5.2 error dialect (NOT platform Problem Details — "
+            "this is a spec-facing endpoint real OAuth/MCP clients parse): "
+            '`{"error": "invalid_grant" | "invalid_client" | "unsupported_grant_type", '
+            '"error_description": "..."}`. A revoked consent grant surfaces on the '
+            'refresh arm as `invalid_grant` with `error_description: "consent grant '
+            'has been revoked"` — clients should treat it as terminal and restart '
+            "the authorization flow."
+        },
+        429: {
+            "description": "Per-client+IP rate limit exceeded (`Retry-After` header set; "
+            "RFC 6749 §5.2 dialect body, `error=slow_down` per RFC 8628 §3.5)."
+        },
+    },
     # RFC 6749 §5.1 + OIDC Core §3.1.3.3: optional members the grant did not
     # mint (id_token on grant-bearing agent-channel codes per D11, refresh_token
     # on grants that don't rotate one) are omitted from the response, never
@@ -263,7 +328,14 @@ async def token_endpoint(
     authorize_svc: AuthorizeService = Depends(get_authorize_service),
     oauth_client_svc: OAuthClientService = Depends(get_oauth_client_service),
 ) -> TokenResponse:
-    """Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens."""
+    """Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
+
+    Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
+    ``error_description``), NOT platform Problem Details — reshaped by
+    ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+    ``invalid_grant`` with ``error_description: "consent grant has been
+    revoked"`` — terminal; restart the authorization flow.
+    """
     # RFC 6749 §5.1: token responses MUST NOT be cached by any intermediary.
     response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
@@ -295,7 +367,9 @@ async def token_endpoint(
             if not await oauth_client_svc.authenticate_for_token_endpoint(
                 body.client_id, body.client_secret
             ):
-                raise InvalidGrantError("invalid_client")
+                raise InvalidGrantError(
+                    "client authentication failed", oauth_error_code="invalid_client"
+                )
             third_party_client_id = body.client_id
         access_token, refresh_token, id_token, scopes = await authorize_svc.exchange_code(
             code=body.code,
@@ -342,7 +416,10 @@ async def token_endpoint(
         )
 
     if body.grant_type != "refresh_token":
-        raise InvalidGrantError(f"unsupported grant_type: {body.grant_type}")
+        raise InvalidGrantError(
+            f"unsupported grant_type: {body.grant_type}",
+            oauth_error_code="unsupported_grant_type",
+        )
 
     if not body.refresh_token:
         raise InvalidGrantError("refresh_token is required for grant_type=refresh_token")
@@ -350,7 +427,9 @@ async def token_endpoint(
     verified_client_id: str | None = None
     if body.client_id and body.client_secret:
         if not await oauth_client_svc.verify_client_secret(body.client_id, body.client_secret):
-            raise InvalidGrantError("invalid_client")
+            raise InvalidGrantError(
+                "client authentication failed", oauth_error_code="invalid_client"
+            )
         verified_client_id = body.client_id
     elif body.client_id and await oauth_client_svc.is_public_client(body.client_id):
         # Public clients can't authenticate — RFC 6749 §6 still requires the
@@ -369,6 +448,11 @@ async def token_endpoint(
         expires_in=token_svc.access_ttl_seconds,
         scope=_scope_member(scopes),
     )
+
+
+# Mounted via its own router so `_TokenRoute` owns the endpoint's error
+# dialect (same include pattern as `revocation_router` below).
+router.include_router(token_router)
 
 
 @router.post("/oauth/mint")

--- a/src/jentic_one/auth/web/routers/oauth.py
+++ b/src/jentic_one/auth/web/routers/oauth.py
@@ -210,7 +210,13 @@ def _basic_auth_credentials(request: Request) -> tuple[str, str] | None:
 
 
 async def _parse_token_request(request: Request) -> TokenRequest:
-    """Parse the token request from JSON or form-encoded body (RFC 6749 §4.1.3)."""
+    """Parse the token request from JSON or form-encoded body (RFC 6749 §4.1.3).
+
+    Parse/validation failures are ``invalid_request`` (§5.2: missing or
+    malformed parameters), never ``invalid_grant`` — the latter tells an
+    RFC-compliant client its grant is dead and it must restart authorization,
+    which is the wrong remediation for a malformed request it can just fix.
+    """
     content_type = (request.headers.get("content-type") or "").split(";")[0].strip().lower()
     if content_type == "application/x-www-form-urlencoded":
         form = await request.form()
@@ -218,14 +224,18 @@ async def _parse_token_request(request: Request) -> TokenRequest:
         try:
             return TokenRequest.model_validate(data)
         except ValidationError as exc:
-            raise InvalidGrantError(str(exc.errors()[0]["msg"])) from None
+            raise InvalidGrantError(
+                str(exc.errors()[0]["msg"]), oauth_error_code="invalid_request"
+            ) from None
     body_bytes = await request.body()
     if not body_bytes:
-        raise InvalidGrantError("request body is required")
+        raise InvalidGrantError("request body is required", oauth_error_code="invalid_request")
     try:
         return TokenRequest.model_validate_json(body_bytes)
     except ValidationError as exc:
-        raise InvalidGrantError(str(exc.errors()[0]["msg"])) from None
+        raise InvalidGrantError(
+            str(exc.errors()[0]["msg"]), oauth_error_code="invalid_request"
+        ) from None
 
 
 _TOKEN_REQUEST_SCHEMA = TokenRequest.model_json_schema()
@@ -266,9 +276,25 @@ class _TokenRoute(APIRoute):
             except InvalidGrantError as exc:
                 # §5.2 error code chosen at the raise site (invalid_grant
                 # unless the condition is named differently — invalid_client,
-                # unsupported_grant_type); the exception reason becomes
-                # error_description.
-                response = _rfc6749_error(400, str(exc), error_code=exc.oauth_error_code)
+                # invalid_request, unsupported_grant_type); the exception
+                # reason becomes error_description.
+                status = 400
+                challenge: str | None = None
+                if exc.oauth_error_code == "invalid_client" and (
+                    request.headers.get("authorization", "").lower().startswith("basic ")
+                ):
+                    # §5.2 MUST: a client that attempted to authenticate via
+                    # the Authorization header gets 401 with a
+                    # WWW-Authenticate challenge matching the scheme it used
+                    # (Basic is the only header scheme this endpoint
+                    # supports — RFC 6749 §2.3.1, merged into the body above
+                    # the grant dispatch). Body-authenticated clients keep
+                    # the §5.2-default 400.
+                    status = 401
+                    challenge = 'Basic realm="oauth/token", charset="UTF-8"'
+                response = _rfc6749_error(status, str(exc), error_code=exc.oauth_error_code)
+                if challenge is not None:
+                    response.headers["WWW-Authenticate"] = challenge
             except RateLimitExceededError as exc:
                 # Mirrors the RFC 7009 form arm: §5.2 defines no rate-limit
                 # code, so `slow_down` (RFC 8628 §3.5) is the registered
@@ -298,11 +324,15 @@ token_router = APIRouter(route_class=_TokenRoute)
         400: {
             "description": "RFC 6749 §5.2 error dialect (NOT platform Problem Details — "
             "this is a spec-facing endpoint real OAuth/MCP clients parse): "
-            '`{"error": "invalid_grant" | "invalid_client" | "unsupported_grant_type", '
-            '"error_description": "..."}`. A revoked consent grant surfaces on the '
-            'refresh arm as `invalid_grant` with `error_description: "consent grant '
-            'has been revoked"` — clients should treat it as terminal and restart '
-            "the authorization flow."
+            '`{"error": "invalid_request" | "invalid_grant" | "invalid_client" | '
+            '"unsupported_grant_type", "error_description": "..."}`. '
+            "`invalid_request` covers malformed/missing parameters; a revoked consent "
+            "grant surfaces on the refresh arm as `invalid_grant` with "
+            '`error_description: "consent grant has been revoked"` — clients should '
+            "treat it as terminal and restart the authorization flow. A client whose "
+            "authentication fails after attempting HTTP Basic (`Authorization` header, "
+            "RFC 6749 §2.3.1) gets the same `invalid_client` dialect body with status "
+            "401 and a `WWW-Authenticate: Basic` challenge, per §5.2."
         },
         429: {
             "description": "Per-client+IP rate limit exceeded (`Retry-After` header set; "
@@ -332,7 +362,10 @@ async def token_endpoint(
 
     Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
     ``error_description``), NOT platform Problem Details — reshaped by
-    ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+    ``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;
+    failed client authentication answers ``invalid_client`` (status 401 with a
+    ``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,
+    400 otherwise). On the refresh arm, a revoked consent grant answers
     ``invalid_grant`` with ``error_description: "consent grant has been
     revoked"`` — terminal; restart the authorization flow.
     """
@@ -352,7 +385,10 @@ async def token_endpoint(
 
     if body.grant_type == _AUTHORIZATION_CODE_GRANT:
         if not body.code or not body.code_verifier or not body.redirect_uri or not body.client_id:
-            raise InvalidGrantError("code, code_verifier, redirect_uri, and client_id are required")
+            raise InvalidGrantError(
+                "code, code_verifier, redirect_uri, and client_id are required",
+                oauth_error_code="invalid_request",
+            )
         # Pre-validate the auth code before spending argon2 on the client secret,
         # so an unauthenticated caller can't turn junk input into 64 MiB per hit.
         await authorize_svc.precheck_auth_code(body.code)
@@ -389,7 +425,10 @@ async def token_endpoint(
 
     if body.grant_type == _JWT_BEARER_GRANT:
         if not body.assertion:
-            raise InvalidGrantError("assertion is required for grant_type=jwt-bearer")
+            raise InvalidGrantError(
+                "assertion is required for grant_type=jwt-bearer",
+                oauth_error_code="invalid_request",
+            )
         access_token, refresh_token, scopes = await assertion_svc.verify_and_exchange(
             body.assertion
         )
@@ -403,7 +442,10 @@ async def token_endpoint(
 
     if body.grant_type == _CLIENT_CREDENTIALS_GRANT:
         if not body.client_id or not body.client_secret:
-            raise InvalidGrantError("client_id and client_secret are required")
+            raise InvalidGrantError(
+                "client_id and client_secret are required",
+                oauth_error_code="invalid_request",
+            )
         access_token, refresh_token, scopes = await sa_auth_svc.authenticate_client_credentials(
             body.client_id, body.client_secret
         )
@@ -422,7 +464,10 @@ async def token_endpoint(
         )
 
     if not body.refresh_token:
-        raise InvalidGrantError("refresh_token is required for grant_type=refresh_token")
+        raise InvalidGrantError(
+            "refresh_token is required for grant_type=refresh_token",
+            oauth_error_code="invalid_request",
+        )
 
     verified_client_id: str | None = None
     if body.client_id and body.client_secret:

--- a/src/jentic_one/shared/web/openapi_meta.py
+++ b/src/jentic_one/shared/web/openapi_meta.py
@@ -866,13 +866,18 @@ NON_BEARER_AUTH_OPERATION_IDS: frozenset[str] = frozenset(
 
 
 #: Operations whose request-validation failures are reshaped at the router into
-#: RFC 7591 §3.2.2 ``400 {"error": "invalid_client_metadata"}`` responses (see
-#: ``_Rfc7591Route`` in ``auth/web/routers/oauth_client_registration.py``).
-#: They never emit the FastAPI 422, so the auto-generated 422 response is
-#: dropped from the spec (the 400 is documented on the route decorator).
-RFC7591_ERROR_OPERATION_IDS: frozenset[str] = frozenset(
+#: their governing spec's error dialect, so the FastAPI 422 can never be
+#: returned and the auto-generated 422 response is dropped from the spec:
+#: the DCR door's RFC 7591 §3.2.2 ``400 {"error": "invalid_client_metadata"}``
+#: (``_Rfc7591Route`` in ``auth/web/routers/oauth_client_registration.py``) and
+#: the token endpoint's RFC 6749 §5.2 dialect (``_TokenRoute`` in
+#: ``auth/web/routers/oauth.py`` — body parsing runs entirely inside
+#: ``_parse_token_request``, which answers §5.2 ``invalid_request``). The
+#: route-specific error responses are documented on the route decorators.
+ROUTER_RESHAPED_422_OPERATION_IDS: frozenset[str] = frozenset(
     {
         "registerOauthClientEndpoint",
+        "tokenEndpoint",
     }
 )
 
@@ -1097,9 +1102,10 @@ def install_openapi_metadata(app: FastAPI) -> None:
                     operation.get("responses", {}).pop("403", None)
                 else:
                     _stamp_scope_metadata(method, path, operation, operation_auth)
-                if op_id in RFC7591_ERROR_OPERATION_IDS:
-                    # Validation failures are reshaped to the RFC 7591 400 at
-                    # the router; the framework 422 can never be returned.
+                if op_id in ROUTER_RESHAPED_422_OPERATION_IDS:
+                    # Validation failures are reshaped to the governing spec's
+                    # dialect at the router; the framework 422 can never be
+                    # returned.
                     operation.get("responses", {}).pop("422", None)
                 _normalise_error_responses(operation.get("responses", {}))
 

--- a/tests/unit/auth/test_service_account_auth_service.py
+++ b/tests/unit/auth/test_service_account_auth_service.py
@@ -130,8 +130,10 @@ async def test_authenticate_client_credentials_invalid_secret(
         return_value=_make_credential_row(client_secret_hash="different_hash")
     )
 
-    with pytest.raises(InvalidGrantError, match="invalid_client"):
+    with pytest.raises(InvalidGrantError, match="client authentication failed") as exc_info:
         await svc.authenticate_client_credentials("sva_test123", "jcs_wrong_secret")
+    # §5.2 names failed client authentication invalid_client on the wire.
+    assert exc_info.value.oauth_error_code == "invalid_client"
 
 
 @pytest.mark.asyncio
@@ -144,8 +146,9 @@ async def test_authenticate_client_credentials_sa_not_found(
 
     mock_sa_repo.get_by_id = AsyncMock(return_value=None)
 
-    with pytest.raises(InvalidGrantError, match="invalid_client"):
+    with pytest.raises(InvalidGrantError, match="client authentication failed") as exc_info:
         await svc.authenticate_client_credentials("sva_nonexist", "jcs_anything")
+    assert exc_info.value.oauth_error_code == "invalid_client"
 
 
 @pytest.mark.asyncio
@@ -158,8 +161,9 @@ async def test_authenticate_client_credentials_sa_not_active(
 
     mock_sa_repo.get_by_id = AsyncMock(return_value=_make_sa_row(status="disabled"))
 
-    with pytest.raises(InvalidGrantError, match="invalid_client"):
+    with pytest.raises(InvalidGrantError, match="client authentication failed") as exc_info:
         await svc.authenticate_client_credentials("sva_test123", "jcs_anything")
+    assert exc_info.value.oauth_error_code == "invalid_client"
 
 
 def _make_agent_row(*, status: str = "active") -> MagicMock:

--- a/tests/unit/auth/web/test_oauth_auth_code.py
+++ b/tests/unit/auth/web/test_oauth_auth_code.py
@@ -241,7 +241,9 @@ def test_public_client_missing_pkce_verifier_is_rejected(
     )
 
     assert resp.status_code == 400
-    assert resp.json()["error"] == "invalid_grant"
+    # §5.2: the missing code_verifier is a malformed token request —
+    # invalid_request — rejected before any client authentication runs.
+    assert resp.json()["error"] == "invalid_request"
     mock_oauth_svc.authenticate_for_token_endpoint.assert_not_awaited()
     mock_authorize_svc.exchange_code.assert_not_awaited()
 

--- a/tests/unit/auth/web/test_oauth_auth_code.py
+++ b/tests/unit/auth/web/test_oauth_auth_code.py
@@ -159,7 +159,9 @@ def test_third_party_client_without_secret_is_rejected(
     )
 
     assert resp.status_code == 400
-    assert resp.json()["type"] == "invalid_grant"
+    # RFC 6749 §5.2: failed client authentication is `invalid_client`, not
+    # a generic invalid_grant (and never platform Problem Details).
+    assert resp.json()["error"] == "invalid_client"
     mock_oauth_svc.authenticate_for_token_endpoint.assert_awaited_once_with(
         _THIRD_PARTY_CLIENT_ID, None
     )
@@ -239,7 +241,7 @@ def test_public_client_missing_pkce_verifier_is_rejected(
     )
 
     assert resp.status_code == 400
-    assert resp.json()["type"] == "invalid_grant"
+    assert resp.json()["error"] == "invalid_grant"
     mock_oauth_svc.authenticate_for_token_endpoint.assert_not_awaited()
     mock_authorize_svc.exchange_code.assert_not_awaited()
 

--- a/tests/unit/auth/web/test_oauth_client_credentials.py
+++ b/tests/unit/auth/web/test_oauth_client_credentials.py
@@ -110,7 +110,8 @@ def test_client_credentials_missing_client_id(
     )
     assert resp.status_code == 400
     data = resp.json()
-    assert data["type"] == "invalid_grant"
+    # RFC 6749 §5.2 dialect (reshaped by _TokenRoute) — not Problem Details.
+    assert data["error"] == "invalid_grant"
 
 
 @patch("jentic_one.auth.web.routers.oauth.ServiceAccountAuthService")
@@ -138,7 +139,7 @@ def test_client_credentials_invalid_secret(
     )
     assert resp.status_code == 400
     data = resp.json()
-    assert data["type"] == "invalid_grant"
+    assert data["error"] == "invalid_grant"
 
 
 @patch("jentic_one.auth.web.routers.oauth.ServiceAccountAuthService")

--- a/tests/unit/auth/web/test_oauth_client_credentials.py
+++ b/tests/unit/auth/web/test_oauth_client_credentials.py
@@ -110,8 +110,9 @@ def test_client_credentials_missing_client_id(
     )
     assert resp.status_code == 400
     data = resp.json()
-    # RFC 6749 §5.2 dialect (reshaped by _TokenRoute) — not Problem Details.
-    assert data["error"] == "invalid_grant"
+    # §5.2: a missing parameter is invalid_request (fix the request), not
+    # invalid_grant (restart authorization).
+    assert data["error"] == "invalid_request"
 
 
 @patch("jentic_one.auth.web.routers.oauth.ServiceAccountAuthService")
@@ -123,7 +124,11 @@ def test_client_credentials_invalid_secret(
 ) -> None:
     mock_sa_auth = MagicMock()
     mock_sa_auth.authenticate_client_credentials = AsyncMock(
-        side_effect=InvalidGrantError("invalid_client")
+        # The REAL service raise (service_account_auth_service.py): §5.2
+        # names failed client authentication invalid_client.
+        side_effect=InvalidGrantError(
+            "client authentication failed", oauth_error_code="invalid_client"
+        )
     )
     mock_sa_auth_cls.return_value = mock_sa_auth
 
@@ -139,7 +144,7 @@ def test_client_credentials_invalid_secret(
     )
     assert resp.status_code == 400
     data = resp.json()
-    assert data["error"] == "invalid_grant"
+    assert data["error"] == "invalid_client"
 
 
 @patch("jentic_one.auth.web.routers.oauth.ServiceAccountAuthService")

--- a/tests/unit/auth/web/test_oauth_jwt_bearer.py
+++ b/tests/unit/auth/web/test_oauth_jwt_bearer.py
@@ -77,8 +77,9 @@ def test_jwt_bearer_grant_missing_assertion(
     )
     assert resp.status_code == 400
     data = resp.json()
-    # RFC 6749 §5.2 dialect (reshaped by _TokenRoute) — not Problem Details.
-    assert data["error"] == "invalid_grant"
+    # §5.2: a missing parameter is invalid_request (reshaped by _TokenRoute)
+    # — not invalid_grant, and never Problem Details.
+    assert data["error"] == "invalid_request"
 
 
 @patch("jentic_one.auth.web.routers.oauth.AssertionService")
@@ -124,5 +125,6 @@ def test_unsupported_grant_type_returns_400(
     )
     assert resp.status_code == 400
     data = resp.json()
-    # Missing credentials on a SUPPORTED grant type stays invalid_grant.
-    assert data["error"] == "invalid_grant"
+    # Missing credentials on a SUPPORTED grant type is a §5.2 invalid_request
+    # (missing required parameter), not unsupported_grant_type.
+    assert data["error"] == "invalid_request"

--- a/tests/unit/auth/web/test_oauth_jwt_bearer.py
+++ b/tests/unit/auth/web/test_oauth_jwt_bearer.py
@@ -77,7 +77,8 @@ def test_jwt_bearer_grant_missing_assertion(
     )
     assert resp.status_code == 400
     data = resp.json()
-    assert data["type"] == "invalid_grant"
+    # RFC 6749 §5.2 dialect (reshaped by _TokenRoute) — not Problem Details.
+    assert data["error"] == "invalid_grant"
 
 
 @patch("jentic_one.auth.web.routers.oauth.AssertionService")
@@ -104,7 +105,8 @@ def test_jwt_bearer_grant_invalid_assertion(
     )
     assert resp.status_code == 400
     data = resp.json()
-    assert data["type"] == "invalid_grant"
+    assert data["error"] == "invalid_grant"
+    assert data["error_description"] == "Assertion is invalid"
 
 
 @patch("jentic_one.auth.web.routers.oauth.AssertionService")
@@ -122,4 +124,5 @@ def test_unsupported_grant_type_returns_400(
     )
     assert resp.status_code == 400
     data = resp.json()
-    assert data["type"] == "invalid_grant"
+    # Missing credentials on a SUPPORTED grant type stays invalid_grant.
+    assert data["error"] == "invalid_grant"

--- a/tests/unit/auth/web/test_oauth_token_error_dialect.py
+++ b/tests/unit/auth/web/test_oauth_token_error_dialect.py
@@ -13,6 +13,7 @@ regress to Problem Details (the ``_TokenRoute`` reshaping in
 
 from __future__ import annotations
 
+import base64
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -133,7 +134,10 @@ def test_dependency_raised_parse_error_speaks_the_dialect_too(
 ) -> None:
     """Errors raised in the DEPENDENCY chain (``_parse_token_request``) are
     reshaped as well — the route-class wrapper sits outside dependency
-    solving, so no arm of the endpoint can leak Problem Details."""
+    solving, so no arm of the endpoint can leak Problem Details. A malformed
+    request is §5.2 ``invalid_request`` (fix and retry), never
+    ``invalid_grant`` (which would tell an RFC-compliant client to restart
+    authorization over a request-shape bug)."""
     mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
 
     resp = client.post("/oauth/token", content=b"", headers={"content-type": "application/json"})
@@ -141,7 +145,38 @@ def test_dependency_raised_parse_error_speaks_the_dialect_too(
     assert resp.status_code == 400
     body = resp.json()
     _assert_rfc6749_shape(body)
-    assert body == {"error": "invalid_grant", "error_description": "request body is required"}
+    assert body == {"error": "invalid_request", "error_description": "request body is required"}
+
+
+@patch("jentic_one.auth.web.routers.oauth.OAuthClientService")
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_basic_auth_failure_is_401_with_www_authenticate(
+    mock_token_cls: MagicMock, mock_oauth_svc_cls: MagicMock, client: TestClient
+) -> None:
+    """§5.2 MUST: failed client authentication that was ATTEMPTED via the
+    ``Authorization`` header (HTTP Basic, RFC 6749 §2.3.1) answers 401 with a
+    matching ``WWW-Authenticate`` challenge — same §5.2 dialect body as the
+    body-credential 400 arm."""
+    mock_oauth_svc = MagicMock()
+    mock_oauth_svc.verify_client_secret = AsyncMock(return_value=False)
+    mock_oauth_svc_cls.return_value = mock_oauth_svc
+    mock_token_svc = MagicMock(access_ttl_seconds=3600)
+    mock_token_svc.refresh = AsyncMock()
+    mock_token_cls.return_value = mock_token_svc
+
+    credentials = base64.b64encode(b"oc_conf_client:jcs_wrong").decode()
+    resp = client.post(
+        "/oauth/token",
+        json={"grant_type": "refresh_token", "refresh_token": "rt_any"},
+        headers={"Authorization": f"Basic {credentials}"},
+    )
+
+    assert resp.status_code == 401
+    body = resp.json()
+    _assert_rfc6749_shape(body)
+    assert body["error"] == "invalid_client"
+    assert resp.headers["WWW-Authenticate"].startswith("Basic")
+    mock_token_svc.refresh.assert_not_awaited()
 
 
 def test_rate_limited_token_request_speaks_slow_down(client: TestClient) -> None:

--- a/tests/unit/auth/web/test_oauth_token_error_dialect.py
+++ b/tests/unit/auth/web/test_oauth_token_error_dialect.py
@@ -1,0 +1,164 @@
+"""Wire-shape tests for the token endpoint's RFC 6749 §5.2 error dialect (#1252).
+
+``POST /oauth/token`` is a spec-facing endpoint parsed by real OAuth/MCP
+clients (mcp-remote, Cursor), which understand only the §5.2 body —
+``{"error": …, "error_description": …}``. The platform's Problem Details
+handlers must never answer here: a revoked-grant client that receives
+``{"type": "invalid_grant", …}`` cannot classify the failure and wedges,
+replaying its dead refresh token forever instead of restarting authorization.
+These tests pin the exact wire shape per error arm so the dialect can't
+regress to Problem Details (the ``_TokenRoute`` reshaping in
+``auth/web/routers/oauth.py``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from jentic_one.auth.services.errors import AuthServiceError, InvalidGrantError
+from jentic_one.auth.web.errors import service_error_handler
+from jentic_one.auth.web.routers import oauth
+from jentic_one.shared.config import AuthConfig
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(oauth.router)
+    # The Problem Details handler is REGISTERED (as in the real app) — the
+    # dialect tests prove the route-level reshaping wins before it ever runs.
+    app.add_exception_handler(AuthServiceError, service_error_handler)
+
+    mock_ctx = MagicMock()
+    mock_ctx.config.auth = AuthConfig(canonical_base_url="https://auth.example.com")
+    app.state.ctx = mock_ctx
+    return TestClient(app)
+
+
+def _assert_rfc6749_shape(body: dict[str, object]) -> None:
+    """The §5.2 members and NOTHING of the Problem Details envelope."""
+    assert set(body) == {"error", "error_description"}
+
+
+@patch("jentic_one.auth.web.routers.oauth.OAuthClientService")
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_refresh_with_revoked_grant_speaks_rfc6749(
+    mock_token_cls: MagicMock, mock_oauth_svc_cls: MagicMock, client: TestClient
+) -> None:
+    """THE #1252 arm: a G10-revoked consent grant answers §5.2 invalid_grant.
+
+    ``TokenService.refresh`` re-checks the consent grant on every rotation and
+    raises ``InvalidGrantError("consent grant has been revoked")``
+    (token_service.py); the wire shape must let an RFC-compliant client see
+    ``error=invalid_grant`` and restart authorization.
+    """
+    mock_token_svc = MagicMock(access_ttl_seconds=3600)
+    mock_token_svc.refresh = AsyncMock(
+        side_effect=InvalidGrantError("consent grant has been revoked")
+    )
+    mock_token_cls.return_value = mock_token_svc
+    mock_oauth_svc_cls.return_value = MagicMock()
+
+    resp = client.post(
+        "/oauth/token",
+        json={"grant_type": "refresh_token", "refresh_token": "rt_revoked_grant"},
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    _assert_rfc6749_shape(body)
+    assert body == {
+        "error": "invalid_grant",
+        "error_description": "consent grant has been revoked",
+    }
+    # §5.2 error responses carry the same no-store posture as §5.1 successes.
+    assert resp.headers["Cache-Control"] == "no-store"
+    assert resp.headers["Pragma"] == "no-cache"
+
+
+@patch("jentic_one.auth.web.routers.oauth.OAuthClientService")
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_refresh_with_failed_client_authentication_is_invalid_client(
+    mock_token_cls: MagicMock, mock_oauth_svc_cls: MagicMock, client: TestClient
+) -> None:
+    """§5.2 names failed client authentication ``invalid_client``."""
+    mock_oauth_svc = MagicMock()
+    mock_oauth_svc.verify_client_secret = AsyncMock(return_value=False)
+    mock_oauth_svc_cls.return_value = mock_oauth_svc
+    mock_token_svc = MagicMock(access_ttl_seconds=3600)
+    mock_token_svc.refresh = AsyncMock()
+    mock_token_cls.return_value = mock_token_svc
+
+    resp = client.post(
+        "/oauth/token",
+        json={
+            "grant_type": "refresh_token",
+            "refresh_token": "rt_any",
+            "client_id": "oc_conf_client",
+            "client_secret": "jcs_wrong",
+        },
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    _assert_rfc6749_shape(body)
+    assert body["error"] == "invalid_client"
+    assert body["error_description"] == "client authentication failed"
+    mock_token_svc.refresh.assert_not_awaited()
+
+
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_unknown_grant_type_is_unsupported_grant_type(
+    mock_token_cls: MagicMock, client: TestClient
+) -> None:
+    """§5.2 names an unknown grant type ``unsupported_grant_type``."""
+    mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
+
+    resp = client.post("/oauth/token", json={"grant_type": "password"})
+
+    assert resp.status_code == 400
+    body = resp.json()
+    _assert_rfc6749_shape(body)
+    assert body["error"] == "unsupported_grant_type"
+    assert body["error_description"] == "unsupported grant_type: password"
+
+
+@patch("jentic_one.auth.web.routers.oauth.TokenService")
+def test_dependency_raised_parse_error_speaks_the_dialect_too(
+    mock_token_cls: MagicMock, client: TestClient
+) -> None:
+    """Errors raised in the DEPENDENCY chain (``_parse_token_request``) are
+    reshaped as well — the route-class wrapper sits outside dependency
+    solving, so no arm of the endpoint can leak Problem Details."""
+    mock_token_cls.return_value = MagicMock(access_ttl_seconds=3600)
+
+    resp = client.post("/oauth/token", content=b"", headers={"content-type": "application/json"})
+
+    assert resp.status_code == 400
+    body = resp.json()
+    _assert_rfc6749_shape(body)
+    assert body == {"error": "invalid_grant", "error_description": "request body is required"}
+
+
+def test_rate_limited_token_request_speaks_slow_down(client: TestClient) -> None:
+    """The 429 arm speaks the dialect (``error=slow_down`` per RFC 8628 §3.5)
+    with ``Retry-After`` intact — mirroring the RFC 7009 form arm."""
+    outcome = MagicMock(allowed=False, retry_after_s=2.0)
+    limiter = MagicMock()
+    limiter.acquire = AsyncMock(return_value=outcome)
+    client.app.state._token_limiter = limiter  # type: ignore[attr-defined]
+
+    resp = client.post(
+        "/oauth/token",
+        json={"grant_type": "refresh_token", "refresh_token": "rt_any"},
+    )
+
+    assert resp.status_code == 429
+    body = resp.json()
+    _assert_rfc6749_shape(body)
+    assert body["error"] == "slow_down"
+    assert resp.headers["Retry-After"] == "2"

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -30463,7 +30463,7 @@
     },
     "/oauth/token": {
       "post": {
-        "description": "Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.\n\nError responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +\n``error_description``), NOT platform Problem Details — reshaped by\n``_TokenRoute``. On the refresh arm, a revoked consent grant answers\n``invalid_grant`` with ``error_description: \"consent grant has been\nrevoked\"`` — terminal; restart the authorization flow.",
+        "description": "Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.\n\nError responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +\n``error_description``), NOT platform Problem Details — reshaped by\n``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;\nfailed client authentication answers ``invalid_client`` (status 401 with a\n``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,\n400 otherwise). On the refresh arm, a revoked consent grant answers\n``invalid_grant`` with ``error_description: \"consent grant has been\nrevoked\"`` — terminal; restart the authorization flow.",
         "operationId": "tokenEndpoint",
         "requestBody": {
           "content": {
@@ -30674,7 +30674,7 @@
             "description": "Successful Response"
           },
           "400": {
-            "description": "RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{\"error\": \"invalid_grant\" | \"invalid_client\" | \"unsupported_grant_type\", \"error_description\": \"...\"}`. A revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: \"consent grant has been revoked\"` — clients should treat it as terminal and restart the authorization flow."
+            "description": "RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{\"error\": \"invalid_request\" | \"invalid_grant\" | \"invalid_client\" | \"unsupported_grant_type\", \"error_description\": \"...\"}`. `invalid_request` covers malformed/missing parameters; a revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: \"consent grant has been revoked\"` — clients should treat it as terminal and restart the authorization flow. A client whose authentication fails after attempting HTTP Basic (`Authorization` header, RFC 6749 §2.3.1) gets the same `invalid_client` dialect body with status 401 and a `WWW-Authenticate: Basic` challenge, per §5.2."
           },
           "422": {
             "content": {

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -30463,7 +30463,7 @@
     },
     "/oauth/token": {
       "post": {
-        "description": "Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.",
+        "description": "Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.\n\nError responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +\n``error_description``), NOT platform Problem Details — reshaped by\n``_TokenRoute``. On the refresh arm, a revoked consent grant answers\n``invalid_grant`` with ``error_description: \"consent grant has been\nrevoked\"`` — terminal; restart the authorization flow.",
         "operationId": "tokenEndpoint",
         "requestBody": {
           "content": {
@@ -30674,21 +30674,7 @@
             "description": "Successful Response"
           },
           "400": {
-            "content": {
-              "application/problem+json": {
-                "example": {
-                  "detail": "The request was malformed or failed a precondition.",
-                  "instance": "/example/path",
-                  "status": 400,
-                  "title": "Bad Request",
-                  "type": "bad_request"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request"
+            "description": "RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{\"error\": \"invalid_grant\" | \"invalid_client\" | \"unsupported_grant_type\", \"error_description\": \"...\"}`. A revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: \"consent grant has been revoked\"` — clients should treat it as terminal and restart the authorization flow."
           },
           "422": {
             "content": {
@@ -30712,6 +30698,9 @@
               }
             },
             "description": "Unprocessable Entity"
+          },
+          "429": {
+            "description": "Per-client+IP rate limit exceeded (`Retry-After` header set; RFC 6749 §5.2 dialect body, `error=slow_down` per RFC 8628 §3.5)."
           },
           "500": {
             "content": {

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -30676,29 +30676,6 @@
           "400": {
             "description": "RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): `{\"error\": \"invalid_request\" | \"invalid_grant\" | \"invalid_client\" | \"unsupported_grant_type\", \"error_description\": \"...\"}`. `invalid_request` covers malformed/missing parameters; a revoked consent grant surfaces on the refresh arm as `invalid_grant` with `error_description: \"consent grant has been revoked\"` — clients should treat it as terminal and restart the authorization flow. A client whose authentication fails after attempting HTTP Basic (`Authorization` header, RFC 6749 §2.3.1) gets the same `invalid_client` dialect body with status 401 and a `WWW-Authenticate: Basic` challenge, per §5.2."
           },
-          "422": {
-            "content": {
-              "application/problem+json": {
-                "example": {
-                  "detail": "Request validation failed; see errors[] for details.",
-                  "errors": [
-                    {
-                      "detail": "Field 'name' must not be blank.",
-                      "pointer": "#/name"
-                    }
-                  ],
-                  "instance": "/example/path",
-                  "status": 422,
-                  "title": "Unprocessable Entity",
-                  "type": "validation_error"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
           "429": {
             "description": "Per-client+IP rate limit exceeded (`Retry-After` header set; RFC 6749 §5.2 dialect body, `error=slow_down` per RFC 8628 §3.5)."
           },

--- a/ui/src/shared/api/generated/services/OAuthService.ts
+++ b/ui/src/shared/api/generated/services/OAuthService.ts
@@ -715,7 +715,6 @@ export class OAuthService {
             mediaType: 'application/json',
             errors: {
                 400: `RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): \`{"error": "invalid_request" | "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}\`. \`invalid_request\` covers malformed/missing parameters; a revoked consent grant surfaces on the refresh arm as \`invalid_grant\` with \`error_description: "consent grant has been revoked"\` — clients should treat it as terminal and restart the authorization flow. A client whose authentication fails after attempting HTTP Basic (\`Authorization\` header, RFC 6749 §2.3.1) gets the same \`invalid_client\` dialect body with status 401 and a \`WWW-Authenticate: Basic\` challenge, per §5.2.`,
-                422: `Unprocessable Entity`,
                 429: `Per-client+IP rate limit exceeded (\`Retry-After\` header set; RFC 6749 §5.2 dialect body, \`error=slow_down\` per RFC 8628 §3.5).`,
                 500: `Internal Server Error`,
                 503: `Service Unavailable`,

--- a/ui/src/shared/api/generated/services/OAuthService.ts
+++ b/ui/src/shared/api/generated/services/OAuthService.ts
@@ -685,7 +685,10 @@ export class OAuthService {
      *
      * Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
      * ``error_description``), NOT platform Problem Details — reshaped by
-     * ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+     * ``_TokenRoute``. Malformed/missing parameters answer ``invalid_request``;
+     * failed client authentication answers ``invalid_client`` (status 401 with a
+     * ``WWW-Authenticate: Basic`` challenge when the client attempted HTTP Basic,
+     * 400 otherwise). On the refresh arm, a revoked consent grant answers
      * ``invalid_grant`` with ``error_description: "consent grant has been
      * revoked"`` — terminal; restart the authorization flow.
      * @returns TokenResponse Successful Response
@@ -711,7 +714,7 @@ export class OAuthService {
             body: requestBody,
             mediaType: 'application/json',
             errors: {
-                400: `RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): \`{"error": "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}\`. A revoked consent grant surfaces on the refresh arm as \`invalid_grant\` with \`error_description: "consent grant has been revoked"\` — clients should treat it as terminal and restart the authorization flow.`,
+                400: `RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): \`{"error": "invalid_request" | "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}\`. \`invalid_request\` covers malformed/missing parameters; a revoked consent grant surfaces on the refresh arm as \`invalid_grant\` with \`error_description: "consent grant has been revoked"\` — clients should treat it as terminal and restart the authorization flow. A client whose authentication fails after attempting HTTP Basic (\`Authorization\` header, RFC 6749 §2.3.1) gets the same \`invalid_client\` dialect body with status 401 and a \`WWW-Authenticate: Basic\` challenge, per §5.2.`,
                 422: `Unprocessable Entity`,
                 429: `Per-client+IP rate limit exceeded (\`Retry-After\` header set; RFC 6749 §5.2 dialect body, \`error=slow_down\` per RFC 8628 §3.5).`,
                 500: `Internal Server Error`,

--- a/ui/src/shared/api/generated/services/OAuthService.ts
+++ b/ui/src/shared/api/generated/services/OAuthService.ts
@@ -682,6 +682,12 @@ export class OAuthService {
     /**
      * Token Endpoint
      * Exchange a refresh token, JWT assertion, authorization code, or client creds for tokens.
+     *
+     * Error responses speak the RFC 6749 §5.2 dialect (top-level ``error`` +
+     * ``error_description``), NOT platform Problem Details — reshaped by
+     * ``_TokenRoute``. On the refresh arm, a revoked consent grant answers
+     * ``invalid_grant`` with ``error_description: "consent grant has been
+     * revoked"`` — terminal; restart the authorization flow.
      * @returns TokenResponse Successful Response
      * @throws ApiError
      */
@@ -705,8 +711,9 @@ export class OAuthService {
             body: requestBody,
             mediaType: 'application/json',
             errors: {
-                400: `Bad Request`,
+                400: `RFC 6749 §5.2 error dialect (NOT platform Problem Details — this is a spec-facing endpoint real OAuth/MCP clients parse): \`{"error": "invalid_grant" | "invalid_client" | "unsupported_grant_type", "error_description": "..."}\`. A revoked consent grant surfaces on the refresh arm as \`invalid_grant\` with \`error_description: "consent grant has been revoked"\` — clients should treat it as terminal and restart the authorization flow.`,
                 422: `Unprocessable Entity`,
+                429: `Per-client+IP rate limit exceeded (\`Retry-After\` header set; RFC 6749 §5.2 dialect body, \`error=slow_down\` per RFC 8628 §3.5).`,
                 500: `Internal Server Error`,
                 503: `Service Unavailable`,
             },


### PR DESCRIPTION
Closes #1252

## Problem

`POST /oauth/token` emitted its errors as RFC 9457 problem-details (`{"type": "invalid_grant", "detail": …}`) via the platform-wide handlers (`auth/web/errors.py`). RFC 6749 §5.2 **REQUIRES** the `{"error": …, "error_description": …}` shape on the token endpoint, and real MCP clients (mcp-remote's zod schema, Cursor's MCP SDK) parse only that shape — so a client whose consent grant was revoked saw an opaque 400 it could not classify and **silently wedged**, replaying its dead refresh token forever instead of restarting authorization.

## Recheck of the issue's original claims (what was already fixed)

- The refresh arm **already** re-checks the consent grant per rotation and raises `InvalidGrantError("consent grant has been revoked")` (`token_service.py`) — no service-layer change needed.
- `/mcp` 401s **already** carry the RFC 9728 challenge.
- The remaining defect was purely the **wire dialect** of the token endpoint's errors. (A recheck comment is on the issue.)

## Fix — scoped ONLY to the spec-facing endpoint

- A route class (`_TokenRoute`) reshapes `POST /oauth/token` errors to §5.2, following the two in-repo precedents: the RFC 7009 form arm of `/oauth/revoke` (`_rfc6749_error`) and the DCR door's RFC 7591 §3.2.2 reshaping. Wrapping the route handler covers errors raised in the **dependency chain** (body parsing, rate limit) too.
- `InvalidGrantError` gains an `oauth_error_code` attribute so raise sites whose condition §5.2 names differently stamp their proper code: `invalid_client` (failed client authentication, both auth-code and refresh arms) and `unsupported_grant_type`. Everything else stays `invalid_grant`; the exception reason becomes `error_description`.
- The 429 arm answers `error=slow_down` (RFC 8628 §3.5 — §5.2 registry's back-off code) with `Retry-After` intact; all reshaped errors carry §5.2's no-store cache posture.
- **Platform problem-details are untouched everywhere else** — including `/oauth/introspect` (RFC 7662 prescribes no §5.2 body for resource-server introspection; its consumers are platform-internal) and `/oauth/mint` (platform-proprietary). 5xx (e.g. database-unavailable) deliberately still speaks problem-details — §5.2 governs the 400-class token-request errors, and the shape is pinned by the existing db-unavailable test.
- OpenAPI: the 400/429 responses are documented on the operation; spec + UI codegen + Go client regen committed.

## Go CLI (same PR, per the issue)

`classifyTokenError` (`cli/client/auth/oauth.go`) **already parsed both shapes** (taught in the V2 port), so no behaviour change was needed — verified, not assumed:

- Comments now name the 6749 shape as the shipped dialect and 7807 as the legacy-backend fallback.
- The register/setup-flow mock backends (`register_test.go`, `setup_test.go`) now emit the **new** shape, so the wait-loop/claim-flow tests prove the CLI against the real backend dialect; the classifier's own table test retains the legacy 7807 case.
- New table test `TestClassifyTokenError_Rfc6749DistinctCodes`: `invalid_client`, `unsupported_grant_type`, and 429 `slow_down` are hard errors carrying code + description — never misclassified as "pending approval".

## Tests

- New `tests/unit/auth/web/test_oauth_token_error_dialect.py` pins the exact wire shape per arm — **refresh-with-revoked-grant** (`{"error":"invalid_grant","error_description":"consent grant has been revoked"}`), `invalid_client`, `unsupported_grant_type`, dependency-raised parse errors, and the 429 `slow_down` + `Retry-After` arm — with the problem-details handler registered, proving the route-level reshaping wins.
- Existing token-endpoint tests updated from `["type"]` to `["error"]` assertions (assertions on non-token endpoints — `/oauth/mint`, `/oauth/approval/status` — intentionally unchanged).
- Gates: backend fmt/lint/typecheck green; 899 unit auth + arch tests, 126 sqlite integration tests green; Go `build` + `client/auth` + `internal/cli/api` suites green.
- Not run locally: the Postgres-only `tests/web` leg (no Docker available on this machine — errors were all `connect 5432` environmental failures; audited that no test in it asserts the old token error shape). CI's Postgres leg covers it.

Made with [Cursor](https://cursor.com)

## Adversarial review lap (post-review fixes on this branch)

- `94abda2` — **§5.2 conformance gaps found in review, fixed**:
  - Malformed/missing token-request parameters now answer `invalid_request`, not `invalid_grant` (which tells an RFC-compliant client to restart authorization over a request-shape bug).
  - Failed client authentication attempted via **HTTP Basic** (§2.3.1 — the endpoint supports it) answers **401 + `WWW-Authenticate: Basic`** — a §5.2 MUST. Body-credential failures keep the 400.
  - The **client_credentials arm** (`service_account_auth_service`) was still emitting `{"error": "invalid_grant", "error_description": "invalid_client"}` — now stamps `oauth_error_code="invalid_client"` like the other two arms.
  - Go classifier table test extended with `invalid_request` and the 401-Basic `invalid_client` arm.
- `743cf9c` — the generated spec advertised an **unreachable RFC 9457 422** on `tokenEndpoint` (body parsing never goes through FastAPI validation); dropped via the DCR door's mechanism (`ROUTER_RESHAPED_422_OPERATION_IDS`).

### Noted, deliberately not changed

- The 401 arm can't be a separate response entry in the generated spec: `tokenEndpoint` is a `PUBLIC_OPERATION_IDS` member and the post-processor strips 401/403 there. It is documented in the 400 response description and the operation description instead. Reclassifying to `NON_BEARER_AUTH_OPERATION_IDS` would cascade into the endpoint reference (`endpoints.json`, `assert_classification_is_sound`) — left as a possible follow-up.
- `_extract_client_id` (the rate-limit bucket key) reads only body credentials, so Basic-authenticated clients bucket by bare IP. Pre-existing; harmless (coarser bucket), noting for completeness.
- `/oauth/mint` reasons like `invalid_scope: …` stay Problem Details — platform-proprietary endpoint, per this PR's scoping.
