### PR TITLE
fix(cli): stop TestListenerFromFD leaking a dup that closes recycled fds

### DIFF
--- a/cli/internal/cli/api/mcp_access_test.go
+++ b/cli/internal/cli/api/mcp_access_test.go
@@ -64,7 +64,7 @@ func TestMCPSearchCatalog_EnvelopePassthroughWithStamp(t *testing.T) {
 		t.Fatalf("handleSearchCatalog: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 	if gotQuery != "sheets" || gotCursor != "c0" || gotLimit != "25" {
 		t.Errorf("wire params = q %q cursor %q limit %q, want the normalized arguments", gotQuery, gotCursor, gotLimit)
@@ -217,7 +217,7 @@ func TestMCPImportAPI_CompletesAndPromotes(t *testing.T) {
 		t.Fatalf("handleImportAPI: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 
 	// The rawPathEditor hazard: the umbrella api_id must reach the backend
@@ -258,7 +258,7 @@ func TestMCPImportAPI_StillRunningReturnsJobForConvergence(t *testing.T) {
 		t.Fatalf("handleImportAPI: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("a slow import is not an error — the model converges by re-calling: %v", res.Content)
+		t.Fatalf("a slow import is not an error — the model converges by re-calling: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["job_id"] != "job_9" || payload["status"] != "running" {
@@ -453,7 +453,7 @@ func TestMCPRequestAccess_FilesComposedPlanPendingWithApproveURL(t *testing.T) {
 		t.Fatalf("handleRequestAccess: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("a pending filing is a normal result, not an error: %v", res.Content)
+		t.Fatalf("a pending filing is a normal result, not an error: %s", toolResultText(res))
 	}
 
 	// The wire body: compose()'s exact plan — the 4-item provisioning chain
@@ -558,7 +558,7 @@ func TestMCPRequestAccess_DuplicatePendingSingleTargetAttaches(t *testing.T) {
 		t.Fatalf("handleRequestAccess: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("a single-target duplicate attaches, like the CLI: %v", res.Content)
+		t.Fatalf("a single-target duplicate attaches, like the CLI: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["id"] != "acr_old" || payload["attached_to_existing"] != true {
@@ -604,7 +604,7 @@ func TestMCPRequestAccess_PollArmReportsApproved(t *testing.T) {
 		t.Fatalf("handleRequestAccess: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("an approved request is a normal result: %v", res.Content)
+		t.Fatalf("an approved request is a normal result: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["id"] != "acr_1" || payload["status"] != statusApproved {
@@ -702,7 +702,7 @@ func TestMCPImportAPI_JobPollFailureIsSoftErrorNotSuccess(t *testing.T) {
 		t.Fatalf("handleImportAPI: %v", err)
 	}
 	if !res.IsError {
-		t.Fatalf("a job-poll failure must be an isError result, never the still-running success shape: %v", res.Content)
+		t.Fatalf("a job-poll failure must be an isError result, never the still-running success shape: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if code, _ := payload["error_code"].(string); code == "" {

--- a/cli/internal/cli/api/mcp_activation.go
+++ b/cli/internal/cli/api/mcp_activation.go
@@ -75,6 +75,15 @@ func launchdListener() (net.Listener, error) {
 }
 
 // listenerFromFD adopts an inherited descriptor as a net.Listener.
+//
+// Ownership contract: the caller DONATES fd — this function closes it (via
+// the os.NewFile wrapper) whether adoption succeeds or not, and the returned
+// listener runs on a fresh dup made by net.FileListener. Correct for its
+// production inputs (systemd's fd 3, launchd's fd 0: this process is the
+// descriptor's sole owner). Never pass an fd number that another live
+// *os.File still wraps — that second owner's Close/finalizer would later
+// close an unrelated recycled descriptor (the cross-test flake mode pinned
+// in TestListenerFromFD's comment).
 func listenerFromFD(fd uintptr, name string) (net.Listener, error) {
 	f := os.NewFile(fd, name)
 	if f == nil {

--- a/cli/internal/cli/api/mcp_activation_unix_test.go
+++ b/cli/internal/cli/api/mcp_activation_unix_test.go
@@ -1,0 +1,45 @@
+//go:build unix
+
+package api
+
+// mcp_activation_unix_test.go pins socket-activation fd adoption against a
+// real inherited descriptor. Unix-tagged: fd donation is a systemd/launchd
+// affair, and the dup below is raw syscall territory.
+
+import (
+	"net"
+	"syscall"
+	"testing"
+)
+
+// TestListenerFromFD proves inherited-fd adoption against a real socket.
+//
+// The donated fd must be a dedicated dup that listenerFromFD exclusively
+// owns. An earlier version donated f.Fd() while keeping f alive — two owners
+// of one fd number. listenerFromFD closes its side, the number gets recycled,
+// and f's GC finalizer later closes whatever unrelated file or socket now
+// holds that number: that stray close surfaced as the cross-test CI flakes
+// in TestRegister_FreshMachine_OneCommand (EBADF on an atomic key-write temp
+// file) and TestMCPSession_AccessLoopDeniedToApprovedRetry (a killed httptest
+// connection turning a normal pending filing into a soft error).
+func TestListenerFromFD(t *testing.T) {
+	ln, err := net.Listen("unix", shortSocketPath(t))
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	f, err := ln.(*net.UnixListener).File()
+	if err != nil {
+		t.Fatalf("File: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	donated, err := syscall.Dup(int(f.Fd()))
+	if err != nil {
+		t.Fatalf("dup: %v", err)
+	}
+	adopted, err := listenerFromFD(uintptr(donated), "test socket")
+	if err != nil {
+		t.Fatalf("listenerFromFD: %v", err)
+	}
+	_ = adopted.Close()
+}

--- a/cli/internal/cli/api/mcp_discovery_test.go
+++ b/cli/internal/cli/api/mcp_discovery_test.go
@@ -70,7 +70,7 @@ func TestMCPSearchAPIs_EnvelopePassthroughWithStamp(t *testing.T) {
 		t.Fatalf("handleSearchAPIs: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 	if gotBody.Query != "pets" || gotBody.Limit == nil || *gotBody.Limit != 5 || gotBody.Cursor == nil || *gotBody.Cursor != "c0" {
 		t.Errorf("wire body = %+v, want query/limit/cursor mirrored", gotBody)
@@ -140,7 +140,7 @@ func TestMCPSearchAPIs_AliasAndStringCoercionReachTheWire(t *testing.T) {
 		t.Fatalf("handleSearchAPIs: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 	if gotBody.Apis == nil || len(*gotBody.Apis) != 1 || (*gotBody.Apis)[0] != "acme/pets/v1" {
 		t.Errorf("apis on the wire = %v, want the coerced one-element list", gotBody.Apis)
@@ -188,7 +188,7 @@ func TestMCPSearchAPIs_InconsistentPaginationForcedConsistent(t *testing.T) {
 		t.Fatalf("handleSearchAPIs: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["has_more"] != false {
@@ -327,7 +327,7 @@ func TestMCPInspectOperation_PassesBodyThroughWithStamp(t *testing.T) {
 		t.Fatalf("handleInspectOperation: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["method"] != "GET" || payload["url"] != "https://api.acme.com/v1/pets" {

--- a/cli/internal/cli/api/mcp_execute_test.go
+++ b/cli/internal/cli/api/mcp_execute_test.go
@@ -64,7 +64,7 @@ func TestMCPExecute_SuccessEnvelopeWithStamp(t *testing.T) {
 		t.Fatalf("handleExecute: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 
 	// The wire request: path param substituted, the leftover input as query,
@@ -231,7 +231,7 @@ func TestMCPExecute_UpstreamErrorIsNormalResult(t *testing.T) {
 		t.Fatalf("handleExecute: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("an upstream 4xx is a normal result, got soft error: %v", res.Content)
+		t.Fatalf("an upstream 4xx is a normal result, got soft error: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["status"] != float64(http.StatusForbidden) {
@@ -258,7 +258,7 @@ func TestMCPExecute_HeldEnvelopePassesThrough(t *testing.T) {
 		t.Fatalf("handleExecute: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("a held (202) envelope is a normal result, got soft error: %v", res.Content)
+		t.Fatalf("a held (202) envelope is a normal result, got soft error: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["status"] != float64(http.StatusAccepted) || payload["execution_id"] != "exec_held" {
@@ -498,7 +498,7 @@ func TestMCPExecute_TruncatesOversizedBody(t *testing.T) {
 		t.Fatalf("handleExecute: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("truncation is not an error: %v", res.Content)
+		t.Fatalf("truncation is not an error: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["truncated"] != true {
@@ -606,7 +606,7 @@ func TestMCPExecute_CapsOversizedResponseHeaders(t *testing.T) {
 		t.Fatalf("handleExecute: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("header truncation is not an error: %v", res.Content)
+		t.Fatalf("header truncation is not an error: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["headers_truncated"] != true {
@@ -671,7 +671,7 @@ func TestMCPExecute_NeverReadsStdin(t *testing.T) {
 		t.Fatalf("handleExecute: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 	if hadBody {
 		t.Errorf("broker received a body (%q); a bodyless tool call must send none", gotBody)
@@ -733,7 +733,7 @@ func TestMCPExecuteRead_AcceptsLowercaseRegistryMethod(t *testing.T) {
 		t.Fatalf("a lowercase registry method must not fail the GET/HEAD gate: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 	if gotMethod != http.MethodGet {
 		t.Errorf("method on the wire = %q, want the canonical GET", gotMethod)
@@ -766,7 +766,7 @@ func TestMCPExecuteRead_GetRoundTrip(t *testing.T) {
 		t.Fatalf("handleExecuteRead: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["status"] != float64(http.StatusOK) {
@@ -812,7 +812,7 @@ func TestMCPExecute_BrokerLegHonorsCAPinAndHook(t *testing.T) {
 		t.Fatalf("handleExecute: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("CA-pinned broker call must succeed against the pinned cert: %v", res.Content)
+		t.Fatalf("CA-pinned broker call must succeed against the pinned cert: %s", toolResultText(res))
 	}
 	if !strings.HasPrefix(gotUA, "jentic-mcp/") {
 		t.Errorf("broker User-Agent = %q, want the attribution hook composed onto the broker leg", gotUA)
@@ -859,7 +859,7 @@ func TestMCPGetExecutionResult_LiveRoutesRoundTrip(t *testing.T) {
 		t.Fatalf("handleGetExecutionResult: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("unexpected soft error: %v", res.Content)
+		t.Fatalf("unexpected soft error: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["job_id"] != "job_9" || payload["status"] != "completed" || payload["execution_id"] != "exec_9" {
@@ -893,7 +893,7 @@ func TestMCPGetExecutionResult_PendingJobHasNoResult(t *testing.T) {
 		t.Fatalf("handleGetExecutionResult: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("a pending job is a normal result the model polls again: %v", res.Content)
+		t.Fatalf("a pending job is a normal result the model polls again: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["status"] != "pending" {

--- a/cli/internal/cli/api/mcp_golden_test.go
+++ b/cli/internal/cli/api/mcp_golden_test.go
@@ -126,7 +126,7 @@ func TestMCPExecute_EnvelopeMatchesSharedGoldens(t *testing.T) {
 				t.Fatalf("handleExecute: %v", err)
 			}
 			if res.IsError {
-				t.Fatalf("unexpected soft error: %v", res.Content)
+				t.Fatalf("unexpected soft error: %s", toolResultText(res))
 			}
 
 			payload := decodeToolJSON(t, res)

--- a/cli/internal/cli/api/mcp_http_posture_test.go
+++ b/cli/internal/cli/api/mcp_http_posture_test.go
@@ -454,20 +454,7 @@ func TestCheckMCPModeFlags(t *testing.T) {
 	}
 }
 
-// TestListenerFromFD proves inherited-fd adoption against a real socket.
-func TestListenerFromFD(t *testing.T) {
-	ln, err := net.Listen("unix", shortSocketPath(t))
-	if err != nil {
-		t.Fatalf("bind: %v", err)
-	}
-	t.Cleanup(func() { _ = ln.Close() })
-	f, err := ln.(*net.UnixListener).File()
-	if err != nil {
-		t.Fatalf("File: %v", err)
-	}
-	adopted, err := listenerFromFD(f.Fd(), "test socket")
-	if err != nil {
-		t.Fatalf("listenerFromFD: %v", err)
-	}
-	_ = adopted.Close()
-}
+// TestListenerFromFD lives in mcp_activation_unix_test.go: donating a raw
+// fd is a unix-only affair (systemd/launchd), and the donation must be a
+// dedicated dup that listenerFromFD exclusively owns — see the fd-ownership
+// contract on listenerFromFD.

--- a/cli/internal/cli/api/mcp_http_test.go
+++ b/cli/internal/cli/api/mcp_http_test.go
@@ -115,7 +115,7 @@ func TestMCPHTTP_GoldenTranscriptsOverStreamableHTTP(t *testing.T) {
 				t.Fatalf("execute over http: %v", err)
 			}
 			if res.IsError {
-				t.Fatalf("execute soft-errored: %v", res.Content)
+				t.Fatalf("execute soft-errored: %s", toolResultText(res))
 			}
 			got := envelopeWithoutStamp(t, decodeToolJSON(t, res))
 			want := sharedGoldenStdout(t, tc.name)

--- a/cli/internal/cli/api/mcp_session_test.go
+++ b/cli/internal/cli/api/mcp_session_test.go
@@ -9,6 +9,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -70,7 +71,7 @@ func connectTestClientWithContext(serverCtx context.Context, t *testing.T, s *mc
 func decodeToolJSON(t *testing.T, res *mcp.CallToolResult) map[string]any {
 	t.Helper()
 	if len(res.Content) != 1 {
-		t.Fatalf("content items = %d, want 1", len(res.Content))
+		t.Fatalf("content items = %d, want 1: %s", len(res.Content), toolResultText(res))
 	}
 	text, ok := res.Content[0].(*mcp.TextContent)
 	if !ok {
@@ -81,6 +82,22 @@ func decodeToolJSON(t *testing.T, res *mcp.CallToolResult) map[string]any {
 		t.Fatalf("tool result is not JSON: %v\n%s", err, text.Text)
 	}
 	return payload
+}
+
+// toolResultText renders a tool result's content for failure messages.
+// %v on the content slice prints bare pointers ("[0xc008c1e280]") — exactly
+// what made the AccessLoop CI flake undiagnosable: the one artifact naming
+// the real error was formatted away.
+func toolResultText(res *mcp.CallToolResult) string {
+	parts := make([]string, 0, len(res.Content))
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			parts = append(parts, tc.Text)
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%#v", c))
+	}
+	return strings.Join(parts, "\n")
 }
 
 func TestMCPSession_ToolsListWorksWithNoConfig(t *testing.T) {
@@ -251,7 +268,7 @@ func TestMCPSession_FullRoundTrip(t *testing.T) {
 		t.Fatalf("whoami: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("whoami soft-errored: %v", res.Content)
+		t.Fatalf("whoami soft-errored: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	if payload["id"] != "agent_1" || payload["status"] != "active" {
@@ -267,7 +284,7 @@ func TestMCPSession_FullRoundTrip(t *testing.T) {
 		t.Fatalf("search_apis: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("search_apis soft-errored: %v", res.Content)
+		t.Fatalf("search_apis soft-errored: %s", toolResultText(res))
 	}
 	payload = decodeToolJSON(t, res)
 	hits, ok := payload["data"].([]any)
@@ -292,7 +309,7 @@ func TestMCPSession_FullRoundTrip(t *testing.T) {
 		t.Fatalf("inspect_operation: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("inspect_operation soft-errored: %v", res.Content)
+		t.Fatalf("inspect_operation soft-errored: %s", toolResultText(res))
 	}
 	payload = decodeToolJSON(t, res)
 	if payload["method"] != "GET" || payload["url"] != "https://acme.com/pets" {
@@ -308,7 +325,7 @@ func TestMCPSession_FullRoundTrip(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("execute soft-errored: %v", res.Content)
+		t.Fatalf("execute soft-errored: %s", toolResultText(res))
 	}
 	payload = decodeToolJSON(t, res)
 	if payload["status"] != float64(200) || payload["execution_id"] != "exec_42" {
@@ -558,7 +575,7 @@ func TestMCPSession_ContextValuesReachHandlersAndTransport(t *testing.T) {
 		t.Fatalf("get_started: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("get_started errored: %v", res.Content)
+		t.Fatalf("get_started errored: %s", toolResultText(res))
 	}
 	payload := decodeToolJSON(t, res)
 	// State "ready" is only reachable when the handler saw the session's
@@ -720,7 +737,7 @@ func TestMCPSession_AccessLoopDeniedToApprovedRetry(t *testing.T) {
 		t.Fatalf("request_access: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("a pending filing is a normal result: %v", res.Content)
+		t.Fatalf("a pending filing is a normal result: %s", toolResultText(res))
 	}
 	payload = decodeToolJSON(t, res)
 	if payload["status"] != statusPending || payload["id"] != "acr_1" {
@@ -747,7 +764,7 @@ func TestMCPSession_AccessLoopDeniedToApprovedRetry(t *testing.T) {
 		t.Fatalf("request_access poll: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("approved poll soft-errored: %v", res.Content)
+		t.Fatalf("approved poll soft-errored: %s", toolResultText(res))
 	}
 	payload = decodeToolJSON(t, res)
 	if payload["status"] != statusApproved {
@@ -763,7 +780,7 @@ func TestMCPSession_AccessLoopDeniedToApprovedRetry(t *testing.T) {
 		t.Fatalf("execute retry: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("the retried execute must succeed after approval: %v", res.Content)
+		t.Fatalf("the retried execute must succeed after approval: %s", toolResultText(res))
 	}
 	payload = decodeToolJSON(t, res)
 	if payload["status"] != float64(200) || payload["execution_id"] != "exec_ok" {


### PR DESCRIPTION
> Issue filing was blocked by the approval policy, so per instruction the **full flake analysis lives in this PR body** instead of a standalone issue.

## Problem

Two `cli/internal/cli/api` tests failed on PR #1332's CI **in code that PR does not touch**, then passed on re-run ([noted on the PR](https://github.com/jentic/jentic-one/pull/1332)). Both pass locally under `go test -race -count=100`.

## Evidence

1. `TestRegister_FreshMachine_OneCommand` (run 34479572633):

   ```
   register_test.go:58: register --url: writing key /tmp/TestRegister_FreshMachine_OneCommand…/config/jentic/keys/crawler_qa.key:
   close temp file: close /tmp/…/keys/.crawler_qa.key.tmp-3736405592: bad file descriptor
   ```

   EBADF on the temp file's **own first `Close()`** — `client/auth/atomic.go` has no double-close; something else in the process closed that fd number out from under it.

2. `TestMCPSession_AccessLoopDeniedToApprovedRetry` (run 34480356312, attempt 1):

   ```
   mcp_session_test.go:723: a pending filing is a normal result: [0xc008c1e280]
   ```

   The `request_access` filing (step 2, **before** the approval flip) soft-errored in 0.03s. A *timing* race can't produce this: the short-poll loop can only return the pending state, which the test accepts — every error path requires a **failed HTTP call against the in-process httptest doubles** (→ transport soft error), i.e. a killed connection. (And the Fatalf printed content **pointers**, losing the actual envelope — a diagnosability bug in itself.)

## Root cause: two owners of one fd number

`TestListenerFromFD` (`mcp_http_posture_test.go`) did:

```go
f, _ := ln.(*net.UnixListener).File()          // dup — f OWNS the new fd, with a GC finalizer that closes it
adopted, _ := listenerFromFD(f.Fd(), "test")   // f is never closed
```

`listenerFromFD` (`mcp_activation.go`) **adopts** the fd it is given: `os.NewFile(fd, …)` + `net.FileListener` (dups again) + `f.Close()` ("close our copy either way"). After it returns, the donated fd **number is closed** — but the test's `f`, a second live `*os.File` wrapping the same number, doesn't know. When the GC later runs `f`'s finalizer (during any subsequent test in the same package binary), it closes **whatever file/socket has since been assigned that fd number**:

- recycled into `TestRegister`'s atomic key-write temp file → its `Close()` gets EBADF (failure 1);
- recycled into a `TestMCPSession` httptest connection → the in-flight `POST /access-requests` dies → soft error (failure 2).

This explains every observed property: failures in untouched code, **two different victims on two runs**, local `-count=100` green (the flake needs whole-package fd-recycling + GC alignment; GOGC=1 stress on the three tests in isolation also passes), and the blast radius confined to `internal/cli/api` (test binaries are per-package).

`os.File` docs for `UnixListener.File()`: *"It is the caller's responsibility to close f when finished."* But closing `f` **after** `listenerFromFD` returns would be equally wrong — that raw-closes the possibly-already-recycled number deterministically.

## Decision

- **Fix the donation, not `listenerFromFD`.** Its adopt-and-close contract is CORRECT for its production inputs (systemd's fd 3, launchd's fd 0 — the process is the descriptor's sole owner, and `net.FileListener` dups before our wrapper closes). Audited `cli/` for other `.File()`/`os.NewFile` double-owner sites: none. The contract is now an explicit doc comment.
- The test donates a dedicated `syscall.Dup` that `listenerFromFD` exclusively owns and closes `f` deterministically. Moved under a `unix` build tag (`mcp_activation_unix_test.go`) — fd adoption is systemd/launchd-only, and `syscall.Dup` doesn't exist on Windows.
- **Diagnosability:** `%v` on `res.Content` prints bare pointers (`[0xc008c1e280]`), which is exactly what made failure 2 undiagnosable from CI logs. Added a `toolResultText` helper and switched every such failure site in the package to it, so any recurrence names the actual error.

## Tests

- `GOWORK=off gofmt -l` clean, `go vet ./...` clean, full `GOWORK=off go test -race ./...` green.
- `GOGC=1 go test -race -count=3 ./internal/cli/api/` (whole-package stress, aggressive GC) green post-fix.
- The pre-fix flake is inherently probabilistic (needs fd-number recycling to land on a victim before a GC cycle) and did not reproduce on demand locally even with `GOGC=1` — the root cause is established statically above.

Made with [Cursor](https://cursor.com)