### PR TITLE
feat(admin): hard delete for OAuth clients

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,21 +164,21 @@
         "filename": "cli/client/generated/control/client.go",
         "hashed_secret": "36c46a098c7543cc8569553d4a8946bc7df395c9",
         "is_verified": false,
-        "line_number": 3989
+        "line_number": 4044
       },
       {
         "type": "Secret Keyword",
         "filename": "cli/client/generated/control/client.go",
         "hashed_secret": "dc0acf6e95f2dcba19616d63c275e8a749126f89",
         "is_verified": false,
-        "line_number": 5272
+        "line_number": 5342
       },
       {
         "type": "Secret Keyword",
         "filename": "cli/client/generated/control/client.go",
         "hashed_secret": "8cf6cb4d35e002c25f800782aab43af23d9e1f2c",
         "is_verified": false,
-        "line_number": 8200
+        "line_number": 8420
       }
     ],
     "cli/client/generated/control/spec.yaml": [
@@ -187,14 +187,14 @@
         "filename": "cli/client/generated/control/spec.yaml",
         "hashed_secret": "dee67f5ea3d3b2b47c2c5d5b9f025652b13ec557",
         "is_verified": false,
-        "line_number": 5051
+        "line_number": 5098
       },
       {
         "type": "Secret Keyword",
         "filename": "cli/client/generated/control/spec.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 20042
+        "line_number": 20307
       }
     ],
     "cli/internal/cli/api/admin_providers.go": [
@@ -499,14 +499,14 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "dee67f5ea3d3b2b47c2c5d5b9f025652b13ec557",
         "is_verified": false,
-        "line_number": 5051
+        "line_number": 5098
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 20042
+        "line_number": 20307
       }
     ],
     "release-please-config.json": [
@@ -1351,14 +1351,14 @@
         "filename": "tests/integration/auth/seeds.py",
         "hashed_secret": "1c417764b451bbedccdd6962ee5d113735fec0f6",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 31
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/auth/seeds.py",
         "hashed_secret": "abf7aad6438836dbe526aa231abde2d0eef74d42",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 55
       }
     ],
     "tests/integration/auth/test_local_login_flow.py": [
@@ -1688,6 +1688,15 @@
         "line_number": 23
       }
     ],
+    "tests/unit/auth/web/test_consent_agent_create.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/auth/web/test_consent_agent_create.py",
+        "hashed_secret": "1a8d32f11d054ac7ca65aa549e20ba4dae7b8f6a",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
     "tests/unit/auth/web/test_consent_agent_picker.py": [
       {
         "type": "Secret Keyword",
@@ -1795,7 +1804,7 @@
         "filename": "tests/unit/auth/web/test_oauth_client_credentials.py",
         "hashed_secret": "bee7a0aa6017e98bbfbae6b7b1dfb5c64105172b",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 142
       }
     ],
     "tests/unit/auth/web/test_oauth_response_shape.py": [
@@ -1805,6 +1814,15 @@
         "hashed_secret": "9251c77b74cbfe6c2e1fbf5f7eeb6e14bd1ba37a",
         "is_verified": false,
         "line_number": 299
+      }
+    ],
+    "tests/unit/auth/web/test_oauth_token_error_dialect.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/auth/web/test_oauth_token_error_dialect.py",
+        "hashed_secret": "4b0fa1dc9ae271edd6703333714ba3c44ef99389",
+        "is_verified": false,
+        "line_number": 103
       }
     ],
     "tests/unit/broker/test_execute_credential_name.py": [
@@ -1962,7 +1980,7 @@
         "filename": "tests/unit/shared/test_instance_identity.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 168
+        "line_number": 181
       }
     ],
     "tests/unit/shared/test_sigv4.py": [
@@ -2097,7 +2115,7 @@
         "filename": "ui/openapi.json",
         "hashed_secret": "dee67f5ea3d3b2b47c2c5d5b9f025652b13ec557",
         "is_verified": false,
-        "line_number": 7731
+        "line_number": 7787
       }
     ],
     "ui/public/mockServiceWorker.js": [
@@ -2122,16 +2140,9 @@
       {
         "type": "Secret Keyword",
         "filename": "ui/src/modules/settings/mocks/handlers.ts",
-        "hashed_secret": "94c5baee3752a08be577c41f893cd5492c8da0f0",
-        "is_verified": false,
-        "line_number": 140
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "ui/src/modules/settings/mocks/handlers.ts",
         "hashed_secret": "174370dab21ffc7e4493d1f9b56305d50f8b70dd",
         "is_verified": false,
-        "line_number": 171
+        "line_number": 351
       }
     ],
     "ui/src/modules/toolkits/api/types.ts": [
@@ -2272,5 +2283,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-08T13:20:43Z"
+  "generated_at": "2026-09-11T10:36:13Z"
 }

--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -5101,6 +5101,21 @@ type ClientInterface interface {
 	// Corresponds with POST /admin/oauth-clients/{id}:approve (the `ApproveOauthClient` operationId).
 	ApproveOauthClient(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// DeleteOauthClient Delete OAuth client
+	//
+	// Permanently delete an OAuth client. This cannot be undone.
+	//
+	// Terminal, unlike the reversible kill switch (``DELETE`` on this
+	// resource, which only sets ``active=false``): every active grant is
+	// revoked, every token carrying the client's lineage is revoked, and the
+	// registration row is removed — connected applications are fully
+	// disconnected. The audit trail survives. A client that later re-registers
+	// via dynamic client registration is a NEW registration and re-enters the
+	// approval queue as pending; it is never re-attached to the deleted one.
+	//
+	// Corresponds with POST /admin/oauth-clients/{id}:delete (the `DeleteOauthClient` operationId).
+	DeleteOauthClient(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// DenyOauthClientWithBody Deny OAuth client
 	//
 	// Deny an OAuth client — sets approval_status=denied and active=false.
@@ -7914,6 +7929,31 @@ func (c *Client) RotateOauthClientSecret(ctx context.Context, id string, reqEdit
 // Corresponds with POST /admin/oauth-clients/{id}:approve (the `ApproveOauthClient` operationId).
 func (c *Client) ApproveOauthClient(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewApproveOauthClientRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// DeleteOauthClient Delete OAuth client
+//
+// Permanently delete an OAuth client. This cannot be undone.
+//
+// Terminal, unlike the reversible kill switch (“DELETE“ on this
+// resource, which only sets “active=false“): every active grant is
+// revoked, every token carrying the client's lineage is revoked, and the
+// registration row is removed — connected applications are fully
+// disconnected. The audit trail survives. A client that later re-registers
+// via dynamic client registration is a NEW registration and re-enters the
+// approval queue as pending; it is never re-attached to the deleted one.
+//
+// Corresponds with POST /admin/oauth-clients/{id}:delete (the `DeleteOauthClient` operationId).
+func (c *Client) DeleteOauthClient(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteOauthClientRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -13166,6 +13206,40 @@ func NewApproveOauthClientRequest(server string, id string) (*http.Request, erro
 	}
 
 	operationPath := fmt.Sprintf("/admin/oauth-clients/%s:approve", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDeleteOauthClientRequest constructs an http.Request for the DeleteOauthClient method
+func NewDeleteOauthClientRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/admin/oauth-clients/%s:delete", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -21694,6 +21768,23 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with POST /admin/oauth-clients/{id}:approve (the `ApproveOauthClient` operationId).
 	ApproveOauthClientWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ApproveOauthClientHTTPResp, error)
 
+	// DeleteOauthClientWithResponse Delete OAuth client
+	//
+	// Permanently delete an OAuth client. This cannot be undone.
+	//
+	// Terminal, unlike the reversible kill switch (``DELETE`` on this
+	// resource, which only sets ``active=false``): every active grant is
+	// revoked, every token carrying the client's lineage is revoked, and the
+	// registration row is removed — connected applications are fully
+	// disconnected. The audit trail survives. A client that later re-registers
+	// via dynamic client registration is a NEW registration and re-enters the
+	// approval queue as pending; it is never re-attached to the deleted one.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /admin/oauth-clients/{id}:delete (the `DeleteOauthClient` operationId).
+	DeleteOauthClientWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteOauthClientHTTPResp, error)
+
 	// DenyOauthClientWithBodyWithResponse Deny OAuth client
 	//
 	// Deny an OAuth client — sets approval_status=denied and active=false.
@@ -26046,6 +26137,89 @@ func (r ApproveOauthClientHTTPResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r ApproveOauthClientHTTPResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteOauthClientHTTPResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// ApplicationproblemJSON400 the response for an HTTP 400 `application/problem+json` response
+	ApplicationproblemJSON400 *ProblemDetail
+	// ApplicationproblemJSON401 the response for an HTTP 401 `application/problem+json` response
+	ApplicationproblemJSON401 *ProblemDetail
+	// ApplicationproblemJSON403 the response for an HTTP 403 `application/problem+json` response
+	ApplicationproblemJSON403 *ProblemDetail
+	// ApplicationproblemJSON404 the response for an HTTP 404 `application/problem+json` response
+	ApplicationproblemJSON404 *ProblemDetail
+	// ApplicationproblemJSON422 the response for an HTTP 422 `application/problem+json` response
+	ApplicationproblemJSON422 *ProblemDetail
+	// ApplicationproblemJSON500 the response for an HTTP 500 `application/problem+json` response
+	ApplicationproblemJSON500 *ProblemDetail
+	// ApplicationproblemJSON503 the response for an HTTP 503 `application/problem+json` response
+	ApplicationproblemJSON503 *ProblemDetail
+}
+
+// GetApplicationproblemJSON400 returns the response for an HTTP 400 `application/problem+json` response
+func (r DeleteOauthClientHTTPResp) GetApplicationproblemJSON400() *ProblemDetail {
+	return r.ApplicationproblemJSON400
+}
+
+// GetApplicationproblemJSON401 returns the response for an HTTP 401 `application/problem+json` response
+func (r DeleteOauthClientHTTPResp) GetApplicationproblemJSON401() *ProblemDetail {
+	return r.ApplicationproblemJSON401
+}
+
+// GetApplicationproblemJSON403 returns the response for an HTTP 403 `application/problem+json` response
+func (r DeleteOauthClientHTTPResp) GetApplicationproblemJSON403() *ProblemDetail {
+	return r.ApplicationproblemJSON403
+}
+
+// GetApplicationproblemJSON404 returns the response for an HTTP 404 `application/problem+json` response
+func (r DeleteOauthClientHTTPResp) GetApplicationproblemJSON404() *ProblemDetail {
+	return r.ApplicationproblemJSON404
+}
+
+// GetApplicationproblemJSON422 returns the response for an HTTP 422 `application/problem+json` response
+func (r DeleteOauthClientHTTPResp) GetApplicationproblemJSON422() *ProblemDetail {
+	return r.ApplicationproblemJSON422
+}
+
+// GetApplicationproblemJSON500 returns the response for an HTTP 500 `application/problem+json` response
+func (r DeleteOauthClientHTTPResp) GetApplicationproblemJSON500() *ProblemDetail {
+	return r.ApplicationproblemJSON500
+}
+
+// GetApplicationproblemJSON503 returns the response for an HTTP 503 `application/problem+json` response
+func (r DeleteOauthClientHTTPResp) GetApplicationproblemJSON503() *ProblemDetail {
+	return r.ApplicationproblemJSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r DeleteOauthClientHTTPResp) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteOauthClientHTTPResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteOauthClientHTTPResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteOauthClientHTTPResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -38949,6 +39123,29 @@ func (c *ClientWithResponses) ApproveOauthClientWithResponse(ctx context.Context
 	return ParseApproveOauthClientHTTPResp(rsp)
 }
 
+// DeleteOauthClientWithResponse Delete OAuth client
+//
+// Permanently delete an OAuth client. This cannot be undone.
+//
+// Terminal, unlike the reversible kill switch (“DELETE“ on this
+// resource, which only sets “active=false“): every active grant is
+// revoked, every token carrying the client's lineage is revoked, and the
+// registration row is removed — connected applications are fully
+// disconnected. The audit trail survives. A client that later re-registers
+// via dynamic client registration is a NEW registration and re-enters the
+// approval queue as pending; it is never re-attached to the deleted one.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /admin/oauth-clients/{id}:delete (the `DeleteOauthClient` operationId).
+func (c *ClientWithResponses) DeleteOauthClientWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteOauthClientHTTPResp, error) {
+	rsp, err := c.DeleteOauthClient(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteOauthClientHTTPResp(rsp)
+}
+
 // DenyOauthClientWithBodyWithResponse Deny OAuth client
 //
 // Deny an OAuth client — sets approval_status=denied and active=false.
@@ -44172,6 +44369,77 @@ func ParseApproveOauthClientHTTPResp(rsp *http.Response) (*ApproveOauthClientHTT
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ProblemDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteOauthClientHTTPResp parses an HTTP response from a DeleteOauthClientWithResponse call
+func ParseDeleteOauthClientHTTPResp(rsp *http.Response) (*DeleteOauthClientHTTPResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteOauthClientHTTPResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 204:
+		break // No content-type
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest ProblemDetail

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -8466,6 +8466,83 @@ paths:
       summary: Approve OAuth client
       tags:
       - OAuth Clients
+  /admin/oauth-clients/{id}:delete:
+    post:
+      description: |-
+        Permanently delete an OAuth client. This cannot be undone.
+
+        Terminal, unlike the reversible kill switch (``DELETE`` on this
+        resource, which only sets ``active=false``): every active grant is
+        revoked, every token carrying the client's lineage is revoked, and the
+        registration row is removed — connected applications are fully
+        disconnected. The audit trail survives. A client that later re-registers
+        via dynamic client registration is a NEW registration and re-enters the
+        approval queue as pending; it is never re-attached to the deleted one.
+      operationId: deleteOauthClient
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          title: Id
+          type: string
+      responses:
+        '204':
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '401':
+          content:
+            application/problem+json:
+              example: *id005
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unauthorized
+        '403':
+          content:
+            application/problem+json:
+              example: *id006
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Forbidden
+        '404':
+          content:
+            application/problem+json:
+              example: *id007
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Not Found
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security:
+      - BearerAuth: []
+      summary: Delete OAuth client
+      tags:
+      - OAuth Clients
   /admin/oauth-clients/{id}:deny:
     post:
       description: |-

--- a/docs/reference/endpoints.json
+++ b/docs/reference/endpoints.json
@@ -509,6 +509,32 @@
         ]
       },
       "method": "POST",
+      "operation_id": "deleteOauthClient",
+      "path": "/admin/oauth-clients/{id}:delete",
+      "public": false,
+      "required_scopes": [
+        "oauth-clients:write"
+      ],
+      "summary": "Delete OAuth client",
+      "surface": "admin",
+      "typical_caller": "any"
+    },
+    {
+      "actor_types": [
+        "user",
+        "agent",
+        "service_account",
+        "toolkit"
+      ],
+      "auth_note": null,
+      "authenticated": true,
+      "group": "Any authenticated actor",
+      "implied_scopes": {
+        "oauth-clients:write": [
+          "oauth-clients:read"
+        ]
+      },
+      "method": "POST",
       "operation_id": "denyOauthClient",
       "path": "/admin/oauth-clients/{id}:deny",
       "public": false,
@@ -5267,5 +5293,5 @@
     ],
     "total": 33
   },
-  "total": 185
+  "total": 186
 }

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -27,7 +27,7 @@ Every API endpoint grouped by its **typical caller**, then by surface, annotated
 
 > The grouping and the _Typical caller_ column are an **advisory hint** at who usually calls a route, inferred from the scope family. They are **not** an enforced restriction: access is gated by the **scope**, not the actor kind, so any actor holding the required scope can call the endpoint.
 
-_Total endpoints: **185**._
+_Total endpoints: **186**._
 
 
 ## Agent-facing (typically agent / service-account / toolkit) (31)
@@ -228,7 +228,7 @@ _Total endpoints: **185**._
 | POST | `/users/{user_id}:enable` | `users:write` | operator | Enable User |
 | POST | `/users/{user_id}:reissue-invite` | `users:write` | operator | Reissue Invite |
 
-## Any authenticated actor (73)
+## Any authenticated actor (74)
 
 
 ### `access-requests`
@@ -255,6 +255,7 @@ _Total endpoints: **185**._
 | PATCH | `/admin/oauth-clients/{id}` | `oauth-clients:write` | any | Update OAuth client |
 | POST | `/admin/oauth-clients/{id}/rotate-secret` | `oauth-clients:write` | any | Rotate client secret |
 | POST | `/admin/oauth-clients/{id}:approve` | `oauth-clients:write` | any | Approve OAuth client |
+| POST | `/admin/oauth-clients/{id}:delete` | `oauth-clients:write` | any | Delete OAuth client |
 | POST | `/admin/oauth-clients/{id}:deny` | `oauth-clients:write` | any | Deny OAuth client |
 | GET | `/admin/oauth-grants` | `oauth-clients:read` | any | List OAuth grants |
 

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -8466,6 +8466,83 @@ paths:
       summary: Approve OAuth client
       tags:
       - OAuth Clients
+  /admin/oauth-clients/{id}:delete:
+    post:
+      description: |-
+        Permanently delete an OAuth client. This cannot be undone.
+
+        Terminal, unlike the reversible kill switch (``DELETE`` on this
+        resource, which only sets ``active=false``): every active grant is
+        revoked, every token carrying the client's lineage is revoked, and the
+        registration row is removed — connected applications are fully
+        disconnected. The audit trail survives. A client that later re-registers
+        via dynamic client registration is a NEW registration and re-enters the
+        approval queue as pending; it is never re-attached to the deleted one.
+      operationId: deleteOauthClient
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          title: Id
+          type: string
+      responses:
+        '204':
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '401':
+          content:
+            application/problem+json:
+              example: *id005
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unauthorized
+        '403':
+          content:
+            application/problem+json:
+              example: *id006
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Forbidden
+        '404':
+          content:
+            application/problem+json:
+              example: *id007
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Not Found
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security:
+      - BearerAuth: []
+      summary: Delete OAuth client
+      tags:
+      - OAuth Clients
   /admin/oauth-clients/{id}:deny:
     post:
       description: |-

--- a/src/jentic_one/admin/repos/access_token_repo.py
+++ b/src/jentic_one/admin/repos/access_token_repo.py
@@ -89,6 +89,25 @@ class AccessTokenRepository:
         return int(result.rowcount)  # type: ignore[attr-defined]
 
     @staticmethod
+    async def revoke_by_client(session: AsyncSession, oauth_client_id: str) -> int:
+        """Revoke every live token carrying one client's lineage.
+
+        The client hard-delete sweep: the per-grant sweep covers grant-lineage
+        tokens, but confidential ``consent_model='user'`` clients mint tokens
+        with ``oauth_client_id`` set and NO grant — this catches those (and is
+        an idempotent belt over the grant sweep). Returns rows revoked.
+        """
+        stmt = (
+            update(AccessToken)
+            .where(AccessToken.oauth_client_id == oauth_client_id)
+            .where(AccessToken.revoked_at.is_(None))
+            .values(revoked_at=datetime.now(UTC))
+        )
+        result = await session.execute(stmt)
+        await session.flush()
+        return int(result.rowcount)  # type: ignore[attr-defined]
+
+    @staticmethod
     async def delete_expired(session: AsyncSession, before: datetime) -> int:
         stmt = delete(AccessToken).where(AccessToken.expires_at < before)
         result = await session.execute(stmt)

--- a/src/jentic_one/admin/repos/oauth_client_grant_repo.py
+++ b/src/jentic_one/admin/repos/oauth_client_grant_repo.py
@@ -81,6 +81,27 @@ class OAuthClientGrantRepository:
         return list(result.scalars().all())
 
     @staticmethod
+    async def list_active_for_client(
+        session: AsyncSession, oauth_client_id: str
+    ) -> list[OAuthClientGrant]:
+        """Every active grant held against ONE public ``client_id`` — the
+        client hard-delete sweep set.
+
+        Like :meth:`list_active_for_agent`, deliberately unpaginated: the
+        delete transaction must revoke the complete set or fail the delete.
+        """
+        stmt = (
+            select(OAuthClientGrant)
+            .where(
+                OAuthClientGrant.oauth_client_id == oauth_client_id,
+                OAuthClientGrant.status == OAuthGrantStatus.ACTIVE.value,
+            )
+            .order_by(OAuthClientGrant.created_at.asc(), OAuthClientGrant.id.asc())
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
     async def list_grants(
         session: AsyncSession,
         *,

--- a/src/jentic_one/admin/repos/oauth_client_repo.py
+++ b/src/jentic_one/admin/repos/oauth_client_repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.admin.core.schema.oauth_clients import OAuthClient
@@ -286,6 +286,22 @@ class OAuthClientRepository:
     async def deactivate(session: AsyncSession, id: str) -> bool:
         """Soft-delete by setting active=False. Returns True if updated."""
         stmt = update(OAuthClient).where(OAuthClient.id == id).values(active=False)
+        result = await session.execute(stmt)
+        await session.flush()
+        return int(result.rowcount) > 0  # type: ignore[attr-defined]
+
+    @staticmethod
+    async def delete(session: AsyncSession, id: str) -> bool:
+        """Hard-delete the row. Returns True if a row was removed.
+
+        Terminal — unlike :meth:`deactivate` (the reversible kill switch) the
+        row is gone: the D8/G13 DCR dedupe can never re-attach to it, so a
+        later re-registration mints a fresh ``pending`` row. Callers own the
+        pre-delete sweeps (grants, tokens) and the terminal audit entry —
+        grant/token/audit rows reference the client by plain id strings (no
+        FKs), so nothing cascades here by construction.
+        """
+        stmt = delete(OAuthClient).where(OAuthClient.id == id)
         result = await session.execute(stmt)
         await session.flush()
         return int(result.rowcount) > 0  # type: ignore[attr-defined]

--- a/src/jentic_one/admin/repos/refresh_token_repo.py
+++ b/src/jentic_one/admin/repos/refresh_token_repo.py
@@ -87,6 +87,23 @@ class RefreshTokenRepository:
         return int(result.rowcount)  # type: ignore[attr-defined]
 
     @staticmethod
+    async def revoke_by_client(session: AsyncSession, oauth_client_id: str) -> int:
+        """Revoke every live refresh token carrying one client's lineage.
+
+        The client hard-delete sweep — see
+        :meth:`AccessTokenRepository.revoke_by_client`. Returns rows revoked.
+        """
+        stmt = (
+            update(RefreshToken)
+            .where(RefreshToken.oauth_client_id == oauth_client_id)
+            .where(RefreshToken.revoked_at.is_(None))
+            .values(revoked_at=datetime.now(UTC))
+        )
+        result = await session.execute(stmt)
+        await session.flush()
+        return int(result.rowcount)  # type: ignore[attr-defined]
+
+    @staticmethod
     async def delete_expired(session: AsyncSession, before: datetime) -> int:
         stmt = delete(RefreshToken).where(RefreshToken.expires_at < before)
         result = await session.execute(stmt)

--- a/src/jentic_one/admin/services/oauth_client_service.py
+++ b/src/jentic_one/admin/services/oauth_client_service.py
@@ -11,8 +11,10 @@ from urllib.parse import urlparse
 import structlog
 
 from jentic_one.admin.core.schema.oauth_clients import OAuthClient
+from jentic_one.admin.repos.access_token_repo import AccessTokenRepository
 from jentic_one.admin.repos.oauth_client_grant_repo import OAuthClientGrantRepository
 from jentic_one.admin.repos.oauth_client_repo import OAuthClientRepository
+from jentic_one.admin.repos.refresh_token_repo import RefreshTokenRepository
 from jentic_one.admin.services._support.passwords import hash_password, verify_password
 from jentic_one.admin.services._support.tokens import generate_client_id, generate_client_secret
 from jentic_one.admin.services.errors import (
@@ -32,11 +34,18 @@ from jentic_one.shared.models.oauth_clients import (
     OAuthConsentModel,
     TokenEndpointAuthMethod,
 )
+from jentic_one.shared.oauth_grant_revocation import revoke_grant_and_sweep_tokens
 
 logger = structlog.get_logger(__name__)
 
 _MAX_REDIRECT_URIS = 20
 _MAX_REDIRECT_URI_LENGTH = 2048
+
+#: The revocation cause stamped (event ``data.reason``) on grants swept by a
+#: client hard delete — distinguishes the delete sweep from the manual
+#: ``:revoke`` (no ``reason`` key), the G10 transfer sweep, the #1340 archive
+#: sweep, and the RFC 7009 disconnect, following the cause-in-data pattern.
+OAUTH_CLIENT_DELETED_REVOCATION_REASON = "oauth_client_deleted"
 
 #: Hosts for which an ``http`` redirect_uri is acceptable (RFC 8252 §7.3
 #: loopback redirects). Applies on every door — the private-use-scheme
@@ -490,7 +499,7 @@ class OAuthClientService:
             return _to_view(client)
 
     async def deactivate(self, id: str, *, identity: Identity) -> None:
-        """Soft-delete an OAuth client by setting active=False."""
+        """Disable an OAuth client — the reversible kill switch (active=False)."""
         async with self._ctx.admin_db.transaction() as session:
             existing = await OAuthClientRepository.get_by_id(session, id)
             if existing is None:
@@ -504,7 +513,10 @@ class OAuthClientService:
 
             await record_audit(
                 session,
-                action=AuditAction.DELETE,
+                # DISABLE, not DELETE (which the hard delete below owns): the
+                # kill switch is reversible — PATCH active=true / the roster's
+                # re-enable verb restores the client, and the row survives.
+                action=AuditAction.DISABLE,
                 target_type=AuditTargetType.OAUTH_CLIENT,
                 target_id=id,
                 actor_type=identity.actor_type,
@@ -513,6 +525,110 @@ class OAuthClientService:
                 after={"active": False},
                 origin=identity.origin.value,
             )
+
+    async def delete(self, id: str, *, identity: Identity) -> None:
+        """Hard-delete an OAuth client — terminal, the GitHub model.
+
+        In ONE transaction, ordered so the full-disconnect semantics (G11)
+        stay coherent while the client row still exists:
+
+        1. every ACTIVE grant is revoked through the single revocation body
+           (:func:`revoke_grant_and_sweep_tokens` — grant row ``revoked``,
+           grant-lineage tokens swept, per-grant audit +
+           ``oauth_grant.revoked`` event with cause ``oauth_client_deleted``);
+        2. any remaining live tokens carrying the client's lineage are swept
+           (``revoke_by_client`` — covers grant-less ``consent_model='user'``
+           confidential-client tokens the grant sweep can't see);
+        3. the row is hard-deleted — the D8/G13 DCR dedupe can never re-attach
+           to it, so a later re-registration mints a fresh ``pending`` row
+           (a genuinely new client, never a resurrection);
+        4. the terminal audit entry is recorded (``audit_entries`` reference
+           the client by plain id strings — no FK — so the trail survives);
+        5. any live actionable ``oauth_client.registered`` event is settled
+           (best-effort), so deleting a pending client clears its queue alert.
+
+        Grant/token history rows survive as revoked history (plain id
+        columns, no FKs); grant listings already tolerate a missing client.
+        Allowed from ANY lifecycle state — the 404 arm is the only refusal.
+        """
+        async with self._ctx.admin_db.transaction() as session:
+            existing = await OAuthClientRepository.get_by_id(session, id)
+            if existing is None:
+                raise OAuthClientNotFoundError(id)
+
+            before_snapshot = _snapshot(existing)
+            before_snapshot["client_id"] = existing.client_id
+            before_snapshot["registration_source"] = existing.registration_source
+            before_snapshot["software_id"] = existing.software_id
+            client_name = existing.name
+            public_client_id = existing.client_id
+
+            grants = await OAuthClientGrantRepository.list_active_for_client(
+                session, public_client_id
+            )
+            for grant in grants:
+                await revoke_grant_and_sweep_tokens(
+                    session,
+                    grant,
+                    actor_type=identity.actor_type,
+                    actor_id=identity.sub,
+                    origin=identity.origin.value,
+                    audit_reason="oauth grant revoked: client deleted",
+                    summary=(
+                        f"OAuth grant {grant.id} for client '{grant.oauth_client_id}' was "
+                        f"revoked because the client was deleted"
+                    ),
+                    event_reason=OAUTH_CLIENT_DELETED_REVOCATION_REASON,
+                )
+            swept_access = await AccessTokenRepository.revoke_by_client(session, public_client_id)
+            swept_refresh = await RefreshTokenRepository.revoke_by_client(session, public_client_id)
+
+            success = await OAuthClientRepository.delete(session, id)
+            if not success:
+                raise OAuthClientNotFoundError(id)
+
+            await record_audit(
+                session,
+                action=AuditAction.DELETE,
+                target_type=AuditTargetType.OAUTH_CLIENT,
+                target_id=id,
+                actor_type=identity.actor_type,
+                actor_id=identity.sub,
+                before=before_snapshot,
+                after={
+                    "deleted": True,
+                    "revoked_grants": len(grants),
+                    "swept_access_tokens": swept_access,
+                    "swept_refresh_tokens": swept_refresh,
+                },
+                reason="oauth client permanently deleted",
+                origin=identity.origin.value,
+            )
+            # A deleted pending client's actionable registration alert must
+            # not stay live on the dashboard (best-effort: the delete must
+            # never roll back over a settle failure) — mirrors _set_approval.
+            try:
+                async with session.begin_nested():
+                    await settle_actionable_events(
+                        session,
+                        event_type=EventType.OAUTH_CLIENT_REGISTERED,
+                        acknowledged_by=identity.sub,
+                        acknowledgement_note="client deleted",
+                        data_match={"oauth_client_id": id},
+                    )
+            except Exception:
+                logger.warning("oauth_client_registered_settle_failed", oauth_client_id=id)
+
+        logger.info(
+            "oauth_client_deleted",
+            oauth_client_id=id,
+            client_id=public_client_id,
+            client_name=client_name,
+            revoked_grants=len(grants),
+            swept_access_tokens=swept_access,
+            swept_refresh_tokens=swept_refresh,
+            actor_id=identity.sub,
+        )
 
     async def approve(self, id: str, *, identity: Identity) -> OAuthClientView:
         """Approve an OAuth client: ``approval_status='approved'`` + ``active=true`` (D7).

--- a/src/jentic_one/admin/web/routers/oauth_clients.py
+++ b/src/jentic_one/admin/web/routers/oauth_clients.py
@@ -202,3 +202,28 @@ async def deactivate_oauth_client(
     """
     await svc.deactivate(id, identity=identity)
     return Response(status_code=204)
+
+
+@router.post(
+    "/admin/oauth-clients/{id}:delete",
+    status_code=204,
+    summary="Delete OAuth client",
+    responses=not_found(),
+)
+async def delete_oauth_client(
+    id: str,
+    identity: Identity = get_current_identity(required_permissions=["oauth-clients:write"]),
+    svc: OAuthClientService = Depends(get_oauth_client_service),
+) -> Response:
+    """Permanently delete an OAuth client. This cannot be undone.
+
+    Terminal, unlike the reversible kill switch (``DELETE`` on this
+    resource, which only sets ``active=false``): every active grant is
+    revoked, every token carrying the client's lineage is revoked, and the
+    registration row is removed — connected applications are fully
+    disconnected. The audit trail survives. A client that later re-registers
+    via dynamic client registration is a NEW registration and re-enters the
+    approval queue as pending; it is never re-attached to the deleted one.
+    """
+    await svc.delete(id, identity=identity)
+    return Response(status_code=204)

--- a/src/jentic_one/auth/services/oauth_grant_service.py
+++ b/src/jentic_one/auth/services/oauth_grant_service.py
@@ -13,10 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.admin.core.schema.oauth_client_grants import OAuthClientGrant
 from jentic_one.admin.repos import (
-    AccessTokenRepository,
     AgentRepository,
     OAuthClientGrantRepository,
-    RefreshTokenRepository,
 )
 from jentic_one.admin.services.oauth_grant_admin_service import (
     GRANT_REVOKE_ADMIN_PERMISSIONS,
@@ -37,7 +35,13 @@ from jentic_one.shared.context import Context
 from jentic_one.shared.events import emit_event_best_effort
 from jentic_one.shared.models import ActorStatus, ActorType
 from jentic_one.shared.models.events import EventSeverity, EventType
-from jentic_one.shared.models.oauth_clients import OAuthGrantStatus
+
+# Re-exported: the single revocation body moved to the shared tier so the
+# admin client hard-delete can run it too (admin must not import auth); every
+# auth caller keeps importing it from here.
+from jentic_one.shared.oauth_grant_revocation import (
+    revoke_grant_and_sweep_tokens as revoke_grant_and_sweep_tokens,
+)
 from jentic_one.shared.pagination import Page
 
 logger = structlog.get_logger(__name__)
@@ -63,72 +67,6 @@ AGENT_TRANSFER_REVOCATION_REASON = "agent_ownership_transferred"
 #: grants" listing/count on a dead agent. Same cause-in-data pattern as the
 #: transfer reason above.
 AGENT_ARCHIVE_REVOCATION_REASON = "agent_archived"
-
-
-async def revoke_grant_and_sweep_tokens(
-    session: AsyncSession,
-    grant: OAuthClientGrant,
-    *,
-    actor_type: ActorType,
-    actor_id: str,
-    origin: str | None,
-    audit_reason: str,
-    summary: str,
-    event_reason: str | None = None,
-) -> bool:
-    """Flip one grant row + sweep its tokens + audit + event, in the caller's session.
-
-    THE single revocation body — the manual ``:revoke`` kill switch, the
-    ownership-transfer sweep (G10), and the RFC 7009 refresh-token full
-    disconnect (G11, :mod:`oauth_revocation_service`) all run through here, so
-    the token kill switch and the emitted ``oauth_grant.revoked`` event can
-    never drift between the causes. Flush-only: it joins whatever transaction
-    the caller owns.
-    Returns False (writing no audit/event) when the grant was already revoked;
-    the token sweep re-runs regardless (idempotent belt).
-    """
-    newly_revoked = grant.status == OAuthGrantStatus.ACTIVE.value and (
-        await OAuthClientGrantRepository.revoke(session, grant.id)
-    )
-    swept_access = await AccessTokenRepository.revoke_by_grant(session, grant.id)
-    swept_refresh = await RefreshTokenRepository.revoke_by_grant(session, grant.id)
-    if not newly_revoked:
-        return False
-
-    await record_audit(
-        session,
-        action=AuditAction.REVOKE,
-        target_type=AuditTargetType.OAUTH_GRANT,
-        target_id=grant.id,
-        actor_type=actor_type,
-        actor_id=actor_id,
-        after={
-            "oauth_client_id": grant.oauth_client_id,
-            "agent_id": grant.agent_id,
-            "swept_access_tokens": swept_access,
-            "swept_refresh_tokens": swept_refresh,
-        },
-        reason=audit_reason,
-        origin=origin,
-    )
-    data: dict[str, object] = {
-        "grant_id": grant.id,
-        "oauth_client_id": grant.oauth_client_id,
-        "agent_id": grant.agent_id,
-        "user_id": grant.user_id,
-    }
-    if event_reason is not None:
-        data["reason"] = event_reason
-    await emit_event_best_effort(
-        session,
-        type=EventType.OAUTH_GRANT_REVOKED,
-        severity=EventSeverity.INFO,
-        summary=summary,
-        requires_action=False,
-        data=data,
-        created_by=actor_id,
-    )
-    return True
 
 
 async def revoke_active_grants_for_agent(

--- a/src/jentic_one/shared/oauth_grant_revocation.py
+++ b/src/jentic_one/shared/oauth_grant_revocation.py
@@ -1,0 +1,96 @@
+"""The single grant-revocation body — grant flip + token sweep + audit + event.
+
+Lives in the **shared** tier (like :mod:`jentic_one.shared.audit` and
+:mod:`jentic_one.shared.events`, which also wrap admin repositories) so every
+consumer can reach it: the auth tier's callers (the manual ``:revoke`` kill
+switch, the G10 ownership-transfer sweep, the #1340 agent-archive sweep, and
+the RFC 7009 refresh-token full disconnect) import it via
+:mod:`jentic_one.auth.services.oauth_grant_service`, and the admin tier's
+client hard-delete (``OAuthClientService.delete``) calls it directly — admin
+must not import auth (``tests/arch/test_module_boundaries``), and admin
+service modules must not take ``AsyncSession`` parameters
+(``tests/arch/test_admin_services_no_sqlalchemy``), while the shared
+audit/events helpers already do.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from jentic_one.admin.core.schema.oauth_client_grants import OAuthClientGrant
+from jentic_one.admin.repos.access_token_repo import AccessTokenRepository
+from jentic_one.admin.repos.oauth_client_grant_repo import OAuthClientGrantRepository
+from jentic_one.admin.repos.refresh_token_repo import RefreshTokenRepository
+from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit
+from jentic_one.shared.events import emit_event_best_effort
+from jentic_one.shared.models import ActorType
+from jentic_one.shared.models.events import EventSeverity, EventType
+from jentic_one.shared.models.oauth_clients import OAuthGrantStatus
+
+
+async def revoke_grant_and_sweep_tokens(
+    session: AsyncSession,
+    grant: OAuthClientGrant,
+    *,
+    actor_type: ActorType,
+    actor_id: str,
+    origin: str | None,
+    audit_reason: str,
+    summary: str,
+    event_reason: str | None = None,
+) -> bool:
+    """Flip one grant row + sweep its tokens + audit + event, in the caller's session.
+
+    THE single revocation body — the manual ``:revoke`` kill switch, the
+    ownership-transfer sweep (G10), the RFC 7009 refresh-token full
+    disconnect (G11, :mod:`jentic_one.auth.services.oauth_revocation_service`),
+    and the OAuth-client hard delete
+    (:meth:`jentic_one.admin.services.oauth_client_service.OAuthClientService.delete`)
+    all run through here, so the token kill switch and the emitted
+    ``oauth_grant.revoked`` event can never drift between the causes.
+    Flush-only: it joins whatever transaction the caller owns.
+    Returns False (writing no audit/event) when the grant was already revoked;
+    the token sweep re-runs regardless (idempotent belt).
+    """
+    newly_revoked = grant.status == OAuthGrantStatus.ACTIVE.value and (
+        await OAuthClientGrantRepository.revoke(session, grant.id)
+    )
+    swept_access = await AccessTokenRepository.revoke_by_grant(session, grant.id)
+    swept_refresh = await RefreshTokenRepository.revoke_by_grant(session, grant.id)
+    if not newly_revoked:
+        return False
+
+    await record_audit(
+        session,
+        action=AuditAction.REVOKE,
+        target_type=AuditTargetType.OAUTH_GRANT,
+        target_id=grant.id,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        after={
+            "oauth_client_id": grant.oauth_client_id,
+            "agent_id": grant.agent_id,
+            "swept_access_tokens": swept_access,
+            "swept_refresh_tokens": swept_refresh,
+        },
+        reason=audit_reason,
+        origin=origin,
+    )
+    data: dict[str, object] = {
+        "grant_id": grant.id,
+        "oauth_client_id": grant.oauth_client_id,
+        "agent_id": grant.agent_id,
+        "user_id": grant.user_id,
+    }
+    if event_reason is not None:
+        data["reason"] = event_reason
+    await emit_event_best_effort(
+        session,
+        type=EventType.OAUTH_GRANT_REVOKED,
+        severity=EventSeverity.INFO,
+        summary=summary,
+        requires_action=False,
+        data=data,
+        created_by=actor_id,
+    )
+    return True

--- a/tests/integration/admin/services/test_oauth_client_hard_delete.py
+++ b/tests/integration/admin/services/test_oauth_client_hard_delete.py
@@ -1,0 +1,387 @@
+"""Integration tests for the OAuth client hard delete (terminal, GitHub model).
+
+Exercises ``OAuthClientService.delete`` against a real database (PostgreSQL or
+SQLite — no mocking): the full-disconnect ordering (grants revoked + tokens
+swept before the row dies), the grant-less confidential-lineage token sweep,
+audit retention (grant/client history survives the delete, terminal entry
+recorded), the 404 arm, the actionable-event settle, and the DCR door
+afterwards — a re-registration mints a NEW pending row, never re-attaching to
+the deleted one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Generator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import delete, select
+
+from jentic_one.admin.core.schema.access_tokens import AccessToken
+from jentic_one.admin.core.schema.audit import AuditEntry
+from jentic_one.admin.core.schema.events import Event
+from jentic_one.admin.core.schema.oauth_client_grants import OAuthClientGrant
+from jentic_one.admin.core.schema.oauth_clients import OAuthClient
+from jentic_one.admin.core.schema.refresh_tokens import RefreshToken
+from jentic_one.admin.repos.access_token_repo import AccessTokenRepository
+from jentic_one.admin.repos.oauth_client_grant_repo import OAuthClientGrantRepository
+from jentic_one.admin.repos.refresh_token_repo import RefreshTokenRepository
+from jentic_one.admin.services.errors import OAuthClientNotFoundError
+from jentic_one.admin.services.oauth_client_service import (
+    OAUTH_CLIENT_DELETED_REVOCATION_REASON,
+    OAuthClientService,
+)
+from jentic_one.auth.services.oauth_dcr_service import OAuthDcrService
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.context import Context
+from jentic_one.shared.models.audit import AuditAction, AuditTargetType
+from jentic_one.shared.models.events import EventType
+from jentic_one.shared.models.oauth_clients import OAuthGrantStatus
+
+pytestmark = pytest.mark.integration
+
+_ADMIN = Identity(sub="usr_hard_delete_admin", email="hard-delete-admin@test.local")
+_REDIRECT_URIS = ["https://client.test.local/callback"]
+_DCR_REDIRECT_URIS = ["http://localhost:33418/callback"]
+
+
+@pytest.fixture()
+def queue_policy_context(integration_context: Context) -> Generator[Context, None, None]:
+    """Pin the DCR approval-queue policy (no auto-approve); restore after."""
+    oauth_cfg = integration_context.config.server.mcp.oauth
+    prior = oauth_cfg.auto_approve_clients
+    oauth_cfg.auto_approve_clients = False
+    yield integration_context
+    oauth_cfg.auto_approve_clients = prior
+
+
+@pytest.fixture()
+async def clean_tables(integration_context: Context) -> AsyncGenerator[None, None]:
+    """Remove client/grant/token rows plus their audit entries and events."""
+
+    async def _clean() -> None:
+        async with integration_context.admin_db.transaction() as session:
+            result = await session.execute(select(OAuthClient.id))
+            client_ids = [row[0] for row in result.all()]
+            result = await session.execute(select(OAuthClientGrant.id))
+            grant_ids = [row[0] for row in result.all()]
+            ids = client_ids + grant_ids
+            if ids:
+                await session.execute(delete(AuditEntry).where(AuditEntry.target_id.in_(ids)))
+            await session.execute(
+                delete(Event).where(
+                    Event.type.in_(
+                        [
+                            EventType.OAUTH_CLIENT_REGISTERED,
+                            EventType.OAUTH_CLIENT_APPROVED,
+                            EventType.OAUTH_GRANT_REVOKED,
+                        ]
+                    )
+                )
+            )
+            await session.execute(
+                delete(AccessToken).where(AccessToken.oauth_client_id.is_not(None))
+            )
+            await session.execute(
+                delete(RefreshToken).where(RefreshToken.oauth_client_id.is_not(None))
+            )
+            await session.execute(delete(OAuthClientGrant))
+            await session.execute(delete(OAuthClient))
+
+    await _clean()
+    yield
+    await _clean()
+
+
+async def _create_client(ctx: Context, *, name: str = "doomed-app") -> str:
+    """Admin-create a confidential client; returns the internal row id."""
+    svc = OAuthClientService(ctx)
+    created = await svc.create(name=name, redirect_uris=_REDIRECT_URIS, identity=_ADMIN)
+    return created.id
+
+
+async def _client_row(ctx: Context, id: str) -> OAuthClient | None:
+    async with ctx.admin_db.session() as session:
+        return (
+            await session.execute(select(OAuthClient).where(OAuthClient.id == id))
+        ).scalar_one_or_none()
+
+
+async def _audit_entries_for(ctx: Context, target_id: str) -> list[AuditEntry]:
+    async with ctx.admin_db.session() as session:
+        result = await session.execute(
+            select(AuditEntry)
+            .where(AuditEntry.target_id == target_id)
+            .order_by(AuditEntry.occurred_at.asc(), AuditEntry.id.asc())
+        )
+        return list(result.scalars().all())
+
+
+async def test_delete_full_disconnect_then_row_removed(
+    integration_context: Context, clean_tables: None
+) -> None:
+    """The G11 ordering: active grants revoked + every lineage token swept,
+    then the row hard-deleted — all effects visible after one service call."""
+    svc = OAuthClientService(integration_context)
+    created = await svc.create(name="doomed-app", redirect_uris=_REDIRECT_URIS, identity=_ADMIN)
+
+    async with integration_context.admin_db.transaction() as session:
+        grant = await OAuthClientGrantRepository.create(
+            session,
+            oauth_client_id=created.client_id,
+            user_id="usr_consenter",
+            agent_id="agt_bound",
+            scopes=["capabilities:read"],
+            created_by="usr_consenter",
+        )
+        grant_id = grant.id
+        expires = datetime.now(UTC) + timedelta(hours=1)
+        access = await AccessTokenRepository.create(
+            session,
+            token_hash="at-hash-grant",
+            actor_id="agt_bound",
+            actor_type="agent",
+            scopes=["capabilities:read"],
+            token_family_id="fam-grant",
+            expires_at=expires,
+            created_by="usr_consenter",
+            oauth_client_id=created.client_id,
+            oauth_grant_id=grant_id,
+        )
+        refresh = await RefreshTokenRepository.create(
+            session,
+            token_hash="rt-hash-grant",
+            actor_id="agt_bound",
+            actor_type="agent",
+            scopes=["capabilities:read"],
+            token_family_id="fam-grant",
+            expires_at=expires,
+            created_by="usr_consenter",
+            oauth_client_id=created.client_id,
+            oauth_grant_id=grant_id,
+        )
+        access_id, refresh_id = access.id, refresh.id
+
+    await svc.delete(created.id, identity=_ADMIN)
+
+    assert await _client_row(integration_context, created.id) is None
+
+    async with integration_context.admin_db.session() as session:
+        grant_row = await OAuthClientGrantRepository.get_by_id(session, grant_id)
+        assert grant_row is not None, "grant history must survive the delete"
+        assert grant_row.status == OAuthGrantStatus.REVOKED.value
+        assert grant_row.revoked_at is not None
+
+        at_row = (
+            await session.execute(select(AccessToken).where(AccessToken.id == access_id))
+        ).scalar_one()
+        rt_row = (
+            await session.execute(select(RefreshToken).where(RefreshToken.id == refresh_id))
+        ).scalar_one()
+        assert at_row.revoked_at is not None
+        assert rt_row.revoked_at is not None
+
+    # The per-grant revocation event carries the delete cause (cause-in-data).
+    async with integration_context.admin_db.session() as session:
+        events = (
+            (
+                await session.execute(
+                    select(Event).where(Event.type == EventType.OAUTH_GRANT_REVOKED)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(events) == 1
+    assert events[0].data["reason"] == OAUTH_CLIENT_DELETED_REVOCATION_REASON
+    assert events[0].data["grant_id"] == grant_id
+
+
+async def test_delete_sweeps_grantless_client_lineage_tokens(
+    integration_context: Context, clean_tables: None
+) -> None:
+    """Confidential ``consent_model='user'`` tokens carry client lineage but
+    no grant — the delete must sweep them too (revoke_by_client arm)."""
+    svc = OAuthClientService(integration_context)
+    created = await svc.create(name="user-model-app", redirect_uris=_REDIRECT_URIS, identity=_ADMIN)
+
+    async with integration_context.admin_db.transaction() as session:
+        expires = datetime.now(UTC) + timedelta(hours=1)
+        access = await AccessTokenRepository.create(
+            session,
+            token_hash="at-hash-grantless",
+            actor_id="usr_direct",
+            actor_type="user",
+            scopes=["capabilities:read"],
+            token_family_id="fam-grantless",
+            expires_at=expires,
+            created_by="usr_direct",
+            oauth_client_id=created.client_id,
+            oauth_grant_id=None,
+        )
+        refresh = await RefreshTokenRepository.create(
+            session,
+            token_hash="rt-hash-grantless",
+            actor_id="usr_direct",
+            actor_type="user",
+            scopes=["capabilities:read"],
+            token_family_id="fam-grantless",
+            expires_at=expires,
+            created_by="usr_direct",
+            oauth_client_id=created.client_id,
+            oauth_grant_id=None,
+        )
+        access_id, refresh_id = access.id, refresh.id
+
+    await svc.delete(created.id, identity=_ADMIN)
+
+    async with integration_context.admin_db.session() as session:
+        at_row = (
+            await session.execute(select(AccessToken).where(AccessToken.id == access_id))
+        ).scalar_one()
+        rt_row = (
+            await session.execute(select(RefreshToken).where(RefreshToken.id == refresh_id))
+        ).scalar_one()
+        assert at_row.revoked_at is not None
+        assert rt_row.revoked_at is not None
+
+
+async def test_delete_audit_trail_survives_with_terminal_entry(
+    integration_context: Context, clean_tables: None
+) -> None:
+    """Audit retention: pre-delete history AND the terminal delete entry both
+    reference the dead client id (plain string, no FK) and survive."""
+    id = await _create_client(integration_context)
+    svc = OAuthClientService(integration_context)
+
+    await svc.delete(id, identity=_ADMIN)
+
+    entries = await _audit_entries_for(integration_context, id)
+    actions = [e.action for e in entries]
+    assert AuditAction.CREATE.value in actions, "pre-delete history must survive"
+    assert actions[-1] == AuditAction.DELETE.value
+
+    terminal = entries[-1]
+    assert terminal.target_type == AuditTargetType.OAUTH_CLIENT.value
+    assert terminal.reason == "oauth client permanently deleted"
+    assert terminal.actor_id == _ADMIN.sub
+    # The before snapshot preserves what was deleted; after records the sweep.
+    assert terminal.before is not None
+    assert terminal.before["name"] == "doomed-app"
+    assert terminal.after is not None
+    assert terminal.after["deleted"] is True
+
+
+async def test_deactivate_now_audits_disable_not_delete(
+    integration_context: Context, clean_tables: None
+) -> None:
+    """The reversible kill switch audits ``disable``; ``delete`` is reserved
+    for the terminal arm so the two are distinguishable in the trail."""
+    id = await _create_client(integration_context)
+    svc = OAuthClientService(integration_context)
+
+    await svc.deactivate(id, identity=_ADMIN)
+
+    entries = await _audit_entries_for(integration_context, id)
+    assert entries[-1].action == AuditAction.DISABLE.value
+    assert entries[-1].after == {"active": False}
+    assert await _client_row(integration_context, id) is not None
+
+
+async def test_delete_unknown_id_raises_not_found(
+    integration_context: Context, clean_tables: None
+) -> None:
+    svc = OAuthClientService(integration_context)
+    with pytest.raises(OAuthClientNotFoundError):
+        await svc.delete("oac_missing", identity=_ADMIN)
+
+
+async def test_delete_pending_dcr_client_settles_actionable_event(
+    queue_policy_context: Context, clean_tables: None
+) -> None:
+    """Deleting a pending DCR client acknowledges its live approval-queue
+    alert — the dashboard must not prompt a decision on a dead row."""
+    dcr = OAuthDcrService(queue_policy_context)
+    result = await dcr.register(
+        client_name="doomed-mcp-client",
+        redirect_uris=_DCR_REDIRECT_URIS,
+        token_endpoint_auth_method="none",
+        software_id="com.example.doomed",
+    )
+    async with queue_policy_context.admin_db.session() as session:
+        row = (
+            await session.execute(
+                select(OAuthClient).where(OAuthClient.client_id == result.client_id)
+            )
+        ).scalar_one()
+        row_id = row.id
+
+    svc = OAuthClientService(queue_policy_context)
+    await svc.delete(row_id, identity=_ADMIN)
+
+    async with queue_policy_context.admin_db.session() as session:
+        events = (
+            (
+                await session.execute(
+                    select(Event).where(Event.type == EventType.OAUTH_CLIENT_REGISTERED)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(events) == 1
+    assert events[0].acknowledged is True
+    assert events[0].acknowledged_by == _ADMIN.sub
+
+
+async def test_dcr_reregister_after_delete_mints_new_pending_row(
+    queue_policy_context: Context, clean_tables: None
+) -> None:
+    """The DCR door after a hard delete: same dedupe key (software_id +
+    redirect set) lands a NEW pending row with a NEW client_id — a genuinely
+    new registration, never a re-attach to (or resurrection of) the dead row."""
+    dcr = OAuthDcrService(queue_policy_context)
+    first = await dcr.register(
+        client_name="Cursor",
+        redirect_uris=_DCR_REDIRECT_URIS,
+        token_endpoint_auth_method="none",
+        software_id="com.cursor.ide",
+    )
+    assert first.created is True
+
+    # Sanity: without a delete the same key re-attaches (created=False).
+    reattach = await dcr.register(
+        client_name="Cursor",
+        redirect_uris=_DCR_REDIRECT_URIS,
+        token_endpoint_auth_method="none",
+        software_id="com.cursor.ide",
+    )
+    assert reattach.created is False
+    assert reattach.client_id == first.client_id
+
+    async with queue_policy_context.admin_db.session() as session:
+        row = (
+            await session.execute(
+                select(OAuthClient).where(OAuthClient.client_id == first.client_id)
+            )
+        ).scalar_one()
+        first_row_id = row.id
+
+    svc = OAuthClientService(queue_policy_context)
+    await svc.delete(first_row_id, identity=_ADMIN)
+
+    second = await dcr.register(
+        client_name="Cursor",
+        redirect_uris=_DCR_REDIRECT_URIS,
+        token_endpoint_auth_method="none",
+        software_id="com.cursor.ide",
+    )
+    assert second.created is True, "post-delete registration must be a fresh row"
+    assert second.client_id != first.client_id
+
+    async with queue_policy_context.admin_db.session() as session:
+        rows = (await session.execute(select(OAuthClient))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].client_id == second.client_id
+    assert rows[0].approval_status == "pending"
+    assert rows[0].active is False

--- a/tests/integration/auth/test_oauth_grant_archive_sweep.py
+++ b/tests/integration/auth/test_oauth_grant_archive_sweep.py
@@ -173,7 +173,7 @@ async def test_archive_rolls_back_when_grant_sweep_fails(
 
     with (
         patch(
-            "jentic_one.auth.services.oauth_grant_service.AccessTokenRepository.revoke_by_grant",
+            "jentic_one.shared.oauth_grant_revocation.AccessTokenRepository.revoke_by_grant",
             new=AsyncMock(side_effect=RuntimeError("sweep exploded")),
         ),
         pytest.raises(RuntimeError, match="sweep exploded"),

--- a/tests/integration/auth/test_oauth_grant_transfer.py
+++ b/tests/integration/auth/test_oauth_grant_transfer.py
@@ -221,7 +221,7 @@ async def test_transfer_rolls_back_when_grant_revocation_fails(
     # repository itself is real; only this one call blows up.
     with (
         patch(
-            "jentic_one.auth.services.oauth_grant_service.AccessTokenRepository.revoke_by_grant",
+            "jentic_one.shared.oauth_grant_revocation.AccessTokenRepository.revoke_by_grant",
             new=AsyncMock(side_effect=RuntimeError("sweep exploded")),
         ),
         pytest.raises(RuntimeError, match="sweep exploded"),

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -13629,6 +13629,162 @@
         ]
       }
     },
+    "/admin/oauth-clients/{id}:delete": {
+      "post": {
+        "description": "Permanently delete an OAuth client. This cannot be undone.\n\nTerminal, unlike the reversible kill switch (``DELETE`` on this\nresource, which only sets ``active=false``): every active grant is\nrevoked, every token carrying the client's lineage is revoked, and the\nregistration row is removed — connected applications are fully\ndisconnected. The audit trail survives. A client that later re-registers\nvia dynamic client registration is a NEW registration and re-enters the\napproval queue as pending; it is never re-attached to the deleted one.",
+        "operationId": "deleteOauthClient",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "title": "Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request was malformed or failed a precondition.",
+                  "instance": "/example/path",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "bad_request"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Authentication is required or the bearer token is invalid.",
+                  "instance": "/example/path",
+                  "status": 401,
+                  "title": "Unauthorized",
+                  "type": "unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The authenticated principal lacks the required permission.",
+                  "instance": "/example/path",
+                  "status": 403,
+                  "title": "Forbidden",
+                  "type": "forbidden"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The requested resource does not exist or is not visible to you.",
+                  "instance": "/example/path",
+                  "status": 404,
+                  "title": "Not Found",
+                  "type": "not_found"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Request validation failed; see errors[] for details.",
+                  "errors": [
+                    {
+                      "detail": "Field 'name' must not be blank.",
+                      "pointer": "#/name"
+                    }
+                  ],
+                  "instance": "/example/path",
+                  "status": 422,
+                  "title": "Unprocessable Entity",
+                  "type": "validation_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "An unexpected error occurred.",
+                  "instance": "/example/path",
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "type": "server_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The database is temporarily unavailable; please retry.",
+                  "instance": "/example/path",
+                  "status": 503,
+                  "title": "Service Unavailable",
+                  "type": "database_unavailable"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Delete OAuth client",
+        "tags": [
+          "OAuth Clients"
+        ]
+      }
+    },
     "/admin/oauth-clients/{id}:deny": {
       "post": {
         "description": "Deny an OAuth client — sets approval_status=denied and active=false.\n\nThe row is retained so a later approve can reverse the decision.",

--- a/ui/src/shared/api/generated/services/OAuthClientsService.ts
+++ b/ui/src/shared/api/generated/services/OAuthClientsService.ts
@@ -229,6 +229,42 @@ export class OAuthClientsService {
         });
     }
     /**
+     * Delete OAuth client
+     * Permanently delete an OAuth client. This cannot be undone.
+     *
+     * Terminal, unlike the reversible kill switch (``DELETE`` on this
+     * resource, which only sets ``active=false``): every active grant is
+     * revoked, every token carrying the client's lineage is revoked, and the
+     * registration row is removed — connected applications are fully
+     * disconnected. The audit trail survives. A client that later re-registers
+     * via dynamic client registration is a NEW registration and re-enters the
+     * approval queue as pending; it is never re-attached to the deleted one.
+     * @returns void
+     * @throws ApiError
+     */
+    public static deleteOauthClient({
+        id,
+    }: {
+        id: string,
+    }): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/admin/oauth-clients/{id}:delete',
+            path: {
+                'id': id,
+            },
+            errors: {
+                400: `Bad Request`,
+                401: `Unauthorized`,
+                403: `Forbidden`,
+                404: `Not Found`,
+                422: `Unprocessable Entity`,
+                500: `Internal Server Error`,
+                503: `Service Unavailable`,
+            },
+        });
+    }
+    /**
      * Deny OAuth client
      * Deny an OAuth client — sets approval_status=denied and active=false.
      *


### PR DESCRIPTION
## Summary

OAuth clients today have only a reversible kill switch (`DELETE /admin/oauth-clients/{id}` sets `active=false`; #1313 made DCR re-registration of a kill-switched client re-queue it as pending). There is no terminal exit: tokens/grants outlive the "deleted" client and a re-registration can re-attach to the old row. This adds a GitHub-model **hard delete** *in addition to* the kill switch: tokens die, grants die, the row dies, and re-registration is a genuinely new app. Design doc: `jentic-one-plans/themes/local-mcp/oauth-client-hard-delete-and-lifecycle-vocabulary.md`.

## Changes

- **New endpoint** (`admin`): `POST /admin/oauth-clients/{id}:delete` → 204, permission `oauth-clients:write`, `OAuthClientNotFoundError` → 404. **Why a colon action, not `DELETE …?hard=true`:** the DELETE method on this resource is already occupied by the soft arm — overloading it with a query param puts the irreversible arm one typo away from the reversible one, and the codebase's non-CRUD idiom is the colon action (`:approve`/`:deny`/`:disable`/`:enable`). Migrating `DELETE` itself to hard semantics would silently break existing consumers (deliberate non-goal).
- **Service arm** (`OAuthClientService.delete`), all in ONE transaction, ordered so full-disconnect (G11) semantics stay coherent: (1) revoke every active grant through the single revocation body — per-grant audit + `oauth_grant.revoked` event with cause `oauth_client_deleted`; (2) sweep remaining client-lineage tokens via new `revoke_by_client` on both token repos (covers grant-less `consent_model='user'` confidential clients); (3) hard-delete the row; (4) terminal audit entry (`action=delete`, full before snapshot, reason `"oauth client permanently deleted"`); (5) settle a pending client's actionable `oauth_client.registered` alert (best-effort nested tx, mirrors `:approve`/`:deny`).
- **Refactor** (first commit): `revoke_grant_and_sweep_tokens` moves to `shared/oauth_grant_revocation.py` (re-exported from its old auth home). Admin must not import auth (`test_module_boundaries`) and admin services must not take `AsyncSession` (`test_admin_services_no_sqlalchemy`); the shared tier is where the session-taking audit/event helpers already live. Every caller still runs THE single revocation body.
- **Audit vocabulary**: the soft kill-switch (`deactivate`) now audits `AuditAction.DISABLE` instead of `DELETE`, which the terminal arm now owns — the two are distinguishable in the trail. This is the one behaviour change beyond the new endpoint.
- **DCR interplay**: a deleted row cannot win the D8/G13 dedupe (it no longer exists) and `requeue_pending_if_killswitched` has nothing to re-attach — post-delete re-registration mints a NEW `pending` row with a NEW `client_id`.
- Regenerated `openapi/control/control.openapi.yaml`, `ui/openapi.json`, `docs/reference/endpoints.{md,json}`, `cli/client/generated/control/*`.
- Out of scope: UI (follow-up PR), copy alignment of the soft arm's "Deactivate" summary (copy-only sweep PR), authorization-code row sweep (short-lived; exchange fails closed on an unknown client).

## Risk & rollback

- **New destructive admin surface** gated by `oauth-clients:write` — same permission as the soft delete. Considered requiring `org:admin`: rejected for consistency (`oauth-clients:write` already administers the whole client lifecycle incl. grant revocation, and `org:admin` bypasses scope gates anyway); flagging for reviewer sign-off.
- **Audit consumers**: dashboards keying on `action=delete` for the *soft* arm will now see `disable`. No in-repo consumer asserts the old value (checked).
- No migration; `audit_entries`/grants/tokens reference clients by plain id strings (no FK), verified — nothing cascades implicitly.
- Rollback: revert the squash commit.

## Test plan

- `tests/integration/admin/services/test_oauth_client_hard_delete.py` (SQLite + Postgres-agnostic, real DB): full-disconnect ordering (grant revoked + grant tokens swept + row gone + cause-stamped event), grant-less lineage token sweep, audit retention (history + terminal entry with before snapshot), deactivate now audits `disable`, 404 arm, actionable-event settle on deleting a pending DCR client, and DCR re-register after delete mints a NEW pending row (with a same-key re-attach sanity check before the delete).
- Ran: `make lint`, `make test-arch` (155 passed), full `tests/unit/` (3864 passed), `make test-integration-sqlite` (784 passed, 2 pre-existing patch targets repointed to the moved module), `make detect-secrets`, `make openapi`/`make endpoints` drift-clean, `cd cli && GOWORK=off make generate-api && go test ./...` (pass). `make score` not run locally (Docker unavailable) — runs in CI.

## Review guide

- Start with `OAuthClientService.delete` (ordering + audit), then the shared-tier move (`shared/oauth_grant_revocation.py` — verbatim body, only the module home changed), then the repos. The spec/client artefacts are generated.

Made with [Cursor](https://cursor.com)