### PR TITLE
chore(deps): bump js-yaml to 4.3.2 for GHSA-2883-xcg3-v3hh

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -6456,9 +6456,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#90](https://github.com/jentic/jentic-one/security/dependabot/90) (high severity): transitive `js-yaml@4.3.1` in `ui/package-lock.json` is vulnerable to [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) ("maxTotalMergeKeys does not limit CPU use for empty merge sources"). Lockfile-only bump to the patched 4.3.2 — no behaviour change.

## Changes

- `ui/package-lock.json`: `js-yaml` 4.3.1 → 4.3.2 (patched). Dev-only transitive dependency, pulled in via `eslint → @eslint/eslintrc` and `openapi-typescript-codegen → @apidevtools/json-schema-ref-parser` (deduped, single v4 lineage; no v3 lineage present).
- No `package.json` change and no `overrides` needed — both parents allow `^4.1.0`, so `npm update js-yaml` sufficed.
- Out of scope: the unrelated `brace-expansion` advisories `npm audit` also reports (separate alert, separate bump).
- js-yaml appears in no other lockfile in the repo (checked root, `cli/`, `docs/`).

## Risk & rollback

- Low risk: patch-level bump of a dev-only transitive dependency; revert the squash commit if needed.

## Test plan

- `npm ls js-yaml` shows only 4.3.2 (both chains)
- `npm audit` no longer reports GHSA-2883-xcg3-v3hh
- `npm run lint` ✅, `npm run build` ✅, `npm run test:run` ✅ (131 files, 1215 tests passed) in `ui/`

## Related issue

Dependabot alert [#90](https://github.com/jentic/jentic-one/security/dependabot/90)

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [ ] `make check` passes — n/a: lockfile-only change under `ui/`; UI gates (`lint`, `build`, `test:run`) run instead
- [ ] Tests added/updated for the change
- [ ] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included

Made with [Cursor](https://cursor.com)
