### PR TITLE
fix(auth): keep grants dormant on agent disable and make listings honest

### DIFF
--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -2438,6 +2438,9 @@ type OAuthGrantAdminResponse struct {
 	// AgentId The agent this grant binds the client to.
 	AgentId string `json:"agent_id"`
 
+	// AgentStatus Lifecycle state of the bound agent (`active`, `disabled`, `archived`, …). A grant on a non-active agent is dormant: the row stays `active` (disable is reversible — re-enable restores the standing consent without a new consent round) but no token resolves while the agent is non-active. Lets listings tell a working connection from a dormant one (#1233).
+	AgentStatus *string `json:"agent_status,omitempty"`
+
 	// CanRevoke Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. a read-only admin.
 	CanRevoke bool `json:"can_revoke"`
 
@@ -2479,6 +2482,9 @@ type OAuthGrantListResponse struct {
 type OAuthGrantResponse struct {
 	// AgentId The agent this grant binds the client to.
 	AgentId string `json:"agent_id"`
+
+	// AgentStatus Lifecycle state of the bound agent (`active`, `disabled`, `archived`, …). A grant on a non-active agent is dormant: the row stays `active` (disable is reversible — re-enable restores the standing consent without a new consent round) but no token resolves while the agent is non-active. Lets listings tell a working connection from a dormant one (#1233).
+	AgentStatus *string `json:"agent_status,omitempty"`
 
 	// CanRevoke Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. the agent's new owner after an ownership transfer, or a read-only admin.
 	CanRevoke bool `json:"can_revoke"`

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -3940,6 +3940,12 @@ components:
           description: The agent this grant binds the client to.
           title: Agent Id
           type: string
+        agent_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: 'Lifecycle state of the bound agent (`active`, `disabled`, `archived`, …). A grant on a non-active agent is dormant: the row stays `active` (disable is reversible — re-enable restores the standing consent without a new consent round) but no token resolves while the agent is non-active. Lets listings tell a working connection from a dormant one (#1233).'
+          title: Agent Status
         can_revoke:
           description: Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. a read-only admin.
           title: Can Revoke
@@ -4038,6 +4044,12 @@ components:
           description: The agent this grant binds the client to.
           title: Agent Id
           type: string
+        agent_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: 'Lifecycle state of the bound agent (`active`, `disabled`, `archived`, …). A grant on a non-active agent is dormant: the row stays `active` (disable is reversible — re-enable restores the standing consent without a new consent round) but no token resolves while the agent is non-active. Lets listings tell a working connection from a dormant one (#1233).'
+          title: Agent Status
         can_revoke:
           description: Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. the agent's new owner after an ownership transfer, or a read-only admin.
           title: Can Revoke

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -3940,6 +3940,12 @@ components:
           description: The agent this grant binds the client to.
           title: Agent Id
           type: string
+        agent_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: 'Lifecycle state of the bound agent (`active`, `disabled`, `archived`, …). A grant on a non-active agent is dormant: the row stays `active` (disable is reversible — re-enable restores the standing consent without a new consent round) but no token resolves while the agent is non-active. Lets listings tell a working connection from a dormant one (#1233).'
+          title: Agent Status
         can_revoke:
           description: Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. a read-only admin.
           title: Can Revoke
@@ -4038,6 +4044,12 @@ components:
           description: The agent this grant binds the client to.
           title: Agent Id
           type: string
+        agent_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: 'Lifecycle state of the bound agent (`active`, `disabled`, `archived`, …). A grant on a non-active agent is dormant: the row stays `active` (disable is reversible — re-enable restores the standing consent without a new consent round) but no token resolves while the agent is non-active. Lets listings tell a working connection from a dormant one (#1233).'
+          title: Agent Status
         can_revoke:
           description: Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. the agent's new owner after an ownership transfer, or a read-only admin.
           title: Can Revoke

--- a/src/jentic_one/admin/repos/agent_repo.py
+++ b/src/jentic_one/admin/repos/agent_repo.py
@@ -59,6 +59,21 @@ class AgentRepository:
         return result.scalar_one_or_none()
 
     @staticmethod
+    async def get_status_by_ids(session: AsyncSession, agent_ids: Sequence[str]) -> dict[str, str]:
+        """Batch-fetch ``{agent_id: status}`` for the given ids.
+
+        One query for a page of rows that need agent-status annotation
+        (#1233: the grant listings surface the bound agent's lifecycle state
+        so a dormant grant on a disabled agent is never mistaken for a
+        working connection). Missing ids are simply absent from the result.
+        """
+        if not agent_ids:
+            return {}
+        stmt = select(Agent.id, Agent.status).where(Agent.id.in_(agent_ids))
+        result = await session.execute(stmt)
+        return {row[0]: row[1] for row in result.all()}
+
+    @staticmethod
     async def list_by_owner(
         session: AsyncSession,
         owner_id: str,

--- a/src/jentic_one/admin/repos/oauth_client_grant_repo.py
+++ b/src/jentic_one/admin/repos/oauth_client_grant_repo.py
@@ -7,7 +7,9 @@ from datetime import UTC, datetime
 from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from jentic_one.admin.core.schema.agents import Agent
 from jentic_one.admin.core.schema.oauth_client_grants import OAuthClientGrant
+from jentic_one.shared.models.actors import ActorStatus
 from jentic_one.shared.models.oauth_clients import OAuthGrantStatus
 
 
@@ -68,6 +70,9 @@ class OAuthClientGrantRepository:
         An agent ownership transfer revokes all of these in the transfer's own
         transaction, so unlike :meth:`list_grants` this is deliberately
         unpaginated: the sweep must see the complete set or fail the transfer.
+        Also deliberately does NOT filter on the agent's status (#1233): the
+        sweeps (transfer, archive) run against agents mid-transition, and a
+        sweep that skipped dormant rows would leave stragglers.
         """
         stmt = (
             select(OAuthClientGrant)
@@ -150,10 +155,21 @@ class OAuthClientGrantRepository:
 
     @staticmethod
     async def count_active_by_client(session: AsyncSession) -> dict[str, int]:
-        """Active-grant counts keyed by public ``client_id`` (per-client count)."""
+        """Working-connection counts keyed by public ``client_id``.
+
+        Counts grants that are ``active`` AND bound to an ``active`` agent:
+        a grant on a disabled agent is dormant (#1233 — no token resolves
+        while the agent is non-active), so counting it as a live connection
+        would make the clients list lie. The dormant rows themselves stay
+        visible in :meth:`list_grants`, annotated with the agent's status.
+        """
         stmt = (
             select(OAuthClientGrant.oauth_client_id, func.count())
-            .where(OAuthClientGrant.status == OAuthGrantStatus.ACTIVE.value)
+            .join(Agent, Agent.id == OAuthClientGrant.agent_id)
+            .where(
+                OAuthClientGrant.status == OAuthGrantStatus.ACTIVE.value,
+                Agent.status == ActorStatus.ACTIVE.value,
+            )
             .group_by(OAuthClientGrant.oauth_client_id)
         )
         result = await session.execute(stmt)
@@ -161,17 +177,20 @@ class OAuthClientGrantRepository:
 
     @staticmethod
     async def count_active_for_client(session: AsyncSession, oauth_client_id: str) -> int:
-        """Active-grant count for ONE public ``client_id``.
+        """Working-connection count for ONE public ``client_id``.
 
         The single-client companion to :meth:`count_active_by_client` — a
         per-client GET must not pay a whole-table aggregate for one row.
+        Same honesty rule: only grants whose agent is ``active`` count.
         """
         stmt = (
             select(func.count())
             .select_from(OAuthClientGrant)
+            .join(Agent, Agent.id == OAuthClientGrant.agent_id)
             .where(
                 OAuthClientGrant.oauth_client_id == oauth_client_id,
                 OAuthClientGrant.status == OAuthGrantStatus.ACTIVE.value,
+                Agent.status == ActorStatus.ACTIVE.value,
             )
         )
         result = await session.execute(stmt)

--- a/src/jentic_one/admin/services/oauth_grant_admin_service.py
+++ b/src/jentic_one/admin/services/oauth_grant_admin_service.py
@@ -9,6 +9,7 @@ owner-or-admin check) the per-agent "Connected clients" panel.
 
 from __future__ import annotations
 
+from jentic_one.admin.repos import AgentRepository
 from jentic_one.admin.repos.oauth_client_grant_repo import OAuthClientGrantRepository
 from jentic_one.admin.repos.oauth_client_repo import OAuthClientRepository
 from jentic_one.admin.services.errors import InvalidInputError
@@ -101,6 +102,12 @@ class OAuthGrantAdminService:
             clients = await OAuthClientRepository.list_by_client_ids(
                 session, sorted({g.oauth_client_id for g in grants})
             )
+            # #1233 honesty: annotate each row with the bound agent's
+            # lifecycle state, so a dormant grant (active row, disabled
+            # agent) is distinguishable from a working connection.
+            agent_statuses = await AgentRepository.get_status_by_ids(
+                session, sorted({g.agent_id for g in grants})
+            )
 
         clients_by_id = {c.client_id: c for c in clients}
         views = [
@@ -108,6 +115,7 @@ class OAuthGrantAdminService:
                 g,
                 clients_by_id.get(g.oauth_client_id),
                 can_revoke=viewer_can_revoke(g.user_id, identity),
+                agent_status=agent_statuses.get(g.agent_id),
             )
             for g in grants
         ]

--- a/src/jentic_one/admin/services/schemas/oauth_grants.py
+++ b/src/jentic_one/admin/services/schemas/oauth_grants.py
@@ -20,6 +20,11 @@ class OAuthGrantView(BaseModel):
     ``can_revoke`` is the viewer's per-item ``:revoke`` capability — computed
     from the same predicate the revoke endpoint enforces, so the UI never
     advertises a revoke that would 403 (the G10 list/revoke divergence).
+    ``agent_status`` is the bound agent's lifecycle state (#1233): a grant on
+    a disabled agent stays ``active`` by design (dormant — nothing resolves
+    while the agent is non-active, and re-enable restores the standing
+    consent), so listings must let the viewer tell a working connection from
+    a dormant one.
     """
 
     id: str
@@ -28,6 +33,7 @@ class OAuthGrantView(BaseModel):
     client_origin: str | None
     user_id: str
     agent_id: str
+    agent_status: str | None
     scopes: list[str]
     status: str
     created_at: datetime
@@ -47,7 +53,11 @@ def redirect_uri_origin(client: OAuthClient | None) -> str | None:
 
 
 def grant_to_view(
-    grant: OAuthClientGrant, client: OAuthClient | None, *, can_revoke: bool
+    grant: OAuthClientGrant,
+    client: OAuthClient | None,
+    *,
+    can_revoke: bool,
+    agent_status: str | None = None,
 ) -> OAuthGrantView:
     """Build the enriched view; ``client`` may be None for a deleted row."""
     return OAuthGrantView(
@@ -57,6 +67,7 @@ def grant_to_view(
         client_origin=redirect_uri_origin(client),
         user_id=grant.user_id,
         agent_id=grant.agent_id,
+        agent_status=agent_status,
         scopes=list(grant.scopes),
         status=grant.status,
         created_at=grant.created_at,

--- a/src/jentic_one/admin/web/routers/oauth_grants.py
+++ b/src/jentic_one/admin/web/routers/oauth_grants.py
@@ -27,6 +27,7 @@ def _to_response(view: OAuthGrantView) -> OAuthGrantAdminResponse:
         client_origin=view.client_origin,
         user_id=view.user_id,
         agent_id=view.agent_id,
+        agent_status=view.agent_status,
         scopes=view.scopes,
         status=view.status,
         created_at=view.created_at,

--- a/src/jentic_one/admin/web/schemas/oauth_grants.py
+++ b/src/jentic_one/admin/web/schemas/oauth_grants.py
@@ -28,6 +28,15 @@ class OAuthGrantAdminResponse(BaseModel):
         "consenter (it is their consent, not the agent's)."
     )
     agent_id: str = Field(description="The agent this grant binds the client to.")
+    agent_status: str | None = Field(
+        default=None,
+        description="Lifecycle state of the bound agent (`active`, `disabled`, "
+        "`archived`, …). A grant on a non-active agent is dormant: the row "
+        "stays `active` (disable is reversible — re-enable restores the "
+        "standing consent without a new consent round) but no token resolves "
+        "while the agent is non-active. Lets listings tell a working "
+        "connection from a dormant one (#1233).",
+    )
     scopes: list[str] = Field(description="Scopes granted at consent (the D2 intersection).")
     status: str = Field(description="Grant lifecycle state: ``active`` or ``revoked``.")
     created_at: datetime

--- a/src/jentic_one/auth/services/agent_service.py
+++ b/src/jentic_one/auth/services/agent_service.py
@@ -389,6 +389,14 @@ class AgentService:
         return AgentView.model_validate(agent)
 
     async def disable(self, agent_id: str, *, identity: Identity) -> None:
+        # #1233 (disable arm, DECIDED): disable does NOT sweep oauth_client_grants.
+        # Disable is a reversible kill-switch — the enforcement layer already
+        # fail-closes everything while disabled (resolvers gate on status,
+        # refresh re-checks per rotation), so the grants stay DORMANT and
+        # re-enable restores the standing consent without a new consent round
+        # (the GitHub app-suspension model). The honesty half of #1233 is
+        # fixed at the listing layer instead: counts exclude and listings
+        # annotate grants whose agent is non-active.
         async with self._ctx.admin_db.transaction() as session:
             await self._check_transition(session, agent_id, ActorVerb.DISABLE)
             await AgentRepository.update_status(session, agent_id, ActorStatus.DISABLED)
@@ -432,8 +440,8 @@ class AgentService:
             # Sweep them in the archive's own transaction, reusing the G10
             # per-agent revocation body (row flip + token sweep + audit +
             # event) with an archive stamp. `disable` deliberately does NOT
-            # sweep: it is reversible, and whether re-enable should require
-            # fresh consent is an open policy question (#1233).
+            # sweep (#1233, decided): it is reversible, grants stay dormant
+            # and re-enable restores the standing consent — see disable().
             await revoke_active_grants_for_agent(
                 session,
                 agent_id,

--- a/src/jentic_one/auth/web/routers/oauth_grants.py
+++ b/src/jentic_one/auth/web/routers/oauth_grants.py
@@ -38,6 +38,7 @@ def grant_response(view: OAuthGrantView) -> OAuthGrantResponse:
         client_origin=view.client_origin,
         user_id=view.user_id,
         agent_id=view.agent_id,
+        agent_status=view.agent_status,
         scopes=view.scopes,
         status=view.status,
         created_at=view.created_at,

--- a/src/jentic_one/auth/web/schemas/oauth_grants.py
+++ b/src/jentic_one/auth/web/schemas/oauth_grants.py
@@ -28,6 +28,15 @@ class OAuthGrantResponse(BaseModel):
         "consenter (it is their consent, not the agent's)."
     )
     agent_id: str = Field(description="The agent this grant binds the client to.")
+    agent_status: str | None = Field(
+        default=None,
+        description="Lifecycle state of the bound agent (`active`, `disabled`, "
+        "`archived`, …). A grant on a non-active agent is dormant: the row "
+        "stays `active` (disable is reversible — re-enable restores the "
+        "standing consent without a new consent round) but no token resolves "
+        "while the agent is non-active. Lets listings tell a working "
+        "connection from a dormant one (#1233).",
+    )
     scopes: list[str] = Field(description="Scopes granted at consent (the D2 intersection).")
     status: str = Field(description="Grant lifecycle state: ``active`` or ``revoked``.")
     created_at: datetime

--- a/tests/integration/auth/test_oauth_grant_archive_sweep.py
+++ b/tests/integration/auth/test_oauth_grant_archive_sweep.py
@@ -10,9 +10,14 @@ cross-view — reported live consent on a dead agent. The fix reuses the G10
 transfer sweep (``revoke_active_grants_for_agent``) inside the archive
 transaction with an archive-specific cause stamp.
 
-``disable`` deliberately does NOT sweep — it is reversible, and whether
-re-enable should require fresh consent is an open policy question tracked in
-#1233. The disable test below PINS that current behaviour on purpose.
+``disable`` deliberately does NOT sweep — DECIDED (#1233, disable arm):
+disable is a reversible kill-switch, so grants go DORMANT (the enforcement
+layer fail-closes everything while disabled) and re-enable restores the
+standing consent without a new consent round — the GitHub app-suspension
+model, not the Google Workspace app-block model. The honesty half of the
+issue is fixed at the listing layer instead: client-level counts exclude,
+and grant listings annotate, grants whose agent is non-active. The disable
+test below PINS the decided behaviour.
 """
 
 from __future__ import annotations
@@ -25,6 +30,8 @@ from sqlalchemy import select
 from jentic_one.admin.core.schema.audit import AuditEntry
 from jentic_one.admin.core.schema.events import Event
 from jentic_one.admin.repos import AgentRepository
+from jentic_one.admin.services.oauth_client_service import OAuthClientService
+from jentic_one.admin.services.oauth_grant_admin_service import OAuthGrantAdminService
 from jentic_one.auth.services.agent_service import AgentService
 from jentic_one.auth.services.errors import InvalidGrantError
 from jentic_one.auth.services.oauth_grant_service import (
@@ -121,15 +128,17 @@ async def test_archive_revokes_active_grants_and_fails_refresh_closed(
 async def test_disable_leaves_grants_active_by_design(
     integration_context: Context, clean_grants: None
 ) -> None:
-    """PINS the deliberately-open half of #1233: ``disable`` does NOT sweep.
+    """PINS the DECIDED disable arm of #1233: ``disable`` does NOT sweep.
 
-    Disable is a reversible state — whether re-enable should require fresh
-    consent (sweep on disable) or restore the standing consent (leave grants)
-    is an open policy question, so this test pins the CURRENT behaviour:
-    the grant row stays ``active``, while the platform still fails closed at
-    the token layer (no token resolves and refresh refuses for a non-active
-    agent — the #1136 gates). If a decision lands to sweep on disable, this
-    test is the one to flip.
+    Decided: dormant + honest listings. Disable is a reversible kill-switch —
+    the enforcement layer already fail-closes everything while disabled (no
+    token resolves and refresh refuses for a non-active agent, the #1136
+    gates), so sweeping would make disable semi-terminal (re-enable would
+    force every connected client through a fresh consent round). The grant
+    rows stay ``active`` (dormant); the listing/count surfaces tell the truth
+    about them instead (see ``test_disabled_agent_grants_excluded_from_client_counts``
+    and ``test_grant_listings_annotate_agent_status``). If this policy is
+    ever reversed, this test is the one to flip.
     """
     ctx = integration_context
     owner = await seeds.seed_user(ctx, "usr_dis_owner")
@@ -153,6 +162,108 @@ async def test_disable_leaves_grants_active_by_design(
     assert resolved is None or resolved.active is False
     with pytest.raises(InvalidGrantError, match="not active"):
         await token_svc.refresh(refresh, client_id=seeds.CLIENT_ID)
+
+
+async def test_reenable_restores_standing_consent(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """The dormancy round-trip that makes the no-sweep decision meaningful:
+    disable → refresh refuses; enable → the SAME grant refreshes to fresh
+    working tokens, with no new consent round. If disable ever started
+    sweeping, this test would fail with the grant revoked."""
+    ctx = integration_context
+    owner = await seeds.seed_user(ctx, "usr_ren_owner")
+    admin_id = await seeds.seed_user(ctx, "usr_ren_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=owner, scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    grant_id, _access, refresh, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=owner, agent_id=agent_id, grant_scopes=["apis:read"]
+    )
+    svc = AgentService(ctx)
+    identity = _admin_identity(admin_id)
+
+    await svc.disable(agent_id, identity=identity)
+    with pytest.raises(InvalidGrantError, match="not active"):
+        await TokenService(ctx).refresh(refresh, client_id=seeds.CLIENT_ID)
+
+    await svc.enable(agent_id, identity=identity)
+
+    grant = await OAuthGrantService(ctx).get_grant(grant_id)
+    assert grant is not None and grant.status == "active"
+    new_access, _new_refresh, _scopes = await TokenService(ctx).refresh(
+        refresh, client_id=seeds.CLIENT_ID
+    )
+    resolved = await TokenService(ctx).resolve_access_token(new_access)
+    assert resolved is not None and resolved.active is True
+
+
+async def test_disabled_agent_grants_excluded_from_client_counts(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """#1233 honesty, count side: a dormant grant (active row, disabled
+    agent) does not count as a working connection on the client surfaces —
+    and comes back when the agent is re-enabled."""
+    ctx = integration_context
+    owner = await seeds.seed_user(ctx, "usr_cnt_owner")
+    admin_id = await seeds.seed_user(ctx, "usr_cnt_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=owner, scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    await seeds.mint_grant_channel_tokens(
+        ctx, user_id=owner, agent_id=agent_id, grant_scopes=["apis:read"]
+    )
+    client_svc = OAuthClientService(ctx)
+    client_view = await client_svc.get_by_client_id(seeds.CLIENT_ID)
+    assert client_view is not None
+
+    async def _counts() -> tuple[int, int]:
+        per_client = (await client_svc.get(client_view.id)).active_grant_count
+        listed = {c.client_id: c.active_grant_count for c in await client_svc.list_all()}
+        return per_client or 0, listed.get(seeds.CLIENT_ID) or 0
+
+    assert await _counts() == (1, 1)
+
+    identity = _admin_identity(admin_id)
+    await AgentService(ctx).disable(agent_id, identity=identity)
+    assert await _counts() == (0, 0)
+
+    await AgentService(ctx).enable(agent_id, identity=identity)
+    assert await _counts() == (1, 1)
+
+
+async def test_grant_listings_annotate_agent_status(
+    integration_context: Context, clean_grants: None
+) -> None:
+    """#1233 honesty, list side: the per-agent "Connected clients" listing
+    and the admin cross-view stamp each row with the bound agent's lifecycle
+    state, so a dormant grant is never mistaken for a working connection."""
+    ctx = integration_context
+    owner = await seeds.seed_user(ctx, "usr_ann_owner")
+    admin_id = await seeds.seed_user(ctx, "usr_ann_admin")
+    agent_id = await seeds.seed_agent(ctx, owner_id=owner, scopes=["apis:read"])
+    await seeds.seed_client(ctx, allowed_scopes=["apis:read"])
+    grant_id, _a, _r, _ = await seeds.mint_grant_channel_tokens(
+        ctx, user_id=owner, agent_id=agent_id, grant_scopes=["apis:read"]
+    )
+    identity = _admin_identity(admin_id)
+
+    async def _statuses() -> tuple[str | None, str | None]:
+        per_agent = await OAuthGrantService(ctx).list_grants_for_agent(agent_id, identity=identity)
+        cross_view = await OAuthGrantAdminService(ctx).list_grants(
+            identity=identity, agent_id=agent_id
+        )
+        by_id_a = {v.id: v.agent_status for v in per_agent.data}
+        by_id_x = {v.id: v.agent_status for v in cross_view.data}
+        return by_id_a[grant_id], by_id_x[grant_id]
+
+    assert await _statuses() == ("active", "active")
+
+    await AgentService(ctx).disable(agent_id, identity=identity)
+    # The row is still an ACTIVE grant — dormant, not revoked — but both
+    # listing surfaces now carry the disabled agent status.
+    assert await _statuses() == ("disabled", "disabled")
+
+    await AgentService(ctx).enable(agent_id, identity=identity)
+    assert await _statuses() == ("active", "active")
 
 
 async def test_archive_rolls_back_when_grant_sweep_fails(

--- a/tests/unit/admin/web/test_oauth_grants_router.py
+++ b/tests/unit/admin/web/test_oauth_grants_router.py
@@ -35,6 +35,7 @@ def _view(*, can_revoke: bool = True) -> OAuthGrantView:
         client_origin="https://mcpapp.example.com",
         user_id="usr_consenter",
         agent_id="agt_1",
+        agent_status="active",
         scopes=["apis:read"],
         status="active",
         created_at=datetime(2026, 8, 1, tzinfo=UTC),

--- a/tests/unit/auth/web/test_agent_oauth_grants_router.py
+++ b/tests/unit/auth/web/test_agent_oauth_grants_router.py
@@ -38,6 +38,7 @@ def _view(grant_id: str = "ocg_1", *, can_revoke: bool = True) -> OAuthGrantView
         client_origin="https://mcpapp.example.com",
         user_id="usr_consenter",
         agent_id="agt_1",
+        agent_status="active",
         scopes=["apis:read"],
         status="active",
         created_at=datetime(2026, 8, 1, tzinfo=UTC),

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -6080,6 +6080,18 @@
             "title": "Agent Id",
             "type": "string"
           },
+          "agent_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Lifecycle state of the bound agent (`active`, `disabled`, `archived`, …). A grant on a non-active agent is dormant: the row stays `active` (disable is reversible — re-enable restores the standing consent without a new consent round) but no token resolves while the agent is non-active. Lets listings tell a working connection from a dormant one (#1233).",
+            "title": "Agent Status"
+          },
           "can_revoke": {
             "description": "Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. a read-only admin.",
             "title": "Can Revoke",
@@ -6225,6 +6237,18 @@
             "description": "The agent this grant binds the client to.",
             "title": "Agent Id",
             "type": "string"
+          },
+          "agent_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Lifecycle state of the bound agent (`active`, `disabled`, `archived`, …). A grant on a non-active agent is dormant: the row stays `active` (disable is reversible — re-enable restores the standing consent without a new consent round) but no token resolves while the agent is non-active. Lets listings tell a working connection from a dormant one (#1233).",
+            "title": "Agent Status"
           },
           "can_revoke": {
             "description": "Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. the agent's new owner after an ownership transfer, or a read-only admin.",

--- a/ui/src/shared/api/generated/models/OAuthGrantAdminResponse.ts
+++ b/ui/src/shared/api/generated/models/OAuthGrantAdminResponse.ts
@@ -11,6 +11,10 @@ export type OAuthGrantAdminResponse = {
      */
     agent_id: string;
     /**
+     * Lifecycle state of the bound agent (`active`, `disabled`, `archived`, …). A grant on a non-active agent is dormant: the row stays `active` (disable is reversible — re-enable restores the standing consent without a new consent round) but no token resolves while the agent is non-active. Lets listings tell a working connection from a dormant one (#1233).
+     */
+    agent_status?: (string | null);
+    /**
      * Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. a read-only admin.
      */
     can_revoke: boolean;

--- a/ui/src/shared/api/generated/models/OAuthGrantResponse.ts
+++ b/ui/src/shared/api/generated/models/OAuthGrantResponse.ts
@@ -11,6 +11,10 @@ export type OAuthGrantResponse = {
      */
     agent_id: string;
     /**
+     * Lifecycle state of the bound agent (`active`, `disabled`, `archived`, …). A grant on a non-active agent is dormant: the row stays `active` (disable is reversible — re-enable restores the standing consent without a new consent round) but no token resolves while the agent is non-active. Lets listings tell a working connection from a dormant one (#1233).
+     */
+    agent_status?: (string | null);
+    /**
      * Whether the CALLER may revoke this grant (the consenting user, or an admin holding the revoke permission set). May be false even for callers who can list — e.g. the agent's new owner after an ownership transfer, or a read-only admin.
      */
     can_revoke: boolean;


### PR DESCRIPTION
## Summary

Decides and closes the **disable arm** of #1233 (the archive arm landed in #1340). Decision: **disable does NOT sweep `oauth_client_grants` — grants go dormant, and the listing/count surfaces tell the truth about them instead.** Re-enabling an agent restores the standing consent without forcing every connected MCP client through a fresh consent round.

## Decision: dormant, not sweep

**Research (industry precedent splits, so our own posture is the tiebreaker):**

| Platform | Reversible control | Effect on grants/tokens | On restore |
| --- | --- | --- | --- |
| GitHub App **installation suspension** | reversible, per-installation | tokens **refused** while suspended (403 "This installation has been suspended"); authorization **not revoked** | unsuspend restores access, no re-consent ([docs](https://docs.github.com/en/apps/maintaining-github-apps/suspending-a-github-app-installation)) |
| Google Workspace **app block/restrict** | reversible, per-app | existing OAuth tokens **revoked** ("apps … stop working and tokens are revoked") | unblock does NOT restore — users re-authorize ([docs](https://support.google.com/a/answer/7281227)) |

GitHub's suspension is the closer analogue to our per-agent disable: a temporary kill-switch on one *installation* (≈ one agent), while Google's block is an admin trust decision about *the app itself* — which in our model maps to OAuth-client deactivation and the per-grant `:revoke` kill switch, both of which already exist and do revoke.

**Our platform's posture (validates dormant):**
- Nothing is live while disabled: both token resolvers gate on `agent.status == 'active'` (#1136), and the refresh arm re-checks grant + actor status per rotation. The enforcement layer fail-closes everything — a sweep adds no security, only irreversibility.
- Sweeping would make disable semi-terminal: re-enable ⇒ every connected client re-consents, which contradicts "reversible kill-switch". (#1252's parseable restart signal makes a sweep *less punishing*, but less punishing ≠ right.)
- The consent is the user's decision that "client X may reach agent Y with scopes Z" — temporarily disabling the agent doesn't invalidate that decision. Archive (terminal) and ownership transfer (consent's subject changed) do, and both already sweep.
- The real #1233 complaint is **listings/counts lying** — fixed directly at the read layer below.

## Changes

- `control`/service: `AgentService.disable` gets the decision as a code comment; **no behavioural change to disable/enable** (that's the decision).
- Repo (`oauth_client_grant_repo`): `count_active_by_client` + `count_active_for_client` now join `agents` and count only grants **on active agents** — the OAuth-clients list/detail `active_grant_count` becomes "working connections", not "rows with status=active". `list_active_for_agent` (the transfer/archive sweep set) deliberately keeps NO status filter — documented why.
- Listings: `OAuthGrantView`/`grant_to_view` + both response models (`OAuthGrantResponse`, `OAuthGrantAdminResponse`) gain **`agent_status`** — the per-agent "Connected clients" panel and the admin cross-view now carry the bound agent's lifecycle state per row (one batched `AgentRepository.get_status_by_ids` query per page).
- OpenAPI + UI generated client regenerated (`make openapi`, `npm run codegen`).
- Pin test `test_disable_leaves_grants_active_by_design` reworded from "open question" to "decided: dormant + honest listings".
- **Deliberately out of scope:** rendering `agent_status` badges in the settings OAuth-clients UI (`ClientDetailSheet`/`ClientsTable`) — that area is being rebuilt concurrently on `feat/oauth-clients-ui-rebuild` (hard-delete + terminology wave); the field is in the API contract ready for it to consume. The agent-detail "Connected clients" panel sits on a page that already shows the agent's status banner.

## Risk & rollback

- Semantics change on a read surface: `active_grant_count` (OAuth clients list + detail) no longer counts grants on disabled agents. No write-path, auth, or token behaviour changes.
- New optional response field `agent_status` on two grant-listing endpoints — additive, non-breaking.
- Rollback: revert the squash commit.

## Test plan

- New integration tests (`tests/integration/auth/test_oauth_grant_archive_sweep.py`):
  - `test_reenable_restores_standing_consent` — disable → refresh refused; enable → the SAME grant refreshes to working tokens (pins the dormancy round-trip).
  - `test_disabled_agent_grants_excluded_from_client_counts` — counts drop to 0 on disable, return on enable (both `get` and `list_all` count paths).
  - `test_grant_listings_annotate_agent_status` — per-agent listing + admin cross-view stamp `disabled`/`active` per row.
- Reworded pin test still asserts: no sweep, no revoked events, token layer fails closed while disabled.
- Ran: `make fmt lint typecheck` clean; `tests/unit` + `tests/arch` (3864 passed); integration-auth suite on sqlite (132 passed); UI `tsc --noEmit` clean after codegen.

Closes #1233

Made with [Cursor](https://cursor.com)