### PR TITLE
fix(setup.sh): retry db readiness through postgres restart window

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,31 +7,63 @@ cd "$PROJECT_ROOT"
 
 PG_PORT="${JENTIC_PG_PORT:-5432}"
 
+COMPOSE_FILE="docker/local-setup/docker-compose.yaml"
+
+# Run psql inside the db container against the jentic database.
+psql_db() {
+    docker compose -f "$COMPOSE_FILE" exec -T db \
+        psql -U postgres -d jentic "$@"
+}
+
 echo "==> Starting Docker services..."
-docker compose -f docker/local-setup/docker-compose.yaml up -d
+docker compose -f "$COMPOSE_FILE" up -d
 
 echo "==> Waiting for database to become healthy..."
-MAX_WAIT=60
-elapsed=0
-# Use a real query rather than pg_isready: on first boot the Postgres image
-# runs a temporary internal server for init scripts that pg_isready can match,
-# then restarts the real server, leaving a brief window where the socket is
-# gone. `SELECT 1` only succeeds once the real server is accepting connections.
-until docker compose -f docker/local-setup/docker-compose.yaml exec -T db \
-    psql -U postgres -d jentic -tAc 'SELECT 1' >/dev/null 2>&1; do
-    if [ "$elapsed" -ge "$MAX_WAIT" ]; then
-        echo "ERROR: db did not become ready within ${MAX_WAIT}s"
-        exit 1
+MAX_WAIT="${JENTIC_DB_MAX_WAIT:-60}"
+# On first boot the Postgres image runs a temporary internal server for init
+# scripts, then shuts it down and starts the real one. That temporary server
+# answers real queries on the container's unix socket, so a single successful
+# `SELECT 1` can land inside the restart window — and the next psql dies with
+# "FATAL: the database system is shutting down" (or "is starting up", or
+# connection refused). Treat all of those as not-yet-ready: require several
+# consecutive successful probes, and only fail once the deadline passes.
+REQUIRED_OK=3
+SECONDS=0
+ok=0
+while [ "$ok" -lt "$REQUIRED_OK" ]; do
+    if psql_db -tAc 'SELECT 1' >/dev/null 2>&1; then
+        ok=$((ok + 1))
+    else
+        ok=0
+        if [ "$SECONDS" -ge "$MAX_WAIT" ]; then
+            echo "ERROR: db did not become ready within ${MAX_WAIT}s; last probe:"
+            psql_db -tAc 'SELECT 1' >/dev/null || true
+            exit 1
+        fi
     fi
     sleep 1
-    elapsed=$((elapsed + 1))
 done
-echo "    db is ready"
+echo "    db is ready (${REQUIRED_OK} consecutive probes over ${SECONDS}s)"
+
+# Run a psql statement, retrying transient startup/shutdown/connection errors
+# until the shared MAX_WAIT deadline (SECONDS keeps counting from the wait
+# above). On timeout, re-run unsuppressed so the real error reaches the log.
+retry_psql() {
+    local what="$1"
+    shift
+    until psql_db "$@" >/dev/null 2>&1; do
+        if [ "$SECONDS" -ge "$MAX_WAIT" ]; then
+            echo "ERROR: ${what} still failing after ${MAX_WAIT}s; last attempt:"
+            psql_db "$@" >/dev/null || true
+            exit 1
+        fi
+        sleep 1
+    done
+}
 
 echo "==> Ensuring schemas exist..."
 for schema in registry control admin; do
-    docker compose -f docker/local-setup/docker-compose.yaml exec -T db psql -U postgres -d jentic -c \
-        "CREATE SCHEMA IF NOT EXISTS ${schema};" >/dev/null
+    retry_psql "CREATE SCHEMA ${schema}" -c "CREATE SCHEMA IF NOT EXISTS ${schema};"
     echo "    schema '$schema' ensured"
 done
 


### PR DESCRIPTION
## Summary

The "Start database fixtures" CI step (`make start-fixtures` → `scripts/setup.sh`) is flaky and failed three times today, on PRs #1344, #1345, and #1348 — see the first attempts of CI runs [34609615566](https://github.com/jentic/jentic-one/actions/runs/34609615566) ("Integration tests (postgres)") and [34607853942](https://github.com/jentic/jentic-one/actions/runs/34607853942) ("UI e2e (real backend)"), both of which only went green on attempt 2. Failure signature:

```
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  the database system is shutting down
make: *** [Makefile:130: start-fixtures] Error 2
```

Root cause: on first boot the `postgres:16` entrypoint runs a **temporary** server for init scripts, then shuts it down and starts the real one. The existing readiness loop's single successful `SELECT 1` (over the container's unix socket, which the temporary server also answers) can land inside that window — and the very next psql, the **unretried** `CREATE SCHEMA` step, dies fatally under `set -e` with "the database system is shutting down", even though Postgres is healthy seconds later.

## Changes

- `scripts/setup.sh` (CI fixture-start path, shared by the postgres integration job and the UI e2e real-backend job at `ci.yml` lines 381/577, and by local `make dev` via `dev-up.sh`):
  - Readiness wait now requires **3 consecutive** successful `SELECT 1` probes, so a lone success inside the init→restart window no longer declares the db ready. "Shutting down" / "starting up" / connection-refused are treated as not-yet-ready; the loop only fails after the bounded deadline (60s default, `JENTIC_DB_MAX_WAIT` override).
  - The `CREATE SCHEMA` psql calls are retried against the same deadline instead of being one-shot fatal.
  - On timeout, the probe is re-run unsuppressed so the real psql error reaches the CI log.
- Out of scope: no CI restructuring (no compose healthcheck/`depends_on` changes, no workflow edits) — the fix is minimal and local to the fixture-start script, so both consumers are covered by one change.

## Risk & rollback

- Low risk: touches only the dev/CI fixture bootstrap script; no product code, config, or workflow changes. Worst case is a slightly longer wait (~2s extra for the consecutive-probe confirmation) before fixtures come up. Revert the squash commit to roll back.

## Test plan

- `shellcheck scripts/setup.sh` and `bash -n` — clean.
- Ran `make start-fixtures` locally end-to-end against a **fresh** Postgres volume (isolated `COMPOSE_PROJECT_NAME`, exercising the exact first-boot init→restart window): readiness confirmed after 3 consecutive probes, all schemas created, all registry/control/admin migrations applied, exit 0. Re-ran against the already-running container: idempotent, exit 0.
- Exercised the timeout path with an unreachable service and a short deadline: fails with the bounded-wait error and exit 1 as intended.
- The actual race is timing-dependent, so "flake no longer occurs" can only be confirmed statistically in CI over future runs of both consuming jobs.

Made with [Cursor](https://cursor.com)