### PR TITLE
docs(api): align lifecycle vocabulary across endpoint summaries and docs

### DIFF
--- a/cli/client/generated/control/client.go
+++ b/cli/client/generated/control/client.go
@@ -5054,11 +5054,13 @@ type ClientInterface interface {
 	// Corresponds with POST /admin/oauth-clients (the `CreateOauthClient` operationId).
 	CreateOauthClient(ctx context.Context, body CreateOauthClientJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeactivateOauthClient Deactivate OAuth client
+	// DeactivateOauthClient Disable OAuth client
 	//
-	// Soft-delete an OAuth client by setting active=False.
+	// Disable an OAuth client — the reversible kill switch (sets active=false).
 	//
-	// Deactivated clients can no longer initiate authorization flows.
+	// Disabled clients can no longer initiate authorization flows and their
+	// outstanding tokens stop resolving. Re-enable by patching ``active: true``.
+	// The row is kept; this is not a delete.
 	//
 	// Corresponds with DELETE /admin/oauth-clients/{id} (the `DeactivateOauthClient` operationId).
 	DeactivateOauthClient(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5184,7 +5186,12 @@ type ClientInterface interface {
 
 	// ArchiveAgent Archive Agent
 	//
-	// Soft-archive an agent — revokes scope grants and toolkit bindings.
+	// Archive an agent — terminal-but-kept.
+	//
+	// The row is retained for history, but the action is not reversible and
+	// the agent's authority is swept: scope grants, toolkit bindings, and
+	// OAuth consent grants are revoked. For the reversible kill switch use
+	// ``:disable`` / ``:enable`` instead.
 	//
 	// Corresponds with DELETE /agents/{agent_id} (the `ArchiveAgent` operationId).
 	ArchiveAgent(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6872,7 +6879,11 @@ type ClientInterface interface {
 
 	// ArchiveServiceAccount Archive Service Account
 	//
-	// Soft-archive a service account — revokes scope grants.
+	// Archive a service account — terminal-but-kept.
+	//
+	// The row is retained for history, but the action is not reversible and
+	// the account's scope grants are revoked. For the reversible kill switch
+	// use ``:disable`` / ``:enable`` instead.
 	//
 	// Corresponds with DELETE /service-accounts/{service_account_id} (the `ArchiveServiceAccount` operationId).
 	ArchiveServiceAccount(ctx context.Context, serviceAccountId string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -7261,7 +7272,12 @@ type ClientInterface interface {
 
 	// DeleteUser Delete User
 	//
-	// Soft-delete a user.
+	// Delete a user account (terminal-but-kept).
+	//
+	// The row is retained — the account is anonymized (tombstone email) and
+	// deactivated so history and audit references stay resolvable — but the
+	// action is terminal: there is no re-enable arm. For the reversible kill
+	// switch use ``:disable`` / ``:enable`` instead.
 	//
 	// Corresponds with DELETE /users/{user_id} (the `DeleteUser` operationId).
 	DeleteUser(ctx context.Context, userId string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -7832,11 +7848,13 @@ func (c *Client) CreateOauthClient(ctx context.Context, body CreateOauthClientJS
 	return c.Client.Do(req)
 }
 
-// DeactivateOauthClient Deactivate OAuth client
+// DeactivateOauthClient Disable OAuth client
 //
-// Soft-delete an OAuth client by setting active=False.
+// Disable an OAuth client — the reversible kill switch (sets active=false).
 //
-// Deactivated clients can no longer initiate authorization flows.
+// Disabled clients can no longer initiate authorization flows and their
+// outstanding tokens stop resolving. Re-enable by patching “active: true“.
+// The row is kept; this is not a delete.
 //
 // Corresponds with DELETE /admin/oauth-clients/{id} (the `DeactivateOauthClient` operationId).
 func (c *Client) DeactivateOauthClient(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -8092,7 +8110,12 @@ func (c *Client) CreateAgent(ctx context.Context, body CreateAgentJSONRequestBod
 
 // ArchiveAgent Archive Agent
 //
-// Soft-archive an agent — revokes scope grants and toolkit bindings.
+// Archive an agent — terminal-but-kept.
+//
+// The row is retained for history, but the action is not reversible and
+// the agent's authority is swept: scope grants, toolkit bindings, and
+// OAuth consent grants are revoked. For the reversible kill switch use
+// “:disable“ / “:enable“ instead.
 //
 // Corresponds with DELETE /agents/{agent_id} (the `ArchiveAgent` operationId).
 func (c *Client) ArchiveAgent(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -11250,7 +11273,11 @@ func (c *Client) CreateServiceAccount(ctx context.Context, body CreateServiceAcc
 
 // ArchiveServiceAccount Archive Service Account
 //
-// Soft-archive a service account — revokes scope grants.
+// Archive a service account — terminal-but-kept.
+//
+// The row is retained for history, but the action is not reversible and
+// the account's scope grants are revoked. For the reversible kill switch
+// use “:disable“ / “:enable“ instead.
 //
 // Corresponds with DELETE /service-accounts/{service_account_id} (the `ArchiveServiceAccount` operationId).
 func (c *Client) ArchiveServiceAccount(ctx context.Context, serviceAccountId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -12069,7 +12096,12 @@ func (c *Client) ChangePassword(ctx context.Context, body ChangePasswordJSONRequ
 
 // DeleteUser Delete User
 //
-// Soft-delete a user.
+// Delete a user account (terminal-but-kept).
+//
+// The row is retained — the account is anonymized (tombstone email) and
+// deactivated so history and audit references stay resolvable — but the
+// action is terminal: there is no re-enable arm. For the reversible kill
+// switch use “:disable“ / “:enable“ instead.
 //
 // Corresponds with DELETE /users/{user_id} (the `DeleteUser` operationId).
 func (c *Client) DeleteUser(ctx context.Context, userId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -21713,11 +21745,13 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with POST /admin/oauth-clients (the `CreateOauthClient` operationId).
 	CreateOauthClientWithResponse(ctx context.Context, body CreateOauthClientJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateOauthClientHTTPResp, error)
 
-	// DeactivateOauthClientWithResponse Deactivate OAuth client
+	// DeactivateOauthClientWithResponse Disable OAuth client
 	//
-	// Soft-delete an OAuth client by setting active=False.
+	// Disable an OAuth client — the reversible kill switch (sets active=false).
 	//
-	// Deactivated clients can no longer initiate authorization flows.
+	// Disabled clients can no longer initiate authorization flows and their
+	// outstanding tokens stop resolving. Re-enable by patching ``active: true``.
+	// The row is kept; this is not a delete.
 	//
 	// Returns a wrapper object for the known response body format(s).
 	//
@@ -21857,7 +21891,12 @@ type ClientWithResponsesInterface interface {
 
 	// ArchiveAgentWithResponse Archive Agent
 	//
-	// Soft-archive an agent — revokes scope grants and toolkit bindings.
+	// Archive an agent — terminal-but-kept.
+	//
+	// The row is retained for history, but the action is not reversible and
+	// the agent's authority is swept: scope grants, toolkit bindings, and
+	// OAuth consent grants are revoked. For the reversible kill switch use
+	// ``:disable`` / ``:enable`` instead.
 	//
 	// Returns a wrapper object for the known response body format(s).
 	//
@@ -23703,7 +23742,11 @@ type ClientWithResponsesInterface interface {
 
 	// ArchiveServiceAccountWithResponse Archive Service Account
 	//
-	// Soft-archive a service account — revokes scope grants.
+	// Archive a service account — terminal-but-kept.
+	//
+	// The row is retained for history, but the action is not reversible and
+	// the account's scope grants are revoked. For the reversible kill switch
+	// use ``:disable`` / ``:enable`` instead.
 	//
 	// Returns a wrapper object for the known response body format(s).
 	//
@@ -24130,7 +24173,12 @@ type ClientWithResponsesInterface interface {
 
 	// DeleteUserWithResponse Delete User
 	//
-	// Soft-delete a user.
+	// Delete a user account (terminal-but-kept).
+	//
+	// The row is retained — the account is anonymized (tombstone email) and
+	// deactivated so history and audit references stay resolvable — but the
+	// action is terminal: there is no re-enable arm. For the reversible kill
+	// switch use ``:disable`` / ``:enable`` instead.
 	//
 	// Returns a wrapper object for the known response body format(s).
 	//
@@ -39032,11 +39080,13 @@ func (c *ClientWithResponses) CreateOauthClientWithResponse(ctx context.Context,
 	return ParseCreateOauthClientHTTPResp(rsp)
 }
 
-// DeactivateOauthClientWithResponse Deactivate OAuth client
+// DeactivateOauthClientWithResponse Disable OAuth client
 //
-// Soft-delete an OAuth client by setting active=False.
+// Disable an OAuth client — the reversible kill switch (sets active=false).
 //
-// Deactivated clients can no longer initiate authorization flows.
+// Disabled clients can no longer initiate authorization flows and their
+// outstanding tokens stop resolving. Re-enable by patching “active: true“.
+// The row is kept; this is not a delete.
 //
 // Returns a wrapper object for the known response body format(s).
 //
@@ -39254,7 +39304,12 @@ func (c *ClientWithResponses) CreateAgentWithResponse(ctx context.Context, body 
 
 // ArchiveAgentWithResponse Archive Agent
 //
-// Soft-archive an agent — revokes scope grants and toolkit bindings.
+// Archive an agent — terminal-but-kept.
+//
+// The row is retained for history, but the action is not reversible and
+// the agent's authority is swept: scope grants, toolkit bindings, and
+// OAuth consent grants are revoked. For the reversible kill switch use
+// “:disable“ / “:enable“ instead.
 //
 // Returns a wrapper object for the known response body format(s).
 //
@@ -41982,7 +42037,11 @@ func (c *ClientWithResponses) CreateServiceAccountWithResponse(ctx context.Conte
 
 // ArchiveServiceAccountWithResponse Archive Service Account
 //
-// Soft-archive a service account — revokes scope grants.
+// Archive a service account — terminal-but-kept.
+//
+// The row is retained for history, but the action is not reversible and
+// the account's scope grants are revoked. For the reversible kill switch
+// use “:disable“ / “:enable“ instead.
 //
 // Returns a wrapper object for the known response body format(s).
 //
@@ -42667,7 +42726,12 @@ func (c *ClientWithResponses) ChangePasswordWithResponse(ctx context.Context, bo
 
 // DeleteUserWithResponse Delete User
 //
-// Soft-delete a user.
+// Delete a user account (terminal-but-kept).
+//
+// The row is retained — the account is anonymized (tombstone email) and
+// deactivated so history and audit references stay resolvable — but the
+// action is terminal: there is no re-enable arm. For the reversible kill
+// switch use “:disable“ / “:enable“ instead.
 //
 // Returns a wrapper object for the known response body format(s).
 //

--- a/cli/client/generated/control/spec.yaml
+++ b/cli/client/generated/control/spec.yaml
@@ -8111,9 +8111,11 @@ paths:
   /admin/oauth-clients/{id}:
     delete:
       description: |-
-        Soft-delete an OAuth client by setting active=False.
+        Disable an OAuth client — the reversible kill switch (sets active=false).
 
-        Deactivated clients can no longer initiate authorization flows.
+        Disabled clients can no longer initiate authorization flows and their
+        outstanding tokens stop resolving. Re-enable by patching ``active: true``.
+        The row is kept; this is not a delete.
       operationId: deactivateOauthClient
       parameters:
       - in: path
@@ -8176,7 +8178,7 @@ paths:
           description: Service Unavailable
       security:
       - BearerAuth: []
-      summary: Deactivate OAuth client
+      summary: Disable OAuth client
       tags:
       - OAuth Clients
     get:
@@ -8913,7 +8915,13 @@ paths:
       - Agents
   /agents/{agent_id}:
     delete:
-      description: Soft-archive an agent — revokes scope grants and toolkit bindings.
+      description: |-
+        Archive an agent — terminal-but-kept.
+
+        The row is retained for history, but the action is not reversible and
+        the agent's authority is swept: scope grants, toolkit bindings, and
+        OAuth consent grants are revoked. For the reversible kill switch use
+        ``:disable`` / ``:enable`` instead.
       operationId: archiveAgent
       parameters:
       - in: path
@@ -17403,7 +17411,12 @@ paths:
       - Service Accounts
   /service-accounts/{service_account_id}:
     delete:
-      description: Soft-archive a service account — revokes scope grants.
+      description: |-
+        Archive a service account — terminal-but-kept.
+
+        The row is retained for history, but the action is not reversible and
+        the account's scope grants are revoked. For the reversible kill switch
+        use ``:disable`` / ``:enable`` instead.
       operationId: archiveServiceAccount
       parameters:
       - in: path
@@ -19645,7 +19658,13 @@ paths:
       - Users
   /users/{user_id}:
     delete:
-      description: Soft-delete a user.
+      description: |-
+        Delete a user account (terminal-but-kept).
+
+        The row is retained — the account is anonymized (tombstone email) and
+        deactivated so history and audit references stay resolvable — but the
+        action is terminal: there is no re-enable arm. For the reversible kill
+        switch use ``:disable`` / ``:enable`` instead.
       operationId: deleteUser
       parameters:
       - in: path
@@ -20358,7 +20377,7 @@ tags:
   name: Monitoring
 - description: Runtime, DB-backed platform configuration. Lets an operator set, read, and list configuration that previously required hand-editing backend YAML and restarting the server — starting with credential provider configs (e.g. Pipedream). A successful write rebuilds the in-process provider registry so the change takes effect without a restart. Secret fields (e.g. `client_secret`) are encrypted at rest and redacted on read. **Topology note:** in the combined (single-process) deployment a write takes effect immediately for all surfaces. In a multi-process deployment the control/broker processes pick up the new config at their next boot, not the instant the admin write lands; cross-process propagation is a tracked follow-up.
   name: Configuration
-- description: Admin-managed registry of third-party OAuth clients (confidential, secret-bearing). Registered clients integrate with Jentic One via the standard Authorization Code + PKCE flow. Admins can create, list, update, rotate secrets, and deactivate clients. Deactivating a client immediately invalidates all tokens issued through it.
+- description: Admin-managed registry of third-party OAuth clients (confidential, secret-bearing). Registered clients integrate with Jentic One via the standard Authorization Code + PKCE flow. Admins can create, list, update, rotate secrets, and disable clients. Disabling a client immediately invalidates all tokens issued through it.
   name: OAuth Clients
 - description: MCP (Model Context Protocol) transport reporting. The `jentic mcp` stdio server terminates all MCP protocol traffic locally; the control plane only sees plain HTTP. This tag covers the small reporting surface behind it — today, the config-registration report `jentic setup`/`jentic skill init` send after writing an MCP server entry for a detected agent runtime, which feeds the config-written → first-session → first-execute adoption funnel.
   name: MCP

--- a/docs/oauth-clients.md
+++ b/docs/oauth-clients.md
@@ -60,7 +60,7 @@ POST /admin/oauth-clients/{id}/rotate-secret
 Immediately invalidates the previous secret. The new secret is returned once.
 Deploy it to the client before rotating, or clients will fail authentication.
 
-## Updating and deactivating
+## Updating and disabling
 
 ```
 PATCH /admin/oauth-clients/{id}
@@ -72,7 +72,7 @@ Pass only the fields you want to change. `allowed_scopes` has three modes:
 - `[]` → deny-all (client cannot request any non-OIDC scopes)
 - `["*"]` → reset to unrestricted (clear the restriction)
 
-To soft-delete a client:
+To disable a client (the reversible kill switch):
 
 ```
 DELETE /admin/oauth-clients/{id}
@@ -80,7 +80,7 @@ DELETE /admin/oauth-clients/{id}
 
 Sets `active=false`. The client can no longer start authorization flows, and
 outstanding access/refresh tokens issued by it stop resolving on both the auth
-surface and the broker data plane on the next request. Reactivate by patching
+surface and the broker data plane on the next request. Re-enable by patching
 `active: true`.
 
 ## Consent

--- a/docs/reference/endpoints.json
+++ b/docs/reference/endpoints.json
@@ -387,7 +387,7 @@
       "required_scopes": [
         "oauth-clients:write"
       ],
-      "summary": "Deactivate OAuth client",
+      "summary": "Disable OAuth client",
       "surface": "admin",
       "typical_caller": "any"
     },
@@ -4857,7 +4857,7 @@
           },
           {
             "action": "write",
-            "description": "Create, update, deactivate, and rotate secrets of OAuth clients",
+            "description": "Create, update, disable, and rotate secrets of OAuth clients",
             "family": "oauth-clients",
             "implies": [
               "oauth-clients:read"
@@ -5075,7 +5075,7 @@
       },
       {
         "action": "write",
-        "description": "Create, update, deactivate, and rotate secrets of OAuth clients",
+        "description": "Create, update, disable, and rotate secrets of OAuth clients",
         "family": "oauth-clients",
         "implies": [
           "oauth-clients:read"

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -250,7 +250,7 @@ _Total endpoints: **186**._
 | PUT | `/admin/config/providers/{name}` | `config:write` | any | Set a credential provider config |
 | GET | `/admin/oauth-clients` | `oauth-clients:read` | any | List OAuth clients |
 | POST | `/admin/oauth-clients` | `oauth-clients:write` | any | Register OAuth client |
-| DELETE | `/admin/oauth-clients/{id}` | `oauth-clients:write` | any | Deactivate OAuth client |
+| DELETE | `/admin/oauth-clients/{id}` | `oauth-clients:write` | any | Disable OAuth client |
 | GET | `/admin/oauth-clients/{id}` | `oauth-clients:read` | any | Get OAuth client |
 | PATCH | `/admin/oauth-clients/{id}` | `oauth-clients:write` | any | Update OAuth client |
 | POST | `/admin/oauth-clients/{id}/rotate-secret` | `oauth-clients:write` | any | Rotate client secret |

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -8111,9 +8111,11 @@ paths:
   /admin/oauth-clients/{id}:
     delete:
       description: |-
-        Soft-delete an OAuth client by setting active=False.
+        Disable an OAuth client — the reversible kill switch (sets active=false).
 
-        Deactivated clients can no longer initiate authorization flows.
+        Disabled clients can no longer initiate authorization flows and their
+        outstanding tokens stop resolving. Re-enable by patching ``active: true``.
+        The row is kept; this is not a delete.
       operationId: deactivateOauthClient
       parameters:
       - in: path
@@ -8176,7 +8178,7 @@ paths:
           description: Service Unavailable
       security:
       - BearerAuth: []
-      summary: Deactivate OAuth client
+      summary: Disable OAuth client
       tags:
       - OAuth Clients
     get:
@@ -8913,7 +8915,13 @@ paths:
       - Agents
   /agents/{agent_id}:
     delete:
-      description: Soft-archive an agent — revokes scope grants and toolkit bindings.
+      description: |-
+        Archive an agent — terminal-but-kept.
+
+        The row is retained for history, but the action is not reversible and
+        the agent's authority is swept: scope grants, toolkit bindings, and
+        OAuth consent grants are revoked. For the reversible kill switch use
+        ``:disable`` / ``:enable`` instead.
       operationId: archiveAgent
       parameters:
       - in: path
@@ -17403,7 +17411,12 @@ paths:
       - Service Accounts
   /service-accounts/{service_account_id}:
     delete:
-      description: Soft-archive a service account — revokes scope grants.
+      description: |-
+        Archive a service account — terminal-but-kept.
+
+        The row is retained for history, but the action is not reversible and
+        the account's scope grants are revoked. For the reversible kill switch
+        use ``:disable`` / ``:enable`` instead.
       operationId: archiveServiceAccount
       parameters:
       - in: path
@@ -19645,7 +19658,13 @@ paths:
       - Users
   /users/{user_id}:
     delete:
-      description: Soft-delete a user.
+      description: |-
+        Delete a user account (terminal-but-kept).
+
+        The row is retained — the account is anonymized (tombstone email) and
+        deactivated so history and audit references stay resolvable — but the
+        action is terminal: there is no re-enable arm. For the reversible kill
+        switch use ``:disable`` / ``:enable`` instead.
       operationId: deleteUser
       parameters:
       - in: path
@@ -20358,7 +20377,7 @@ tags:
   name: Monitoring
 - description: Runtime, DB-backed platform configuration. Lets an operator set, read, and list configuration that previously required hand-editing backend YAML and restarting the server — starting with credential provider configs (e.g. Pipedream). A successful write rebuilds the in-process provider registry so the change takes effect without a restart. Secret fields (e.g. `client_secret`) are encrypted at rest and redacted on read. **Topology note:** in the combined (single-process) deployment a write takes effect immediately for all surfaces. In a multi-process deployment the control/broker processes pick up the new config at their next boot, not the instant the admin write lands; cross-process propagation is a tracked follow-up.
   name: Configuration
-- description: Admin-managed registry of third-party OAuth clients (confidential, secret-bearing). Registered clients integrate with Jentic One via the standard Authorization Code + PKCE flow. Admins can create, list, update, rotate secrets, and deactivate clients. Deactivating a client immediately invalidates all tokens issued through it.
+- description: Admin-managed registry of third-party OAuth clients (confidential, secret-bearing). Registered clients integrate with Jentic One via the standard Authorization Code + PKCE flow. Admins can create, list, update, rotate secrets, and disable clients. Disabling a client immediately invalidates all tokens issued through it.
   name: OAuth Clients
 - description: MCP (Model Context Protocol) transport reporting. The `jentic mcp` stdio server terminates all MCP protocol traffic locally; the control plane only sees plain HTTP. This tag covers the small reporting surface behind it — today, the config-registration report `jentic setup`/`jentic skill init` send after writing an MCP server entry for a detected agent runtime, which feeds the config-written → first-session → first-execute adoption funnel.
   name: MCP

--- a/src/jentic_one/admin/web/routers/oauth_clients.py
+++ b/src/jentic_one/admin/web/routers/oauth_clients.py
@@ -188,7 +188,7 @@ async def rotate_oauth_client_secret(
 @router.delete(
     "/admin/oauth-clients/{id}",
     status_code=204,
-    summary="Deactivate OAuth client",
+    summary="Disable OAuth client",
     responses=not_found(),
 )
 async def deactivate_oauth_client(
@@ -196,9 +196,11 @@ async def deactivate_oauth_client(
     identity: Identity = get_current_identity(required_permissions=["oauth-clients:write"]),
     svc: OAuthClientService = Depends(get_oauth_client_service),
 ) -> Response:
-    """Soft-delete an OAuth client by setting active=False.
+    """Disable an OAuth client — the reversible kill switch (sets active=false).
 
-    Deactivated clients can no longer initiate authorization flows.
+    Disabled clients can no longer initiate authorization flows and their
+    outstanding tokens stop resolving. Re-enable by patching ``active: true``.
+    The row is kept; this is not a delete.
     """
     await svc.deactivate(id, identity=identity)
     return Response(status_code=204)

--- a/src/jentic_one/admin/web/routers/users.py
+++ b/src/jentic_one/admin/web/routers/users.py
@@ -128,7 +128,13 @@ async def delete_user(
     identity: Identity = get_current_identity(required_permissions=["users:write"]),
     user_svc: UserService = Depends(get_user_service),
 ) -> Response:
-    """Soft-delete a user."""
+    """Delete a user account (terminal-but-kept).
+
+    The row is retained — the account is anonymized (tombstone email) and
+    deactivated so history and audit references stay resolvable — but the
+    action is terminal: there is no re-enable arm. For the reversible kill
+    switch use ``:disable`` / ``:enable`` instead.
+    """
     await user_svc.delete(user_id, identity=identity)
     return Response(status_code=204)
 

--- a/src/jentic_one/auth/services/token_service.py
+++ b/src/jentic_one/auth/services/token_service.py
@@ -327,7 +327,7 @@ class TokenService:
                     # The D7 approval gate fails closed here too: deny flips
                     # active off, but a pending row force-set active must
                     # still never mint tokens.
-                    raise InvalidGrantError("issuing OAuth client has been deactivated")
+                    raise InvalidGrantError("issuing OAuth client is not active")
                 if oauth_client.allowed_scopes is not None:
                     client_ceiling = frozenset(oauth_client.allowed_scopes)
                 if client_id is None:

--- a/src/jentic_one/auth/web/routers/agents.py
+++ b/src/jentic_one/auth/web/routers/agents.py
@@ -208,7 +208,13 @@ async def archive_agent(
     identity: Identity = get_current_identity(required_permissions=["agents:write"]),
     agent_svc: AgentService = Depends(get_agent_service),
 ) -> Response:
-    """Soft-archive an agent — revokes scope grants and toolkit bindings."""
+    """Archive an agent — terminal-but-kept.
+
+    The row is retained for history, but the action is not reversible and
+    the agent's authority is swept: scope grants, toolkit bindings, and
+    OAuth consent grants are revoked. For the reversible kill switch use
+    ``:disable`` / ``:enable`` instead.
+    """
     await agent_svc.archive(agent_id, identity=identity)
     return Response(status_code=204)
 

--- a/src/jentic_one/auth/web/routers/service_accounts.py
+++ b/src/jentic_one/auth/web/routers/service_accounts.py
@@ -153,7 +153,12 @@ async def archive_service_account(
     identity: Identity = get_current_identity(required_permissions=["service-accounts:write"]),
     sa_svc: ServiceAccountService = Depends(get_service_account_service),
 ) -> Response:
-    """Soft-archive a service account — revokes scope grants."""
+    """Archive a service account — terminal-but-kept.
+
+    The row is retained for history, but the action is not reversible and
+    the account's scope grants are revoked. For the reversible kill switch
+    use ``:disable`` / ``:enable`` instead.
+    """
     await sa_svc.archive(service_account_id, identity=identity)
     return Response(status_code=204)
 

--- a/src/jentic_one/shared/auth/permission_catalog.py
+++ b/src/jentic_one/shared/auth/permission_catalog.py
@@ -216,7 +216,7 @@ ALL_PERMISSIONS: dict[str, Permission] = {
     ),
     OAUTH_CLIENTS_WRITE: Permission(
         name=OAUTH_CLIENTS_WRITE,
-        description="Create, update, deactivate, and rotate secrets of OAuth clients",
+        description="Create, update, disable, and rotate secrets of OAuth clients",
         implies=frozenset({OAUTH_CLIENTS_READ}),
     ),
     OAUTH_CLIENTS_READ: Permission(

--- a/src/jentic_one/shared/web/openapi_meta.py
+++ b/src/jentic_one/shared/web/openapi_meta.py
@@ -660,8 +660,8 @@ OPENAPI_TAGS: list[dict[str, str]] = [
         "description": (
             "Admin-managed registry of third-party OAuth clients (confidential, secret-bearing). "
             "Registered clients integrate with Jentic One via the standard Authorization Code + "
-            "PKCE flow. Admins can create, list, update, rotate secrets, and deactivate clients. "
-            "Deactivating a client immediately invalidates all tokens issued through it."
+            "PKCE flow. Admins can create, list, update, rotate secrets, and disable clients. "
+            "Disabling a client immediately invalidates all tokens issued through it."
         ),
     },
     {

--- a/tests/integration/auth/test_oauth_grant_channel.py
+++ b/tests/integration/auth/test_oauth_grant_channel.py
@@ -480,7 +480,7 @@ async def test_kill_radius_client_deactivate(
     assert await token_svc.resolve_access_token(access) is None
     broker_resolved = await broker.resolve_access_token(access)
     assert broker_resolved is not None and broker_resolved.active is False
-    with pytest.raises(InvalidGrantError, match="deactivated"):
+    with pytest.raises(InvalidGrantError, match="not active"):
         await token_svc.refresh(refresh, client_id=_CLIENT_ID)
 
 

--- a/tests/unit/auth/test_token_service.py
+++ b/tests/unit/auth/test_token_service.py
@@ -671,7 +671,7 @@ async def test_refresh_unapproved_issuing_client_rejected(
     mock_client_repo.get_by_client_id = AsyncMock(return_value=client_row)
 
     svc = TokenService(ctx)
-    with pytest.raises(InvalidGrantError, match="deactivated"):
+    with pytest.raises(InvalidGrantError, match="not active"):
         await svc.refresh("rt_pendingclient", client_id="oc_pending")
 
     mock_at_repo.create.assert_not_called()

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -12841,7 +12841,7 @@
     },
     "/admin/oauth-clients/{id}": {
       "delete": {
-        "description": "Soft-delete an OAuth client by setting active=False.\n\nDeactivated clients can no longer initiate authorization flows.",
+        "description": "Disable an OAuth client — the reversible kill switch (sets active=false).\n\nDisabled clients can no longer initiate authorization flows and their\noutstanding tokens stop resolving. Re-enable by patching ``active: true``.\nThe row is kept; this is not a delete.",
         "operationId": "deactivateOauthClient",
         "parameters": [
           {
@@ -12989,7 +12989,7 @@
             "BearerAuth": []
           }
         ],
-        "summary": "Deactivate OAuth client",
+        "summary": "Disable OAuth client",
         "tags": [
           "OAuth Clients"
         ]
@@ -14556,7 +14556,7 @@
     },
     "/agents/{agent_id}": {
       "delete": {
-        "description": "Soft-archive an agent — revokes scope grants and toolkit bindings.",
+        "description": "Archive an agent — terminal-but-kept.\n\nThe row is retained for history, but the action is not reversible and\nthe agent's authority is swept: scope grants, toolkit bindings, and\nOAuth consent grants are revoked. For the reversible kill switch use\n``:disable`` / ``:enable`` instead.",
         "operationId": "archiveAgent",
         "parameters": [
           {
@@ -32136,7 +32136,7 @@
     },
     "/service-accounts/{service_account_id}": {
       "delete": {
-        "description": "Soft-archive a service account — revokes scope grants.",
+        "description": "Archive a service account — terminal-but-kept.\n\nThe row is retained for history, but the action is not reversible and\nthe account's scope grants are revoked. For the reversible kill switch\nuse ``:disable`` / ``:enable`` instead.",
         "operationId": "archiveServiceAccount",
         "parameters": [
           {
@@ -37033,7 +37033,7 @@
     },
     "/users/{user_id}": {
       "delete": {
-        "description": "Soft-delete a user.",
+        "description": "Delete a user account (terminal-but-kept).\n\nThe row is retained — the account is anonymized (tombstone email) and\ndeactivated so history and audit references stay resolvable — but the\naction is terminal: there is no re-enable arm. For the reversible kill\nswitch use ``:disable`` / ``:enable`` instead.",
         "operationId": "deleteUser",
         "parameters": [
           {
@@ -38417,7 +38417,7 @@
       "name": "Configuration"
     },
     {
-      "description": "Admin-managed registry of third-party OAuth clients (confidential, secret-bearing). Registered clients integrate with Jentic One via the standard Authorization Code + PKCE flow. Admins can create, list, update, rotate secrets, and deactivate clients. Deactivating a client immediately invalidates all tokens issued through it.",
+      "description": "Admin-managed registry of third-party OAuth clients (confidential, secret-bearing). Registered clients integrate with Jentic One via the standard Authorization Code + PKCE flow. Admins can create, list, update, rotate secrets, and disable clients. Disabling a client immediately invalidates all tokens issued through it.",
       "name": "OAuth Clients"
     },
     {

--- a/ui/src/shared/api/generated/services/AgentsService.ts
+++ b/ui/src/shared/api/generated/services/AgentsService.ts
@@ -83,7 +83,12 @@ export class AgentsService {
     }
     /**
      * Archive Agent
-     * Soft-archive an agent — revokes scope grants and toolkit bindings.
+     * Archive an agent — terminal-but-kept.
+     *
+     * The row is retained for history, but the action is not reversible and
+     * the agent's authority is swept: scope grants, toolkit bindings, and
+     * OAuth consent grants are revoked. For the reversible kill switch use
+     * ``:disable`` / ``:enable`` instead.
      * @returns void
      * @throws ApiError
      */

--- a/ui/src/shared/api/generated/services/OAuthClientsService.ts
+++ b/ui/src/shared/api/generated/services/OAuthClientsService.ts
@@ -78,10 +78,12 @@ export class OAuthClientsService {
         });
     }
     /**
-     * Deactivate OAuth client
-     * Soft-delete an OAuth client by setting active=False.
+     * Disable OAuth client
+     * Disable an OAuth client — the reversible kill switch (sets active=false).
      *
-     * Deactivated clients can no longer initiate authorization flows.
+     * Disabled clients can no longer initiate authorization flows and their
+     * outstanding tokens stop resolving. Re-enable by patching ``active: true``.
+     * The row is kept; this is not a delete.
      * @returns void
      * @throws ApiError
      */

--- a/ui/src/shared/api/generated/services/ServiceAccountsService.ts
+++ b/ui/src/shared/api/generated/services/ServiceAccountsService.ts
@@ -74,7 +74,11 @@ export class ServiceAccountsService {
     }
     /**
      * Archive Service Account
-     * Soft-archive a service account — revokes scope grants.
+     * Archive a service account — terminal-but-kept.
+     *
+     * The row is retained for history, but the action is not reversible and
+     * the account's scope grants are revoked. For the reversible kill switch
+     * use ``:disable`` / ``:enable`` instead.
      * @returns void
      * @throws ApiError
      */

--- a/ui/src/shared/api/generated/services/UsersService.ts
+++ b/ui/src/shared/api/generated/services/UsersService.ts
@@ -182,7 +182,12 @@ export class UsersService {
     }
     /**
      * Delete User
-     * Soft-delete a user.
+     * Delete a user account (terminal-but-kept).
+     *
+     * The row is retained — the account is anonymized (tombstone email) and
+     * deactivated so history and audit references stay resolvable — but the
+     * action is terminal: there is no re-enable arm. For the reversible kill
+     * switch use ``:disable`` / ``:enable`` instead.
      * @returns void
      * @throws ApiError
      */


### PR DESCRIPTION
## What

Copy-only sweep applying the lifecycle vocabulary matrix from the hard-delete design plan:

> **Disable/Enable** = reversible kill switch · **Archive** = terminal-but-kept · **Delete** = hard removal · **Revoke** = invalidating issued authority · never **"Deactivate"** in user-facing copy.

- **OAuth clients** — `DELETE /admin/oauth-clients/{id}` summary/docstring now reads **Disable** (reversible kill switch, re-enable via `PATCH active: true`, "the row is kept; this is not a delete"); the *OAuth Clients* tag description and the `oauth-clients:write` permission description (which surfaces in the UI permission catalogue) say *disable*; `docs/oauth-clients.md` drops "soft-delete"/"Reactivate" for disable/re-enable.
- **Users** — `DELETE /users/{user_id}` docstring states the actual terminal-but-kept semantics (row retained, anonymized tombstone email, deactivated, **no re-enable arm**) instead of the bare "Soft-delete a user", and points at `:disable`/`:enable` for the reversible switch.
- **Agents / service accounts** — archive docstrings drop the self-contradicting "Soft-archive" for "Archive — terminal-but-kept", spell out the authority sweep (scope grants, toolkit bindings, and the #1340 OAuth-grant sweep for agents), and point at `:disable`/`:enable`.

Regenerated downstream artifacts: `openapi/control/control.openapi.yaml`, `ui/openapi.json` + generated TS services, `docs/reference/endpoints.{md,json}`, Go control client (`cli/client/generated/control`).

## Deliberately NOT done

- **No path / operationId / handler-name changes** — `deactivate_oauth_client` and `delete_user` stay put because operationIds derive from handler names (`deactivateOauthClient`, `deleteUser`); renaming them breaks generated-client consumers. Non-goal per the plan.
- No behaviour changes of any kind; no UI component copy (the OAuth-clients UI vocabulary lands in the stacked UI PR, which owns those strings).
- `docs/credentials-and-toolkits.md`'s "API delete deactivates its credentials" left as-is: it describes the internal cross-DB safety mechanism (credentials stop *resolving*), not a user-facing lifecycle verb.

## Validation

- `ruff` + `mypy` clean (650 files)
- `pytest`: 3909 passed; the only failures/errors (helm smoke, flywheel web) reproduce identically on clean `main` — environmental (need Docker/live services)
- UI triad in this branch: lint clean, build clean, 1211 tests passed
- `GOWORK=off go build ./... && go test ./...` clean; `make generate-api` drift-free

Made with [Cursor](https://cursor.com)