### PR TITLE
feat(cli): move the agent contract to the credential-binding vocabulary (theme 5 phase 5c)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -240,7 +240,7 @@ jentic register                                       # local install (defaults 
 jentic register --url https://jentic.example.com --broker-url https://broker.jentic.example.com
 jentic catalog
 jentic access whoami                                  # a fresh agent is bound to no APIs
-jentic access request --toolkit <vendor/name> --wait  # ask a human to grant access
+jentic access request --api <vendor/name> --wait  # ask a human to grant access
 jentic execute <operation>
 ```
 
@@ -310,7 +310,7 @@ jentic register --url http://127.0.0.1:8000
 jentic doctor                 # identity + reachability + clock-skew report
 jentic catalog                # browse APIs
 jentic access whoami          # a fresh agent starts bound to no APIs
-jentic access request --toolkit <vendor/name> --wait  # ask a human to grant access
+jentic access request --api <vendor/name> --wait  # ask a human to grant access
 jentic execute listPets       # routed through http://127.0.0.1:8100 automatically
 ```
 

--- a/cli/internal/agentops/classify.go
+++ b/cli/internal/agentops/classify.go
@@ -9,9 +9,11 @@ import (
 )
 
 // IsBrokerDenial reports whether a result is one the broker itself emitted to
-// deny a call the agent can recover from: missing toolkit binding → 403,
-// ambiguous toolkit → 409, credential needs reconnect → 401, no credential →
-// 424. Each carries an agent_directive (see broker/web/errors.STATUS_BY_ERROR).
+// deny a call the agent can recover from: missing credential binding → 403
+// (wire type no_credential_binding; the legacy flag-off path still emits
+// no_toolkit_binding), ambiguous credential binding → 409, credential needs
+// reconnect → 401, no credential provisioned → 424. Each carries an
+// agent_directive (see broker/web/errors.STATUS_BY_ERROR).
 //
 // Status alone is NOT sufficient: the broker is a transparent forward proxy, so
 // an *upstream* API can return these same 4xx codes on a call the broker

--- a/cli/internal/cli/api/access.go
+++ b/cli/internal/cli/api/access.go
@@ -13,9 +13,9 @@ import (
 func newAccessCmd(app *app) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "access",
-		Short: "Inspect your access and request more (toolkits, scopes)",
+		Short: "Inspect your access and request more (credentials, scopes)",
 		Long: "access is how an agent closes the gap between having an identity and having\n" +
-			"the access to use it. An approved agent starts bound to no toolkits, so its\n" +
+			"the access to use it. An approved agent starts bound to no credentials, so its\n" +
 			"first execute fails with a 403 telling it to request access. Use this group\n" +
 			"to see what you can do now (whoami), ask a human to grant more (request),\n" +
 			"and track those requests (list, status, withdraw).\n\n" +
@@ -38,10 +38,11 @@ func newAccessWhoamiCmd(app *app) *cobra.Command {
 	var jsonFlag bool
 	cmd := &cobra.Command{
 		Use:   "whoami",
-		Short: "Show your agent identity, scopes, and toolkit bindings",
+		Short: "Show your agent identity, scopes, and credential bindings",
 		Long: "whoami answers \"what can I do right now?\" — your agent id, status, granted\n" +
-			"scopes, and the toolkits you are bound to. An empty bindings list means you\n" +
-			"cannot execute against any API yet; use `jentic access request` to ask.",
+			"scopes, and the credentials you are bound to (each with the APIs it serves).\n" +
+			"An empty bindings list means you cannot execute against any API yet; use\n" +
+			"`jentic access request` to ask.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return app.accessWhoamiE(cmd, jsonFlag)
@@ -55,24 +56,24 @@ func newAccessRequestCmd(app *app) *cobra.Command {
 	opts := &accessRequestOptions{}
 	cmd := &cobra.Command{
 		Use:   "request",
-		Short: "File a request for toolkit bindings, scope grants, or provisioning plans",
+		Short: "File a request for credential bindings, scope grants, or provisioning plans",
 		Long: "request files one access request for the access you are missing and prints an\n" +
-			"approve_url for your human operator. Name a toolkit by the API you found in\n" +
-			"search (--toolkit vendor/name), by id (--toolkit-id tk_…), or ask for a scope\n" +
+			"approve_url for your human operator. Name an API you found in search to be\n" +
+			"bound to a credential serving it (--api vendor/name), or ask for a scope\n" +
 			"(--scope). Use --wait to block until a human decides (or --timeout elapses).\n\n" +
-			"When nothing serves an API yet (a fresh import with no toolkit/credential),\n" +
-			"use --provision vendor/name to file the whole path to first execution as one\n" +
-			"plan: create a toolkit, provision a credential, bind it (with your proposed\n" +
-			"--rules-json), and bind yourself. A human fulfils the create/provision steps\n" +
-			"in the dashboard (they enter the secret — it never rides in your request) and\n" +
-			"approves. Use --auth to declare the credential type you detected from the spec\n" +
-			"(bearer, api_key, basic, oauth2, or none for a no-auth API).\n\n" +
+			"When no credential serves an API yet (a fresh import), use --provision\n" +
+			"vendor/name to file the whole path to first execution as one plan: provision\n" +
+			"a credential and bind yourself to it (with your proposed --rules-json). A\n" +
+			"human fulfils the provision step in the dashboard (they enter the secret —\n" +
+			"it never rides in your request) and approves. Use --auth to declare the\n" +
+			"credential type you detected from the spec (bearer, api_key, basic, oauth2,\n" +
+			"or none for a no-auth API).\n\n" +
 			"All target flags repeat and combine, so a job needing several APIs files ONE\n" +
 			"composite request the human decides in one sitting: each --provision appends\n" +
-			"a provisioning plan, each --toolkit/--toolkit-id/--scope appends a single\n" +
-			"item. With more than one --provision, key --auth and --rules-json by the\n" +
-			"same vendor/name[/version] passed to --provision; the bare form applies\n" +
-			"when there is exactly one.\n\n" +
+			"a provisioning plan, each --api/--scope appends a single item. With more\n" +
+			"than one --provision, key --auth and --rules-json by the same\n" +
+			"vendor/name[/version] passed to --provision; the bare form applies when\n" +
+			"there is exactly one.\n\n" +
 			"An existing pending request for the same resource is reused when this request\n" +
 			"names a single target; a composite aborts instead (drop the already-pending\n" +
 			"target or withdraw the older request, then re-file).\n\n" +
@@ -81,22 +82,29 @@ func newAccessRequestCmd(app *app) *cobra.Command {
 			"  2 — request was denied, expired, or withdrawn (only with --wait)\n" +
 			"  3 — still pending when --timeout elapsed (only with --wait)\n" +
 			"  4 — partially approved; not all items granted (only with --wait)",
-		Example: "  jentic access request --toolkit httpbin.org/httpbin --reason \"smoke test\"\n" +
-			"  jentic access request --toolkit-id tk_123 --wait\n" +
-			"  jentic access request --scope owner:toolkits:read --json\n" +
+		Example: "  jentic access request --api httpbin.org/httpbin --reason \"smoke test\"\n" +
+			"  jentic access request --scope owner:credentials:read --json\n" +
 			"  jentic access request --provision posthog.com/posthog-api --auth bearer \\\n" +
 			"    --rules-json '[{\"effect\":\"allow\",\"methods\":[\"GET\"],\"path\":\".*\"}]' --wait\n" +
 			"  jentic access request --provision slack.com/api --auth slack.com/api=bearer \\\n" +
 			"    --provision googleapis.com/sheets --auth googleapis.com/sheets=oauth2 \\\n" +
-			"    --toolkit github.com/api --scope apis:write \\\n" +
+			"    --api github.com/api --scope apis:write \\\n" +
 			"    --reason \"release-notes automation\" --wait",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return app.accessRequestE(cmd, opts)
 		},
 	}
-	cmd.Flags().StringArrayVar(&opts.toolkits, "toolkit", nil, "request a binding to the toolkit serving this API (vendor/name[/version]; repeatable)")
-	cmd.Flags().StringArrayVar(&opts.toolkitIDs, "toolkit-id", nil, "request a binding to this toolkit id (tk_…; repeatable)")
+	cmd.Flags().StringArrayVar(&opts.apis, "api", nil, "request a binding to a credential serving this API (vendor/name[/version]; repeatable)")
+	// --toolkit is the deprecated spelling of --api (toolkits were retired,
+	// theme-5): hidden from help, accepted for one release, folded into the
+	// same list. accessRequestE prints the deprecation warning.
+	cmd.Flags().StringArrayVar(&opts.deprecatedToolkits, "toolkit", nil, "deprecated alias for --api")
+	_ = cmd.Flags().MarkHidden("toolkit")
+	// --toolkit-id stays registered (hidden) so old callers get compose()'s
+	// re-file error naming --api instead of an unknown-flag failure.
+	cmd.Flags().StringArrayVar(&opts.toolkitIDs, "toolkit-id", nil, "retired; use --api <vendor/name>")
+	_ = cmd.Flags().MarkHidden("toolkit-id")
 	cmd.Flags().StringArrayVar(&opts.scopes, "scope", nil, "request this scope be granted (repeatable)")
 	cmd.Flags().StringArrayVar(&opts.provisions, "provision", nil, "file a full provisioning plan to make this API executable (vendor/name[/version]; repeatable)")
 	cmd.Flags().StringArrayVar(&opts.auths, "auth", nil, "credential auth type for --provision: bearer, api_key, basic, oauth2, or none (default bearer); key by API when --provision repeats (vendor/name[/version]=<type>)")

--- a/cli/internal/cli/api/access_plan.go
+++ b/cli/internal/cli/api/access_plan.go
@@ -11,42 +11,53 @@ import (
 	"github.com/jentic/jentic-one/cli/client/generated/control"
 )
 
-var errAccessTargetRequired = errors.New("specify what to request: --toolkit <vendor/name>, --toolkit-id <tk_…>, --scope <scope>, or --provision <vendor/name> (repeat and combine to compose one request)")
+var errAccessTargetRequired = errors.New("specify what to request: --api <vendor/name>, --scope <scope>, or --provision <vendor/name> (repeat and combine to compose one request)")
 
 type accessRequestOptions struct {
-	toolkits   []string
-	toolkitIDs []string
-	scopes     []string
-	provisions []string
-	auths      []string
-	rulesJSONs []string
-	reason     string
-	wait       bool
-	timeout    time.Duration
-	json       bool
+	apis []string
+	// deprecatedToolkits backs the hidden --toolkit alias (deprecated for one
+	// release); its values fold into apis via allAPIs().
+	deprecatedToolkits []string
+	toolkitIDs         []string
+	scopes             []string
+	provisions         []string
+	auths              []string
+	rulesJSONs         []string
+	reason             string
+	wait               bool
+	timeout            time.Duration
+	json               bool
+}
+
+// allAPIs folds the deprecated --toolkit alias values into the --api list, in
+// flag order (--api values first). Both flags file the same credential:bind
+// item, so the fold happens once here and everything downstream sees one list.
+func (o *accessRequestOptions) allAPIs() []string {
+	return cleanValues(append(append([]string{}, o.apis...), o.deprecatedToolkits...))
 }
 
 // targetCount is the number of distinct targets the request names — each
-// --provision plan counts as one target, as does each --toolkit/--toolkit-id/
-// --scope item. It decides composite behavior (e.g. the 409 handling).
+// --provision plan counts as one target, as does each --api/--scope item (and
+// each value of the hidden legacy flags). It decides composite behavior (e.g.
+// the 409 handling).
 func (o *accessRequestOptions) targetCount() int {
-	return len(cleanValues(o.provisions)) + len(cleanValues(o.toolkits)) +
+	return len(cleanValues(o.provisions)) + len(o.allAPIs()) +
 		len(cleanValues(o.toolkitIDs)) + len(cleanValues(o.scopes))
 }
 
 // compose builds the full item list for the request from every target flag, in
-// fulfilment order: provisioning plans first (one 4-item chain per --provision,
-// in flag order), then toolkit binds by reference, by id, and scope grants.
-// Targets are validated as a set — duplicates and a --toolkit/--provision pair
+// fulfilment order: provisioning plans first (one 2-item chain per --provision,
+// in flag order), then credential binds by API reference, and scope grants.
+// Targets are validated as a set — duplicates and an --api/--provision pair
 // naming the same API are rejected, since they would file conflicting or
 // redundant intents the approving human then has to untangle.
 func (o *accessRequestOptions) compose() ([]control.AccessRequestItemRequest, error) {
 	provisions := cleanValues(o.provisions)
-	toolkits := cleanValues(o.toolkits)
+	apis := o.allAPIs()
 	toolkitIDs := cleanValues(o.toolkitIDs)
 	scopes := cleanValues(o.scopes)
 
-	if len(provisions)+len(toolkits)+len(toolkitIDs)+len(scopes) == 0 {
+	if len(provisions)+len(apis)+len(toolkitIDs)+len(scopes) == 0 {
 		return nil, errAccessTargetRequired
 	}
 	if len(provisions) == 0 && (len(cleanValues(o.auths)) > 0 || len(cleanValues(o.rulesJSONs)) > 0) {
@@ -60,15 +71,15 @@ func (o *accessRequestOptions) compose() ([]control.AccessRequestItemRequest, er
 	if err != nil {
 		return nil, err
 	}
-	toolkitKeys, err := canonicalRefKeys("--toolkit", toolkits)
+	apiKeys, err := canonicalRefKeys("--api", apis)
 	if err != nil {
 		return nil, err
 	}
-	for _, k := range toolkitKeys {
+	for _, k := range apiKeys {
 		for _, p := range provKeys {
 			if k == p {
-				return nil, fmt.Errorf("%s is named by both --toolkit and --provision; "+
-					"a provisioning plan already ends with the toolkit binding, so drop the --toolkit", k)
+				return nil, fmt.Errorf("%s is named by both --api and --provision; "+
+					"a provisioning plan already ends with the credential binding, so drop the --api", k)
 			}
 		}
 	}
@@ -96,13 +107,13 @@ func (o *accessRequestOptions) compose() ([]control.AccessRequestItemRequest, er
 		}
 		items = append(items, chain...)
 	}
-	for _, t := range toolkits {
-		ref, refErr := parseToolkitRef(t)
+	for _, t := range apis {
+		ref, refErr := parseAccessRef(t)
 		if refErr != nil {
 			return nil, refErr
 		}
 		// Theme-5 Phase 3: the surviving bind verb is credential:bind
-		// (agent↔credential); a --toolkit vendor/name files it by API
+		// (agent↔credential); an --api vendor/name files it by API
 		// reference. The approver resolves the reference to a concrete,
 		// visible credential at decide time. The server substitutes a
 		// read-only default policy when no rules are given.
@@ -115,7 +126,7 @@ func (o *accessRequestOptions) compose() ([]control.AccessRequestItemRequest, er
 		// (theme-5 phase 3) and access is granted per credential. Fail with a
 		// re-file directive rather than filing an item the server will 422.
 		return nil, fmt.Errorf("--toolkit-id is no longer supported: toolkits were retired; "+
-			"use --toolkit <vendor/name> to request access to the API by reference "+
+			"use --api <vendor/name> to request access to the API by reference "+
 			"(got --toolkit-id %s)", toolkitIDs[0])
 	}
 	for _, s := range scopes {
@@ -154,7 +165,7 @@ func firstDuplicate(values []string) string {
 func canonicalRefKeys(flag string, values []string) ([]string, error) {
 	keys := make([]string, 0, len(values))
 	for _, v := range values {
-		ref, err := parseToolkitRef(v)
+		ref, err := parseAccessRef(v)
 		if err != nil {
 			return nil, err
 		}
@@ -239,7 +250,7 @@ func splitKeyedValue(flag, raw string, provKeys []string) (key, value string, ke
 		return "", "", false, nil
 	}
 	candidate := strings.TrimSpace(raw[:eq])
-	ref, refErr := parseToolkitRef(candidate)
+	ref, refErr := parseAccessRef(candidate)
 	if refErr != nil {
 		return "", "", false, nil //nolint:nilerr // an unparsable key prefix means "bare value", not a failure.
 	}
@@ -273,7 +284,7 @@ var validAuthTypes = map[string]bool{
 // dashboard, which writes the resulting credential id back onto the bind item
 // before approving. Returns the items in fulfilment order.
 func buildProvisionPlan(provision, auth, rulesJSON string) ([]control.AccessRequestItemRequest, error) {
-	ref, err := parseToolkitRef(provision)
+	ref, err := parseAccessRef(provision)
 	if err != nil {
 		return nil, err
 	}
@@ -349,13 +360,13 @@ func parseProposedRules(raw string) (*[]control.JenticOneControlWebSchemasAccess
 	return &rules, nil
 }
 
-// parseToolkitRef splits "vendor/name[/version]" into a resource_reference. The
+// parseAccessRef splits "vendor/name[/version]" into a resource_reference. The
 // agent names the API it discovered via search; the server resolves it to a
-// concrete toolkit at decide time.
-func parseToolkitRef(s string) (map[string]any, error) {
+// concrete credential at decide time.
+func parseAccessRef(s string) (map[string]any, error) {
 	parts := strings.Split(strings.TrimSpace(s), "/")
 	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
-		return nil, fmt.Errorf("--toolkit must be vendor/name or vendor/name/version, got %q", s)
+		return nil, fmt.Errorf("an API reference must be vendor/name or vendor/name/version, got %q", s)
 	}
 	ref := map[string]any{"vendor": parts[0], "name": parts[1]}
 	if len(parts) >= 3 && parts[2] != "" {

--- a/cli/internal/cli/api/access_plan_test.go
+++ b/cli/internal/cli/api/access_plan_test.go
@@ -91,10 +91,10 @@ func TestPlanRejectsBadRulesJSON(t *testing.T) {
 	}
 }
 
-func TestComposeToolkitFlagFilesCredentialBind(t *testing.T) {
-	// --toolkit vendor/name survives as an alias for the direct
-	// credential:bind-by-reference (the toolkit vocabulary is retired).
-	opts := &accessRequestOptions{toolkits: []string{"github.com/rest-api"}}
+func TestComposeAPIFlagFilesCredentialBind(t *testing.T) {
+	// --api vendor/name files the direct credential:bind-by-reference (the
+	// toolkit vocabulary is retired).
+	opts := &accessRequestOptions{apis: []string{"github.com/rest-api"}}
 	items, err := opts.compose()
 	if err != nil {
 		t.Fatalf("compose() error: %v", err)
@@ -112,11 +112,32 @@ func TestComposeToolkitFlagFilesCredentialBind(t *testing.T) {
 	}
 }
 
+func TestComposeDeprecatedToolkitAliasFoldsIntoAPIs(t *testing.T) {
+	// The hidden --toolkit alias files the same credential:bind item as --api
+	// (one release of compatibility); duplicates across the two spellings are
+	// rejected like any other duplicate --api.
+	opts := &accessRequestOptions{deprecatedToolkits: []string{"github.com/rest-api"}}
+	items, err := opts.compose()
+	if err != nil {
+		t.Fatalf("compose() error: %v", err)
+	}
+	if len(items) != 1 || string(items[0].ResourceType) != "credential" || string(items[0].Action) != "bind" {
+		t.Fatalf("expected the alias to file one credential:bind, got %+v", items)
+	}
+	dup := &accessRequestOptions{
+		apis:               []string{"github.com/rest-api"},
+		deprecatedToolkits: []string{"github.com/rest-api"},
+	}
+	if _, err := dup.compose(); err == nil || !strings.Contains(err.Error(), "more than once") {
+		t.Errorf("the same API via --api and --toolkit should be rejected as a duplicate, got: %v", err)
+	}
+}
+
 func TestComposeToolkitIDIsRetired(t *testing.T) {
 	opts := &accessRequestOptions{toolkitIDs: []string{"tk_123"}}
 	if _, err := opts.compose(); err == nil {
 		t.Fatal("expected --toolkit-id to be rejected after toolkit retirement")
-	} else if !strings.Contains(err.Error(), "--toolkit <vendor/name>") {
+	} else if !strings.Contains(err.Error(), "--api <vendor/name>") {
 		t.Errorf("the error should carry the re-file directive, got: %v", err)
 	}
 }

--- a/cli/internal/cli/api/access_print.go
+++ b/cli/internal/cli/api/access_print.go
@@ -27,10 +27,38 @@ func (a *app) printMe(ctx context.Context, me *control.MeAgent) {
 		fmt.Fprintln(a.Out, "  "+st.Dim.Render("run `jentic access refresh` to pick them up"))
 	}
 
-	fmt.Fprintln(a.Out, st.Heading.Render("Toolkit bindings"))
-	if len(me.ToolkitBindings) == 0 {
-		fmt.Fprintln(a.Out, "  "+st.Dim.Render("none — you cannot execute yet; run `jentic access request --toolkit <vendor/name>`"))
+	fmt.Fprintln(a.Out, st.Heading.Render("Credential bindings"))
+	var credBindings []control.CredentialBindingEntry
+	if me.CredentialBindings != nil {
+		credBindings = *me.CredentialBindings
+	}
+	if len(credBindings) == 0 {
+		fmt.Fprintln(a.Out, "  "+st.Dim.Render("none — you cannot execute yet; run `jentic access request --api <vendor/name>`"))
 	} else {
+		for i := range credBindings {
+			b := &credBindings[i]
+			line := "  "
+			if name := deref(b.Name); name != "" {
+				line += st.Command.Render(name) + "  " + st.Dim.Render(b.CredentialId)
+			} else {
+				line += st.Command.Render(b.CredentialId)
+			}
+			if b.Suspended != nil && *b.Suspended {
+				line += "  " + st.Warn.Render("suspended")
+			}
+			fmt.Fprintln(a.Out, line)
+			if serves := servedAPIs(b.Serves); serves != "" {
+				fmt.Fprintln(a.Out, "    "+st.Dim.Render("serves: "+serves))
+			}
+		}
+	}
+
+	// Legacy toolkit bindings: a pre-retirement server may still report them
+	// (the toolkit tables retire in theme-5 phase 6b). Render only when
+	// non-empty, clearly labelled — credential bindings above are the
+	// authoritative "what can I execute" view.
+	if len(me.ToolkitBindings) > 0 {
+		fmt.Fprintln(a.Out, st.Heading.Render("Toolkit bindings (legacy)"))
 		for _, b := range me.ToolkitBindings {
 			if name := deref(b.Name); name != "" {
 				fmt.Fprintln(a.Out, "  "+st.Command.Render(name)+"  "+st.Dim.Render(b.ToolkitId))
@@ -40,12 +68,32 @@ func (a *app) printMe(ctx context.Context, me *control.MeAgent) {
 		}
 	}
 
-	// whoami is the control-plane view of "what can I do?" (scopes + toolkit
+	// whoami is the control-plane view of "what can I do?" (scopes + credential
 	// bindings above). There is no per-directory access surface for a plain
 	// agent — `context view` shows only environment/identity/mode — so point at
 	// doctor for local-setup health rather than a command that surfaces nothing.
 	fmt.Fprintln(a.Out)
-	fmt.Fprintln(a.Out, st.Dim.Render("Toolkit bindings above are your control-plane access. Run `jentic doctor` to check your local setup."))
+	fmt.Fprintln(a.Out, st.Dim.Render("Credential bindings above are your control-plane access. Run `jentic doctor` to check your local setup."))
+}
+
+// servedAPIs renders a binding's served-API references as a comma-separated
+// vendor/name[/version] list ("" when the server reported none).
+func servedAPIs(serves *[]control.ServedApiRef) string {
+	if serves == nil || len(*serves) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(*serves))
+	for _, s := range *serves {
+		ref := s.ApiVendor
+		if name := deref(s.ApiName); name != "" {
+			ref += "/" + name
+		}
+		if version := deref(s.ApiVersion); version != "" {
+			ref += "/" + version
+		}
+		parts = append(parts, ref)
+	}
+	return strings.Join(parts, ", ")
 }
 
 func (a *app) printRequestList(ctx context.Context, reqs []control.AccessRequestResponse, hasMore bool) {
@@ -79,7 +127,7 @@ func (a *app) printRequest(ctx context.Context, r *control.AccessRequestResponse
 		it := &r.Items[i]
 		fmt.Fprintln(a.Out, "  "+st.Dim.Render(itemSummary(it))+"  "+statusStyle(st, it.Status))
 		// A denied item carries the reason it couldn't be granted (e.g. "No
-		// toolkit serves API …; provision and bind a credential for it first").
+		// credential serves API …; provision and bind one for it first").
 		// Surface it so the agent/operator learns what to fix; JSON output
 		// already includes decision_reason.
 		if reason := deref(it.DecisionReason); reason != "" {

--- a/cli/internal/cli/api/access_run.go
+++ b/cli/internal/cli/api/access_run.go
@@ -114,6 +114,11 @@ func (a *app) getMe(ctx context.Context) (*control.MeAgent, error) {
 }
 
 func (a *app) accessRequestE(cmd *cobra.Command, opts *accessRequestOptions) error {
+	if len(cleanValues(opts.deprecatedToolkits)) > 0 {
+		// One warning regardless of how many times the alias repeats; the
+		// values already fold into the --api list via allAPIs().
+		fmt.Fprintln(a.Err, theme.StylesFromContext(cmd.Context()).Warnf("--toolkit is deprecated; use --api"))
+	}
 	items, err := opts.compose()
 	if err != nil {
 		return err
@@ -214,7 +219,7 @@ func (a *app) accessRequestE(cmd *cobra.Command, opts *accessRequestOptions) err
 	// Fully approved. A newly-granted scope bakes into the token at mint time, so
 	// re-mint now if the request granted one — the agent can then execute
 	// immediately without a separate `access refresh`. A binding-only plan
-	// (toolkit/credential binds, no scope) needs no re-mint: bindings are live
+	// (credential binds, no scope) needs no re-mint: bindings are live
 	// server-side, so this is a no-op in that case.
 	a.refreshIfScopeGranted(cmd, req)
 	return nil
@@ -259,8 +264,8 @@ func terminalAccessError(req *control.AccessRequestResponse) error {
 
 // refreshIfScopeGranted re-mints the agent's token when (and only when) the
 // decided request granted a new scope — the one thing that is baked into the
-// token at mint time and so needs a refresh to become usable. Toolkit/credential
-// bindings are resolved live by the broker, so a `--provision`/`--toolkit` plan
+// token at mint time and so needs a refresh to become usable. Credential
+// bindings are resolved live by the broker, so a `--provision`/`--api` plan
 // needs no re-mint; re-minting anyway would be a wasted round-trip. Best-effort:
 // a mint failure is non-fatal (the agent can still run `jentic access refresh`),
 // and static credentials (injected token, API key) are skipped.
@@ -293,7 +298,7 @@ func (a *app) refreshIfScopeGranted(cmd *cobra.Command, req *control.AccessReque
 
 // requestGrantedScope reports whether a decided request approved a scope:grant
 // item — the only grant that bakes into the token and so needs a re-mint.
-// Toolkit/credential binds are resolved live by the broker, so a binding-only
+// Credential binds are resolved live by the broker, so a binding-only
 // plan returns false (no re-mint needed).
 func requestGrantedScope(req *control.AccessRequestResponse) bool {
 	for _, it := range req.Items {

--- a/cli/internal/cli/api/api.go
+++ b/cli/internal/cli/api/api.go
@@ -51,7 +51,7 @@ func newAPICmd(app *app) *cobra.Command {
 			"By default any transport-successful response (2xx or 4xx/5xx) exits 0 and\n" +
 			"the body is emitted as-is; --fail-on-error maps non-2xx to exit 1.",
 		Example: "  jentic api GET /credentials\n" +
-			"  jentic api POST /toolkits -d '{\"name\":\"clarity\"}'\n" +
+			"  jentic api POST /service-accounts -d '{\"name\":\"clarity\"}'\n" +
 			"  jentic api POST /apis < api.json\n" +
 			"  jentic api GET \"/apis?limit=10\"",
 		Args: cobra.ExactArgs(2),

--- a/cli/internal/cli/api/curated.go
+++ b/cli/internal/cli/api/curated.go
@@ -99,14 +99,14 @@ func CuratedBindings() []CuratedBinding {
 		},
 		{
 			// access request: the file body is the composed access request. `items`
-			// is built from the target-flag FAMILY (--toolkit/--toolkit-id/--scope/
-			// --provision, plus --auth/--rules-json shaping the provision chain), so
-			// it is bound to the primary --toolkit flag as a representative; --reason
-			// carries the free-text justification (ARCH-21 A3, off internal/accessclient).
+			// is built from the target-flag FAMILY (--api/--scope/--provision, plus
+			// --auth/--rules-json shaping the provision chain), so it is bound to
+			// the primary --api flag as a representative; --reason carries the
+			// free-text justification (ARCH-21 A3, off internal/accessclient).
 			Command: "access request",
 			Params:  control.AccessRequestFileRequest{},
 			Bind: map[string]string{
-				"items":  "toolkit",
+				"items":  "api",
 				"reason": "reason",
 			},
 			NotExposed: map[string]string{},

--- a/cli/internal/cli/api/endpoints.go
+++ b/cli/internal/cli/api/endpoints.go
@@ -40,7 +40,7 @@ func newEndpointsCmd(app *app) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&o.json, "json", false, "emit JSON instead of formatted output")
 	cmd.Flags().StringVar(&o.scope, "scope", "", "only endpoints requiring this scope")
-	cmd.Flags().StringVar(&o.actor, "actor", "", "only endpoints callable by this actor type (user, agent, service_account, toolkit)")
+	cmd.Flags().StringVar(&o.actor, "actor", "", "only endpoints callable by this actor type (user, agent, service_account)")
 	return cmd
 }
 
@@ -155,7 +155,7 @@ func (ep endpoint) group() string {
 }
 
 const (
-	groupAgent    = "Agent-facing (typically agent / service-account / toolkit)"
+	groupAgent    = "Agent-facing (typically agent / service-account)"
 	groupOperator = "Operator-facing (typically a human operator / admin)"
 	groupAny      = "Any authenticated actor"
 	groupPublic   = "Public (unauthenticated)"

--- a/cli/internal/cli/api/endpoints_test.go
+++ b/cli/internal/cli/api/endpoints_test.go
@@ -31,7 +31,7 @@ const sampleReference = `{
       "path": "/credentials",
       "summary": "Create Credential",
       "public": false,
-      "actor_types": ["user", "agent", "service_account", "toolkit"],
+      "actor_types": ["user", "agent", "service_account"],
       "required_scopes": [],
       "typical_caller": "any"
     },

--- a/cli/internal/cli/api/execute.go
+++ b/cli/internal/cli/api/execute.go
@@ -65,7 +65,7 @@ func newExecuteCmd(app *app) *cobra.Command {
 			"     verbatim (e.g. GET:/v1/pets); the caller supplies the broker path.\n\n" +
 			"Path parameters, query parameters, headers, and a request body can be\n" +
 			"supplied via flags.\n\n" +
-			"When the broker denies the call (e.g. you are not bound to a toolkit\n" +
+			"When the broker denies the call (e.g. you have no credential binding\n" +
 			"for the API, or no credential is provisioned), it returns an\n" +
 			"agent_directive describing how to recover. execute surfaces that\n" +
 			"directive on stderr and exits 2 so a script can branch on the denial.\n\n" +

--- a/cli/internal/cli/api/execute_test.go
+++ b/cli/internal/cli/api/execute_test.go
@@ -163,8 +163,8 @@ func TestExecuteCmdDeniedSurfacesDirectiveAndExits2(t *testing.T) {
 			"error_origin": "broker",
 			"agent_directive": {
 				"strategy": "prompt_human",
-				"parameters": {"suggested_command": "jentic access request --toolkit api.example.com --wait"},
-				"human_readable_instruction": "You are not bound to a toolkit for this API."
+				"parameters": {"suggested_command": "jentic access request --api api.example.com --wait"},
+				"human_readable_instruction": "You have no credential binding for this API."
 			}
 		}`))
 	}))
@@ -193,10 +193,10 @@ func TestExecuteCmdDeniedSurfacesDirectiveAndExits2(t *testing.T) {
 		t.Fatalf("expected exit code 2 on denial, got err=%v", err)
 	}
 	// The recovery directive must be surfaced on stderr, including the command.
-	if !strings.Contains(errBuf.String(), "jentic access request --toolkit api.example.com --wait") {
+	if !strings.Contains(errBuf.String(), "jentic access request --api api.example.com --wait") {
 		t.Errorf("stderr missing suggested_command; got: %s", errBuf.String())
 	}
-	if !strings.Contains(errBuf.String(), "not bound to a toolkit") {
+	if !strings.Contains(errBuf.String(), "no credential binding") {
 		t.Errorf("stderr missing instruction; got: %s", errBuf.String())
 	}
 	// The 403 envelope is still emitted on stdout for machine parsing.
@@ -264,7 +264,7 @@ func TestExecuteCmdDirectivelessDenialExits2(t *testing.T) {
 		w.WriteHeader(http.StatusForbidden) // 403, no agent_directive
 		_, _ = w.Write([]byte(`{
 			"type": "action_denied",
-			"title": "The requested operation is denied by a toolkit permission rule.",
+			"title": "The requested operation is denied by a permission rule.",
 			"status": 403,
 			"error_origin": "broker"
 		}`))

--- a/cli/internal/cli/api/mcp_access.go
+++ b/cli/internal/cli/api/mcp_access.go
@@ -38,7 +38,7 @@ import (
 const defaultImportWaitBudget = 20 * time.Second
 
 // defaultAccessPollBudget is request_access's short post-file poll: long
-// enough to catch a server-side auto-decision (a bare toolkit:bind for an
+// enough to catch a server-side auto-decision (a bare credential:bind for an
 // unserved API auto-denies), far too short to sit out a human approval —
 // that wait belongs to the model's own request_id polling, never inside one
 // tool call (client-side tool timeouts, §3.4).
@@ -67,7 +67,11 @@ var importAPIParams = []paramSpec{
 var requestAccessParams = []paramSpec{
 	{name: "request_id", aliases: []string{"id"}, kind: paramString},
 	{name: "provision", aliases: []string{"provisions"}, kind: paramStringList},
-	{name: "toolkits", aliases: []string{"toolkit"}, kind: paramStringList},
+	// "toolkits"/"toolkit" are the deprecated spellings of "apis" (toolkits
+	// were retired, theme-5); accepted as aliases for one release.
+	{name: "apis", aliases: []string{"api", "toolkits", "toolkit"}, kind: paramStringList},
+	// toolkit_ids stays accepted so an old caller gets compose()'s re-file
+	// error naming "apis"/--api instead of an unknown-parameter failure.
 	{name: "toolkit_ids", aliases: []string{"toolkit_id"}, kind: paramStringList},
 	{name: "scopes", aliases: []string{"scope"}, kind: paramStringList},
 	{name: "auth", aliases: []string{"auths"}, kind: paramStringList},
@@ -391,7 +395,7 @@ func (s *mcpServer) handleRequestAccess(ctx context.Context, req *mcp.CallToolRe
 		}
 		if opts.targetCount() > 0 || opts.reason != "" || len(opts.auths) > 0 || len(opts.rulesJSONs) > 0 {
 			return nil, invalidParams(errors.New(`pass EITHER "request_id" (to poll an existing request) ` +
-				`OR filing parameters ("provision"/"toolkits"/"toolkit_ids"/"scopes" with "auth"/"rules_json"/"reason") ` +
+				`OR filing parameters ("provision"/"apis"/"scopes" with "auth"/"rules_json"/"reason") ` +
 				`to file a new one, not both`))
 		}
 		reqState, getErr := s.app.getAccessRequest(cctx, client, requestID)
@@ -424,7 +428,7 @@ func (s *mcpServer) handleRequestAccess(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		if errors.Is(err, errAccessTargetRequired) {
 			return nil, invalidParams(errors.New(`request_access requires a target: "provision" (vendor/name plans), ` +
-				`"toolkits" (vendor/name binds), "toolkit_ids" (tk_… binds), or "scopes" — or "request_id" to poll ` +
+				`"apis" (vendor/name binds), or "scopes" — or "request_id" to poll ` +
 				`an existing request`))
 		}
 		// compose()'s messages name the CLI spellings (--provision, --auth,
@@ -501,7 +505,7 @@ func (s *mcpServer) handleRequestAccess(ctx context.Context, req *mcp.CallToolRe
 }
 
 // awaitAutoDecision short-polls a just-filed request so a server-side
-// auto-decision (e.g. the auto-deny of a bare toolkit:bind for an unserved
+// auto-decision (e.g. the auto-deny of a bare credential:bind for an unserved
 // API) reaches the model in the SAME tool result. Bounded by
 // accessPollBudget — a human approval takes minutes and belongs to the
 // model's own request_id polling, never inside one call.
@@ -564,7 +568,7 @@ func (s *mcpServer) accessRequestResult(ctx context.Context, st *clictx.ActiveSt
 			Code: ux.CodeBrokerDenied,
 			Msg:  fmt.Sprintf("access request %s was denied", req.Id),
 			Actionable: "Read the items' decision_reason in this result to learn why before giving up. A bare " +
-				"toolkit bind for an API nothing serves auto-denies — file a provisioning plan " +
+				"bind request for an API no credential serves auto-denies — file a provisioning plan " +
 				`({"provision": ["vendor/name"], …}) instead. Only re-file if something material changed.`,
 		}, "whoami", map[string]any{"request": payload})
 	case statusExpired, statusWithdrawn:
@@ -667,8 +671,8 @@ func requestAccessOptions(args map[string]any) (*accessRequestOptions, error) {
 	if v, ok := args["provision"].([]string); ok {
 		opts.provisions = v
 	}
-	if v, ok := args["toolkits"].([]string); ok {
-		opts.toolkits = v
+	if v, ok := args["apis"].([]string); ok {
+		opts.apis = v
 	}
 	if v, ok := args["toolkit_ids"].([]string); ok {
 		opts.toolkitIDs = v
@@ -789,21 +793,16 @@ var requestAccessSchema = map[string]any{
 			"type":  "array",
 			"items": map[string]any{"type": "string"},
 			"description": "APIs to file full provisioning plans for, as vendor/name[/version] references " +
-				"(e.g. \"stripe.com/api\"). Use when NOTHING you're bound to serves the API yet: the plan " +
-				"describes the whole path to first execution (create toolkit, provision + bind a credential " +
-				"with your proposed rules, bind you), which a human fulfils and approves.",
+				"(e.g. \"stripe.com/api\"). Use when NO credential you're bound to serves the API yet: the plan " +
+				"describes the whole path to first execution (provision a credential, bind you to it " +
+				"with your proposed rules), which a human fulfils and approves.",
 		},
-		"toolkits": map[string]any{
+		"apis": map[string]any{
 			"type":  "array",
 			"items": map[string]any{"type": "string"},
-			"description": "Toolkits to be bound to, as vendor/name[/version] API references. The LAST MILE only: " +
-				"use when a toolkit already serves the API and you just aren't bound to it — for an unserved " +
-				"API this auto-denies; use provision instead.",
-		},
-		"toolkit_ids": map[string]any{
-			"type":        "array",
-			"items":       map[string]any{"type": "string"},
-			"description": "Toolkits to be bound to, by id (tk_…).",
+			"description": "APIs to be bound to a credential for, as vendor/name[/version] references. The LAST MILE " +
+				"only: use when a credential already serves the API and you just aren't bound to it — for an " +
+				"unserved API this auto-denies; use provision instead.",
 		},
 		"scopes": map[string]any{
 			"type":        "array",
@@ -869,7 +868,7 @@ func (s *mcpServer) accessToolSpecs() []mcpToolSpec {
 					"converges (idempotent) and finishes the promotion. Requires the catalog:import scope " +
 					"(agents hold it by default); on a denial, request it via request_access — do not guess " +
 					"other scopes. Importing makes an API discoverable but does NOT grant access to call " +
-					"it: check whoami for a toolkit binding serving it — never execute just to probe — and " +
+					"it: check whoami for a credential binding serving it — never execute just to probe — and " +
 					"use request_access if nothing serves it.",
 				InputSchema: importAPISchema,
 				Annotations: &mcp.ToolAnnotations{IdempotentHint: true},
@@ -885,10 +884,10 @@ func (s *mcpServer) accessToolSpecs() []mcpToolSpec {
 					"access. If a whoami binding already serves the API, you have access; if NOTHING serves " +
 					`it, file a provisioning plan: {"provision": ["vendor/name"], "auth": ["bearer"], ` +
 					`"rules_json": [{"effect":"allow","methods":["GET"],"path":".*"}], "reason": "…"} — it ` +
-					"describes the whole path to first execution (create toolkit, provision + bind a " +
-					"credential with your proposed rules, bind you), which a human fulfils in the dashboard " +
-					"(they enter the secret; it never rides in your request). A bare toolkit bind " +
-					`({"toolkits": ["vendor/name"]}) is only the last mile when a toolkit already serves the ` +
+					"describes the whole path to first execution (provision a credential, bind you to it " +
+					"with your proposed rules), which a human fulfils in the dashboard " +
+					"(they enter the secret; it never rides in your request). A bare bind request " +
+					`({"apis": ["vendor/name"]}) is only the last mile when a credential already serves the ` +
 					"API; for an unserved API it auto-denies — use provision. ALWAYS include reason. File " +
 					"once, richly: combine every target this task needs into ONE composite request instead " +
 					"of filing piecemeal. The result carries approve_url: relay it to your human operator — " +

--- a/cli/internal/cli/api/mcp_access_test.go
+++ b/cli/internal/cli/api/mcp_access_test.go
@@ -445,7 +445,7 @@ func TestMCPRequestAccess_FilesComposedPlanPendingWithApproveURL(t *testing.T) {
 		"provision": ["stripe.com/api"],
 		"auth": ["bearer"],
 		"rules_json": [{"effect":"allow","methods":["GET"],"path":".*"}],
-		"toolkits": ["github.com/api"],
+		"apis": ["github.com/api"],
 		"scopes": ["catalog:import"],
 		"reason": "read invoices for the summary task"
 	}`))
@@ -491,7 +491,7 @@ func TestMCPRequestAccess_FilesComposedPlanPendingWithApproveURL(t *testing.T) {
 		t.Errorf("credential:bind rules = %s, want the proposed rules_json intact (never comma-split)", wire.Items[1].Rules)
 	}
 	if ref := wire.Items[2].ResourceReference; ref["vendor"] != "github.com" {
-		t.Errorf("reference bind = %v, want the --toolkit api filed as a credential bind by reference", ref)
+		t.Errorf("reference bind = %v, want the apis target filed as a credential bind by reference", ref)
 	}
 	if wire.Items[3].ResourceID == nil || *wire.Items[3].ResourceID != "catalog:import" {
 		t.Errorf("scope item = %+v, want resource_id catalog:import", wire.Items[3])
@@ -521,13 +521,13 @@ func TestMCPRequestAccess_AutoDenialSurfacesInSameResult(t *testing.T) {
 	plane := &accessControlPlane{
 		fileStatus: statusPending,
 		pollStatus: statusDenied,
-		itemsJSON:  `[{"id":"item_1","resource_type":"toolkit","action":"bind","status":"denied","decision_reason":"No toolkit serves API acme/pets; provision and bind a credential for it first"}]`,
+		itemsJSON:  `[{"id":"item_1","resource_type":"credential","action":"bind","status":"denied","decision_reason":"No credential serves API acme/pets; provision one for it first"}]`,
 	}
 	srv := httptest.NewServer(plane.handler(t))
 	defer srv.Close()
 
 	s := fastAccessServer(t)
-	res, err := s.handleRequestAccess(activeCtx(srv.URL), callToolRequest("request_access", `{"toolkits":["acme/pets"],"reason":"r"}`))
+	res, err := s.handleRequestAccess(activeCtx(srv.URL), callToolRequest("request_access", `{"apis":["acme/pets"],"reason":"r"}`))
 	if err != nil {
 		t.Fatalf("handleRequestAccess: %v", err)
 	}
@@ -546,7 +546,7 @@ func TestMCPRequestAccess_AutoDenialSurfacesInSameResult(t *testing.T) {
 		t.Fatalf("denial must carry the full request for its decision_reason: %v", payload)
 	}
 	items, _ := request["items"].([]any)
-	if len(items) != 1 || !strings.Contains(fmt.Sprint(items[0]), "No toolkit serves") {
+	if len(items) != 1 || !strings.Contains(fmt.Sprint(items[0]), "No credential serves") {
 		t.Errorf("request.items = %v, want the decision_reason relayed", request["items"])
 	}
 }
@@ -557,6 +557,8 @@ func TestMCPRequestAccess_DuplicatePendingSingleTargetAttaches(t *testing.T) {
 	defer srv.Close()
 
 	s := fastAccessServer(t)
+	// The legacy "toolkits" spelling rides the deprecated alias — this doubles
+	// as the alias-compat regression while the alias survives (one release).
 	res, err := s.handleRequestAccess(activeCtx(srv.URL), callToolRequest("request_access", `{"toolkits":["acme/pets"]}`))
 	if err != nil {
 		t.Fatalf("handleRequestAccess: %v", err)
@@ -577,7 +579,7 @@ func TestMCPRequestAccess_DuplicatePendingCompositeIsSoftError(t *testing.T) {
 
 	s := fastAccessServer(t)
 	res, err := s.handleRequestAccess(activeCtx(srv.URL),
-		callToolRequest("request_access", `{"toolkits":["acme/pets"],"scopes":["catalog:import"]}`))
+		callToolRequest("request_access", `{"apis":["acme/pets"],"scopes":["catalog:import"]}`))
 	if err != nil {
 		t.Fatalf("handleRequestAccess: %v", err)
 	}
@@ -631,7 +633,7 @@ func TestMCPRequestAccess_MissingTargetIsInvalidParams(t *testing.T) {
 	if res != nil {
 		t.Fatalf("want a protocol error, got a result: %v", res)
 	}
-	for _, name := range []string{"provision", "toolkits", "scopes", "request_id"} {
+	for _, name := range []string{"provision", "apis", "scopes", "request_id"} {
 		if err == nil || !strings.Contains(err.Error(), name) {
 			t.Errorf("err %v must name the parameter %q", err, name)
 		}
@@ -641,7 +643,7 @@ func TestMCPRequestAccess_MissingTargetIsInvalidParams(t *testing.T) {
 func TestMCPRequestAccess_RequestIDPlusTargetsIsInvalidParams(t *testing.T) {
 	s := fastAccessServer(t)
 	res, err := s.handleRequestAccess(activeCtx("http://127.0.0.1:0"),
-		callToolRequest("request_access", `{"request_id":"acr_1","toolkits":["acme/pets"]}`))
+		callToolRequest("request_access", `{"request_id":"acr_1","apis":["acme/pets"]}`))
 	if res != nil {
 		t.Fatalf("want a protocol error, got a result: %v", res)
 	}
@@ -661,7 +663,7 @@ func TestMCPRequestAccess_NeverSelfApproves(t *testing.T) {
 
 	s := fastAccessServer(t)
 	ctx := activeCtx(srv.URL)
-	if res, err := s.handleRequestAccess(ctx, callToolRequest("request_access", `{"toolkits":["acme/pets"],"reason":"r"}`)); err != nil || res.IsError {
+	if res, err := s.handleRequestAccess(ctx, callToolRequest("request_access", `{"apis":["acme/pets"],"reason":"r"}`)); err != nil || res.IsError {
 		t.Fatalf("filing arm: err %v, res %v", err, res)
 	}
 	if res, err := s.handleRequestAccess(ctx, callToolRequest("request_access", `{"request_id":"acr_1"}`)); err != nil || res.IsError {
@@ -813,7 +815,7 @@ func TestMCPRequestAccess_FilingForbiddenIsBrokerDenied(t *testing.T) {
 	defer srv.Close()
 
 	s := fastAccessServer(t)
-	res, err := s.handleRequestAccess(activeCtx(srv.URL), callToolRequest("request_access", `{"toolkits":["acme/pets"],"reason":"r"}`))
+	res, err := s.handleRequestAccess(activeCtx(srv.URL), callToolRequest("request_access", `{"apis":["acme/pets"],"reason":"r"}`))
 	if err != nil {
 		t.Fatalf("handleRequestAccess: %v", err)
 	}
@@ -843,7 +845,7 @@ func TestMCPRequestAccess_PollArmRejectsStrayFilingParams(t *testing.T) {
 		"stray auth":          `{"request_id":"acr_1","auth":["bearer"]}`,
 		"stray rules_json":    `{"request_id":"acr_1","rules_json":[{"effect":"allow"}]}`,
 		"malformed rules":     `{"request_id":"acr_1","rules_json":42}`,
-		"target and poll mix": `{"request_id":"acr_1","toolkits":["acme/pets"]}`,
+		"target and poll mix": `{"request_id":"acr_1","apis":["acme/pets"]}`,
 	} {
 		res, err := s.handleRequestAccess(activeCtx("http://127.0.0.1:0"), callToolRequest("request_access", argsJSON))
 		if res != nil {

--- a/cli/internal/cli/api/mcp_execute.go
+++ b/cli/internal/cli/api/mcp_execute.go
@@ -417,14 +417,18 @@ func (s *mcpServer) executeDenialError(ctx context.Context, denial *agentops.Den
 func synthesizedDenialHint(status int) string {
 	switch status {
 	case http.StatusForbidden:
-		return "This agent isn't bound to a toolkit serving this API. Call whoami to see your bindings, " +
-			"then ask your operator to grant access (`jentic access request --toolkit <vendor/name> --wait`)."
+		return "This agent has no credential binding covering this API. Call whoami to see your bindings, " +
+			"then ask your operator to grant access (`jentic access request --api <vendor/name> --wait`)."
+	case http.StatusConflict:
+		return "Multiple bound credentials cover this API. Resend the same call with the " +
+			"Jentic-Credential-Id header naming one of them (Jentic-Credential-Name also works " +
+			"when names are unique); whoami lists your bindings."
 	case http.StatusFailedDependency:
 		return "No credential is provisioned for this call. Ask your operator to provision one " +
-			"(`jentic access request --toolkit <vendor/name> --provision --wait`), then retry."
+			"(`jentic access request --provision <vendor/name> --wait`), then retry."
 	case http.StatusUnauthorized:
 		return "The stored upstream credential needs reconnecting. Ask your operator to re-provision it " +
-			"(`jentic access request --toolkit <vendor/name> --provision --wait`), then retry."
+			"(`jentic access request --provision <vendor/name> --wait`), then retry."
 	default:
 		return "The broker denied this call before it reached the upstream API. Call whoami to check what you can run."
 	}

--- a/cli/internal/cli/api/mcp_execute_test.go
+++ b/cli/internal/cli/api/mcp_execute_test.go
@@ -109,7 +109,7 @@ func TestMCPExecute_DenialPassesDirectiveThrough(t *testing.T) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.Header().Set("Jentic-Error-Origin", "broker")
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"detail":"no toolkit binding","agent_directive":{"strategy":"prompt_human","parameters":{"suggested_command":"jentic access request --toolkit acme/pets --wait"},"human_readable_instruction":"Ask your operator to bind this agent to acme/pets."}}`))
+		_, _ = w.Write([]byte(`{"detail":"no credential binding","agent_directive":{"strategy":"prompt_human","parameters":{"suggested_command":"jentic access request --api acme/pets --wait"},"human_readable_instruction":"Ask your operator to bind this agent to a credential for acme/pets."}}`))
 	}))
 	defer broker.Close()
 
@@ -145,7 +145,7 @@ func TestMCPExecute_DenialPassesDirectiveThrough(t *testing.T) {
 		t.Errorf("directive.strategy = %v, want prompt_human", directive["strategy"])
 	}
 	params, _ := directive["parameters"].(map[string]any)
-	if params["suggested_command"] != "jentic access request --toolkit acme/pets --wait" {
+	if params["suggested_command"] != "jentic access request --api acme/pets --wait" {
 		t.Errorf("directive.parameters = %v, want the suggested_command verbatim", directive["parameters"])
 	}
 	if step, _ := payload["actionable_step"].(string); !strings.Contains(step, "acme/pets") {
@@ -162,7 +162,7 @@ func TestMCPExecute_DenialRelaysUnknownDirectiveFields(t *testing.T) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.Header().Set("Jentic-Error-Origin", "broker")
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"detail":"no toolkit binding","agent_directive":{"strategy":"prompt_human",` +
+		_, _ = w.Write([]byte(`{"detail":"no credential binding","agent_directive":{"strategy":"prompt_human",` +
 			`"future_field":"must-survive","parameters":{"nested_unknown":{"keep":"me"}},` +
 			`"human_readable_instruction":"Ask your operator."}}`))
 	}))

--- a/cli/internal/cli/api/mcp_server.go
+++ b/cli/internal/cli/api/mcp_server.go
@@ -108,7 +108,7 @@ func newMCPServer(a *app, version string, opts *mcpOptions, logger *slog.Logger)
 			Instructions: "Jentic One tool server. On a new machine, or after any tool returns an " +
 				"auth or connectivity error, call get_started first — it diagnoses this " +
 				"machine's setup state and returns the exact operator instruction to fix it. " +
-				"Call whoami to see the agent identity, status, scopes, and toolkit bindings. " +
+				"Call whoami to see the agent identity, status, scopes, and credential bindings. " +
 				"Every tool result carries a top-level `instance` key identifying the Jentic " +
 				"One instance it came from; instance.backend is \"unreachable\" when the " +
 				"control plane could not be reached. The skill://jentic resource is the " +
@@ -236,7 +236,7 @@ func (s *mcpServer) toolSpecs() []mcpToolSpec {
 				Name:  "whoami",
 				Title: "Show agent identity",
 				Description: "Show the calling agent's identity as the Jentic control plane sees it: " +
-					"id, status, scopes, and toolkit bindings with the APIs each one serves. " +
+					"id, status, scopes, and credential bindings with the APIs each one serves. " +
 					"Call after get_started reports ready, and before requesting access or " +
 					"executing operations — never execute an operation just to probe whether " +
 					"you have access. On an auth error, call get_started for the fix.",

--- a/cli/internal/cli/api/mcp_session_test.go
+++ b/cli/internal/cli/api/mcp_session_test.go
@@ -220,7 +220,7 @@ func TestMCPSession_FullRoundTrip(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/me":
-			_, _ = w.Write([]byte(`{"type":"agent","id":"agent_1","name":"pets-agent","scopes":["execute"],"status":"active","token_scopes":["execute"],"toolkit_bindings":[]}`))
+			_, _ = w.Write([]byte(`{"type":"agent","id":"agent_1","name":"pets-agent","scopes":["execute"],"status":"active","token_scopes":["execute"],"toolkit_bindings":[],"credential_bindings":[]}`))
 		case "/search":
 			_, _ = w.Write([]byte(`{
 				"data": [{"type":"operation","api":{"vendor":"acme","name":"pets","version":"v1","host":"acme.com"},"operation_id":"op1","method":"GET","url":"/pets","name":"List Pets","relevance_score":0.9,"_links":{"inspect":"/inspect?id=GET%20/pets"}}],
@@ -651,9 +651,9 @@ func TestMCPSession_AccessLoopDeniedToApprovedRetry(t *testing.T) {
 			w.Header().Set("Content-Type", "application/problem+json")
 			w.Header().Set("Jentic-Error-Origin", "broker")
 			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte(`{"detail":"no toolkit binding","agent_directive":{"strategy":"prompt_human",` +
-				`"parameters":{"suggested_command":"jentic access request --toolkit acme/pets --wait"},` +
-				`"human_readable_instruction":"Ask your operator to bind this agent to acme/pets."}}`))
+			_, _ = w.Write([]byte(`{"detail":"no credential binding","agent_directive":{"strategy":"prompt_human",` +
+				`"parameters":{"suggested_command":"jentic access request --api acme/pets --wait"},` +
+				`"human_readable_instruction":"Ask your operator to bind this agent to a credential for acme/pets."}}`))
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -666,7 +666,7 @@ func TestMCPSession_AccessLoopDeniedToApprovedRetry(t *testing.T) {
 		return `{"id":"acr_1","status":"` + status + `","actor_id":"agent_1","created_by":"agent_1",` +
 			`"requested_by":"agent_1","approve_url":"/console/access-requests/acr_1",` +
 			`"filed_at":"2026-08-31T12:00:00Z","expires_at":"2026-09-07T12:00:00Z",` +
-			`"items":[{"id":"item_1","resource_type":"toolkit","action":"bind","status":"` + status + `"}]}`
+			`"items":[{"id":"item_1","resource_type":"credential","action":"bind","status":"` + status + `"}]}`
 	}
 	control := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -714,7 +714,7 @@ func TestMCPSession_AccessLoopDeniedToApprovedRetry(t *testing.T) {
 	// 2. request_access files the bind and returns approve_url + pending.
 	res, err = cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "request_access",
-		Arguments: map[string]any{"toolkits": []string{"acme/pets"}, "reason": "list pets for the demo"},
+		Arguments: map[string]any{"apis": []string{"acme/pets"}, "reason": "list pets for the demo"},
 	})
 	if err != nil {
 		t.Fatalf("request_access: %v", err)

--- a/cli/internal/cli/api/mcp_tools.go
+++ b/cli/internal/cli/api/mcp_tools.go
@@ -101,7 +101,7 @@ const (
 		"restart it with `jenticctl start` (then `jenticctl status` to confirm), and retry. " +
 		"This server never starts or stops the instance."
 	instructionReady = "You're set up. Call the `whoami` tool to see your identity, status, scopes, " +
-		"and toolkit bindings. Request access before executing anything new; discovery and " +
+		"and credential bindings. Request access before executing anything new; discovery and " +
 		"execution follow the search → inspect → execute flow."
 )
 

--- a/cli/internal/cli/cmdcore/register_flow.go
+++ b/cli/internal/cli/cmdcore/register_flow.go
@@ -214,7 +214,7 @@ func (a *App) printNextSteps(st theme.Styles) {
 		{"Browse the API catalog", "jentic catalog"},
 		{"Find an operation (each result prints a ready-to-paste inspect/execute target)", "jentic search \"send a slack message\""},
 		{"See what you can run right now", "jentic access whoami"},
-		{"A fresh agent is bound to no APIs — request access to one you found", "jentic access request --toolkit <vendor/name> --wait"},
+		{"A fresh agent is bound to no APIs — request access to one you found", "jentic access request --api <vendor/name> --wait"},
 		{"Inspect that operation (paste the target search printed)", "jentic inspect <METHOD:url from search>"},
 		{"Run it (same target)", "jentic execute <METHOD:url from search> -d '{\"key\":\"value\"}'"},
 	}

--- a/cli/internal/cli/ux/execute.go
+++ b/cli/internal/cli/ux/execute.go
@@ -116,16 +116,20 @@ func RenderSynthesizedDenialRecovery(ctx context.Context, w io.Writer, status in
 	st := theme.StylesFromContext(ctx)
 	fmt.Fprintln(w, st.Warn.Render("Denied — recovery required:"))
 	switch status {
-	case http.StatusForbidden: // 403: have an identity, no access to this toolkit yet
-		fmt.Fprintln(w, "  This agent isn't bound to the toolkit you called. Check what you can run, then request access.")
+	case http.StatusForbidden: // 403: have an identity, no credential binding for this API yet
+		fmt.Fprintln(w, "  This agent has no credential binding for the API you called. Check what you can run, then request access.")
 		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access whoami"))
-		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access request --toolkit <vendor/name> --wait"))
+		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access request --api <vendor/name> --wait"))
+	case http.StatusConflict: // 409: several bound credentials cover the API
+		fmt.Fprintln(w, "  Multiple bound credentials cover this API. Resend the same call naming one of them")
+		fmt.Fprintln(w, "  with the Jentic-Credential-Id header (Jentic-Credential-Name also works when names are unique).")
+		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access whoami"))
 	case http.StatusFailedDependency: // 424: no credential provisioned for the call
-		fmt.Fprintln(w, "  No credential is provisioned for this call. Provision one, then retry.")
-		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access request --toolkit <vendor/name> --provision --wait"))
+		fmt.Fprintln(w, "  No credential is provisioned for this call. File a provisioning plan, then retry.")
+		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access request --provision <vendor/name> --wait"))
 	case http.StatusUnauthorized: // 401: credential expired / needs reconnecting
-		fmt.Fprintln(w, "  Your credential needs reconnecting. Re-run access to refresh it.")
-		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access request --toolkit <vendor/name> --provision --wait"))
+		fmt.Fprintln(w, "  Your credential needs reconnecting. Ask your operator to re-provision it, or file a plan.")
+		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access request --provision <vendor/name> --wait"))
 	default:
 		fmt.Fprintln(w, "  The broker denied this call. Check what you can run and your setup.")
 		fmt.Fprintln(w, "  run: "+st.Accent.Render("jentic access whoami"))

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -78,13 +78,13 @@ context).
 
 ### 2. Check what you can do, and request access if needed
 
-See your own identity, status, scopes, and which toolkits you're bound to:
+See your own identity, status, scopes, and which credentials you're bound to:
 
 ```
 jentic access whoami
 ```
 
-Each toolkit binding lists the APIs it **serves** (`serves: [{vendor, name,
+Each credential binding lists the API it **serves** (`serves: [{vendor, name,
 version}]`). This tells you exactly what you can already call. Combined with the
 catalog (what's available to add — see step 3), it's your map of the workspace.
 
@@ -107,8 +107,8 @@ jentic access request --provision <vendor/name> \
 ```
 
 `--wait` blocks until a human fulfils and approves the plan in the dashboard;
-once approved, the toolkit binding is live immediately — just retry `execute`.
-Always pass `--reason` on **every** access request (`--provision`, `--toolkit`,
+once approved, the credential binding is live immediately — just retry `execute`.
+Always pass `--reason` on **every** access request (`--provision`, `--api`,
 or `--scope`): a human reviews it before approving and your reason is shown to
 them — a clear one-liner ("fetch the user's open PRs to summarise them") is what
 gets you approved faster.
@@ -128,14 +128,14 @@ jentic access request \
   --rules-json 'slack.com/api=[{"effect":"allow","methods":["POST"],"path":"/chat\\.postMessage"}]' \
   --provision googleapis.com/sheets --auth googleapis.com/sheets=oauth2 \
   --rules-json 'googleapis.com/sheets=[{"effect":"allow","methods":["GET"],"path":".*"}]' \
-  --toolkit github.com/api \
+  --api github.com/api \
   --reason "one reason covering the whole job" \
   --wait
 ```
 
 Each `--provision` adds a full plan for that API — keep every plan complete
 (auth, rules, reason), exactly as you would for a single one;
-`--toolkit`/`--toolkit-id`/`--scope` add single items. With more than one
+`--api`/`--scope` add single items. With more than one
 `--provision`, key `--auth` and `--rules-json` by the same
 `vendor/name[/version]` you passed to `--provision` (include the version in
 the key if you used one); the bare form applies when there is exactly one.
@@ -152,10 +152,8 @@ it prints a recovery line on stderr (the `agent_directive`) and **exits 2**, so
 you can branch on the exit code instead of mistaking the 4xx body for success.
 The directive tells you exactly how to recover — which differs by denial:
 
-- **`no_toolkit_binding` (403)** — nothing serves this API yet (no toolkit, and
-  usually no credential). File a **provisioning plan** describing the whole path
-  to first execution, and propose the auth type and permission rules you read
-  from the API spec:
+- **`no_credential_binding` (403)** — no credential binding of yours serves this
+  API. Check the directive's `parameters.api_served`:
 
 ```
 jentic access request --provision stripe.com/api \
@@ -165,21 +163,18 @@ jentic access request --provision stripe.com/api \
   --wait
 ```
 
-  - `toolkit_serves_api: false` — **no** toolkit serves this API yet, so a bare
-    `--toolkit` binding request would be denied ("No toolkit serves API …").
-    Filing it now is a dead-end. File the `--provision` plan above instead: it
-    describes the whole path (create toolkit, provision + bind a credential with
-    your proposed rules, bind you), which a human fulfils and approves in the
-    dashboard. The directive's `suggested_command` already points at `--provision`
-    in this case. The plan does **not** force a new toolkit: during fulfilment
-    the operator can add the credential to a toolkit they already have (the
-    wizard offers both) — worth relaying when your operator mentions an
-    existing toolkit they want to extend.
-  - `toolkit_serves_api: true` — a toolkit already serves this API and you just
-    aren't bound to it; the directive suggests `jentic access request --toolkit
+  - `api_served: false` — **no** credential is provisioned for this API yet, so
+    a bare `--api` binding request would be denied ("No credential covers API
+    …"). Filing it now is a dead-end. File the `--provision` plan above instead:
+    it describes the whole path to first execution (provision a credential with
+    your proposed auth type and rules, bind you), which a human fulfils and
+    approves in the dashboard. The directive's `suggested_command` already
+    points at `--provision` in this case.
+  - `api_served: true` — a credential already serves this API and you just
+    aren't bound to it; the directive suggests `jentic access request --api
     <vendor/name> --wait`. File that and wait for approval.
 
-- **`credential_not_provisioned` (424)** — you're bound to a toolkit, but no
+- **`credential_not_provisioned` (424)** — you're bound, but no
   credential (account) is connected. Filing an access request will **not** fix
   this; the directive carries a `provisioning_url` — hand it to your operator to
   connect the account, then retry.
@@ -188,7 +183,7 @@ jentic access request --provision stripe.com/api \
   encryption key rotated underneath it, e.g. a reinstall over existing data).
   Neither an access request nor retrying will fix this — ask your operator to
   remove and re-add the credential, then retry.
-- **`credential_identity_mismatch` (403)** — a toolkit *is* bound and a
+- **`credential_identity_mismatch` (403)** — a binding exists and a
   credential *is* connected, but that credential's stored identity doesn't cover
   this API (e.g. it targets a different name/version, or was stored in a
   non-canonical form). Filing an access request will **not** fix this — the
@@ -197,10 +192,12 @@ jentic access request --provision stripe.com/api \
   is `true` the credential just needs re-provisioning to canonicalize its
   identity. Either way, ask your operator to fix or re-provision the credential
   so it targets `expected`, then retry.
-- **`ambiguous_toolkit` (409)** — multiple toolkits you're bound to serve this
-  API. The directive lists `candidates`; resend the same `execute` with
-  `--header Jentic-Toolkit-Id=<toolkit_id>` (the directive also gives a
-  copy-pasteable `suggested_command`).
+- **`ambiguous_credential_binding` (409)** — multiple credentials you're bound
+  to cover this API. The directive lists `candidates` and carries
+  `parameters.headers`; resend the same `execute` with
+  `--header Jentic-Credential-Id=<credential_id>` (the authoritative
+  tie-breaker — `--header Jentic-Credential-Name=<name>` also works when
+  credential names are unique).
 
 Always follow the `agent_directive`'s `suggested_command` / `provisioning_url`
 rather than assuming which recovery applies. You can also request access
@@ -238,12 +235,12 @@ approving. Do the work up front:
 4. You never enter the credential secret and you never approve — the human fills
    the secret in the dashboard and grants the plan. You propose; they decide.
 
-A plain `toolkit:bind` (`--toolkit`) is only the **last mile** — use it when a
-toolkit for the API already exists (e.g. an operator created one) and you just
-need to be bound to it. When nothing serves the API yet, `--provision` is the
-right first move; a bare `--toolkit` would auto-deny.
+A plain `credential:bind` (`--api`) is only the **last mile** — use it when a
+credential for the API already exists (e.g. an operator provisioned one) and you
+just need to be bound to it. When nothing serves the API yet, `--provision` is
+the right first move; a bare `--api` would auto-deny.
 
-`--toolkit`/`--provision` take a `vendor/name[/version]` reference (the broker
+`--api`/`--provision` take a `vendor/name[/version]` reference (the broker
 also suggests the exact command in its `agent_directive`). `--wait` blocks until
 a human decides and sets the exit code: **0** = approved, **2** = denied —
 read the item's `decision_reason` (in the JSON, or shown under the item on a
@@ -253,10 +250,10 @@ approved. Without `--wait` you get a request id and an `approve_url` to hand to
 your operator. Granting is always a human action — you file and wait, you never
 approve yourself.
 
-If you file a bare `toolkit:bind` (`--toolkit`) for an API that nothing serves
-yet, approval comes back **denied** with `decision_reason: "No toolkit serves
-API <vendor/name>; provision and bind a credential for it first"`. That is the
-signal to file a `--provision` plan instead: it describes the missing toolkit,
+If you file a bare `credential:bind` (`--api`) for an API that nothing serves
+yet, approval comes back **denied** with `decision_reason: "No credential covers
+API <vendor/name>; provision a credential for it first"`. That is the
+signal to file a `--provision` plan instead: it describes the missing
 credential, rules, and binding as one request the operator can fulfil and
 approve in the dashboard.
 
@@ -343,7 +340,7 @@ the catalog manifest from upstream but requires `org:admin`, so it too is an
 operator action.)
 
 **Before concluding "the data is gone", confirm which backend you're on.** If
-APIs, credentials, or toolkits you *know* existed appear missing — or IDs look
+APIs or credentials you *know* existed appear missing — or IDs look
 unfamiliar — you may be talking to a **different** backend than you expect. A
 hosted (`remote`) Jentic install and a `local` self-hosted one have independent
 registries and credentials, and the CLI, an agent, or an MCP server can each be
@@ -445,14 +442,16 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   the control plane (Reference → CLI) — the same reference rendered for humans,
   next to the HTTP API and Broker API references.
 - `jentic context view` — the active context (environment + identity + base_url); start here.
-- `jentic access whoami` — your identity, status, scopes, and toolkit bindings
-  with the APIs each one **serves** (check this before executing or provisioning).
+- `jentic access whoami` — your identity, status, scopes, and credential
+  bindings with the API each one **serves** (check this before executing or
+  provisioning).
 - `jentic access request` — ask a human for access. `--provision <vendor/name>`
   files the whole path to first execution as one plan when nothing serves the
-  API yet; `--toolkit <vendor/name>` asks to be bound to an **existing**
-  toolkit; `--scope <scope>` requests a missing scope. All target flags repeat
-  and combine into **one composite request**. Always pass `--reason`; add
-  `--wait` to block on approval (see Procedure for full examples).
+  API yet; `--api <vendor/name>` asks to be bound to an **existing**
+  credential serving that API; `--scope <scope>` requests a missing scope. All
+  target flags repeat and combine into **one composite request**. Always pass
+  `--reason`; add `--wait` to block on approval (see Procedure for full
+  examples).
 - `jentic access list | status <id> | withdraw <id>` — track your requests.
 - `jentic access refresh` — re-mint your token after an approved **scope**
   grant that `whoami` flags as not yet on your token. Bindings need no
@@ -534,15 +533,14 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   `jenticctl start`, then retry rather than abandoning the task. Only a
   broker **denial** (an `agent_directive` on stderr, exit **2**) is an
   access/credential issue:
-  - **403 `no_toolkit_binding`** → check the directive's
-    `parameters.toolkit_serves_api`. If `true`, a toolkit already serves the API
-    and you just aren't bound — run the `jentic access request --toolkit …` it
+  - **403 `no_credential_binding`** → check the directive's
+    `parameters.api_served`. If `true`, a credential already serves the API
+    and you just aren't bound — run the `jentic access request --api …` it
     suggests and wait for approval. If `false`, nothing serves the API yet and a
-    bare `--toolkit` bind would be **denied** ("No toolkit serves API …"); the
+    bare `--api` bind would be **denied** ("No credential covers API …"); the
     directive suggests `--provision` instead — file that plan (propose `--auth`
     and `--rules-json` from the spec, pass `--reason`) and your operator fulfils
-    it in the dashboard, into a new toolkit **or one they already have** — an
-    existing toolkit never has to be recreated.
+    it in the dashboard.
   - **424 `credential_not_provisioned`** → the directive gives a
     `provisioning_url` for your operator to connect an account (an access
     request won't help).
@@ -553,6 +551,10 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
     identity doesn't cover this API (`parameters.expected` vs
     `parameters.found`). An access request won't help — ask your operator to fix
     or re-provision the credential so it targets `expected`, then retry.
+  - **409 `ambiguous_credential_binding`** → several bound credentials cover
+    this API; resend with `--header Jentic-Credential-Id=<id>` picked from the
+    directive's `candidates` (`Jentic-Credential-Name` works too when names
+    are unique).
   Follow the directive; don't keep re-sending the same `execute`.
 - You file and wait for access; you can't approve your own requests.
 - **Don't execute to test access.** `whoami` already tells you what your bindings

--- a/cli/tests/golden/agentops_parity_test.go
+++ b/cli/tests/golden/agentops_parity_test.go
@@ -96,12 +96,12 @@ func TestAgentopsReproducesGoldens(t *testing.T) {
 			"agent_directive": {
 				"strategy": "wait",
 				"parameters": {
-					"suggested_command": "jentic access request --toolkit acme/pets --wait",
+					"suggested_command": "jentic access request --api acme/pets --wait",
 					"provisioning_url": "https://console.example/connect/acme",
 					"candidates": ["acme/pets", "acme/pets-admin"],
 					"retry_after_seconds": 30
 				},
-				"human_readable_instruction": "You are not bound to a toolkit for this API."
+				"human_readable_instruction": "You are not bound for 'acme/pets'. File an access request yourself with \u0060jentic access request --api acme/pets --wait\u0060, then ask your operator to approve it — only a human can grant the binding. Once approved, retry this call."
 			}
 		}`))
 		}))

--- a/cli/tests/golden/execute_contract_test.go
+++ b/cli/tests/golden/execute_contract_test.go
@@ -66,6 +66,8 @@ func TestGolden_ExecuteContract(t *testing.T) {
 	}
 	// A broker denial carrying a rich agent_directive: every rendering branch
 	// (instruction, run:, open:, candidates, retry-after, stuck?) is frozen.
+	// The wire type is the legacy flag-off no_toolkit_binding — still emitted
+	// by pre-direct-binding brokers — with the surviving --api command copy.
 	brokerDenial403Directive := func(w http.ResponseWriter, _ *http.Request) {
 		w.Header()["Date"] = nil
 		w.Header().Set("Content-Type", "application/problem+json")
@@ -79,12 +81,35 @@ func TestGolden_ExecuteContract(t *testing.T) {
 			"agent_directive": {
 				"strategy": "wait",
 				"parameters": {
-					"suggested_command": "jentic access request --toolkit acme/pets --wait",
+					"suggested_command": "jentic access request --api acme/pets --wait",
 					"provisioning_url": "https://console.example/connect/acme",
 					"candidates": ["acme/pets", "acme/pets-admin"],
 					"retry_after_seconds": 30
 				},
-				"human_readable_instruction": "You are not bound to a toolkit for this API."
+				"human_readable_instruction": "You are not bound for 'acme/pets'. File an access request yourself with \u0060jentic access request --api acme/pets --wait\u0060, then ask your operator to approve it — only a human can grant the binding. Once approved, retry this call."
+			}
+		}`))
+	}
+	// The default direct-binding denial (no_credential_binding, theme-5): the
+	// 403 an agent without a credential binding gets when the flag is on.
+	brokerDenial403CredentialBinding := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header()["Date"] = nil
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.Header().Set("Jentic-Error-Origin", "broker")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{
+			"type": "no_credential_binding",
+			"title": "No credential binding for this API",
+			"status": 403,
+			"error_origin": "broker",
+			"agent_directive": {
+				"strategy": "prompt_human",
+				"parameters": {
+					"api": {"vendor": "acme", "name": "pets", "version": "v1"},
+					"api_served": true,
+					"suggested_command": "jentic access request --api acme/pets --wait"
+				},
+				"human_readable_instruction": "You have no credential binding for 'acme/pets'. File an access request yourself with \u0060jentic access request --api acme/pets --wait\u0060, then ask your operator to approve it — only a human can grant the binding (they can also bind directly via POST /agents/{agent_id}/credentials). Once bound, retry this call."
 			}
 		}`))
 	}
@@ -135,6 +160,11 @@ func TestGolden_ExecuteContract(t *testing.T) {
 			name:   "execute_broker_denial_directive_json",
 			target: "GET:/v1/pets",
 			broker: brokerDenial403Directive,
+		},
+		{
+			name:   "execute_broker_denial_credential_binding_json",
+			target: "GET:/v1/pets",
+			broker: brokerDenial403CredentialBinding,
 		},
 		{
 			name:   "execute_broker_denial_no_directive_json",

--- a/cli/tests/golden/testdata/golden/v2/execute_broker_denial_credential_binding_json.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_broker_denial_credential_binding_json.txt
@@ -1,0 +1,36 @@
+exit: 2
+--- stdout ---
+{
+  "body": {
+    "agent_directive": {
+      "human_readable_instruction": "You have no credential binding for 'acme/pets'. File an access request yourself with `jentic access request --api acme/pets --wait`, then ask your operator to approve it — only a human can grant the binding (they can also bind directly via POST /agents/{agent_id}/credentials). Once bound, retry this call.",
+      "parameters": {
+        "api": {
+          "name": "pets",
+          "vendor": "acme",
+          "version": "v1"
+        },
+        "api_served": true,
+        "suggested_command": "jentic access request --api acme/pets --wait"
+      },
+      "strategy": "prompt_human"
+    },
+    "error_origin": "broker",
+    "status": 403,
+    "title": "No credential binding for this API",
+    "type": "no_credential_binding"
+  },
+  "headers": {
+    "Content-Length": "744",
+    "Content-Type": "application/problem+json",
+    "Jentic-Error-Origin": "broker"
+  },
+  "schema_version": "1",
+  "status": 403
+}
+--- stderr ---
+Denied — recovery required:
+  You have no credential binding for 'acme/pets'. File an access request yourself with `jentic access request --api acme/pets --wait`, then ask your operator to approve it — only a human can grant the binding (they can also bind directly via POST /agents/{agent_id}/credentials). Once bound, retry this call.
+  run: jentic access request --api acme/pets --wait
+  stuck? jentic doctor
+{"details":{"http_status":403},"error":"the broker denied this call before it reached the upstream API","error_code":"BROKER_DENIED","schema_version":"1"}

--- a/cli/tests/golden/testdata/golden/v2/execute_broker_denial_directive_json.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_broker_denial_directive_json.txt
@@ -3,7 +3,7 @@ exit: 2
 {
   "body": {
     "agent_directive": {
-      "human_readable_instruction": "You are not bound to a toolkit for this API.",
+      "human_readable_instruction": "You are not bound for 'acme/pets'. File an access request yourself with `jentic access request --api acme/pets --wait`, then ask your operator to approve it — only a human can grant the binding. Once approved, retry this call.",
       "parameters": {
         "candidates": [
           "acme/pets",
@@ -11,7 +11,7 @@ exit: 2
         ],
         "provisioning_url": "https://console.example/connect/acme",
         "retry_after_seconds": 30,
-        "suggested_command": "jentic access request --toolkit acme/pets --wait"
+        "suggested_command": "jentic access request --api acme/pets --wait"
       },
       "strategy": "wait"
     },
@@ -21,7 +21,7 @@ exit: 2
     "type": "no_toolkit_binding"
   },
   "headers": {
-    "Content-Length": "520",
+    "Content-Length": "710",
     "Content-Type": "application/problem+json",
     "Jentic-Error-Origin": "broker"
   },
@@ -30,8 +30,8 @@ exit: 2
 }
 --- stderr ---
 Denied — recovery required:
-  You are not bound to a toolkit for this API.
-  run: jentic access request --toolkit acme/pets --wait
+  You are not bound for 'acme/pets'. File an access request yourself with `jentic access request --api acme/pets --wait`, then ask your operator to approve it — only a human can grant the binding. Once approved, retry this call.
+  run: jentic access request --api acme/pets --wait
   open: https://console.example/connect/acme
   candidates: acme/pets, acme/pets-admin
   retry after: 30

--- a/cli/tests/golden/testdata/golden/v2/execute_broker_denial_no_directive_json.txt
+++ b/cli/tests/golden/testdata/golden/v2/execute_broker_denial_no_directive_json.txt
@@ -17,7 +17,7 @@ exit: 2
 }
 --- stderr ---
 Denied — recovery required:
-  No credential is provisioned for this call. Provision one, then retry.
-  run: jentic access request --toolkit <vendor/name> --provision --wait
+  No credential is provisioned for this call. File a provisioning plan, then retry.
+  run: jentic access request --provision <vendor/name> --wait
   stuck? jentic doctor
 {"details":{"http_status":424},"error":"the broker denied this call before it reached the upstream API","error_code":"BROKER_DENIED","schema_version":"1"}

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -17,7 +17,7 @@
     {
       "name": "whoami",
       "title": "Show agent identity",
-      "description": "Show the calling agent's identity as the Jentic control plane sees it: id, status, scopes, and toolkit bindings with the APIs each one serves. Call after get_started reports ready, and before requesting access or executing operations — never execute an operation just to probe whether you have access. On an auth error, call get_started for the fix.",
+      "description": "Show the calling agent's identity as the Jentic control plane sees it: id, status, scopes, and credential bindings with the APIs each one serves. Call after get_started reports ready, and before requesting access or executing operations — never execute an operation just to probe whether you have access. On an auth error, call get_started for the fix.",
       "input_schema": {
         "properties": {},
         "type": "object"
@@ -194,7 +194,7 @@
     {
       "name": "import_api",
       "title": "Import a catalog API into the registry",
-      "description": "Import a catalog API into this instance's registry so its operations become searchable and executable. Example: {\"api_id\": \"googleapis.com/sheets\"} with an api_id from a search_catalog hit. The import runs as a job: this call tracks it briefly and, on completion, promotes the imported revisions live, returning {job_id, status, revisions, promoted}. If it returns a non-terminal status, call import_api again with the same api_id — re-importing converges (idempotent) and finishes the promotion. Requires the catalog:import scope (agents hold it by default); on a denial, request it via request_access — do not guess other scopes. Importing makes an API discoverable but does NOT grant access to call it: check whoami for a toolkit binding serving it — never execute just to probe — and use request_access if nothing serves it.",
+      "description": "Import a catalog API into this instance's registry so its operations become searchable and executable. Example: {\"api_id\": \"googleapis.com/sheets\"} with an api_id from a search_catalog hit. The import runs as a job: this call tracks it briefly and, on completion, promotes the imported revisions live, returning {job_id, status, revisions, promoted}. If it returns a non-terminal status, call import_api again with the same api_id — re-importing converges (idempotent) and finishes the promotion. Requires the catalog:import scope (agents hold it by default); on a denial, request it via request_access — do not guess other scopes. Importing makes an API discoverable but does NOT grant access to call it: check whoami for a credential binding serving it — never execute just to probe — and use request_access if nothing serves it.",
       "input_schema": {
         "properties": {
           "api_id": {
@@ -214,9 +214,16 @@
     {
       "name": "request_access",
       "title": "Request access from a human operator",
-      "description": "File one access request for the access you are missing, or poll a filed one by id. Decide from whoami FIRST — never execute an operation just to probe whether you have access. If a whoami binding already serves the API, you have access; if NOTHING serves it, file a provisioning plan: {\"provision\": [\"vendor/name\"], \"auth\": [\"bearer\"], \"rules_json\": [{\"effect\":\"allow\",\"methods\":[\"GET\"],\"path\":\".*\"}], \"reason\": \"…\"} — it describes the whole path to first execution (create toolkit, provision + bind a credential with your proposed rules, bind you), which a human fulfils in the dashboard (they enter the secret; it never rides in your request). A bare toolkit bind ({\"toolkits\": [\"vendor/name\"]}) is only the last mile when a toolkit already serves the API; for an unserved API it auto-denies — use provision. ALWAYS include reason. File once, richly: combine every target this task needs into ONE composite request instead of filing piecemeal. The result carries approve_url: relay it to your human operator — granting is always a human action and this tool NEVER approves. Poll the decision with {\"request_id\": \"\u003cid\u003e\"}; never re-file while a request is pending. Once approved, bindings are live immediately — retry the execute that was denied.",
+      "description": "File one access request for the access you are missing, or poll a filed one by id. Decide from whoami FIRST — never execute an operation just to probe whether you have access. If a whoami binding already serves the API, you have access; if NOTHING serves it, file a provisioning plan: {\"provision\": [\"vendor/name\"], \"auth\": [\"bearer\"], \"rules_json\": [{\"effect\":\"allow\",\"methods\":[\"GET\"],\"path\":\".*\"}], \"reason\": \"…\"} — it describes the whole path to first execution (provision a credential, bind you to it with your proposed rules), which a human fulfils in the dashboard (they enter the secret; it never rides in your request). A bare bind request ({\"apis\": [\"vendor/name\"]}) is only the last mile when a credential already serves the API; for an unserved API it auto-denies — use provision. ALWAYS include reason. File once, richly: combine every target this task needs into ONE composite request instead of filing piecemeal. The result carries approve_url: relay it to your human operator — granting is always a human action and this tool NEVER approves. Poll the decision with {\"request_id\": \"\u003cid\u003e\"}; never re-file while a request is pending. Once approved, bindings are live immediately — retry the execute that was denied.",
       "input_schema": {
         "properties": {
+          "apis": {
+            "description": "APIs to be bound to a credential for, as vendor/name[/version] references. The LAST MILE only: use when a credential already serves the API and you just aren't bound to it — for an unserved API this auto-denies; use provision instead.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "auth": {
             "description": "Credential auth type for a provision plan, read from the API's security schemes: bearer, api_key, basic, oauth2, or none (default bearer). With several provisions, key each value by API: \"vendor/name=bearer\".",
             "items": {
@@ -225,7 +232,7 @@
             "type": "array"
           },
           "provision": {
-            "description": "APIs to file full provisioning plans for, as vendor/name[/version] references (e.g. \"stripe.com/api\"). Use when NOTHING you're bound to serves the API yet: the plan describes the whole path to first execution (create toolkit, provision + bind a credential with your proposed rules, bind you), which a human fulfils and approves.",
+            "description": "APIs to file full provisioning plans for, as vendor/name[/version] references (e.g. \"stripe.com/api\"). Use when NO credential you're bound to serves the API yet: the plan describes the whole path to first execution (provision a credential, bind you to it with your proposed rules), which a human fulfils and approves.",
             "items": {
               "type": "string"
             },
@@ -244,20 +251,6 @@
           },
           "scopes": {
             "description": "Token scopes to request, e.g. \"catalog:import\".",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "toolkit_ids": {
-            "description": "Toolkits to be bound to, by id (tk_…).",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "toolkits": {
-            "description": "Toolkits to be bound to, as vendor/name[/version] API references. The LAST MILE only: use when a toolkit already serves the API and you just aren't bound to it — for an unserved API this auto-denies; use provision instead.",
             "items": {
               "type": "string"
             },

--- a/skills/jentic/SKILL.md
+++ b/skills/jentic/SKILL.md
@@ -78,13 +78,13 @@ context).
 
 ### 2. Check what you can do, and request access if needed
 
-See your own identity, status, scopes, and which toolkits you're bound to:
+See your own identity, status, scopes, and which credentials you're bound to:
 
 ```
 jentic access whoami
 ```
 
-Each toolkit binding lists the APIs it **serves** (`serves: [{vendor, name,
+Each credential binding lists the API it **serves** (`serves: [{vendor, name,
 version}]`). This tells you exactly what you can already call. Combined with the
 catalog (what's available to add — see step 3), it's your map of the workspace.
 
@@ -107,8 +107,8 @@ jentic access request --provision <vendor/name> \
 ```
 
 `--wait` blocks until a human fulfils and approves the plan in the dashboard;
-once approved, the toolkit binding is live immediately — just retry `execute`.
-Always pass `--reason` on **every** access request (`--provision`, `--toolkit`,
+once approved, the credential binding is live immediately — just retry `execute`.
+Always pass `--reason` on **every** access request (`--provision`, `--api`,
 or `--scope`): a human reviews it before approving and your reason is shown to
 them — a clear one-liner ("fetch the user's open PRs to summarise them") is what
 gets you approved faster.
@@ -128,14 +128,14 @@ jentic access request \
   --rules-json 'slack.com/api=[{"effect":"allow","methods":["POST"],"path":"/chat\\.postMessage"}]' \
   --provision googleapis.com/sheets --auth googleapis.com/sheets=oauth2 \
   --rules-json 'googleapis.com/sheets=[{"effect":"allow","methods":["GET"],"path":".*"}]' \
-  --toolkit github.com/api \
+  --api github.com/api \
   --reason "one reason covering the whole job" \
   --wait
 ```
 
 Each `--provision` adds a full plan for that API — keep every plan complete
 (auth, rules, reason), exactly as you would for a single one;
-`--toolkit`/`--toolkit-id`/`--scope` add single items. With more than one
+`--api`/`--scope` add single items. With more than one
 `--provision`, key `--auth` and `--rules-json` by the same
 `vendor/name[/version]` you passed to `--provision` (include the version in
 the key if you used one); the bare form applies when there is exactly one.
@@ -152,10 +152,8 @@ it prints a recovery line on stderr (the `agent_directive`) and **exits 2**, so
 you can branch on the exit code instead of mistaking the 4xx body for success.
 The directive tells you exactly how to recover — which differs by denial:
 
-- **`no_toolkit_binding` (403)** — nothing serves this API yet (no toolkit, and
-  usually no credential). File a **provisioning plan** describing the whole path
-  to first execution, and propose the auth type and permission rules you read
-  from the API spec:
+- **`no_credential_binding` (403)** — no credential binding of yours serves this
+  API. Check the directive's `parameters.api_served`:
 
 ```
 jentic access request --provision stripe.com/api \
@@ -165,21 +163,18 @@ jentic access request --provision stripe.com/api \
   --wait
 ```
 
-  - `toolkit_serves_api: false` — **no** toolkit serves this API yet, so a bare
-    `--toolkit` binding request would be denied ("No toolkit serves API …").
-    Filing it now is a dead-end. File the `--provision` plan above instead: it
-    describes the whole path (create toolkit, provision + bind a credential with
-    your proposed rules, bind you), which a human fulfils and approves in the
-    dashboard. The directive's `suggested_command` already points at `--provision`
-    in this case. The plan does **not** force a new toolkit: during fulfilment
-    the operator can add the credential to a toolkit they already have (the
-    wizard offers both) — worth relaying when your operator mentions an
-    existing toolkit they want to extend.
-  - `toolkit_serves_api: true` — a toolkit already serves this API and you just
-    aren't bound to it; the directive suggests `jentic access request --toolkit
+  - `api_served: false` — **no** credential is provisioned for this API yet, so
+    a bare `--api` binding request would be denied ("No credential covers API
+    …"). Filing it now is a dead-end. File the `--provision` plan above instead:
+    it describes the whole path to first execution (provision a credential with
+    your proposed auth type and rules, bind you), which a human fulfils and
+    approves in the dashboard. The directive's `suggested_command` already
+    points at `--provision` in this case.
+  - `api_served: true` — a credential already serves this API and you just
+    aren't bound to it; the directive suggests `jentic access request --api
     <vendor/name> --wait`. File that and wait for approval.
 
-- **`credential_not_provisioned` (424)** — you're bound to a toolkit, but no
+- **`credential_not_provisioned` (424)** — you're bound, but no
   credential (account) is connected. Filing an access request will **not** fix
   this; the directive carries a `provisioning_url` — hand it to your operator to
   connect the account, then retry.
@@ -188,7 +183,7 @@ jentic access request --provision stripe.com/api \
   encryption key rotated underneath it, e.g. a reinstall over existing data).
   Neither an access request nor retrying will fix this — ask your operator to
   remove and re-add the credential, then retry.
-- **`credential_identity_mismatch` (403)** — a toolkit *is* bound and a
+- **`credential_identity_mismatch` (403)** — a binding exists and a
   credential *is* connected, but that credential's stored identity doesn't cover
   this API (e.g. it targets a different name/version, or was stored in a
   non-canonical form). Filing an access request will **not** fix this — the
@@ -197,10 +192,12 @@ jentic access request --provision stripe.com/api \
   is `true` the credential just needs re-provisioning to canonicalize its
   identity. Either way, ask your operator to fix or re-provision the credential
   so it targets `expected`, then retry.
-- **`ambiguous_toolkit` (409)** — multiple toolkits you're bound to serve this
-  API. The directive lists `candidates`; resend the same `execute` with
-  `--header Jentic-Toolkit-Id=<toolkit_id>` (the directive also gives a
-  copy-pasteable `suggested_command`).
+- **`ambiguous_credential_binding` (409)** — multiple credentials you're bound
+  to cover this API. The directive lists `candidates` and carries
+  `parameters.headers`; resend the same `execute` with
+  `--header Jentic-Credential-Id=<credential_id>` (the authoritative
+  tie-breaker — `--header Jentic-Credential-Name=<name>` also works when
+  credential names are unique).
 
 Always follow the `agent_directive`'s `suggested_command` / `provisioning_url`
 rather than assuming which recovery applies. You can also request access
@@ -238,12 +235,12 @@ approving. Do the work up front:
 4. You never enter the credential secret and you never approve — the human fills
    the secret in the dashboard and grants the plan. You propose; they decide.
 
-A plain `toolkit:bind` (`--toolkit`) is only the **last mile** — use it when a
-toolkit for the API already exists (e.g. an operator created one) and you just
-need to be bound to it. When nothing serves the API yet, `--provision` is the
-right first move; a bare `--toolkit` would auto-deny.
+A plain `credential:bind` (`--api`) is only the **last mile** — use it when a
+credential for the API already exists (e.g. an operator provisioned one) and you
+just need to be bound to it. When nothing serves the API yet, `--provision` is
+the right first move; a bare `--api` would auto-deny.
 
-`--toolkit`/`--provision` take a `vendor/name[/version]` reference (the broker
+`--api`/`--provision` take a `vendor/name[/version]` reference (the broker
 also suggests the exact command in its `agent_directive`). `--wait` blocks until
 a human decides and sets the exit code: **0** = approved, **2** = denied —
 read the item's `decision_reason` (in the JSON, or shown under the item on a
@@ -253,10 +250,10 @@ approved. Without `--wait` you get a request id and an `approve_url` to hand to
 your operator. Granting is always a human action — you file and wait, you never
 approve yourself.
 
-If you file a bare `toolkit:bind` (`--toolkit`) for an API that nothing serves
-yet, approval comes back **denied** with `decision_reason: "No toolkit serves
-API <vendor/name>; provision and bind a credential for it first"`. That is the
-signal to file a `--provision` plan instead: it describes the missing toolkit,
+If you file a bare `credential:bind` (`--api`) for an API that nothing serves
+yet, approval comes back **denied** with `decision_reason: "No credential covers
+API <vendor/name>; provision a credential for it first"`. That is the
+signal to file a `--provision` plan instead: it describes the missing
 credential, rules, and binding as one request the operator can fulfil and
 approve in the dashboard.
 
@@ -343,7 +340,7 @@ the catalog manifest from upstream but requires `org:admin`, so it too is an
 operator action.)
 
 **Before concluding "the data is gone", confirm which backend you're on.** If
-APIs, credentials, or toolkits you *know* existed appear missing — or IDs look
+APIs or credentials you *know* existed appear missing — or IDs look
 unfamiliar — you may be talking to a **different** backend than you expect. A
 hosted (`remote`) Jentic install and a `local` self-hosted one have independent
 registries and credentials, and the CLI, an agent, or an MCP server can each be
@@ -445,14 +442,16 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   the control plane (Reference → CLI) — the same reference rendered for humans,
   next to the HTTP API and Broker API references.
 - `jentic context view` — the active context (environment + identity + base_url); start here.
-- `jentic access whoami` — your identity, status, scopes, and toolkit bindings
-  with the APIs each one **serves** (check this before executing or provisioning).
+- `jentic access whoami` — your identity, status, scopes, and credential
+  bindings with the API each one **serves** (check this before executing or
+  provisioning).
 - `jentic access request` — ask a human for access. `--provision <vendor/name>`
   files the whole path to first execution as one plan when nothing serves the
-  API yet; `--toolkit <vendor/name>` asks to be bound to an **existing**
-  toolkit; `--scope <scope>` requests a missing scope. All target flags repeat
-  and combine into **one composite request**. Always pass `--reason`; add
-  `--wait` to block on approval (see Procedure for full examples).
+  API yet; `--api <vendor/name>` asks to be bound to an **existing**
+  credential serving that API; `--scope <scope>` requests a missing scope. All
+  target flags repeat and combine into **one composite request**. Always pass
+  `--reason`; add `--wait` to block on approval (see Procedure for full
+  examples).
 - `jentic access list | status <id> | withdraw <id>` — track your requests.
 - `jentic access refresh` — re-mint your token after an approved **scope**
   grant that `whoami` flags as not yet on your token. Bindings need no
@@ -534,15 +533,14 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   `jenticctl start`, then retry rather than abandoning the task. Only a
   broker **denial** (an `agent_directive` on stderr, exit **2**) is an
   access/credential issue:
-  - **403 `no_toolkit_binding`** → check the directive's
-    `parameters.toolkit_serves_api`. If `true`, a toolkit already serves the API
-    and you just aren't bound — run the `jentic access request --toolkit …` it
+  - **403 `no_credential_binding`** → check the directive's
+    `parameters.api_served`. If `true`, a credential already serves the API
+    and you just aren't bound — run the `jentic access request --api …` it
     suggests and wait for approval. If `false`, nothing serves the API yet and a
-    bare `--toolkit` bind would be **denied** ("No toolkit serves API …"); the
+    bare `--api` bind would be **denied** ("No credential covers API …"); the
     directive suggests `--provision` instead — file that plan (propose `--auth`
     and `--rules-json` from the spec, pass `--reason`) and your operator fulfils
-    it in the dashboard, into a new toolkit **or one they already have** — an
-    existing toolkit never has to be recreated.
+    it in the dashboard.
   - **424 `credential_not_provisioned`** → the directive gives a
     `provisioning_url` for your operator to connect an account (an access
     request won't help).
@@ -553,6 +551,10 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
     identity doesn't cover this API (`parameters.expected` vs
     `parameters.found`). An access request won't help — ask your operator to fix
     or re-provision the credential so it targets `expected`, then retry.
+  - **409 `ambiguous_credential_binding`** → several bound credentials cover
+    this API; resend with `--header Jentic-Credential-Id=<id>` picked from the
+    directive's `candidates` (`Jentic-Credential-Name` works too when names
+    are unique).
   Follow the directive; don't keep re-sending the same `execute`.
 - You file and wait for access; you can't approve your own requests.
 - **Don't execute to test access.** `whoami` already tells you what your bindings

--- a/src/jentic_one/broker/core/exceptions.py
+++ b/src/jentic_one/broker/core/exceptions.py
@@ -191,17 +191,18 @@ class InvalidCredentialNameError(BrokerError):
 
 
 class ActionDeniedError(BrokerError):
-    """The request was denied by a toolkit permission rule (403)."""
+    """The request was denied by a permission rule on the caller's binding (403)."""
 
 
 class CredentialIdentityMismatchError(BrokerError):
-    """Bound to a toolkit, but no credential's identity covers this API (403).
+    """Bound, but no bound credential's identity covers this API (403).
 
-    Distinct from :class:`ActionDeniedError` and ``no_toolkit_binding``: the
-    agent *is* bound and a credential *is* bound to a toolkit, but the
-    credential's stored API identity does not cover the resolved operation
-    identity (#747/#748). The recovery is to fix/re-provision the **credential**,
-    not to file an access request (which would auto-deny).
+    Distinct from :class:`ActionDeniedError` and the missing-binding denials
+    (``no_credential_binding``; ``no_toolkit_binding`` on the flag-off
+    fallback): the agent *is* bound, but the bound credential's stored API
+    identity does not cover the resolved operation identity (#747/#748). The
+    recovery is to fix/re-provision the **credential**, not to file an access
+    request (which would auto-deny).
     """
 
 
@@ -254,12 +255,18 @@ class RunnerUnavailableError(BrokerError):
 
 
 def switch_toolkit_directive(status: int) -> AgentDirective:
-    """The standard directive for a mirrored upstream 5xx — try an alternative vendor."""
+    """The standard directive for a mirrored upstream 5xx — try an alternative vendor.
+
+    The ``switch_toolkit`` strategy literal is wire contract (agents hard-code
+    the strategy vocabulary); the prose names the surviving recovery — pick a
+    different vendor/API you already have a credential binding for.
+    """
     return AgentDirective(
         strategy="switch_toolkit",
         parameters={"upstream_status": status},
         human_readable_instruction=(
-            "The upstream vendor returned a server error; try an alternative toolkit/vendor."
+            "The upstream vendor returned a server error; try an alternative "
+            "vendor/API you are already bound for."
         ),
     )
 
@@ -269,24 +276,25 @@ def no_toolkit_binding_directive(
 ) -> AgentDirective:
     """Directive for a ``no_toolkit_binding`` 403 — recover the missing binding.
 
-    The caller is authenticated but bound to no toolkit that serves this API. The
-    right recovery depends on whether a toolkit serves the API *at all*:
+    Emitted only on the flag-off toolkit-derivation fallback
+    (``broker.direct_bindings_enabled=false``): the caller is authenticated but
+    bound to no toolkit that serves this API. The remediation it names is the
+    surviving access-request vocabulary — a ``credential:bind`` filed by API
+    reference (``jentic access request --api``) or a ``credential:provision``
+    plan (``--provision``) — chosen by whether anything serves the API at all:
 
-    - ``toolkit_serves_api=True`` — a toolkit already serves it, the caller just
-      isn't bound to it. Filing a ``toolkit:bind`` access request is the correct,
+    - ``toolkit_serves_api=True`` — something already serves it, the caller
+      just isn't bound. Filing a bind request by API reference is the correct,
       approvable next step.
-    - ``toolkit_serves_api=False`` — **no** toolkit serves it yet (no credential
-      has been provisioned/bound). A ``toolkit:bind`` request here would be a
-      guaranteed dead-end: the approval denies with "no toolkit serves API …"
-      because a toolkit only serves an API once a credential for it is bound
-      (issue #683). So point the caller at credential provisioning first — the
-      step that actually creates a serving toolkit — before the binding request.
-      The instruction also says the operator may fulfil the plan **into an
-      existing toolkit** (#897): toolkits serving *other* APIs may well exist,
-      and without the hint the flow reads as "recreate everything from scratch".
-      Deliberately text-only — the broker never enumerates other toolkits here
-      (that would leak instance inventory to an unbound agent, and this
-      stateless edge has no scoped view of what a future approver could reuse).
+    - ``toolkit_serves_api=False`` — nothing serves it yet (no credential has
+      been provisioned/bound). A bare bind request here would be a guaranteed
+      dead-end: the approval denies with "no toolkit serves API …" because an
+      API is only served once a credential for it exists (issue #683). So point
+      the caller at the provisioning plan first — the step that actually
+      creates a serving credential — before the binding. Deliberately
+      text-only — the broker never enumerates other credentials here (that
+      would leak instance inventory to an unbound agent, and this stateless
+      edge has no scoped view of what a future approver could reuse).
 
     Both variants name the exact next step so an autonomous agent can hand it to
     its operator verbatim instead of reading docs.
@@ -298,10 +306,10 @@ def no_toolkit_binding_directive(
     }
 
     if toolkit_serves_api:
-        parameters["suggested_command"] = f"jentic access request --toolkit {api} --wait"
+        parameters["suggested_command"] = f"jentic access request --api {api} --wait"
         instruction = (
-            f"You are not bound to a toolkit for '{api}'. File an access request yourself with "
-            f"`jentic access request --toolkit {api} --wait`, then ask your operator to approve "
+            f"You are not bound for '{api}'. File an access request yourself with "
+            f"`jentic access request --api {api} --wait`, then ask your operator to approve "
             f"it — only a human can grant the binding. Once approved, retry this call."
         )
         return AgentDirective(
@@ -310,22 +318,20 @@ def no_toolkit_binding_directive(
             human_readable_instruction=instruction,
         )
 
-    # No toolkit serves this API yet: a credential must be provisioned and bound
-    # first (which creates the serving toolkit), then the agent is bound. A bare
-    # `toolkit:bind` request now can never be approved — so steer the agent to
-    # file the whole path as one provisioning plan (`--provision`), which a human
-    # fulfils and approves in the dashboard (they enter the secret + grant, into
-    # a new toolkit or one they already have — the wizard offers both, #897).
+    # Nothing serves this API yet: a credential must be provisioned and bound
+    # first, then the agent is bound to it. A bare bind request (`--api`) now
+    # can never be approved — so steer the agent to file the whole path as one
+    # provisioning plan (`--provision`), which a human fulfils and approves in
+    # the dashboard (they enter the secret and grant the plan).
     parameters["suggested_command"] = (
         f'jentic access request --provision {api} --reason "<why you need this>" --wait'
     )
     instruction = (
-        f"Nothing serves '{api}' yet, so a bare toolkit-binding request cannot be approved. "
+        f"Nothing serves '{api}' yet, so a bare binding request (`--api`) cannot be approved. "
         f'File a provisioning plan with `jentic access request --provision {api} --reason "<why>" '
         "--wait` — propose the auth type (`--auth`) and permission rules (`--rules-json`) you read "
         "from the API spec, and pass a `--reason` the approver sees; then ask your operator to "
-        "fulfil it in the dashboard (they enter the credential secret and approve; the wizard "
-        "lets them add it to one of their existing toolkits instead of creating a new one). "
+        "fulfil it in the dashboard (they enter the credential secret and approve). "
         "Only a human can grant this. Once approved, retry this call."
     )
     return AgentDirective(
@@ -348,10 +354,11 @@ def _render_identity(vendor: str, name: str | None, version: str | None) -> str:
 def credential_identity_mismatch_directive(*, mismatch: IdentityMismatch) -> AgentDirective:
     """Directive for a ``credential_identity_mismatch`` 403 — fix the credential.
 
-    The agent is bound and a credential is bound to a toolkit, but the
-    credential's stored API identity does not cover the resolved operation
-    (#747/#748). Filing an access request here auto-denies, so the directive
-    points at re-provisioning/fixing the **credential** and names the concrete
+    The flag-off (toolkit-derivation fallback) variant: the agent is bound and
+    a credential exists behind that binding, but the credential's stored API
+    identity does not cover the resolved operation (#747/#748). Filing an
+    access request here auto-denies, so the directive points at
+    re-provisioning/fixing the **credential** and names the concrete
     expected-vs-found identity so the operator has an actionable diagnostic. The
     strategy is the fixed ``prompt_human`` (only a human can fix the credential).
 
@@ -367,7 +374,7 @@ def credential_identity_mismatch_directive(*, mismatch: IdentityMismatch) -> Age
     found = _render_identity(mismatch.found_vendor, mismatch.found_name, mismatch.found_version)
     if mismatch.would_match_if_normalized:
         instruction = (
-            f"A toolkit is bound for this API, but the bound credential's stored identity "
+            f"A binding exists for this API, but the bound credential's stored identity "
             f"'{found}' only matches '{expected}' after normalization — it was stored in a "
             f"non-canonical form. Ask your operator to re-provision (or recreate) the "
             f"credential for '{expected}' so its identity is canonical, then retry. Do not "
@@ -375,7 +382,7 @@ def credential_identity_mismatch_directive(*, mismatch: IdentityMismatch) -> Age
         )
     else:
         instruction = (
-            f"A toolkit is bound for this API, but its credential's identity '{found}' does "
+            f"A binding exists for this API, but its credential's identity '{found}' does "
             f"not match this API '{expected}'. Ask your operator to fix or re-provision the "
             f"credential so it targets '{expected}', then retry. Do not file an access "
             f"request — the binding already exists."
@@ -402,10 +409,17 @@ def credential_identity_mismatch_directive(*, mismatch: IdentityMismatch) -> Age
 def ambiguous_toolkit_directive(candidates: list[str]) -> AgentDirective:
     """Directive for an ``ambiguous_toolkit`` 409 — pick one bound toolkit and retry.
 
-    Several toolkits the caller is bound to serve this API; the agent must resend
-    with the ``Jentic-Toolkit-Id`` header naming one of ``candidates``. The
-    directive names the exact CLI flag form so an autonomous agent can recover
-    without reading docs, mirroring :func:`no_toolkit_binding_directive`.
+    Emitted only on the flag-off toolkit-derivation fallback
+    (``broker.direct_bindings_enabled=false``), where several toolkits the
+    caller is bound to serve this API; the agent must resend with the
+    ``Jentic-Toolkit-Id`` header naming one of ``candidates`` — the one header
+    that disambiguates *this* denial (it stays functional for as long as the
+    fallback exists). The direct-binding path has its own twin,
+    :func:`ambiguous_credential_binding_directive`, which disambiguates on the
+    credential axis via ``Jentic-Credential-Name`` / ``Jentic-Credential-Id``.
+    The directive names the exact CLI flag form (``jentic execute --header``)
+    so an autonomous agent can recover without reading docs, mirroring
+    :func:`no_toolkit_binding_directive`.
     """
     pick = candidates[0] if candidates else "<toolkit_id>"
     return AgentDirective(
@@ -428,28 +442,31 @@ def ambiguous_toolkit_directive(candidates: list[str]) -> AgentDirective:
 def action_denied_directive() -> AgentDirective:
     """Directive for an ``action_denied`` 403 — a permission rule forbids this op.
 
-    The caller *is* bound to a toolkit for this API, but a toolkit permission
-    rule denies this specific operation. Unlike a missing binding, the agent
-    cannot self-recover by switching toolkit or filing a binding request — only
-    a human can relax the rule — so the strategy is ``prompt_human``.
+    The flag-off (toolkit-derivation fallback) variant: the caller *is* bound
+    for this API, but a permission rule on the legacy toolkit path denies this
+    specific operation. The agent cannot self-recover by switching bindings or
+    filing a binding request — only a human can relax the rule — so the
+    strategy is ``prompt_human``. No ``suggested_command``: relaxing a rule is
+    an operator action with no verbatim agent-runnable command, mirroring
+    :func:`direct_action_denied_directive`.
     """
     return AgentDirective(
         strategy="prompt_human",
         parameters={},
         human_readable_instruction=(
-            "This operation is denied by a toolkit permission rule. You are bound "
-            "to a toolkit for this API, but the rule forbids this specific call — "
-            "ask your operator to adjust the toolkit's permission rules. This is "
-            "not something you can grant yourself."
+            "This operation is denied by a permission rule. You are bound "
+            "for this API, but the rule forbids this specific call — "
+            "ask your operator to adjust the permission rules governing "
+            "your access. This is not something you can grant yourself."
         ),
     )
 
 
 # ---------------------------------------------------------------------------
-# Direct-binding (theme-5 Phase 2) directives — the agent→credential twins of
-# the toolkit directives above. Active only when
-# ``broker.direct_bindings_enabled`` is on; the toolkit directives keep serving
-# the legacy path (and toolkit-key callers) untouched.
+# Direct-binding directives — the agent→credential twins of the toolkit
+# directives above. These serve the default path
+# (``broker.direct_bindings_enabled``, default on); the toolkit directives
+# serve only the flag-off derivation fallback until it is retired.
 # ---------------------------------------------------------------------------
 
 
@@ -463,16 +480,17 @@ def no_credential_binding_directive(
     serves the API *at all*:
 
     - ``api_served=True`` — a credential exists, the caller just isn't bound to
-      it. An operator can grant the binding (``POST /agents/{id}/credentials``).
+      it. Filing a ``credential:bind`` access request by API reference
+      (``jentic access request --api``) is the correct, approvable next step;
+      an operator can also grant the binding directly
+      (``POST /agents/{id}/credentials``).
     - ``api_served=False`` — no credential is provisioned for this API yet, so a
-      binding grant alone cannot help: the operator must provision the
-      credential first, then bind it.
+      bare bind request auto-denies: file a provisioning plan
+      (``jentic access request --provision``) that a human fulfils and approves
+      in the dashboard.
 
-    No ``suggested_command`` is emitted: the direct-binding access-request verbs
-    land in Phase 3, so promising a CLI command here would be a dead-end. The
-    prose names the operator action instead. Deliberately never enumerates
-    other owners' credentials (that would leak instance inventory to an unbound
-    agent).
+    Deliberately never enumerates other owners' credentials (that would leak
+    instance inventory to an unbound agent).
     """
     api = "/".join(part for part in (vendor, name) if part)
     parameters: dict[str, Any] = {
@@ -480,18 +498,25 @@ def no_credential_binding_directive(
         "api_served": api_served,
     }
     if api_served:
+        parameters["suggested_command"] = f"jentic access request --api {api} --wait"
         instruction = (
-            f"You have no credential binding for '{api}'. Ask your operator to bind a "
-            f"credential for '{api}' to this agent (POST /agents/{{agent_id}}/credentials) "
-            "and attach permission rules; only a human can grant the binding. Once bound, "
-            "retry this call."
+            f"You have no credential binding for '{api}'. File an access request yourself "
+            f"with `jentic access request --api {api} --wait`, then ask your operator to "
+            "approve it — only a human can grant the binding (they can also bind directly "
+            "via POST /agents/{agent_id}/credentials). Once bound, retry this call."
         )
     else:
+        parameters["suggested_command"] = (
+            f'jentic access request --provision {api} --reason "<why you need this>" --wait'
+        )
         instruction = (
-            f"No credential is provisioned for '{api}' yet, so a binding cannot be granted. "
-            f"Ask your operator to provision a credential for '{api}', bind it to this agent "
-            "(POST /agents/{agent_id}/credentials) and attach permission rules. Only a human "
-            "can do this. Once bound, retry this call."
+            f"No credential is provisioned for '{api}' yet, so a bare binding request "
+            f"(`--api`) cannot be approved. File a provisioning plan with `jentic access "
+            f'request --provision {api} --reason "<why>" --wait` — propose the auth type '
+            "(`--auth`) and permission rules (`--rules-json`) you read from the API spec; "
+            "then ask your operator to fulfil it in the dashboard (they enter the "
+            "credential secret and approve). Only a human can do this. Once bound, retry "
+            "this call."
         )
     return AgentDirective(
         strategy="prompt_human",

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -937,9 +937,10 @@ async def _handle(
                 else "Operation denied by toolkit permission rule (no rule matched)"
             )
             detail = (
-                "The requested operation is denied — this toolkit has no permission rules "
-                "loaded for the target API's vendor. Attach rules to the vendor's binding "
-                "under PUT /toolkits/{toolkit_id}/credentials/{credential_id}/permissions."
+                "The requested operation is denied — no permission rules are loaded for the "
+                "target API's vendor on this binding. Ask your operator to attach rules "
+                "(with direct bindings, under "
+                "PUT /credentials/{credential_id}/agents/{agent_id}/permissions)."
                 if no_rules
                 else "The requested operation is denied by a toolkit permission rule."
             )

--- a/src/jentic_one/mcp/_spec/mcp-tools.json
+++ b/src/jentic_one/mcp/_spec/mcp-tools.json
@@ -17,7 +17,7 @@
     {
       "name": "whoami",
       "title": "Show agent identity",
-      "description": "Show the calling agent's identity as the Jentic control plane sees it: id, status, scopes, and toolkit bindings with the APIs each one serves. Call after get_started reports ready, and before requesting access or executing operations — never execute an operation just to probe whether you have access. On an auth error, call get_started for the fix.",
+      "description": "Show the calling agent's identity as the Jentic control plane sees it: id, status, scopes, and credential bindings with the APIs each one serves. Call after get_started reports ready, and before requesting access or executing operations — never execute an operation just to probe whether you have access. On an auth error, call get_started for the fix.",
       "input_schema": {
         "properties": {},
         "type": "object"
@@ -194,7 +194,7 @@
     {
       "name": "import_api",
       "title": "Import a catalog API into the registry",
-      "description": "Import a catalog API into this instance's registry so its operations become searchable and executable. Example: {\"api_id\": \"googleapis.com/sheets\"} with an api_id from a search_catalog hit. The import runs as a job: this call tracks it briefly and, on completion, promotes the imported revisions live, returning {job_id, status, revisions, promoted}. If it returns a non-terminal status, call import_api again with the same api_id — re-importing converges (idempotent) and finishes the promotion. Requires the catalog:import scope (agents hold it by default); on a denial, request it via request_access — do not guess other scopes. Importing makes an API discoverable but does NOT grant access to call it: check whoami for a toolkit binding serving it — never execute just to probe — and use request_access if nothing serves it.",
+      "description": "Import a catalog API into this instance's registry so its operations become searchable and executable. Example: {\"api_id\": \"googleapis.com/sheets\"} with an api_id from a search_catalog hit. The import runs as a job: this call tracks it briefly and, on completion, promotes the imported revisions live, returning {job_id, status, revisions, promoted}. If it returns a non-terminal status, call import_api again with the same api_id — re-importing converges (idempotent) and finishes the promotion. Requires the catalog:import scope (agents hold it by default); on a denial, request it via request_access — do not guess other scopes. Importing makes an API discoverable but does NOT grant access to call it: check whoami for a credential binding serving it — never execute just to probe — and use request_access if nothing serves it.",
       "input_schema": {
         "properties": {
           "api_id": {
@@ -214,9 +214,16 @@
     {
       "name": "request_access",
       "title": "Request access from a human operator",
-      "description": "File one access request for the access you are missing, or poll a filed one by id. Decide from whoami FIRST — never execute an operation just to probe whether you have access. If a whoami binding already serves the API, you have access; if NOTHING serves it, file a provisioning plan: {\"provision\": [\"vendor/name\"], \"auth\": [\"bearer\"], \"rules_json\": [{\"effect\":\"allow\",\"methods\":[\"GET\"],\"path\":\".*\"}], \"reason\": \"…\"} — it describes the whole path to first execution (create toolkit, provision + bind a credential with your proposed rules, bind you), which a human fulfils in the dashboard (they enter the secret; it never rides in your request). A bare toolkit bind ({\"toolkits\": [\"vendor/name\"]}) is only the last mile when a toolkit already serves the API; for an unserved API it auto-denies — use provision. ALWAYS include reason. File once, richly: combine every target this task needs into ONE composite request instead of filing piecemeal. The result carries approve_url: relay it to your human operator — granting is always a human action and this tool NEVER approves. Poll the decision with {\"request_id\": \"\u003cid\u003e\"}; never re-file while a request is pending. Once approved, bindings are live immediately — retry the execute that was denied.",
+      "description": "File one access request for the access you are missing, or poll a filed one by id. Decide from whoami FIRST — never execute an operation just to probe whether you have access. If a whoami binding already serves the API, you have access; if NOTHING serves it, file a provisioning plan: {\"provision\": [\"vendor/name\"], \"auth\": [\"bearer\"], \"rules_json\": [{\"effect\":\"allow\",\"methods\":[\"GET\"],\"path\":\".*\"}], \"reason\": \"…\"} — it describes the whole path to first execution (provision a credential, bind you to it with your proposed rules), which a human fulfils in the dashboard (they enter the secret; it never rides in your request). A bare bind request ({\"apis\": [\"vendor/name\"]}) is only the last mile when a credential already serves the API; for an unserved API it auto-denies — use provision. ALWAYS include reason. File once, richly: combine every target this task needs into ONE composite request instead of filing piecemeal. The result carries approve_url: relay it to your human operator — granting is always a human action and this tool NEVER approves. Poll the decision with {\"request_id\": \"\u003cid\u003e\"}; never re-file while a request is pending. Once approved, bindings are live immediately — retry the execute that was denied.",
       "input_schema": {
         "properties": {
+          "apis": {
+            "description": "APIs to be bound to a credential for, as vendor/name[/version] references. The LAST MILE only: use when a credential already serves the API and you just aren't bound to it — for an unserved API this auto-denies; use provision instead.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "auth": {
             "description": "Credential auth type for a provision plan, read from the API's security schemes: bearer, api_key, basic, oauth2, or none (default bearer). With several provisions, key each value by API: \"vendor/name=bearer\".",
             "items": {
@@ -225,7 +232,7 @@
             "type": "array"
           },
           "provision": {
-            "description": "APIs to file full provisioning plans for, as vendor/name[/version] references (e.g. \"stripe.com/api\"). Use when NOTHING you're bound to serves the API yet: the plan describes the whole path to first execution (create toolkit, provision + bind a credential with your proposed rules, bind you), which a human fulfils and approves.",
+            "description": "APIs to file full provisioning plans for, as vendor/name[/version] references (e.g. \"stripe.com/api\"). Use when NO credential you're bound to serves the API yet: the plan describes the whole path to first execution (provision a credential, bind you to it with your proposed rules), which a human fulfils and approves.",
             "items": {
               "type": "string"
             },
@@ -244,20 +251,6 @@
           },
           "scopes": {
             "description": "Token scopes to request, e.g. \"catalog:import\".",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "toolkit_ids": {
-            "description": "Toolkits to be bound to, by id (tk_…).",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "toolkits": {
-            "description": "Toolkits to be bound to, as vendor/name[/version] API references. The LAST MILE only: use when a toolkit already serves the API and you just aren't bound to it — for an unserved API this auto-denies; use provision instead.",
             "items": {
               "type": "string"
             },

--- a/src/jentic_one/mcp/app.py
+++ b/src/jentic_one/mcp/app.py
@@ -352,7 +352,7 @@ def build_mcp_server(ctx: Context) -> Server[Any]:
         version=version,
         instructions=(
             "Jentic One tool server (daemon-native HTTP endpoint). Call whoami to see "
-            "the agent identity, status, scopes, and toolkit bindings before "
+            "the agent identity, status, scopes, and credential bindings before "
             "requesting access or executing operations. Every tool result carries a "
             "top-level `instance` key identifying the Jentic One instance it came "
             "from. The flow is whoami → search_apis → inspect_operation → execute; "

--- a/src/jentic_one/mcp/execute.py
+++ b/src/jentic_one/mcp/execute.py
@@ -211,21 +211,21 @@ def _synthesized_denial_hint(status: int) -> str:
     """Status-keyed recovery when the denial carried no directive (Go twin)."""
     if status == 403:
         return (
-            "This agent isn't bound to a toolkit serving this API. Call whoami to see "
+            "This agent has no credential binding serving this API. Call whoami to see "
             "your bindings, then ask your operator to grant access "
-            "(`jentic access request --toolkit <vendor/name> --wait`)."
+            "(`jentic access request --api <vendor/name> --wait`)."
         )
     if status == 424:
         return (
             "No credential is provisioned for this call. Ask your operator to provision "
-            "one (`jentic access request --toolkit <vendor/name> --provision --wait`), "
+            "one (`jentic access request --provision <vendor/name> --wait`), "
             "then retry."
         )
     if status == 401:
         return (
             "The stored upstream credential needs reconnecting. Ask your operator to "
-            "re-provision it (`jentic access request --toolkit <vendor/name> "
-            "--provision --wait`), then retry."
+            "re-provision it (`jentic access request --provision <vendor/name> "
+            "--wait`), then retry."
         )
     return (
         "The broker denied this call before it reached the upstream API. "

--- a/src/jentic_one/shared/access_guidance.py
+++ b/src/jentic_one/shared/access_guidance.py
@@ -1,10 +1,10 @@
 """Canonical access-recovery guidance shared across broker and control.
 
-A toolkit only "serves" an API once a credential for it is provisioned and
-bound; only then can an agent be bound to that toolkit. When no toolkit serves
-an API yet, the broker's ``no_toolkit_binding`` recovery directive and the
-control approval-denial reason must recommend the *same* first step — provision
-a credential — instead of contradicting each other (see issue #683).
+An API is only "served" once a credential covering it is provisioned; only
+then can an agent be bound to it. When nothing serves an API yet, the broker's
+missing-binding recovery directive and the control approval-denial reason must
+recommend the *same* first step — provision a credential — instead of
+contradicting each other (see issue #683).
 
 This module holds the single wording both layers reference so the two messages
 can never drift. It lives under ``shared`` because both the public broker
@@ -15,27 +15,16 @@ may import ``shared`` but not each other.
 from __future__ import annotations
 
 
-def no_toolkit_serves_api_reason(api: str) -> str:
-    """The canonical denial reason when no toolkit serves ``api`` yet.
-
-    ``api`` is a ``vendor[/name][@version]`` label. Phrased as a statement of the
-    condition plus the recommended first step, matching the broker directive.
-    """
-    return (
-        f"No toolkit serves API {api}; provision and bind a credential for it "
-        "first, then request the toolkit binding"
-    )
-
-
 def no_credential_serves_api_reason(api: str) -> str:
     """The canonical denial reason when no credential serves ``api`` yet.
 
-    Theme-5 Phase 3 successor of :func:`no_toolkit_serves_api_reason` for the
-    direct agent↔credential model: a ``credential:bind`` filed by API reference
-    can only resolve once a credential covering that API exists and is visible
-    to the approver. The recommended first step — provision a credential — is
-    the same one the broker's ``no_credential_binding`` directive names, so the
-    two layers never contradict each other (see issue #683).
+    ``api`` is a ``vendor[/name][@version]`` label. A ``credential:bind`` filed
+    by API reference can only resolve once a credential covering that API
+    exists and is visible to the approver. The recommended first step —
+    provision a credential — is the same one the broker's missing-binding
+    directives name, so the two layers never contradict each other (see issue
+    #683). Phrased as a statement of the condition plus the recommended first
+    step, matching the broker directive.
     """
     return (
         f"No credential covers API {api}; provision a credential for it first "

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -78,13 +78,13 @@ context).
 
 ### 2. Check what you can do, and request access if needed
 
-See your own identity, status, scopes, and which toolkits you're bound to:
+See your own identity, status, scopes, and which credentials you're bound to:
 
 ```
 jentic access whoami
 ```
 
-Each toolkit binding lists the APIs it **serves** (`serves: [{vendor, name,
+Each credential binding lists the API it **serves** (`serves: [{vendor, name,
 version}]`). This tells you exactly what you can already call. Combined with the
 catalog (what's available to add — see step 3), it's your map of the workspace.
 
@@ -107,8 +107,8 @@ jentic access request --provision <vendor/name> \
 ```
 
 `--wait` blocks until a human fulfils and approves the plan in the dashboard;
-once approved, the toolkit binding is live immediately — just retry `execute`.
-Always pass `--reason` on **every** access request (`--provision`, `--toolkit`,
+once approved, the credential binding is live immediately — just retry `execute`.
+Always pass `--reason` on **every** access request (`--provision`, `--api`,
 or `--scope`): a human reviews it before approving and your reason is shown to
 them — a clear one-liner ("fetch the user's open PRs to summarise them") is what
 gets you approved faster.
@@ -128,14 +128,14 @@ jentic access request \
   --rules-json 'slack.com/api=[{"effect":"allow","methods":["POST"],"path":"/chat\\.postMessage"}]' \
   --provision googleapis.com/sheets --auth googleapis.com/sheets=oauth2 \
   --rules-json 'googleapis.com/sheets=[{"effect":"allow","methods":["GET"],"path":".*"}]' \
-  --toolkit github.com/api \
+  --api github.com/api \
   --reason "one reason covering the whole job" \
   --wait
 ```
 
 Each `--provision` adds a full plan for that API — keep every plan complete
 (auth, rules, reason), exactly as you would for a single one;
-`--toolkit`/`--toolkit-id`/`--scope` add single items. With more than one
+`--api`/`--scope` add single items. With more than one
 `--provision`, key `--auth` and `--rules-json` by the same
 `vendor/name[/version]` you passed to `--provision` (include the version in
 the key if you used one); the bare form applies when there is exactly one.
@@ -152,10 +152,8 @@ it prints a recovery line on stderr (the `agent_directive`) and **exits 2**, so
 you can branch on the exit code instead of mistaking the 4xx body for success.
 The directive tells you exactly how to recover — which differs by denial:
 
-- **`no_toolkit_binding` (403)** — nothing serves this API yet (no toolkit, and
-  usually no credential). File a **provisioning plan** describing the whole path
-  to first execution, and propose the auth type and permission rules you read
-  from the API spec:
+- **`no_credential_binding` (403)** — no credential binding of yours serves this
+  API. Check the directive's `parameters.api_served`:
 
 ```
 jentic access request --provision stripe.com/api \
@@ -165,21 +163,18 @@ jentic access request --provision stripe.com/api \
   --wait
 ```
 
-  - `toolkit_serves_api: false` — **no** toolkit serves this API yet, so a bare
-    `--toolkit` binding request would be denied ("No toolkit serves API …").
-    Filing it now is a dead-end. File the `--provision` plan above instead: it
-    describes the whole path (create toolkit, provision + bind a credential with
-    your proposed rules, bind you), which a human fulfils and approves in the
-    dashboard. The directive's `suggested_command` already points at `--provision`
-    in this case. The plan does **not** force a new toolkit: during fulfilment
-    the operator can add the credential to a toolkit they already have (the
-    wizard offers both) — worth relaying when your operator mentions an
-    existing toolkit they want to extend.
-  - `toolkit_serves_api: true` — a toolkit already serves this API and you just
-    aren't bound to it; the directive suggests `jentic access request --toolkit
+  - `api_served: false` — **no** credential is provisioned for this API yet, so
+    a bare `--api` binding request would be denied ("No credential covers API
+    …"). Filing it now is a dead-end. File the `--provision` plan above instead:
+    it describes the whole path to first execution (provision a credential with
+    your proposed auth type and rules, bind you), which a human fulfils and
+    approves in the dashboard. The directive's `suggested_command` already
+    points at `--provision` in this case.
+  - `api_served: true` — a credential already serves this API and you just
+    aren't bound to it; the directive suggests `jentic access request --api
     <vendor/name> --wait`. File that and wait for approval.
 
-- **`credential_not_provisioned` (424)** — you're bound to a toolkit, but no
+- **`credential_not_provisioned` (424)** — you're bound, but no
   credential (account) is connected. Filing an access request will **not** fix
   this; the directive carries a `provisioning_url` — hand it to your operator to
   connect the account, then retry.
@@ -188,7 +183,7 @@ jentic access request --provision stripe.com/api \
   encryption key rotated underneath it, e.g. a reinstall over existing data).
   Neither an access request nor retrying will fix this — ask your operator to
   remove and re-add the credential, then retry.
-- **`credential_identity_mismatch` (403)** — a toolkit *is* bound and a
+- **`credential_identity_mismatch` (403)** — a binding exists and a
   credential *is* connected, but that credential's stored identity doesn't cover
   this API (e.g. it targets a different name/version, or was stored in a
   non-canonical form). Filing an access request will **not** fix this — the
@@ -197,10 +192,12 @@ jentic access request --provision stripe.com/api \
   is `true` the credential just needs re-provisioning to canonicalize its
   identity. Either way, ask your operator to fix or re-provision the credential
   so it targets `expected`, then retry.
-- **`ambiguous_toolkit` (409)** — multiple toolkits you're bound to serve this
-  API. The directive lists `candidates`; resend the same `execute` with
-  `--header Jentic-Toolkit-Id=<toolkit_id>` (the directive also gives a
-  copy-pasteable `suggested_command`).
+- **`ambiguous_credential_binding` (409)** — multiple credentials you're bound
+  to cover this API. The directive lists `candidates` and carries
+  `parameters.headers`; resend the same `execute` with
+  `--header Jentic-Credential-Id=<credential_id>` (the authoritative
+  tie-breaker — `--header Jentic-Credential-Name=<name>` also works when
+  credential names are unique).
 
 Always follow the `agent_directive`'s `suggested_command` / `provisioning_url`
 rather than assuming which recovery applies. You can also request access
@@ -238,12 +235,12 @@ approving. Do the work up front:
 4. You never enter the credential secret and you never approve — the human fills
    the secret in the dashboard and grants the plan. You propose; they decide.
 
-A plain `toolkit:bind` (`--toolkit`) is only the **last mile** — use it when a
-toolkit for the API already exists (e.g. an operator created one) and you just
-need to be bound to it. When nothing serves the API yet, `--provision` is the
-right first move; a bare `--toolkit` would auto-deny.
+A plain `credential:bind` (`--api`) is only the **last mile** — use it when a
+credential for the API already exists (e.g. an operator provisioned one) and you
+just need to be bound to it. When nothing serves the API yet, `--provision` is
+the right first move; a bare `--api` would auto-deny.
 
-`--toolkit`/`--provision` take a `vendor/name[/version]` reference (the broker
+`--api`/`--provision` take a `vendor/name[/version]` reference (the broker
 also suggests the exact command in its `agent_directive`). `--wait` blocks until
 a human decides and sets the exit code: **0** = approved, **2** = denied —
 read the item's `decision_reason` (in the JSON, or shown under the item on a
@@ -253,10 +250,10 @@ approved. Without `--wait` you get a request id and an `approve_url` to hand to
 your operator. Granting is always a human action — you file and wait, you never
 approve yourself.
 
-If you file a bare `toolkit:bind` (`--toolkit`) for an API that nothing serves
-yet, approval comes back **denied** with `decision_reason: "No toolkit serves
-API <vendor/name>; provision and bind a credential for it first"`. That is the
-signal to file a `--provision` plan instead: it describes the missing toolkit,
+If you file a bare `credential:bind` (`--api`) for an API that nothing serves
+yet, approval comes back **denied** with `decision_reason: "No credential covers
+API <vendor/name>; provision a credential for it first"`. That is the
+signal to file a `--provision` plan instead: it describes the missing
 credential, rules, and binding as one request the operator can fulfil and
 approve in the dashboard.
 
@@ -343,7 +340,7 @@ the catalog manifest from upstream but requires `org:admin`, so it too is an
 operator action.)
 
 **Before concluding "the data is gone", confirm which backend you're on.** If
-APIs, credentials, or toolkits you *know* existed appear missing — or IDs look
+APIs or credentials you *know* existed appear missing — or IDs look
 unfamiliar — you may be talking to a **different** backend than you expect. A
 hosted (`remote`) Jentic install and a `local` self-hosted one have independent
 registries and credentials, and the CLI, an agent, or an MCP server can each be
@@ -445,14 +442,16 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   the control plane (Reference → CLI) — the same reference rendered for humans,
   next to the HTTP API and Broker API references.
 - `jentic context view` — the active context (environment + identity + base_url); start here.
-- `jentic access whoami` — your identity, status, scopes, and toolkit bindings
-  with the APIs each one **serves** (check this before executing or provisioning).
+- `jentic access whoami` — your identity, status, scopes, and credential
+  bindings with the API each one **serves** (check this before executing or
+  provisioning).
 - `jentic access request` — ask a human for access. `--provision <vendor/name>`
   files the whole path to first execution as one plan when nothing serves the
-  API yet; `--toolkit <vendor/name>` asks to be bound to an **existing**
-  toolkit; `--scope <scope>` requests a missing scope. All target flags repeat
-  and combine into **one composite request**. Always pass `--reason`; add
-  `--wait` to block on approval (see Procedure for full examples).
+  API yet; `--api <vendor/name>` asks to be bound to an **existing**
+  credential serving that API; `--scope <scope>` requests a missing scope. All
+  target flags repeat and combine into **one composite request**. Always pass
+  `--reason`; add `--wait` to block on approval (see Procedure for full
+  examples).
 - `jentic access list | status <id> | withdraw <id>` — track your requests.
 - `jentic access refresh` — re-mint your token after an approved **scope**
   grant that `whoami` flags as not yet on your token. Bindings need no
@@ -534,15 +533,14 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   `jenticctl start`, then retry rather than abandoning the task. Only a
   broker **denial** (an `agent_directive` on stderr, exit **2**) is an
   access/credential issue:
-  - **403 `no_toolkit_binding`** → check the directive's
-    `parameters.toolkit_serves_api`. If `true`, a toolkit already serves the API
-    and you just aren't bound — run the `jentic access request --toolkit …` it
+  - **403 `no_credential_binding`** → check the directive's
+    `parameters.api_served`. If `true`, a credential already serves the API
+    and you just aren't bound — run the `jentic access request --api …` it
     suggests and wait for approval. If `false`, nothing serves the API yet and a
-    bare `--toolkit` bind would be **denied** ("No toolkit serves API …"); the
+    bare `--api` bind would be **denied** ("No credential covers API …"); the
     directive suggests `--provision` instead — file that plan (propose `--auth`
     and `--rules-json` from the spec, pass `--reason`) and your operator fulfils
-    it in the dashboard, into a new toolkit **or one they already have** — an
-    existing toolkit never has to be recreated.
+    it in the dashboard.
   - **424 `credential_not_provisioned`** → the directive gives a
     `provisioning_url` for your operator to connect an account (an access
     request won't help).
@@ -553,6 +551,10 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
     identity doesn't cover this API (`parameters.expected` vs
     `parameters.found`). An access request won't help — ask your operator to fix
     or re-provision the credential so it targets `expected`, then retry.
+  - **409 `ambiguous_credential_binding`** → several bound credentials cover
+    this API; resend with `--header Jentic-Credential-Id=<id>` picked from the
+    directive's `candidates` (`Jentic-Credential-Name` works too when names
+    are unique).
   Follow the directive; don't keep re-sending the same `execute`.
 - You file and wait for access; you can't approve your own requests.
 - **Don't execute to test access.** `whoami` already tells you what your bindings

--- a/tests/unit/broker/test_problem_json.py
+++ b/tests/unit/broker/test_problem_json.py
@@ -19,8 +19,12 @@ from jentic_one.broker.core.exceptions import (
     OperationNotFoundError,
     UpstreamTimeoutError,
     action_denied_directive,
+    ambiguous_credential_binding_directive,
     ambiguous_toolkit_directive,
     credential_identity_mismatch_directive,
+    direct_action_denied_directive,
+    direct_credential_identity_mismatch_directive,
+    no_credential_binding_directive,
     no_toolkit_binding_directive,
     switch_toolkit_directive,
 )
@@ -61,9 +65,71 @@ def test_directive_factories_emit_known_strategies() -> None:
             )
         ),
         action_denied_directive(),
+        no_credential_binding_directive(
+            vendor="acme", name="widgets", version="1.0.0", api_served=True
+        ),
+        ambiguous_credential_binding_directive(["cred_a", "cred_b"]),
+        direct_credential_identity_mismatch_directive(
+            mismatch=IdentityMismatch(
+                expected_vendor="acme",
+                expected_name="widgets",
+                expected_version="1.0.0",
+                found_vendor="acme",
+                found_name="gadgets",
+                found_version="1.0.0",
+                would_match_if_normalized=False,
+            )
+        ),
+        direct_action_denied_directive(),
     ]
     for d in directives:
         assert d.strategy in _ALLOWED_STRATEGIES, d.strategy
+
+
+def test_no_credential_binding_directive_names_surviving_commands() -> None:
+    """The default-path missing-binding directive carries a runnable command.
+
+    U-03 (phase 5c): every directive names a surviving flag/command. Served →
+    a bind request by API reference (`--api`); unserved → the provisioning
+    plan (`--provision`). Neither variant may reference the retired toolkit
+    vocabulary.
+    """
+    served = no_credential_binding_directive(
+        vendor="acme", name="widgets", version="1.0.0", api_served=True
+    )
+    assert served.strategy == "prompt_human"
+    assert served.parameters["api_served"] is True
+    assert served.parameters["suggested_command"] == (
+        "jentic access request --api acme/widgets --wait"
+    )
+    assert "toolkit" not in served.human_readable_instruction.lower()
+
+    unserved = no_credential_binding_directive(
+        vendor="acme", name="widgets", version="1.0.0", api_served=False
+    )
+    assert unserved.strategy == "prompt_human"
+    assert unserved.parameters["api_served"] is False
+    assert unserved.parameters["suggested_command"] == (
+        'jentic access request --provision acme/widgets --reason "<why you need this>" --wait'
+    )
+    instruction = unserved.human_readable_instruction
+    assert "--auth" in instruction
+    assert "--rules-json" in instruction
+    assert "toolkit" not in instruction.lower()
+
+
+def test_ambiguous_credential_binding_directive_disambiguates_by_header() -> None:
+    """The direct-path 409 twin retries via the Jentic-Credential-Id header.
+
+    ``modify_headers`` + ``parameters.headers`` is the machine contract; the
+    prose names ``Jentic-Credential-Name`` as the alternative when names are
+    unique.
+    """
+    d = ambiguous_credential_binding_directive(["cred_a", "cred_b"])
+    assert d.strategy == "modify_headers"
+    assert d.parameters["candidates"] == ["cred_a", "cred_b"]
+    assert d.parameters["headers"] == {"Jentic-Credential-Id": "cred_a"}
+    assert "Jentic-Credential-Name" in d.human_readable_instruction
 
 
 def test_ambiguous_toolkit_suggested_command_is_runnable() -> None:

--- a/tests/unit/broker/test_toolkit_select.py
+++ b/tests/unit/broker/test_toolkit_select.py
@@ -21,7 +21,7 @@ from jentic_one.broker.web.routers.execute import (
     _is_unserved_no_toolkit_binding,
     select_toolkit,
 )
-from jentic_one.shared.access_guidance import no_toolkit_serves_api_reason
+from jentic_one.shared.access_guidance import no_credential_serves_api_reason
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.broker.protocols import IdentityMismatch, ToolkitDerivation
 from jentic_one.shared.models import ActorType
@@ -105,7 +105,8 @@ async def test_single_candidate_no_header_uses_it() -> None:
 
 async def test_zero_candidates_no_header_toolkit_serves_recommends_binding() -> None:
     # A toolkit serves this API; the caller just isn't bound. The directive
-    # recommends the (approvable) toolkit-binding request.
+    # recommends the (approvable) binding request in the surviving
+    # access-request vocabulary (`--api`, phase-5c agent contract).
     with pytest.raises(ActionDeniedError) as exc:
         await _select(_StubDeriver([], toolkit_serves_api=True), header_toolkit=None)
     assert exc.value.type == "no_toolkit_binding"
@@ -114,7 +115,7 @@ async def test_zero_candidates_no_header_toolkit_serves_recommends_binding() -> 
     assert exc.value.directive.strategy == "prompt_human"
     assert exc.value.directive.parameters["toolkit_serves_api"] is True
     assert exc.value.directive.parameters["suggested_command"] == (
-        "jentic access request --toolkit acme/widgets --wait"
+        "jentic access request --api acme/widgets --wait"
     )
 
 
@@ -134,19 +135,21 @@ async def test_zero_candidates_no_toolkit_serves_recommends_credential_first() -
     assert "provision" in instruction.lower()
 
 
-async def test_no_toolkit_serves_instruction_mentions_existing_toolkit_reuse() -> None:
-    # #897: the provisioning plan does not force a NEW toolkit — the wizard can
-    # fulfil it into a toolkit the operator already has. The agent-relayed
-    # instruction must say so, or an operator with existing toolkits reads the
-    # flow as "recreate everything" and denies (the reporter's dead-end). The
-    # hint lives in the TEXT only: `parameters` stays machine-stable so CLI and
-    # skill parsing of `suggested_command`/`toolkit_serves_api` never breaks.
+async def test_no_toolkit_serves_instruction_names_surviving_provision_contract() -> None:
+    # U-03 (phase 5c): the instruction must name only surviving flags/commands —
+    # the `--provision` plan with proposed `--auth`/`--rules-json` — and never a
+    # retired toolkit-management surface. The hint lives in the TEXT only:
+    # `parameters` stays machine-stable so CLI and skill parsing of
+    # `suggested_command`/`toolkit_serves_api` never breaks.
     deriver = _StubDeriver([], toolkit_serves_api=False)
     with pytest.raises(ActionDeniedError) as exc:
         await _select(deriver, header_toolkit=None)
     directive = exc.value.directive
     assert directive is not None
-    assert "existing toolkit" in directive.human_readable_instruction.lower()
+    instruction = directive.human_readable_instruction
+    assert "toolkit" not in instruction.lower()
+    assert "--auth" in instruction
+    assert "--rules-json" in instruction
     assert directive.parameters["suggested_command"] == (
         'jentic access request --provision acme/widgets --reason "<why you need this>" --wait'
     )
@@ -235,7 +238,7 @@ async def test_header_present_not_bound_and_no_candidates_prompts_human() -> Non
     assert exc.value.directive.strategy == "prompt_human"
     assert exc.value.directive.parameters["toolkit_serves_api"] is True
     assert exc.value.directive.parameters["suggested_command"] == (
-        "jentic access request --toolkit acme/widgets --wait"
+        "jentic access request --api acme/widgets --wait"
     )
 
 
@@ -292,16 +295,17 @@ def test_no_toolkit_binding_body_carries_prompt_human_directive() -> None:
     assert body["type"] == "no_toolkit_binding"
     assert body["agent_directive"]["strategy"] == "prompt_human"
     assert body["agent_directive"]["parameters"]["suggested_command"] == (
-        "jentic access request --toolkit acme/widgets --wait"
+        "jentic access request --api acme/widgets --wait"
     )
 
 
 def test_no_toolkit_binding_credential_first_directive_and_denial_reason_agree() -> None:
-    """The broker directive (no toolkit yet) and the control denial reason agree.
+    """The broker directive (nothing serves the API) and the control denial reason agree.
 
-    Regression for issue #683: the ``no_toolkit_binding`` directive must recommend
-    provisioning a credential first, matching the reason the toolkit:bind approval
-    denies with when no toolkit serves the API — so the two never contradict.
+    Pins #683 on the surviving vocabulary: the flag-off ``no_toolkit_binding``
+    directive must recommend provisioning a credential first, matching the
+    reason a bare ``credential:bind`` approval denies with when no credential
+    covers the API — so the two layers never contradict each other.
     """
     directive = no_toolkit_binding_directive(
         vendor="acme", name="widgets", version="1.0.0", toolkit_serves_api=False
@@ -311,11 +315,11 @@ def test_no_toolkit_binding_credential_first_directive_and_denial_reason_agree()
     assert "credential" in instruction
     assert "provision" in instruction
 
-    denial_reason = no_toolkit_serves_api_reason("acme/widgets").lower()
-    # Both recommend provisioning/binding a credential as the first step.
+    denial_reason = no_credential_serves_api_reason("acme/widgets").lower()
+    # Both recommend provisioning a credential as the first step.
     assert "credential" in denial_reason
     assert "provision" in denial_reason
-    assert "no toolkit serves" in denial_reason
+    assert "no credential covers" in denial_reason
 
 
 # --- unserved-API operator event (theme 3 residual) --------------------------

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -1473,7 +1473,7 @@
             {
               "name": "actor",
               "type": "string",
-              "usage": "only endpoints callable by this actor type (user, agent, service_account, toolkit)"
+              "usage": "only endpoints callable by this actor type (user, agent, service_account)"
             },
             {
               "name": "context",
@@ -1702,7 +1702,7 @@
           "path": "jentic execute",
           "use": "execute \u003cMETHOD:url | METHOD:/path | operation_id\u003e",
           "short": "Execute an operation through the Jentic broker",
-          "long": "execute sends an HTTP request through the Jentic broker. The broker\nauthenticates the caller with their agent token and injects the stored\nupstream credential, so the agent token is never sent to the upstream\nAPI directly. The target can be specified in three ways:\n\n  1. METHOD:url — a discovered operation's full URL, the same form\n     `jentic search`/`jentic inspect` accept (e.g.\n     GET:https://rest.coincap.io/v3/markets). Resolved via inspect, then\n     routed through the broker. The space form (`GET \u003curl\u003e`) is also\n     accepted, but the colon form is canonical (it needs no shell quoting).\n  2. operation_id — resolve via inspect, then route through the broker.\n  3. METHOD:/path — a broker-relative path sent to --broker-host\n     verbatim (e.g. GET:/v1/pets); the caller supplies the broker path.\n\nPath parameters, query parameters, headers, and a request body can be\nsupplied via flags.\n\nWhen the broker denies the call (e.g. you are not bound to a toolkit\nfor the API, or no credential is provisioned), it returns an\nagent_directive describing how to recover. execute surfaces that\ndirective on stderr and exits 2 so a script can branch on the denial.\n\nExit codes:\n  0 — broker returned a non-denial HTTP response (incl. 2xx and upstream errors)\n  1 — local/transport failure (DNS, TLS, timeout, connection refused)\n  2 — denied by the broker (carries an agent_directive) or resolve failure\n      (inspect error, e.g. unknown operation_id)\n\nBroker target: resolved as built-in default (https://127.0.0.1:8100) \u003c\nthe active environment's broker_url \u003c --broker-scheme/--broker-host. A\nlocal install serves the broker over plain HTTP, so `jentic register`\nseeds broker_url=http://127.0.0.1:8100 for a loopback environment. A TLS\nerror like \"server gave HTTP response to HTTPS client\" means the target\nresolved to https against a local http broker — set the environment's\nbroker_url (`jentic env add \u003cenv\u003e --broker-url http://127.0.0.1:8100\n--force`) or override per call with --broker-scheme http. For a REMOTE\ncontrol plane you MUST set broker_url (or JENTIC_BROKER_URL); execute\nrefuses with RESOLVE_FAILED rather than dialing the local default.",
+          "long": "execute sends an HTTP request through the Jentic broker. The broker\nauthenticates the caller with their agent token and injects the stored\nupstream credential, so the agent token is never sent to the upstream\nAPI directly. The target can be specified in three ways:\n\n  1. METHOD:url — a discovered operation's full URL, the same form\n     `jentic search`/`jentic inspect` accept (e.g.\n     GET:https://rest.coincap.io/v3/markets). Resolved via inspect, then\n     routed through the broker. The space form (`GET \u003curl\u003e`) is also\n     accepted, but the colon form is canonical (it needs no shell quoting).\n  2. operation_id — resolve via inspect, then route through the broker.\n  3. METHOD:/path — a broker-relative path sent to --broker-host\n     verbatim (e.g. GET:/v1/pets); the caller supplies the broker path.\n\nPath parameters, query parameters, headers, and a request body can be\nsupplied via flags.\n\nWhen the broker denies the call (e.g. you have no credential binding\nfor the API, or no credential is provisioned), it returns an\nagent_directive describing how to recover. execute surfaces that\ndirective on stderr and exits 2 so a script can branch on the denial.\n\nExit codes:\n  0 — broker returned a non-denial HTTP response (incl. 2xx and upstream errors)\n  1 — local/transport failure (DNS, TLS, timeout, connection refused)\n  2 — denied by the broker (carries an agent_directive) or resolve failure\n      (inspect error, e.g. unknown operation_id)\n\nBroker target: resolved as built-in default (https://127.0.0.1:8100) \u003c\nthe active environment's broker_url \u003c --broker-scheme/--broker-host. A\nlocal install serves the broker over plain HTTP, so `jentic register`\nseeds broker_url=http://127.0.0.1:8100 for a loopback environment. A TLS\nerror like \"server gave HTTP response to HTTPS client\" means the target\nresolved to https against a local http broker — set the environment's\nbroker_url (`jentic env add \u003cenv\u003e --broker-url http://127.0.0.1:8100\n--force`) or override per call with --broker-scheme http. For a REMOTE\ncontrol plane you MUST set broker_url (or JENTIC_BROKER_URL); execute\nrefuses with RESOLVE_FAILED rather than dialing the local default.",
           "example": "  jentic execute GET:https://rest.coincap.io/v3/markets --json\n  jentic execute listPets --query limit=10 --json\n  jentic execute GET:/v1/pets/{petId} --path petId=123 --raw\n  echo '{\"name\":\"Bob\"}' | jentic execute POST:/v1/users --json\n  # Local broker over http, one-off (usually unnecessary — register seeds broker_url):\n  jentic execute listPets --broker-scheme http --broker-host 127.0.0.1:8100",
           "group_title": "Find and run operations",
           "flags": [
@@ -1802,8 +1802,8 @@
           "name": "access",
           "path": "jentic access",
           "use": "access",
-          "short": "Inspect your access and request more (toolkits, scopes)",
-          "long": "access is how an agent closes the gap between having an identity and having\nthe access to use it. An approved agent starts bound to no toolkits, so its\nfirst execute fails with a 403 telling it to request access. Use this group\nto see what you can do now (whoami), ask a human to grant more (request),\nand track those requests (list, status, withdraw).\n\nApproval is a human action: filing a request prints an approve_url for your\noperator. Output defaults to JSON when stdout is not a TTY (agent-friendly).",
+          "short": "Inspect your access and request more (credentials, scopes)",
+          "long": "access is how an agent closes the gap between having an identity and having\nthe access to use it. An approved agent starts bound to no credentials, so its\nfirst execute fails with a 403 telling it to request access. Use this group\nto see what you can do now (whoami), ask a human to grant more (request),\nand track those requests (list, status, withdraw).\n\nApproval is a human action: filing a request prints an approve_url for your\noperator. Output defaults to JSON when stdout is not a TTY (agent-friendly).",
           "group_title": "Find and run operations",
           "flags": [
             {
@@ -1827,8 +1827,8 @@
               "name": "whoami",
               "path": "jentic access whoami",
               "use": "whoami",
-              "short": "Show your agent identity, scopes, and toolkit bindings",
-              "long": "whoami answers \"what can I do right now?\" — your agent id, status, granted\nscopes, and the toolkits you are bound to. An empty bindings list means you\ncannot execute against any API yet; use `jentic access request` to ask.",
+              "short": "Show your agent identity, scopes, and credential bindings",
+              "long": "whoami answers \"what can I do right now?\" — your agent id, status, granted\nscopes, and the credentials you are bound to (each with the APIs it serves).\nAn empty bindings list means you cannot execute against any API yet; use\n`jentic access request` to ask.",
               "flags": [
                 {
                   "name": "context",
@@ -1857,10 +1857,16 @@
               "name": "request",
               "path": "jentic access request",
               "use": "request",
-              "short": "File a request for toolkit bindings, scope grants, or provisioning plans",
-              "long": "request files one access request for the access you are missing and prints an\napprove_url for your human operator. Name a toolkit by the API you found in\nsearch (--toolkit vendor/name), by id (--toolkit-id tk_…), or ask for a scope\n(--scope). Use --wait to block until a human decides (or --timeout elapses).\n\nWhen nothing serves an API yet (a fresh import with no toolkit/credential),\nuse --provision vendor/name to file the whole path to first execution as one\nplan: create a toolkit, provision a credential, bind it (with your proposed\n--rules-json), and bind yourself. A human fulfils the create/provision steps\nin the dashboard (they enter the secret — it never rides in your request) and\napproves. Use --auth to declare the credential type you detected from the spec\n(bearer, api_key, basic, oauth2, or none for a no-auth API).\n\nAll target flags repeat and combine, so a job needing several APIs files ONE\ncomposite request the human decides in one sitting: each --provision appends\na provisioning plan, each --toolkit/--toolkit-id/--scope appends a single\nitem. With more than one --provision, key --auth and --rules-json by the\nsame vendor/name[/version] passed to --provision; the bare form applies\nwhen there is exactly one.\n\nAn existing pending request for the same resource is reused when this request\nnames a single target; a composite aborts instead (drop the already-pending\ntarget or withdraw the older request, then re-file).\n\nExit codes:\n  0 — request filed (or, with --wait, fully approved)\n  2 — request was denied, expired, or withdrawn (only with --wait)\n  3 — still pending when --timeout elapsed (only with --wait)\n  4 — partially approved; not all items granted (only with --wait)",
-              "example": "  jentic access request --toolkit httpbin.org/httpbin --reason \"smoke test\"\n  jentic access request --toolkit-id tk_123 --wait\n  jentic access request --scope owner:toolkits:read --json\n  jentic access request --provision posthog.com/posthog-api --auth bearer \\\n    --rules-json '[{\"effect\":\"allow\",\"methods\":[\"GET\"],\"path\":\".*\"}]' --wait\n  jentic access request --provision slack.com/api --auth slack.com/api=bearer \\\n    --provision googleapis.com/sheets --auth googleapis.com/sheets=oauth2 \\\n    --toolkit github.com/api --scope apis:write \\\n    --reason \"release-notes automation\" --wait",
+              "short": "File a request for credential bindings, scope grants, or provisioning plans",
+              "long": "request files one access request for the access you are missing and prints an\napprove_url for your human operator. Name an API you found in search to be\nbound to a credential serving it (--api vendor/name), or ask for a scope\n(--scope). Use --wait to block until a human decides (or --timeout elapses).\n\nWhen no credential serves an API yet (a fresh import), use --provision\nvendor/name to file the whole path to first execution as one plan: provision\na credential and bind yourself to it (with your proposed --rules-json). A\nhuman fulfils the provision step in the dashboard (they enter the secret —\nit never rides in your request) and approves. Use --auth to declare the\ncredential type you detected from the spec (bearer, api_key, basic, oauth2,\nor none for a no-auth API).\n\nAll target flags repeat and combine, so a job needing several APIs files ONE\ncomposite request the human decides in one sitting: each --provision appends\na provisioning plan, each --api/--scope appends a single item. With more\nthan one --provision, key --auth and --rules-json by the same\nvendor/name[/version] passed to --provision; the bare form applies when\nthere is exactly one.\n\nAn existing pending request for the same resource is reused when this request\nnames a single target; a composite aborts instead (drop the already-pending\ntarget or withdraw the older request, then re-file).\n\nExit codes:\n  0 — request filed (or, with --wait, fully approved)\n  2 — request was denied, expired, or withdrawn (only with --wait)\n  3 — still pending when --timeout elapsed (only with --wait)\n  4 — partially approved; not all items granted (only with --wait)",
+              "example": "  jentic access request --api httpbin.org/httpbin --reason \"smoke test\"\n  jentic access request --scope owner:credentials:read --json\n  jentic access request --provision posthog.com/posthog-api --auth bearer \\\n    --rules-json '[{\"effect\":\"allow\",\"methods\":[\"GET\"],\"path\":\".*\"}]' --wait\n  jentic access request --provision slack.com/api --auth slack.com/api=bearer \\\n    --provision googleapis.com/sheets --auth googleapis.com/sheets=oauth2 \\\n    --api github.com/api --scope apis:write \\\n    --reason \"release-notes automation\" --wait",
               "flags": [
+                {
+                  "name": "api",
+                  "type": "stringArray",
+                  "default": "[]",
+                  "usage": "request a binding to a credential serving this API (vendor/name[/version]; repeatable)"
+                },
                 {
                   "name": "auth",
                   "type": "stringArray",
@@ -1916,18 +1922,6 @@
                   "type": "duration",
                   "default": "10m0s",
                   "usage": "max time to wait with --wait"
-                },
-                {
-                  "name": "toolkit",
-                  "type": "stringArray",
-                  "default": "[]",
-                  "usage": "request a binding to the toolkit serving this API (vendor/name[/version]; repeatable)"
-                },
-                {
-                  "name": "toolkit-id",
-                  "type": "stringArray",
-                  "default": "[]",
-                  "usage": "request a binding to this toolkit id (tk_…; repeatable)"
                 },
                 {
                   "name": "wait",
@@ -2244,7 +2238,7 @@
           "use": "api \u003cMETHOD\u003e \u003cPATH\u003e",
           "short": "Authenticated passthrough to the control plane",
           "long": "api sends an arbitrary request to the control plane, reusing the same\nauth, session, and transport as every other command. The PATH must match a\nroute in the CLI's embedded OpenAPI spec (use --live to allow routes the\nconnected server serves that this binary predates). Discover routes with\n`jentic api ops` and their contract with `jentic api describe`.\n\nRequest body (mirrors `jentic execute`): -d/--data inline JSON, -d - for\nstdin, --data-file \u003cpath\u003e, or auto-stdin when a body is piped/redirected.\n\nBy default any transport-successful response (2xx or 4xx/5xx) exits 0 and\nthe body is emitted as-is; --fail-on-error maps non-2xx to exit 1.",
-          "example": "  jentic api GET /credentials\n  jentic api POST /toolkits -d '{\"name\":\"clarity\"}'\n  jentic api POST /apis \u003c api.json\n  jentic api GET \"/apis?limit=10\"",
+          "example": "  jentic api GET /credentials\n  jentic api POST /service-accounts -d '{\"name\":\"clarity\"}'\n  jentic api POST /apis \u003c api.json\n  jentic api GET \"/apis?limit=10\"",
           "group_title": "Find and run operations",
           "flags": [
             {


### PR DESCRIPTION
## Summary

Phase 5c of the theme-5 toolkit removal ([plan](https://github.com/jentic/jentic-one-plans/blob/main/themes/theme-5-remove-toolkits.md), stacked on #1352): the **agent contract** — CLI flags, denial-recovery directives, whoami, MCP tool copy, and the served skill — moves to the credential-binding vocabulary. `jentic access request --toolkit` becomes `--api` (hidden deprecated alias for one release), and every remediation string an agent can receive now names a surviving route, flag, or header (the plan's U-03 invariant).

## Changes

- **cli**: `--api <vendor/name>` replaces `--toolkit` (hidden alias, single stderr deprecation warning; `--toolkit-id` keeps its re-file error, now pointing at `--api`); whoami renders **credential bindings** (name, suspended, `serves:` line) as the primary section with toolkit bindings demoted to a legacy label; 403/424/401 recovery copy reworked and a new 409 branch names `Jentic-Credential-Id`/`Jentic-Credential-Name`; MCP tools take `apis` (compat aliases kept); endpoints `--actor` drops the retired toolkit actor; README/help sweep.
- **broker**: all denial/remediation copy (`exceptions.py`) speaks `--api`/`--provision`; the flag-on `no_credential_binding` directive now emits a `suggested_command` (it previously deferred to "Phase 3 will land the verbs" — they landed); the flag-off `ambiguous_toolkit` directive deliberately keeps `Jentic-Toolkit-Id` (the only header that can recover toolkit derivation, alive until 6b) with its scoping documented; flag-off no-rules detail points at the surviving permissions route; dead `no_toolkit_serves_api_reason` deleted.
- **mcp**: Python server instructions + synthesized denial hints on the credential vocabulary; `mcp-tools.json` regenerated from its Go source and byte-synced to the packaged copy (both drift gates green).
- **skills**: `skills/jentic/SKILL.md` rewritten to the direct-binding contract (whoami-first, two access verbs, denial recovery by type); mirrors regenerated via `make skills`, never hand-edited.
- **goldens**: legacy `no_toolkit_binding` fixtures keep the wire type with the new copy; new `no_credential_binding` fixture pins the flag-on directive; `ui/public/cli-reference.json` + `docs/reference/mcp-tools.json` regenerated (pure codegen, drift-gated inside `go test`).
- Out of scope: wire `type` strings and the `switch_toolkit` strategy (flag-off contract until 6b), `toolkit_bindings` on `/me`, docs pages (5d), enterprise.

## Risk & rollback

- Low risk: copy/flag contract only — no schema, route, or wire-type changes. The deprecated `--toolkit` alias keeps existing agent scripts working for one release.
- Goldens embed the exact server strings; both halves were aligned verbatim (drift gates enforce it).
- Rollback: revert the squash commit.

## Test plan

- Python: `make test-unit` 3356 ✓ · `make test-arch` 154 ✓ · `make test-integration` (Postgres) 1146 ✓ · sqlite 814 ✓ · mypy clean (incl. skill-drift + mcp-spec byte-identity gates)
- Go: `go build`/`vet`/`go test -count=1 ./...` 30/30 packages ✓ · `make test-arch` ✓ `make test-golden` ✓ `make check-cli-gen` ✓
- UI: vitest 1125 ✓ (only the regenerated `cli-reference.json` asset changed)
- Manual: `--api` help/warn/error paths exercised (`--toolkit` warns once; `--toolkit-id` errors with the re-file directive).

## Review guide

- Start with `cli/internal/cli/api/access_plan.go` (the alias fold), then `broker/core/exceptions.py` (the directive copy + the one kept-toolkit decision), then `skills/jentic/SKILL.md` (the contract narrative). Goldens show the final wire copy at a glance.

Made with [Cursor](https://cursor.com)