### PR TITLE
fix(auth): revoke oauth consent grants when an agent is archived

### DIFF
--- a/src/jentic_one/auth/services/agent_service.py
+++ b/src/jentic_one/auth/services/agent_service.py
@@ -29,7 +29,10 @@ from jentic_one.auth.services.errors import (
     ToolkitBindingConflictError,
     ToolkitBindingNotFoundError,
 )
-from jentic_one.auth.services.oauth_grant_service import revoke_active_grants_for_agent
+from jentic_one.auth.services.oauth_grant_service import (
+    AGENT_ARCHIVE_REVOCATION_REASON,
+    revoke_active_grants_for_agent,
+)
 from jentic_one.auth.services.registration_service import validate_jwks
 from jentic_one.auth.services.schemas.agents import (
     AgentCreatePayload,
@@ -423,6 +426,23 @@ class AgentService:
             await AgentRepository.archive(session, agent_id)
             await ActorScopeGrantRepository.revoke_all(session, agent_id)
             await AgentToolkitBindingRepository.delete_for_agent(session, agent_id)
+            # #1233 (archive arm): archive is terminal — the status enum has
+            # no exit — so any consent grant left `active` would misreport
+            # every "active grants" listing/count on a dead agent forever.
+            # Sweep them in the archive's own transaction, reusing the G10
+            # per-agent revocation body (row flip + token sweep + audit +
+            # event) with an archive stamp. `disable` deliberately does NOT
+            # sweep: it is reversible, and whether re-enable should require
+            # fresh consent is an open policy question (#1233).
+            await revoke_active_grants_for_agent(
+                session,
+                agent_id,
+                identity=identity,
+                audit_reason="oauth grant revoked: agent archived",
+                event_reason=AGENT_ARCHIVE_REVOCATION_REASON,
+                summary_cause="was archived",
+                log_event="oauth_grants_revoked_on_agent_archive",
+            )
             await record_audit(
                 session,
                 action=AuditAction.ARCHIVE,

--- a/src/jentic_one/auth/services/oauth_grant_service.py
+++ b/src/jentic_one/auth/services/oauth_grant_service.py
@@ -57,6 +57,13 @@ _ADMIN_READ_PERMISSIONS: frozenset[str] = GRANT_REVOKE_ADMIN_PERMISSIONS | {OAUT
 #: following the ``OVERLAY_DEPRECATED`` cause-in-data pattern).
 AGENT_TRANSFER_REVOCATION_REASON = "agent_ownership_transferred"
 
+#: The revocation cause stamped on grants swept by an agent archive (#1233):
+#: archive is terminal (the status enum has no exit from it), so leaving the
+#: agent's consent grants ``active`` forever would misreport every "active
+#: grants" listing/count on a dead agent. Same cause-in-data pattern as the
+#: transfer reason above.
+AGENT_ARCHIVE_REVOCATION_REASON = "agent_archived"
+
 
 async def revoke_grant_and_sweep_tokens(
     session: AsyncSession,
@@ -129,22 +136,30 @@ async def revoke_active_grants_for_agent(
     agent_id: str,
     *,
     identity: Identity,
+    audit_reason: str = "oauth grant revoked: agent ownership transferred",
+    event_reason: str = AGENT_TRANSFER_REVOCATION_REASON,
+    summary_cause: str = "changed owner",
+    log_event: str = "oauth_grants_revoked_on_agent_transfer",
 ) -> int:
-    """Revoke EVERY active grant bound to ``agent_id`` — the transfer sweep (G10, #1222).
+    """Revoke EVERY active grant bound to ``agent_id`` — the per-agent sweep.
 
-    Called by ``AgentService.update_agent`` inside the ownership-transfer
-    transaction: a transferred agent must not keep grants consented by its
-    previous owner (the new owner could not revoke them self-serve — the
-    ``:revoke`` predicate keys on the consenting user). Runs the same
-    per-grant revocation body as the manual kill switch, stamped with
-    :data:`AGENT_TRANSFER_REVOCATION_REASON` and attributed to the actor
-    performing the transfer.
+    Born as the transfer sweep (G10, #1222; the cause parameters default to
+    that stamp so the transfer call site reads unchanged): a transferred
+    agent must not keep grants consented by its previous owner (the new owner
+    could not revoke them self-serve — the ``:revoke`` predicate keys on the
+    consenting user). ``AgentService.archive`` reuses it with the archive
+    stamp (#1233): archive is terminal, so its grants would otherwise stay
+    ``active`` forever. Any new caller MUST pass its own ``audit_reason`` /
+    ``event_reason`` / ``summary_cause`` / ``log_event`` — never let a
+    different cause masquerade as a transfer. Runs the same per-grant
+    revocation body as the manual kill switch, attributed to the actor
+    performing the mutation.
 
     Deliberately NO ``viewer_can_revoke`` check: authority comes from the
-    ``agents:write`` gate on the transfer itself. Flush-only and NOT
+    ``agents:write`` gate on the mutation itself. Flush-only and NOT
     best-effort — an exception propagates so a failed sweep rolls the whole
-    transfer back rather than leaving a transferred agent with live grants.
-    Returns the number of grants revoked.
+    mutation back rather than leaving a dead/transferred agent with live
+    grants. Returns the number of grants revoked.
     """
     grants = await OAuthClientGrantRepository.list_active_for_agent(session, agent_id)
     for grant in grants:
@@ -154,16 +169,16 @@ async def revoke_active_grants_for_agent(
             actor_type=identity.actor_type,
             actor_id=identity.sub,
             origin=identity.origin.value,
-            audit_reason="oauth grant revoked: agent ownership transferred",
+            audit_reason=audit_reason,
             summary=(
                 f"OAuth grant {grant.id} for client '{grant.oauth_client_id}' was "
-                f"revoked because agent {agent_id} changed owner"
+                f"revoked because agent {agent_id} {summary_cause}"
             ),
-            event_reason=AGENT_TRANSFER_REVOCATION_REASON,
+            event_reason=event_reason,
         )
     if grants:
         logger.info(
-            "oauth_grants_revoked_on_agent_transfer",
+            log_event,
             agent_id=agent_id,
             count=len(grants),
             actor_id=identity.sub,

--- a/tests/integration/auth/test_oauth_grant_archive_sweep.py
+++ b/tests/integration/auth/test_oauth_grant_archive_sweep.py
@@ -1,0 +1,188 @@
+"""Integration tests for grant revocation on agent archive (#1233, archive arm).
+
+``AgentService.archive`` is terminal — ``ActorStatus`` has no exit from
+``ARCHIVED`` — yet before this fix it swept scope grants and toolkit bindings
+while leaving the agent's ``oauth_client_grants`` rows ``active`` forever.
+That is not a live credential (both resolvers and refresh gate on
+``agent.status == 'active'``), but every "active grants" listing/count — the
+per-agent "Connected clients" panel, ``count_active_by_client``, the admin
+cross-view — reported live consent on a dead agent. The fix reuses the G10
+transfer sweep (``revoke_active_grants_for_agent``) inside the archive
+transaction with an archive-specific cause stamp.
+
+``disable`` deliberately does NOT sweep — it is reversible, and whether
+re-enable should require fresh consent is an open policy question tracked in
+#1233. The disable test below PINS that current behaviour on purpose.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from jentic_one.admin.core.schema.audit import AuditEntry
+from jentic_one.admin.core.schema.events import Event
+from jentic_one.admin.repos import AgentRepository
+from jentic_one.auth.services.agent_service import AgentService
+from jentic_one.auth.services.errors import InvalidGrantError
+from jentic_one.auth.services.oauth_grant_service import (
+    AGENT_ARCHIVE_REVOCATION_REASON,
+    OAuthGrantService,
+)
+from jentic_one.auth.services.token_service import TokenService
+from jentic_one.broker.repos.token_resolver import InProcessTokenResolver
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.context import Context
+from jentic_one.shared.models.events import EventType
+from tests.integration.auth import seeds
+
+pytestmark = pytest.mark.integration
+
+
+def _admin_identity(admin_id: str) -> Identity:
+    return Identity(
+        sub=admin_id,
+        email="admin@archive-sweep.test",
+        permissions=["agents:write", "agents:read", "org:admin"],
+    )
+
+
+async def _revoked_events(ctx: Context, agent_id: str) -> list[Event]:
+    """``oauth_grant.revoked`` events for one agent (events survive clean_grants)."""
+    async with ctx.admin_db.session() as session:
+        result = await session.execute(
+            select(Event).where(Event.type == EventType.OAUTH_GRANT_REVOKED)
+        )
+        return [e for e in result.scalars().all() if (e.data or {}).get("agent_id") == agent_id]
+
+
+async def _revoke_audit_rows(ctx: Context, grant_ids: set[str]) -> list[AuditEntry]:
+    async with ctx.admin_db.session() as session:
+        result = await session.execute(
+            select(AuditEntry).where(
+                AuditEntry.target_type == "oauth_grant",
+                AuditEntry.target_id.in_(grant_ids),
+                AuditEntry.action == "revoke",
+            )
+        )
+        return list(result.scalars().all())
+
+
+async def test_archive_revokes_active_grants_and_fails_refresh_closed(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """Archive → the agent's active grant is revoked in the same mutation,
+    its tokens are dead on BOTH resolvers, refresh fails closed, and the
+    audit row + event carry the ARCHIVE stamp (never the transfer one)."""
+    ctx = integration_context
+    owner = await seeds.seed_user(ctx, "usr_arc_owner")
+    admin_id = await seeds.seed_user(ctx, "usr_arc_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=owner, scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    grant_id, access, refresh, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=owner, agent_id=agent_id, grant_scopes=["apis:read"]
+    )
+
+    await AgentService(ctx).archive(agent_id, identity=_admin_identity(admin_id))
+
+    # The grant row itself is revoked — not merely masked by the status gate.
+    grant = await OAuthGrantService(ctx).get_grant(grant_id)
+    assert grant is not None and grant.status == "revoked"
+    assert grant.revoked_at is not None
+
+    # Tokens dead on both resolvers; refresh fails closed (the grant re-check
+    # and the actor-active gate both refuse — either way InvalidGrantError).
+    token_svc = TokenService(ctx)
+    assert await token_svc.resolve_access_token(access) is None
+    broker_resolved = await InProcessTokenResolver(ctx.admin_db).resolve_access_token(access)
+    assert broker_resolved is not None and broker_resolved.active is False
+    with pytest.raises(InvalidGrantError):
+        await token_svc.refresh(refresh, client_id=seeds.CLIENT_ID)
+
+    # Audit: one REVOKE for the grant, stamped with the archive reason and
+    # attributed to the archiving admin.
+    audits = await _revoke_audit_rows(ctx, {grant_id})
+    assert len(audits) == 1
+    assert audits[0].reason == "oauth grant revoked: agent archived"
+    assert audits[0].actor_id == admin_id
+
+    # Event: oauth_grant.revoked with data.reason distinguishing the archive
+    # cause from a manual :revoke and from the G10 transfer sweep.
+    events = await _revoked_events(ctx, agent_id)
+    assert [e for e in events if (e.data or {}).get("grant_id") == grant_id]
+    for event in events:
+        if (event.data or {}).get("grant_id") == grant_id:
+            assert (event.data or {}).get("reason") == AGENT_ARCHIVE_REVOCATION_REASON
+            assert event.created_by == admin_id
+
+
+async def test_disable_leaves_grants_active_by_design(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """PINS the deliberately-open half of #1233: ``disable`` does NOT sweep.
+
+    Disable is a reversible state — whether re-enable should require fresh
+    consent (sweep on disable) or restore the standing consent (leave grants)
+    is an open policy question, so this test pins the CURRENT behaviour:
+    the grant row stays ``active``, while the platform still fails closed at
+    the token layer (no token resolves and refresh refuses for a non-active
+    agent — the #1136 gates). If a decision lands to sweep on disable, this
+    test is the one to flip.
+    """
+    ctx = integration_context
+    owner = await seeds.seed_user(ctx, "usr_dis_owner")
+    admin_id = await seeds.seed_user(ctx, "usr_dis_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=owner, scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    grant_id, access, refresh, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=owner, agent_id=agent_id, grant_scopes=["apis:read"]
+    )
+
+    await AgentService(ctx).disable(agent_id, identity=_admin_identity(admin_id))
+
+    # The grant row is untouched (the open question) …
+    grant = await OAuthGrantService(ctx).get_grant(grant_id)
+    assert grant is not None and grant.status == "active"
+    assert await _revoked_events(ctx, agent_id) == []
+
+    # … but nothing is live: the status gates fail the tokens closed anyway.
+    token_svc = TokenService(ctx)
+    resolved = await token_svc.resolve_access_token(access)
+    assert resolved is None or resolved.active is False
+    with pytest.raises(InvalidGrantError, match="not active"):
+        await token_svc.refresh(refresh, client_id=seeds.CLIENT_ID)
+
+
+async def test_archive_rolls_back_when_grant_sweep_fails(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """Same-transaction pin (mirrors the G10 rollback test): if the sweep
+    fails mid-archive, the WHOLE archive rolls back — the agent stays active
+    and the grant lives on. Fails if the sweep ever moves outside the archive
+    transaction."""
+    ctx = integration_context
+    owner = await seeds.seed_user(ctx, "usr_arb_owner")
+    admin_id = await seeds.seed_user(ctx, "usr_arb_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=owner, scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    grant_id, access, _refresh, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=owner, agent_id=agent_id, grant_scopes=["apis:read"]
+    )
+
+    with (
+        patch(
+            "jentic_one.auth.services.oauth_grant_service.AccessTokenRepository.revoke_by_grant",
+            new=AsyncMock(side_effect=RuntimeError("sweep exploded")),
+        ),
+        pytest.raises(RuntimeError, match="sweep exploded"),
+    ):
+        await AgentService(ctx).archive(agent_id, identity=_admin_identity(admin_id))
+
+    async with ctx.admin_db.session() as session:
+        agent = await AgentRepository.get_by_id(session, agent_id)
+    assert agent is not None and agent.status == "active"
+    grant = await OAuthGrantService(ctx).get_grant(grant_id)
+    assert grant is not None and grant.status == "active"
+    assert await TokenService(ctx).resolve_access_token(access) is not None


### PR DESCRIPTION
Refs #1233 (archive arm — the disable arm is deliberately left open, see below)

## Problem

`AgentService.archive` swept `ActorScopeGrantRepository.revoke_all` and `AgentToolkitBindingRepository.delete_for_agent`, but never `oauth_client_grants`. Archive is **terminal** (`ActorStatus` has no exit from `ARCHIVED`), so the agent's consent grants stayed `active` forever — not a live credential (both token resolvers and refresh gate on `agent.status == 'active'`), but every "active grants" surface (per-agent connected-clients panel, `count_active_by_client`, the admin cross-view) reported live consent on a dead agent, and no self-serve revoke was guaranteed to happen.

## Fix

- `revoke_active_grants_for_agent` (`oauth_grant_service.py`, the G10/#1231 transfer sweep) is extended **minimally** with cause parameters — `audit_reason`, `event_reason`, `summary_cause`, `log_event` — defaulting to the transfer stamp so the existing transfer call site reads unchanged. Its docstring now requires any new caller to pass its own cause, so a different mutation can never masquerade as a transfer in audit/events.
- New constant `AGENT_ARCHIVE_REVOCATION_REASON = "agent_archived"`, following the transfer constant's cause-in-data pattern.
- `AgentService.archive` calls the sweep **inside the archive transaction** (audit reason `"oauth grant revoked: agent archived"`, event `data.reason = "agent_archived"`, log event `oauth_grants_revoked_on_agent_archive`) — same per-grant body as the manual kill switch and the G10 sweep: row flip + token sweep + audit + event, flush-only, fail-safe (a failed sweep rolls the whole archive back).

## The disable arm — explicitly NOT touched

`disable()` is a **reversible** state, and whether re-enable should require fresh consent (sweep on disable) or restore standing consent (leave grants) is an open policy question. This PR pins the current behaviour with a test (`test_disable_leaves_grants_active_by_design`) that also proves the platform still fails disabled agents closed at the token layer (#1136 gates: nothing resolves, refresh refuses `not active`). The issue names both arms, so it stays **open** for the disable-policy decision — comment posted there.

## Tests (`tests/integration/auth/test_oauth_grant_archive_sweep.py`)

- **Archive sweeps**: grant exists → archive → grant row `revoked` + `revoked_at`, tokens dead on both resolvers (TokenService + broker InProcessTokenResolver), **refresh after archive fails closed** (grant re-check + actor gate), audit row with the archive reason attributed to the archiving admin, `oauth_grant.revoked` event with `data.reason = "agent_archived"`.
- **Disable does not sweep** (pins the open question; asserts token-layer fail-closed anyway).
- **Same-transaction pin**: a failure injected inside the sweep rolls back the whole archive (agent stays `active`, grant lives on) — fails if the sweep ever moves out of the archive transaction.
- Existing coverage verified, not duplicated: `test_archived_agent_token_is_inactive` and `test_disabled_agent_cannot_refresh_to_fresh_tokens` (`test_token_endpoints.py`) already pin the status gates; the G10 transfer suite (7 tests) still green against the parametrised helper.
- Gates: fmt/lint/typecheck green; 894 unit auth + arch tests and the full sqlite integration-auth suite (129) green. No web/OpenAPI/UI surface touched (service layer only), so no codegen needed.

Made with [Cursor](https://cursor.com)