### PR TITLE
feat(ui): hard-delete OAuth clients from the danger zone + Disable/Enable vocabulary

### DIFF
--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -69,7 +69,7 @@ describe('OAuth clients surface (via SettingsPage)', () => {
 		expect(screen.queryByText('Legacy App')).not.toBeInTheDocument();
 	});
 
-	it('status segments carry live counts and Inactive surfaces the approved+inactive zombie (#1312)', async () => {
+	it('status segments carry live counts and Disabled surfaces the approved+inactive zombie (#1312)', async () => {
 		const user = userEvent.setup();
 		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
@@ -79,22 +79,22 @@ describe('OAuth clients surface (via SettingsPage)', () => {
 		expect(screen.getByRole('button', { name: 'Active 1' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Pending 1' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Denied 1' })).toBeInTheDocument();
-		expect(screen.getByRole('button', { name: 'Inactive 1' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Disabled 1' })).toBeInTheDocument();
 
-		// The zombie — approved but deactivated, invisible to both queue
-		// filters — lives under the Inactive segment with its chip.
-		await user.click(screen.getByRole('button', { name: 'Inactive 1' }));
+		// The zombie — approved but disabled, invisible to both queue
+		// filters — lives under the Disabled segment with its chip.
+		await user.click(screen.getByRole('button', { name: 'Disabled 1' }));
 		expect(await screen.findByText('Legacy App')).toBeInTheDocument();
-		expect(screen.getByText('Inactive')).toBeInTheDocument();
+		expect(screen.getByText('Disabled')).toBeInTheDocument();
 		expect(screen.queryByText('Internal Dashboard')).not.toBeInTheDocument();
 	});
 
-	it('never offers Reactivate on a denied row — its recovery routes to the queue', async () => {
+	it('never offers Enable on a denied row — its recovery routes to the queue', async () => {
 		const user = userEvent.setup();
 		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
-		// The denied row's kebab: Review in queue, but NO Reactivate (a PATCH
+		// The denied row's kebab: Review in queue, but NO Enable (a PATCH
 		// active=true would leave approval_status=denied — still gate-blocked).
 		await user.click(screen.getByRole('button', { name: 'Denied 1' }));
 		await screen.findByText('Sketchy Tool');
@@ -102,16 +102,16 @@ describe('OAuth clients surface (via SettingsPage)', () => {
 		expect(
 			await screen.findByRole('menuitem', { name: 'Review in queue Sketchy Tool' }),
 		).toBeInTheDocument();
-		expect(screen.queryByRole('menuitem', { name: /Reactivate/ })).not.toBeInTheDocument();
+		expect(screen.queryByRole('menuitem', { name: /Enable/ })).not.toBeInTheDocument();
 		await user.keyboard('{Escape}');
 
-		// The approved+inactive zombie DOES get Reactivate — the one state
+		// The approved+inactive zombie DOES get Enable — the one state
 		// where a plain PATCH active=true actually un-blocks the client.
-		await user.click(screen.getByRole('button', { name: 'Inactive 1' }));
+		await user.click(screen.getByRole('button', { name: 'Disabled 1' }));
 		await screen.findByText('Legacy App');
 		await user.click(screen.getByRole('button', { name: 'Actions for Legacy App' }));
 		expect(
-			await screen.findByRole('menuitem', { name: 'Reactivate Legacy App' }),
+			await screen.findByRole('menuitem', { name: 'Enable Legacy App' }),
 		).toBeInTheDocument();
 	});
 
@@ -360,20 +360,95 @@ describe('OAuth clients surface (via SettingsPage)', () => {
 		await checkA11y(document.body);
 	});
 
-	it("offers Reactivate in a zombie's detail sheet (recovery from its own console)", async () => {
+	it("offers Enable in a zombie's detail sheet (recovery from its own console)", async () => {
 		const user = userEvent.setup();
 		renderSettingsPage();
 		await screen.findByText('Internal Dashboard');
 
 		// The approved+inactive zombie must not be stranded: its own console
 		// (the danger zone) carries the recovery verb.
-		await user.click(screen.getByRole('button', { name: 'Inactive 1' }));
+		await user.click(screen.getByRole('button', { name: 'Disabled 1' }));
 		await screen.findByText('Legacy App');
 		await user.click(screen.getByRole('button', { name: 'View details for Legacy App' }));
 		const sheet = await screen.findByTestId('sheet-primitive');
 
-		await user.click(within(sheet).getByRole('button', { name: 'Reactivate Legacy App' }));
-		expect(await screen.findByText('Legacy App reactivated')).toBeInTheDocument();
+		await user.click(within(sheet).getByRole('button', { name: 'Enable Legacy App' }));
+		expect(await screen.findByText('Legacy App enabled')).toBeInTheDocument();
+	});
+
+	// ------------------------------------------------------------------
+	// Lifecycle: Disable (reversible) vs Delete (permanent)
+	// ------------------------------------------------------------------
+
+	it('disables a client from the kebab via the Disable confirm (reversible kill switch)', async () => {
+		const user = userEvent.setup();
+		renderSettingsPage();
+		await screen.findByText('Internal Dashboard');
+
+		await user.click(screen.getByRole('button', { name: 'Actions for Internal Dashboard' }));
+		await user.click(
+			await screen.findByRole('menuitem', { name: 'Disable Internal Dashboard' }),
+		);
+
+		const dialog = await screen.findByRole('dialog', { name: 'Disable OAuth Client?' });
+		await user.click(within(dialog).getByRole('button', { name: 'Disable' }));
+
+		expect(await screen.findByText('OAuth client disabled')).toBeInTheDocument();
+		// The row leaves the Active segment for the Disabled one — reversibly.
+		expect(await screen.findByRole('button', { name: 'Disabled 2' })).toBeInTheDocument();
+	});
+
+	it('hard-deletes a client: type-to-confirm gates the verb, then the row is gone for good', async () => {
+		const user = userEvent.setup();
+		renderSettingsPage();
+		await screen.findByText('Internal Dashboard');
+
+		await user.click(screen.getByRole('button', { name: 'Actions for Internal Dashboard' }));
+		await user.click(
+			await screen.findByRole('menuitem', { name: 'Delete Internal Dashboard' }),
+		);
+
+		// The GitHub-pattern friction gate: the danger button stays disabled
+		// until the user types the confirm word.
+		const dialog = await screen.findByRole('dialog', { name: 'Delete OAuth client' });
+		const confirmBtn = within(dialog).getByRole('button', { name: /Delete client/ });
+		expect(confirmBtn).toBeDisabled();
+		await user.type(within(dialog).getByLabelText(/Type/), 'delete');
+		expect(confirmBtn).toBeEnabled();
+
+		// The opened type-to-confirm dialog passes axe (body portal).
+		await settleHeader();
+		await checkA11y(document.body);
+
+		await user.click(confirmBtn);
+		expect(await screen.findByText('Internal Dashboard deleted')).toBeInTheDocument();
+
+		// Terminal: the row is gone from EVERY segment, not parked under
+		// Disabled — and the store's grants were revoked with it. The roster
+		// refetch after the invalidation is async, so poll the disappearance.
+		await expect.poll(() => screen.queryByText('Internal Dashboard')).toBeNull();
+		expect(await screen.findByRole('button', { name: 'All 3' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Disabled 1' })).toBeInTheDocument();
+	});
+
+	it('deletes from the detail sheet danger zone and closes the sheet (its row is gone)', async () => {
+		const user = userEvent.setup();
+		renderSettingsPage();
+		await screen.findByText('Internal Dashboard');
+
+		await user.click(
+			screen.getByRole('button', { name: 'View details for Internal Dashboard' }),
+		);
+		const sheet = await screen.findByTestId('sheet-primitive');
+		await user.click(within(sheet).getByRole('button', { name: 'Delete Internal Dashboard' }));
+
+		const dialog = await screen.findByRole('dialog', { name: 'Delete OAuth client' });
+		await user.type(within(dialog).getByLabelText(/Type/), 'delete');
+		await user.click(within(dialog).getByRole('button', { name: /Delete client/ }));
+
+		expect(await screen.findByText('Internal Dashboard deleted')).toBeInTheDocument();
+		// The sheet must not stay open on a row that now 404s.
+		await expect.poll(() => screen.queryByTestId('sheet-primitive')).toBeNull();
 	});
 
 	it('revoke honours can_revoke: enabled kill switch vs. disabled with explanation', async () => {

--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -431,6 +431,40 @@ describe('OAuth clients surface (via SettingsPage)', () => {
 		expect(screen.getByRole('button', { name: 'Disabled 1' })).toBeInTheDocument();
 	});
 
+	it('renders a failed delete inline in the dialog (no toast) and keeps it open for retry', async () => {
+		const user = userEvent.setup();
+		// The backend refuses (e.g. a conflicting concurrent decision) — the
+		// dialog must surface the error inline and stay open; the row survives.
+		worker.use(
+			http.post('/admin/oauth-clients/:id\\:delete', () =>
+				HttpResponse.json(
+					{ title: 'Conflict', detail: 'client has a decision in flight' },
+					{ status: 409 },
+				),
+			),
+		);
+		renderSettingsPage();
+		await screen.findByText('Internal Dashboard');
+
+		await user.click(screen.getByRole('button', { name: 'Actions for Internal Dashboard' }));
+		await user.click(
+			await screen.findByRole('menuitem', { name: 'Delete Internal Dashboard' }),
+		);
+
+		const dialog = await screen.findByRole('dialog', { name: 'Delete OAuth client' });
+		await user.type(within(dialog).getByLabelText(/Type/), 'delete');
+		await user.click(within(dialog).getByRole('button', { name: /Delete client/ }));
+
+		// One error surface: inline in the dialog (post-attempt), never a toast.
+		expect(await within(dialog).findByRole('alert')).toBeInTheDocument();
+		expect(screen.getByRole('dialog', { name: 'Delete OAuth client' })).toBeInTheDocument();
+		expect(screen.queryByText('Internal Dashboard deleted')).not.toBeInTheDocument();
+
+		// The row is untouched — closing the dialog lands back on the intact roster.
+		await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+		expect(await screen.findByText('Internal Dashboard')).toBeInTheDocument();
+	});
+
 	it('deletes from the detail sheet danger zone and closes the sheet (its row is gone)', async () => {
 		const user = userEvent.setup();
 		renderSettingsPage();

--- a/ui/src/modules/settings/api/hooks.ts
+++ b/ui/src/modules/settings/api/hooks.ts
@@ -156,6 +156,24 @@ export function useDeactivateOAuthClient() {
 	});
 }
 
+/**
+ * Permanently delete a client (`POST /admin/oauth-clients/{id}:delete`) —
+ * terminal, unlike the disable kill switch above: the backend revokes every
+ * active grant + token and removes the row, so the sweep also covers the
+ * shared oauth-grants root (the agents module's "Connected clients" panels
+ * must not keep showing grants of a dead client as active).
+ */
+export function useDeleteOAuthClient() {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (id: string) => OAuthClientsService.deleteOauthClient({ id }),
+		onSuccess: () => {
+			void qc.invalidateQueries({ queryKey: QUERY_KEY });
+			void qc.invalidateQueries({ queryKey: sharedQueryKeys.oauthGrantsRoot });
+		},
+	});
+}
+
 export function useReactivateOAuthClient() {
 	const qc = useQueryClient();
 	return useMutation({

--- a/ui/src/modules/settings/components/ClientDetailSheet.tsx
+++ b/ui/src/modules/settings/components/ClientDetailSheet.tsx
@@ -6,7 +6,8 @@
  * ConnectedClientsCard, via the admin cross-view `GET
  * /admin/oauth-grants?client_id=…`), the client-scoped audit trail ("Recent
  * changes" — where deny reasons finally surface), and a danger zone
- * (deactivate / rotate secret, confirmed at the section level).
+ * (disable/enable, rotate secret, and the permanent delete — all confirmed
+ * at the section level).
  *
  * A detail view, not a form — no drafts to preserve — but the revoke confirm
  * is a stateless Dialog (conditional mount is fine per the dialog-state
@@ -286,10 +287,12 @@ export interface ClientDetailSheetProps {
 	onEdit: (client: OAuthClient) => void;
 	/** Opens the section-level rotate confirm (then the one-time secret dialog). */
 	onRotate: (client: OAuthClient) => void;
-	/** Opens the section-level deactivate confirm (explains the DCR re-queue). */
+	/** Opens the section-level disable confirm (explains the DCR re-queue). */
 	onDeactivate: (client: OAuthClient) => void;
-	/** Fires the section-level reactivate mutation (approved+inactive only). */
+	/** Fires the section-level enable mutation (approved+inactive only). */
 	onReactivate: (client: OAuthClient) => void;
+	/** Opens the section-level type-to-confirm delete dialog (permanent). */
+	onDelete: (client: OAuthClient) => void;
 }
 
 export function ClientDetailSheet({
@@ -300,6 +303,7 @@ export function ClientDetailSheet({
 	onRotate,
 	onDeactivate,
 	onReactivate,
+	onDelete,
 }: ClientDetailSheetProps) {
 	// Re-read while open so decisions taken from the queue/roster (approve,
 	// rotate, deactivate) refresh the sheet; the seed row renders immediately.
@@ -315,27 +319,27 @@ export function ClientDetailSheet({
 			? [
 					{
 						key: 'deactivate',
-						title: 'Deactivate client',
+						title: 'Disable client',
 						description:
-							'Blocks new authorization flows. A deactivated client that re-registers via DCR returns to the approval queue.',
-						buttonLabel: 'Deactivate',
-						ariaLabel: `Deactivate ${client.name}`,
+							'Blocks new authorization flows — reversible. A disabled client that re-registers via DCR returns to the approval queue.',
+						buttonLabel: 'Disable',
+						ariaLabel: `Disable ${client.name}`,
 						emphasis: 'outline' as const,
 					},
 				]
 			: []),
 		// The approved+inactive zombie's escape hatch — without it a
-		// deactivated client's own console offers no recovery path.
+		// disabled client's own console offers no recovery path.
 		// (Denied rows never reach here: `canReactivate` requires approved.)
 		...(canReactivate(client)
 			? [
 					{
 						key: 'reactivate',
-						title: 'Reactivate client',
+						title: 'Enable client',
 						description:
 							'Restores the client — it can start authorization flows again immediately.',
-						buttonLabel: 'Reactivate',
-						ariaLabel: `Reactivate ${client.name}`,
+						buttonLabel: 'Enable',
+						ariaLabel: `Enable ${client.name}`,
 						emphasis: 'outline' as const,
 					},
 				]
@@ -353,6 +357,19 @@ export function ClientDetailSheet({
 					},
 				]
 			: []),
+		// Delete is offered in EVERY lifecycle state (the GitHub model:
+		// terminal removal is always available); the type-to-confirm dialog
+		// owned by the section carries the friction. Solid emphasis — the one
+		// irreversible verb in the zone.
+		{
+			key: 'delete',
+			title: 'Delete client',
+			description:
+				'Permanently deletes the client: every grant and token is revoked and connected applications are disconnected. This cannot be undone.',
+			buttonLabel: 'Delete',
+			ariaLabel: `Delete ${client.name}`,
+			emphasis: 'solid' as const,
+		},
 	];
 
 	return (
@@ -493,6 +510,7 @@ export function ClientDetailSheet({
 							if (key === 'deactivate') onDeactivate(client);
 							if (key === 'reactivate') onReactivate(client);
 							if (key === 'rotate') onRotate(client);
+							if (key === 'delete') onDelete(client);
 						}}
 					/>
 				)}

--- a/ui/src/modules/settings/components/ClientLifecycleDialogs.tsx
+++ b/ui/src/modules/settings/components/ClientLifecycleDialogs.tsx
@@ -82,7 +82,13 @@ export function RotateConfirmDialog({
 	);
 }
 
-export function DeactivateConfirmDialog({
+/**
+ * The reversible kill-switch confirm. The wire verb stays `deactivate`
+ * (`DELETE /admin/oauth-clients/{id}`); user-facing copy says **Disable** —
+ * the lifecycle vocabulary's reversible pair (Disable/Enable), distinct from
+ * the permanent Delete in the danger zone's type-to-confirm dialog.
+ */
+export function DisableConfirmDialog({
 	open,
 	onClose,
 	onConfirm,
@@ -101,27 +107,27 @@ export function DeactivateConfirmDialog({
 		<Dialog
 			open={open}
 			onClose={onClose}
-			title="Deactivate OAuth Client?"
+			title="Disable OAuth Client?"
 			footer={
 				<>
 					<Button variant="outline" onClick={onClose}>
 						Cancel
 					</Button>
 					<Button variant="danger" onClick={onConfirm} disabled={isPending}>
-						{isPending ? 'Deactivating...' : 'Deactivate'}
+						{isPending ? 'Disabling...' : 'Disable'}
 					</Button>
 				</>
 			}
 		>
 			<p className="text-muted-foreground">
 				This will prevent <strong>{clientName}</strong> from initiating new authorization
-				flows. Existing sessions are not affected. You can reactivate the client later — and
-				a deactivated client that re-registers via DCR returns to the approval queue.
+				flows. Existing sessions are not affected. You can enable the client again later —
+				and a disabled client that re-registers via DCR returns to the approval queue.
 			</p>
 			{error != null && (
 				<div className="mt-3">
 					<ErrorAlert
-						message={error instanceof Error ? error : 'Failed to deactivate the client'}
+						message={error instanceof Error ? error : 'Failed to disable the client'}
 					/>
 				</div>
 			)}

--- a/ui/src/modules/settings/components/ClientsTable.tsx
+++ b/ui/src/modules/settings/components/ClientsTable.tsx
@@ -8,8 +8,8 @@
  * table swaps to stacked cards (`renderCard`).
  *
  * The toolbar replaces the old unlabelled "Show inactive" checkbox with
- * status segments carrying live counts — the Inactive segment surfaces the
- * approved-but-deactivated zombies (#1312) that used to match neither the
+ * status segments carrying live counts — the Disabled segment surfaces the
+ * approved-but-disabled zombies (#1312) that used to match neither the
  * default list nor the queue filters. The filter input is the client-side
  * Filter affordance (status-and-filter rule), disabled when there is nothing
  * to narrow.
@@ -56,13 +56,17 @@ import {
 	TimeCell,
 } from '@/modules/settings/components/clientBadges';
 
-export type ClientAction = 'edit' | 'rotate' | 'deactivate' | 'reactivate' | 'review-in-queue';
+export type ClientAction =
+	'edit' | 'rotate' | 'deactivate' | 'reactivate' | 'delete' | 'review-in-queue';
 
 const ACTION_LABEL: Record<ClientAction, string> = {
 	edit: 'Edit',
 	rotate: 'Rotate secret',
-	deactivate: 'Deactivate',
-	reactivate: 'Reactivate',
+	// Lifecycle vocabulary: Disable/Enable is the reversible kill switch
+	// (the wire verbs stay deactivate/reactivate); Delete is permanent.
+	deactivate: 'Disable',
+	reactivate: 'Enable',
+	delete: 'Delete',
 	'review-in-queue': 'Review in queue',
 };
 
@@ -81,15 +85,18 @@ const SEGMENT_ORDER: Record<Exclude<ClientStatusFilter, 'all'>, number> = {
  */
 const SEGMENT_EMPTY_MESSAGE: Record<ClientStatusFilter, string> = {
 	all: 'No clients registered yet.',
-	active: 'No active clients — check the Pending or Inactive views.',
+	active: 'No active clients — check the Pending or Disabled views.',
 	pending: 'No pending clients — new DCR registrations land in the approval queue.',
 	denied: 'No denied clients.',
-	inactive: 'No inactive clients — every approved client is live.',
+	inactive: 'No disabled clients — every approved client is live.',
 };
 
 /**
  * The lifecycle verbs a row offers. Reactivate deliberately requires
  * approved+inactive (see module comment); denied rows get "Review in queue".
+ * Delete (permanent) is offered on EVERY row — the GitHub model: any
+ * lifecycle state can be terminally removed (the section-level
+ * type-to-confirm dialog carries the friction).
  */
 function actionsFor(client: OAuthClient): ClientAction[] {
 	const actions: ClientAction[] = ['edit'];
@@ -97,10 +104,11 @@ function actionsFor(client: OAuthClient): ClientAction[] {
 	if (client.active) actions.push('deactivate');
 	if (canReactivate(client)) actions.push('reactivate');
 	if (toApprovalStatus(client.approval_status) === 'denied') actions.push('review-in-queue');
+	actions.push('delete');
 	return actions;
 }
 
-const DANGER_ACTIONS: ReadonlySet<ClientAction> = new Set(['deactivate']);
+const DANGER_ACTIONS: ReadonlySet<ClientAction> = new Set(['deactivate', 'delete']);
 
 function RowActionsMenu({
 	client,

--- a/ui/src/modules/settings/components/clientBadges.tsx
+++ b/ui/src/modules/settings/components/clientBadges.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/modules/settings/components/clientStatus';
 
 /**
- * Approval-status badge + the orthogonal "Inactive" chip. `showApproved`
+ * Approval-status badge + the orthogonal "Disabled" chip. `showApproved`
  * opts the happy state in (detail header wants the full picture; the queue
  * rows only ever carry pending/denied).
  */
@@ -35,7 +35,7 @@ export function ClientStatusBadges({
 			)}
 			{isInactiveChipVisible(client) && (
 				<span className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 font-mono text-xs">
-					Inactive
+					Disabled
 				</span>
 			)}
 		</>

--- a/ui/src/modules/settings/components/clientStatus.ts
+++ b/ui/src/modules/settings/components/clientStatus.ts
@@ -74,7 +74,11 @@ export const CLIENT_STATUS_FILTER_LABEL: Record<ClientStatusFilter, string> = {
 	active: 'Active',
 	pending: 'Pending',
 	denied: 'Denied',
-	inactive: 'Inactive',
+	// User-facing label for the approved+inactive segment: "Disabled" — the
+	// lifecycle vocabulary's reversible kill-switch verb (Disable/Enable),
+	// matching the roster's Disable/Enable actions. The segment ID stays
+	// `inactive` (internal state, mirrors the wire `active` flag).
+	inactive: 'Disabled',
 };
 
 /** Which segment (other than `all`) a client row belongs to. */

--- a/ui/src/modules/settings/mocks/handlers.ts
+++ b/ui/src/modules/settings/mocks/handlers.ts
@@ -341,6 +341,23 @@ export const settingsHandlers = [
 		appendAudit(row, 'oauth_client.deactivate');
 		return new HttpResponse(null, { status: 204 });
 	}),
+	// Hard delete (the terminal arm): revoke the client's active grants (full
+	// disconnect), then remove the row. Audit rows survive — appended before
+	// the removal, like the backend's FK-free audit table.
+	http.post('/admin/oauth-clients/:id\\:delete', ({ params }) => {
+		const row = oauthClients.find((c) => c.id === params.id);
+		if (!row) return new HttpResponse(null, { status: 404 });
+		for (const grant of oauthGrants) {
+			if (grant.oauth_client_id === row.client_id && grant.status === 'active') {
+				grant.status = 'revoked';
+				grant.revoked_at = now();
+				grant.can_revoke = false;
+			}
+		}
+		appendAudit(row, 'oauth_client.delete');
+		oauthClients = oauthClients.filter((c) => c.id !== row.id);
+		return new HttpResponse(null, { status: 204 });
+	}),
 	http.post('/admin/oauth-clients/:id/rotate-secret', ({ params }) => {
 		const row = oauthClients.find((c) => c.id === params.id);
 		if (!row) return new HttpResponse(null, { status: 404 });

--- a/ui/src/modules/settings/pages/OAuthClientsSection.tsx
+++ b/ui/src/modules/settings/pages/OAuthClientsSection.tsx
@@ -16,9 +16,10 @@
  * Denied slice.
  */
 import { useState } from 'react';
-import { toast } from '@/shared/ui';
+import { CascadeDeleteDialog, toast } from '@/shared/ui';
 import {
 	useDeactivateOAuthClient,
+	useDeleteOAuthClient,
 	useOAuthClients,
 	useReactivateOAuthClient,
 	useRotateOAuthClientSecret,
@@ -30,7 +31,7 @@ import { ClientDetailSheet } from '@/modules/settings/components/ClientDetailShe
 import { ClientFormSheet } from '@/modules/settings/components/ClientFormSheet';
 import { McpConnectCard } from '@/modules/settings/components/McpConnectCard';
 import {
-	DeactivateConfirmDialog,
+	DisableConfirmDialog,
 	RotateConfirmDialog,
 	SecretDialog,
 } from '@/modules/settings/components/ClientLifecycleDialogs';
@@ -73,6 +74,7 @@ export function OAuthClientsSection({
 	const [detailTarget, setDetailTarget] = useState<OAuthClient | null>(null);
 	const [detailOpen, setDetailOpen] = useState(false);
 	const [deactivateTarget, setDeactivateTarget] = useState<OAuthClient | null>(null);
+	const [deleteTarget, setDeleteTarget] = useState<OAuthClient | null>(null);
 	const [rotateTarget, setRotateTarget] = useState<OAuthClient | null>(null);
 	const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
 	const [secretDialogTitle, setSecretDialogTitle] = useState('Client Secret');
@@ -80,7 +82,8 @@ export function OAuthClientsSection({
 	const deactivateMutation = useDeactivateOAuthClient();
 	const reactivateMutation = useReactivateOAuthClient();
 	const rotateMutation = useRotateOAuthClientSecret();
-	const inFlight = [deactivateMutation, reactivateMutation, rotateMutation].find(
+	const deleteMutation = useDeleteOAuthClient();
+	const inFlight = [deactivateMutation, reactivateMutation, rotateMutation, deleteMutation].find(
 		(m) => m.isPending,
 	);
 	const pendingId = typeof inFlight?.variables === 'string' ? inFlight.variables : null;
@@ -101,10 +104,10 @@ export function OAuthClientsSection({
 	const handleReactivate = async (client: OAuthClient): Promise<void> => {
 		try {
 			await reactivateMutation.mutateAsync(client.id);
-			toast({ title: `${client.name} reactivated`, variant: 'success' });
+			toast({ title: `${client.name} enabled`, variant: 'success' });
 		} catch (err) {
 			toast({
-				title: 'Failed to reactivate client',
+				title: 'Failed to enable client',
 				description: err instanceof Error ? err.message : undefined,
 				variant: 'error',
 			});
@@ -127,6 +130,9 @@ export function OAuthClientsSection({
 				// a denied row's recovery is the queue's Approve verb instead.
 				void handleReactivate(client);
 				break;
+			case 'delete':
+				setDeleteTarget(client);
+				break;
 			case 'review-in-queue':
 				setQueueFilter('denied');
 				onTabChange('queue');
@@ -138,14 +144,30 @@ export function OAuthClientsSection({
 		if (!deactivateTarget) return;
 		try {
 			await deactivateMutation.mutateAsync(deactivateTarget.id);
-			toast({ title: 'OAuth client deactivated', variant: 'success' });
+			toast({ title: 'OAuth client disabled', variant: 'success' });
 			setDeactivateTarget(null);
 		} catch (err) {
 			toast({
-				title: 'Failed to deactivate client',
+				title: 'Failed to disable client',
 				description: err instanceof Error ? err.message : undefined,
 				variant: 'error',
 			});
+		}
+	};
+
+	const handleDelete = async (): Promise<void> => {
+		if (!deleteTarget) return;
+		try {
+			await deleteMutation.mutateAsync(deleteTarget.id);
+			toast({ title: `${deleteTarget.name} deleted`, variant: 'success' });
+			setDeleteTarget(null);
+			// The row is gone — a detail sheet still open on it would re-read
+			// into a 404. Close it (delete is reachable from inside the sheet).
+			if (detailTarget?.id === deleteTarget.id) setDetailOpen(false);
+		} catch {
+			// The CascadeDeleteDialog renders `deleteMutation.error` inline
+			// (post-attempt), so no toast here — one error surface, no double
+			// reporting, and the dialog stays open for a retry.
 		}
 	};
 
@@ -213,17 +235,35 @@ export function OAuthClientsSection({
 				onRotate={setRotateTarget}
 				onDeactivate={setDeactivateTarget}
 				onReactivate={(client): void => void handleReactivate(client)}
+				onDelete={setDeleteTarget}
 			/>
 
 			{/* Stateless confirms — conditional mounting is fine here. */}
 			{deactivateTarget != null && (
-				<DeactivateConfirmDialog
+				<DisableConfirmDialog
 					open
 					onClose={(): void => setDeactivateTarget(null)}
 					onConfirm={(): void => void handleDeactivate()}
 					isPending={deactivateMutation.isPending}
 					clientName={deactivateTarget.name}
 					error={deactivateMutation.error}
+				/>
+			)}
+			{/* Permanent delete — the shared type-to-confirm friction gate.
+			    Reset the mutation on close so a failed attempt's error doesn't
+			    leak into the next client's dialog session. */}
+			{deleteTarget != null && (
+				<CascadeDeleteDialog
+					open
+					onClose={(): void => {
+						setDeleteTarget(null);
+						deleteMutation.reset();
+					}}
+					onConfirm={(): void => void handleDelete()}
+					entityType="oauth-client"
+					entityName={deleteTarget.name}
+					loading={deleteMutation.isPending}
+					error={deleteMutation.error}
 				/>
 			)}
 			{rotateTarget != null && (

--- a/ui/src/shared/ui/CascadeDeleteDialog.tsx
+++ b/ui/src/shared/ui/CascadeDeleteDialog.tsx
@@ -10,7 +10,8 @@ import { Label } from '@/shared/ui/Label';
  * The entity kinds that expose a hard delete (or a terminal,
  * delete-equivalent action like agent/service-account *archive*).
  */
-export type CascadeEntityType = 'credential' | 'api' | 'toolkit' | 'agent' | 'service-account';
+export type CascadeEntityType =
+	'credential' | 'api' | 'toolkit' | 'agent' | 'service-account' | 'oauth-client';
 
 /**
  * One group in the blast-radius list. `count` is authoritative (drives the
@@ -65,6 +66,7 @@ const DEFAULT_CONFIRM_WORD: Record<CascadeEntityType, string> = {
 	toolkit: 'delete',
 	agent: 'archive',
 	'service-account': 'archive',
+	'oauth-client': 'delete',
 };
 
 /**
@@ -116,6 +118,14 @@ const TYPE_COPY: Record<
 		warning:
 			'Archiving is permanent — the service account can no longer authenticate or be restored, and its grants are released.',
 		icon: Archive,
+	},
+	'oauth-client': {
+		title: 'Delete OAuth client',
+		confirmLabel: 'Delete client',
+		noun: 'OAuth client',
+		warning:
+			'Deleting is permanent — every consent grant and token issued to this client is revoked, and connected applications are disconnected immediately. If the application registers itself again, it starts over as a new client awaiting approval.',
+		icon: Trash2,
 	},
 };
 


### PR DESCRIPTION
## What

The UI arm of the OAuth-client hard delete (stacked on the backend PR — **review/merge that first**; base is `feat/oauth-client-hard-delete`).

- **Delete in the danger zone (GitHub pattern).** `ClientDetailSheet`'s danger zone gains a solid-emphasis **Delete** action, offered on every lifecycle state; `ClientsTable`'s kebab carries the same verb. Both route to the shared `CascadeDeleteDialog` type-to-confirm gate (new `'oauth-client'` entity kind) — the user must type `delete` before the button arms. Copy spells out the blast radius: every grant and token is revoked, connected apps are disconnected, and re-registration starts over as a new client awaiting approval.
- **Section-owned mutation.** `useDeleteOAuthClient` calls the new `POST /admin/oauth-clients/{id}:delete` (regenerated client) and invalidates both the oauth-clients root and the shared oauth-grants root (agent consoles must not keep showing a dead client's grants as active). Delete failure reports inline in the dialog (single error surface, dialog stays open for retry); success toasts and closes a detail sheet left open on the now-404 row.
- **Disable/Enable vocabulary.** The reversible kill switch reads **Disable / Enable** everywhere it surfaces (kebab, danger zone, confirm dialog title/buttons, toasts), and the status segment + chip read **Disabled** — "Deactivate/Reactivate/Inactive" no longer appear in user-facing copy, so the reversible verb can't be confused with the new permanent Delete.

## Deliberately unchanged

- Wire verbs and generated identifiers (`deactivateOauthClient`, `DELETE /admin/oauth-clients/{id}`) — copy-only rename per the vocabulary matrix; API renames are a non-goal.
- The `inactive` segment/filter id and `isInactiveChipVisible` internals — they mirror the wire `active` flag; only labels changed.

## Tests

MSW store mirrors the backend delete (grant sweep before row removal, audit row survives, 404 arm). New specs: type-to-confirm gating (button disabled until the word is typed), terminal removal from every segment vs the Disabled parking lot, delete-from-sheet auto-close, the Disable confirm flow, axe on the open dialog. Existing specs updated to the new vocabulary.

## Validation

- `npm run lint:fix` clean
- `npm run build` clean
- `npm run test:run` — 131 files, 1214 tests passed (incl. axe checks)

Made with [Cursor](https://cursor.com)