### PR TITLE
fix(mcp): make served tool descriptions and actionable prose lane-true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,13 @@ jobs:
               - 'openapi/control/**'
               - 'openapi/broker/**'
               - 'config/config-schema.json'
+              # TestMCPToolSurfaceSpec pins the MCP tool-surface contract
+              # (incl. lane_overrides) from toolSpecs() into this document. A
+              # hand-edit to the pin that keeps the Python side consistent
+              # (byte-identical packaged copy + honest prose) would otherwise
+              # merge green and only fail the Go pin test post-merge on main
+              # (the same class of hole as the openapi/** entries above).
+              - 'docs/reference/mcp-tools.json'
             installer:
               - 'tools/install.sh'
               - 'tests/tools/**'

--- a/cli/internal/cli/api/mcp_server.go
+++ b/cli/internal/cli/api/mcp_server.go
@@ -138,9 +138,25 @@ func (s *mcpServer) run(ctx context.Context) error {
 // filters. There is deliberately NO separate read-only flag: --read-only
 // filters on the tool's own ReadOnlyHint annotation, so the advertised
 // annotation and the serving filter can never drift apart.
+// mcpToolLaneOverride carries a per-lane re-rendering of a tool declaration.
+// The stdio server always serves the base rendering; other lanes substitute
+// the override at tools/list time (today the only other lane is "http" — the
+// daemon-native Streamable HTTP /mcp mount, src/jentic_one/mcp). Only prose
+// that would LIE on the other lane may differ (e.g. instructions naming a
+// tool that lane does not serve); wire shape — name, input schema,
+// annotations — is lane-invariant by design.
+type mcpToolLaneOverride struct {
+	description string
+}
+
 type mcpToolSpec struct {
 	tool    *mcp.Tool
 	handler mcp.ToolHandler
+	// laneOverrides maps a lane name to its re-rendered prose. Pinned into
+	// docs/reference/mcp-tools.json as "lane_overrides" so BOTH renderings
+	// ride the one contract document and drift on either side fails a gate
+	// (Go: TestMCPToolSurfaceSpec; Python: tests/unit/mcp/test_tool_surface.py).
+	laneOverrides map[string]mcpToolLaneOverride
 }
 
 // noArgsSchema is the input schema for the parameterless tools. Kept
@@ -244,6 +260,21 @@ func (s *mcpServer) toolSpecs() []mcpToolSpec {
 				Annotations: readOnly,
 			},
 			handler: s.handleWhoami,
+			// The base prose routes auth recovery through get_started, which
+			// diagnoses the LOCAL machine's CLI setup — meaningless on the
+			// daemon-native HTTP lane, which serves no get_started (#1327
+			// deferred work). The http rendering keeps every lane-true
+			// sentence and re-roots recovery at the operator.
+			laneOverrides: map[string]mcpToolLaneOverride{
+				"http": {
+					description: "Show the calling agent's identity as the Jentic control plane sees it: " +
+						"id, status, scopes, and toolkit bindings with the APIs each one serves. " +
+						"Call before requesting access or executing operations — never execute " +
+						"an operation just to probe whether you have access. On an auth error, " +
+						"relay it to your human operator: this connection's credentials and the " +
+						"agent's status are managed in the Jentic One dashboard.",
+				},
+			},
 		},
 		{
 			tool: &mcp.Tool{

--- a/cli/internal/cli/api/mcp_spec_test.go
+++ b/cli/internal/cli/api/mcp_spec_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -56,11 +57,12 @@ func TestMCPToolSurfaceSpec_PinnedAtDocsReference(t *testing.T) {
 	s := newTestMCPServer(t, &mcpOptions{})
 
 	type toolDoc struct {
-		Name        string          `json:"name"`
-		Title       string          `json:"title"`
-		Description string          `json:"description"`
-		InputSchema map[string]any  `json:"input_schema"`
-		Annotations map[string]bool `json:"annotations"`
+		Name          string                       `json:"name"`
+		Title         string                       `json:"title"`
+		Description   string                       `json:"description"`
+		InputSchema   map[string]any               `json:"input_schema"`
+		Annotations   map[string]bool              `json:"annotations"`
+		LaneOverrides map[string]map[string]string `json:"lane_overrides,omitempty"`
 	}
 	specs := s.toolSpecs()
 	tools := make([]toolDoc, 0, len(specs))
@@ -69,12 +71,20 @@ func TestMCPToolSurfaceSpec_PinnedAtDocsReference(t *testing.T) {
 		if !ok {
 			t.Fatalf("tool %s: input schema is not a map[string]any", spec.tool.Name)
 		}
+		var overrides map[string]map[string]string
+		if len(spec.laneOverrides) > 0 {
+			overrides = make(map[string]map[string]string, len(spec.laneOverrides))
+			for lane, o := range spec.laneOverrides {
+				overrides[lane] = map[string]string{"description": o.description}
+			}
+		}
 		tools = append(tools, toolDoc{
-			Name:        spec.tool.Name,
-			Title:       spec.tool.Title,
-			Description: spec.tool.Description,
-			InputSchema: schema,
-			Annotations: specAnnotations(spec.tool.Annotations),
+			Name:          spec.tool.Name,
+			Title:         spec.tool.Title,
+			Description:   spec.tool.Description,
+			InputSchema:   schema,
+			Annotations:   specAnnotations(spec.tool.Annotations),
+			LaneOverrides: overrides,
 		})
 	}
 	doc := map[string]any{
@@ -106,5 +116,43 @@ func TestMCPToolSurfaceSpec_PinnedAtDocsReference(t *testing.T) {
 		t.Errorf("toolSpecs() diverged from docs/reference/mcp-tools.json.\n" +
 			"The pinned spec is the cross-implementation contract the /mcp mount consumes; " +
 			"if the change is deliberate, regenerate with UPDATE_MCP_SPEC=1 and commit the diff.")
+	}
+}
+
+// TestMCPToolSpecs_LaneOverridesAreDeliberate guards the per-lane override
+// mechanism itself: an override exists only for a known lane, is non-empty,
+// and genuinely differs from the base rendering (an identical override is
+// dead weight that would mask real drift). It also pins WHY the one current
+// override exists: the base whoami prose routes auth recovery through
+// get_started, which the http lane does not serve — the http rendering must
+// not name it. The lane-completeness invariant (no served description may
+// name a tool absent from that lane's served set) lives with the lane's
+// served-set owner: tests/unit/mcp/test_tool_surface.py.
+func TestMCPToolSpecs_LaneOverridesAreDeliberate(t *testing.T) {
+	s := newTestMCPServer(t, &mcpOptions{})
+	knownLanes := map[string]bool{"http": true}
+
+	overridden := map[string]bool{}
+	for _, spec := range s.toolSpecs() {
+		for lane, o := range spec.laneOverrides {
+			if !knownLanes[lane] {
+				t.Errorf("tool %s: override for unknown lane %q", spec.tool.Name, lane)
+			}
+			if o.description == "" {
+				t.Errorf("tool %s: empty %s description override", spec.tool.Name, lane)
+			}
+			if o.description == spec.tool.Description {
+				t.Errorf("tool %s: %s override is identical to the base description", spec.tool.Name, lane)
+			}
+			overridden[spec.tool.Name] = true
+		}
+		if http, ok := spec.laneOverrides["http"]; ok {
+			if strings.Contains(http.description, "get_started") {
+				t.Errorf("tool %s: http description override names get_started, which the http lane does not serve", spec.tool.Name)
+			}
+		}
+	}
+	if !overridden["whoami"] {
+		t.Error("whoami: expected an http description override — its base prose names get_started, which the http lane does not serve")
 	}
 }

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -24,6 +24,11 @@
       },
       "annotations": {
         "read_only_hint": true
+      },
+      "lane_overrides": {
+        "http": {
+          "description": "Show the calling agent's identity as the Jentic control plane sees it: id, status, scopes, and toolkit bindings with the APIs each one serves. Call before requesting access or executing operations — never execute an operation just to probe whether you have access. On an auth error, relay it to your human operator: this connection's credentials and the agent's status are managed in the Jentic One dashboard."
+        }
       }
     },
     {

--- a/src/jentic_one/mcp/_spec/mcp-tools.json
+++ b/src/jentic_one/mcp/_spec/mcp-tools.json
@@ -24,6 +24,11 @@
       },
       "annotations": {
         "read_only_hint": true
+      },
+      "lane_overrides": {
+        "http": {
+          "description": "Show the calling agent's identity as the Jentic control plane sees it: id, status, scopes, and toolkit bindings with the APIs each one serves. Call before requesting access or executing operations — never execute an operation just to probe whether you have access. On an auth error, relay it to your human operator: this connection's credentials and the agent's status are managed in the Jentic One dashboard."
+        }
       }
     },
     {

--- a/src/jentic_one/mcp/spec.py
+++ b/src/jentic_one/mcp/spec.py
@@ -22,6 +22,13 @@ from typing import Any
 
 import mcp.types as mcp_types
 
+#: The lane this mount serves. The pinned spec's base renderings are the
+#: stdio server's; a tool may carry ``lane_overrides[LANE]`` re-rendering
+#: prose that would lie on this lane (e.g. recovery instructions naming
+#: ``get_started``, which only stdio serves). Wire shape — names, input
+#: schemas, annotations — is lane-invariant by design.
+LANE = "http"
+
 #: The tools this mount serves — the subset of the pinned surface whose
 #: dispatch is clean in-process (registry search/inspect/catalog + the catalog
 #: import loop, admin jobs, auth whoami, control access requests) or a
@@ -50,6 +57,20 @@ class ToolSpec:
     description: str
     input_schema: dict[str, Any]
     annotations: dict[str, bool]
+    lane_overrides: dict[str, dict[str, str]]
+
+    @property
+    def served_description(self) -> str:
+        """This lane's rendering: the ``LANE`` override when pinned, else base.
+
+        Both renderings ride the one contract document
+        (``docs/reference/mcp-tools.json``) and both are drift-guarded —
+        the Go side pins the overrides' existence and content
+        (``TestMCPToolSurfaceSpec`` / ``TestMCPToolSpecs_LaneOverridesAreDeliberate``),
+        this side pins that the SERVED rendering never names an unserved tool
+        (``tests/unit/mcp/test_tool_surface.py``).
+        """
+        return self.lane_overrides.get(LANE, {}).get("description") or self.description
 
     def as_mcp_tool(self) -> mcp_types.Tool:
         """Project the pinned declaration onto the SDK's ``Tool`` type."""
@@ -62,7 +83,7 @@ class ToolSpec:
         return mcp_types.Tool(
             name=self.name,
             title=self.title,
-            description=self.description,
+            description=self.served_description,
             input_schema=self.input_schema,
             annotations=annotations,
         )
@@ -81,6 +102,7 @@ def load_spec() -> dict[str, ToolSpec]:
             description=tool["description"],
             input_schema=tool["input_schema"],
             annotations=tool["annotations"],
+            lane_overrides=tool.get("lane_overrides", {}),
         )
     return specs
 

--- a/src/jentic_one/mcp/tools.py
+++ b/src/jentic_one/mcp/tools.py
@@ -234,8 +234,13 @@ def require_scopes(identity: Identity, required: list[str]) -> None:
         "the control plane rejected this agent's credentials "
         f"(http 403: This action requires one of: {', '.join(required)}) — "
         "the identity may have been revoked or disabled",
-        actionable="call get_started to diagnose this machine's setup and relay its "
-        "instruction to your operator",
+        # Lane-aware prose (#1327 deferred work): the stdio taxonomy points
+        # this code at get_started, which this mount does not serve. whoami
+        # DOES resolve here (the credential authenticated; it lacks scopes),
+        # so it is the honest next step on this lane.
+        actionable="call whoami to see this connection's identity and granted scopes, "
+        "and relay the missing scopes to your operator — scopes are granted by a "
+        "human in the Jentic One dashboard",
     )
 
 
@@ -314,8 +319,13 @@ async def handle_whoami(env: CallEnv, arguments: dict[str, Any]) -> mcp_types.Ca
             "the control plane rejected this agent's credentials "
             f"({getattr(exc, 'detail', exc)}) — the identity may have been revoked "
             "or disabled",
-            actionable="call get_started to diagnose this machine's setup and relay "
-            "its instruction to your operator",
+            # Lane-aware prose (#1327 deferred work): the stdio taxonomy
+            # points this code at get_started, unserved here — and whoami
+            # itself just failed, so no served tool can help. Re-root the
+            # recovery at the operator.
+            actionable="relay this to your human operator: this connection's "
+            "credentials and the agent's status are managed in the Jentic One "
+            "dashboard",
         ) from None
     payload = me.model_dump(mode="json")
     payload["schema_version"] = SCHEMA_VERSION

--- a/tests/unit/mcp/test_scopes.py
+++ b/tests/unit/mcp/test_scopes.py
@@ -69,7 +69,12 @@ def test_require_scopes_failure_is_the_coded_wire_403() -> None:
         require_scopes(identity, ["apis:read"])
     assert err.value.code == "NOT_AUTHENTICATED"
     assert "apis:read" in err.value.message
-    assert "get_started" in err.value.actionable
+    # Lane-true prose (#1327): the stdio taxonomy points at get_started,
+    # which this mount does not serve — the served prose routes through
+    # whoami (which resolves here: the credential authenticated, it merely
+    # lacks scopes) and the operator.
+    assert "whoami" in err.value.actionable
+    assert "get_started" not in err.value.actionable
 
 
 @pytest.mark.parametrize(
@@ -92,10 +97,12 @@ async def test_scope_failure_renders_not_authenticated(
     assert payload["error_code"] == "NOT_AUTHENTICATED"
     # The code-keyed stdio default pointer is get_started, which this mount
     # does not serve — the lane-aware filter (#1254) drops it rather than
-    # pointing the model at a tool absent from tools/list. The get_started
-    # spelling still rides the actionable prose (shared contract).
+    # pointing the model at a tool absent from tools/list, and since #1327's
+    # deferred pass the actionable PROSE is lane-true too (no unserved tool
+    # is ever named; the invariant lives in test_tool_surface.py).
     assert "next_tool" not in payload
-    assert "get_started" in payload["actionable_step"]
+    assert "get_started" not in payload["actionable_step"]
+    assert "whoami" in payload["actionable_step"]
 
 
 async def test_search_catalog_scope_failure_is_the_agent_fixable_special_case() -> None:

--- a/tests/unit/mcp/test_tool_surface.py
+++ b/tests/unit/mcp/test_tool_surface.py
@@ -18,11 +18,13 @@ copies it into the package data, and shows up in review as a doc diff.
 
 from __future__ import annotations
 
+import ast
 import json
+import re
 from importlib import resources
 from pathlib import Path
 
-from jentic_one.mcp.spec import SERVED_TOOLS, load_spec, served_tools
+from jentic_one.mcp.spec import LANE, SERVED_TOOLS, load_spec, served_tools
 from jentic_one.mcp.tools import HANDLERS
 
 _REPO_SPEC = Path(__file__).resolve().parents[3] / "docs" / "reference" / "mcp-tools.json"
@@ -54,12 +56,21 @@ def test_served_tools_follow_spec_order() -> None:
 
 
 def test_tools_list_payload_matches_the_pinned_declarations() -> None:
-    """Name/title/description/schema/annotations project verbatim from the pin."""
+    """Name/title/description/schema/annotations project verbatim from the pin.
+
+    The description is the pinned LANE rendering: the ``lane_overrides``
+    entry for this mount's lane when the spec pins one, else the base
+    (stdio) rendering — BOTH ride the same pinned document, so either
+    rendering drifting fails this side or the Go side against the same file.
+    """
     pinned = {tool["name"]: tool for tool in json.loads(_REPO_SPEC.read_bytes())["tools"]}
     for tool in served_tools():
         want = pinned[tool.name]
+        want_description = (
+            want.get("lane_overrides", {}).get(LANE, {}).get("description") or want["description"]
+        )
         assert tool.title == want["title"]
-        assert tool.description == want["description"]
+        assert tool.description == want_description
         assert tool.input_schema == want["input_schema"]
         annotations = tool.annotations
         assert annotations is not None
@@ -87,3 +98,68 @@ def test_unserved_phase1_tools_stay_stdio_only_for_now() -> None:
     specs = load_spec()
     deferred = set(specs) - set(SERVED_TOOLS)
     assert deferred == {"get_started"}
+
+
+def _tool_name_mentions(text: str, names: set[str]) -> set[str]:
+    """Which of ``names`` appear in ``text`` as whole words."""
+    return {name for name in names if re.search(rf"\b{re.escape(name)}\b", text)}
+
+
+def test_served_descriptions_never_name_unserved_tools() -> None:
+    """THE lane-honesty invariant (#1327): no description served on this lane
+    may name a tool absent from this lane's ``tools/list``. A future tool
+    whose prose routes the model at an unserved tool fails HERE, loudly —
+    the fix is a ``lane_overrides`` entry in the Go ``toolSpecs()`` pin, not
+    a silent fork."""
+    specs = load_spec()
+    unserved = set(specs) - set(SERVED_TOOLS)
+    for tool in served_tools():
+        assert tool.description is not None
+        dangling = _tool_name_mentions(tool.description, unserved)
+        assert not dangling, (
+            f"{tool.name}: served description names unserved tool(s) {sorted(dangling)} — "
+            f"add/extend a lane_overrides[{LANE!r}] rendering in the Go toolSpecs() pin"
+        )
+
+
+def test_actionable_prose_never_names_unserved_tools() -> None:
+    """The same lane-honesty invariant for ``actionable_step`` prose: every
+    ``actionable=…`` string literal in this mount's handler modules must not
+    name a tool absent from ``SERVED_TOOLS``. (The machine-readable
+    ``next_tool`` pointers are lane-filtered at render time in
+    ``soft_error_result`` — #1254; prose cannot be rewritten at render time,
+    so it is guarded at the source instead.)"""
+    specs = load_spec()
+    unserved = set(specs) - set(SERVED_TOOLS)
+    mcp_pkg = Path(__file__).resolve().parents[3] / "src" / "jentic_one" / "mcp"
+
+    def _literal_text(node: ast.expr) -> str:
+        """Collect the string-constant parts of an expression (handles
+        implicit/explicit concatenation and f-string literal segments)."""
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.BinOp):
+            return _literal_text(node.left) + _literal_text(node.right)
+        if isinstance(node, ast.JoinedStr):
+            return "".join(_literal_text(v) for v in node.values)
+        return ""
+
+    checked = 0
+    for path in sorted(mcp_pkg.glob("*.py")):
+        tree = ast.parse(path.read_text("utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for kw in node.keywords:
+                if kw.arg != "actionable" or kw.value is None:
+                    continue
+                text = _literal_text(kw.value)
+                if not text:
+                    continue
+                checked += 1
+                dangling = _tool_name_mentions(text, unserved)
+                assert not dangling, (
+                    f"{path.name}:{node.lineno}: actionable prose names unserved "
+                    f"tool(s) {sorted(dangling)}: {text!r}"
+                )
+    assert checked >= 10, "the actionable= scan found suspiciously few call sites"


### PR DESCRIPTION
## Summary

Completes the deferred half of #1254 / PR #1327: the HTTP `/mcp` mount's machine-readable `next_tool` pointers were already lane-filtered, but the pinned tool **descriptions** and **`actionable_step` prose** still routed the model at `get_started` — a tool this lane does not serve. Since #1326/#1331 ported `import_api` and `request_access` to the HTTP lane, `get_started` is the only remaining stdio-only tool, and only `whoami`'s description plus two Python actionable strings still lied (verified against the current `SERVED_TOOLS` in `src/jentic_one/mcp/spec.py`).

## Design: per-lane overrides in the one pinned contract

The Go stdio server's `toolSpecs()` stays the **single source of truth**. Rather than forking the descriptions silently:

- `mcpToolSpec` gains `laneOverrides` (`lane → {description}`); `whoami` pins an `"http"` rendering that keeps every lane-true sentence and re-roots auth recovery at the operator instead of `get_started`.
- The pin test (`TestMCPToolSurfaceSpec`) writes the overrides into `docs/reference/mcp-tools.json` as `lane_overrides` — **both renderings ride the one contract document**, so drift on either side still fails against the identical file.
- Python's `spec.py` consumes the override: `ToolSpec.served_description` = the `LANE = "http"` override when pinned, else base. `tools/list` serves that rendering; the drift guard (`test_tools_list_payload_matches_the_pinned_declarations`) pins it.
- The two lying actionables (`require_scopes`, `handle_whoami`'s auth error — HTTP-mount-only code) are rewritten at the source: the scopes failure now points at `whoami` (honest on this lane — the credential authenticated, it merely lacks scopes) + the operator; the whoami auth failure re-roots at the operator (whoami itself just failed, no served tool can help). Machine-readable envelope keys and error-code spellings are untouched; `next_tool` handling (render-time filter, #1254) is unchanged.

**The loud-failure invariant** (new, `tests/unit/mcp/test_tool_surface.py`):
- `test_served_descriptions_never_name_unserved_tools` — no served description may name a tool absent from this lane's `SERVED_TOOLS`; the prescribed fix is a `lane_overrides` entry in the Go pin.
- `test_actionable_prose_never_names_unserved_tools` — AST scan of every `actionable=` string literal in `src/jentic_one/mcp/` (incl. concatenations and f-string segments) against the unserved set; a future tool/handler whose prose names an unserved tool fails here, loudly.
- Go side: `TestMCPToolSpecs_LaneOverridesAreDeliberate` — overrides only for known lanes, non-empty, differ from base, http overrides never name `get_started`, and whoami's override must exist.

## Changes

- `cli/internal/cli/api/mcp_server.go`: `mcpToolLaneOverride` + whoami http rendering.
- `cli/internal/cli/api/mcp_spec_test.go`: pin writes `lane_overrides` (omitempty); new deliberateness guard test.
- `docs/reference/mcp-tools.json` + packaged copy: regenerated via `UPDATE_MCP_SPEC=1` (5-line diff: whoami `lane_overrides`).
- `src/jentic_one/mcp/spec.py`: `LANE`, `ToolSpec.lane_overrides`, `served_description`.
- `src/jentic_one/mcp/tools.py`: two lane-true actionable rewrites.
- `tests/unit/mcp/test_tool_surface.py` (+2 invariants, both-renderings pin), `tests/unit/mcp/test_scopes.py` (pins flip from "get_started rides the prose" to "prose is lane-true").
- Stdio lane untouched behaviourally: the Go server still serves the base renderings; shared goldens unchanged.

## Risk & rollback

Low risk: prose-only changes on one lane's `tools/list` and two error envelopes; no wire-shape, auth, or success-path changes. Revert the squash commit.

## Test plan

- `uv run pytest tests/unit/mcp/` — 254 passed (incl. the 3 new tests); full `tests/unit` + `tests/arch` — 3866 passed; `make fmt lint typecheck` clean.
- `cd cli && GOWORK=off gofmt -l . && go vet ./... && go test ./...` — all packages ok (the api package's unix-socket tests need to run unsandboxed).

Refs #1254 (its deferred descriptions/prose arm; the pointer arm landed in #1327)

Made with [Cursor](https://cursor.com)