### PR TITLE
feat(ui): render agent_status dormancy marker on OAuth grant rows

### DIFF
--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -67,6 +67,16 @@ const actorDirectorySeed = [
 		created_at: '2026-01-01T00:00:00Z',
 	},
 	{
+		// The DISABLED agent behind the settings store's dormant grant
+		// (#1345) — resolves so the grant row reads "Nightly Reporter ·
+		// Agent disabled", not a raw id next to the dormancy chip.
+		id: 'nightly-reporter',
+		actor_type: 'agent',
+		name: 'Nightly Reporter',
+		active: false,
+		created_at: '2026-01-01T00:00:00Z',
+	},
+	{
 		id: 'agnt_active_1',
 		actor_type: 'agent',
 		name: 'support-agent',

--- a/ui/src/modules/agents/__tests__/ConnectedClientsCard.test.tsx
+++ b/ui/src/modules/agents/__tests__/ConnectedClientsCard.test.tsx
@@ -69,6 +69,33 @@ describe('ConnectedClientsCard', () => {
 		expect(screen.getByText('Old Integration')).toBeInTheDocument();
 	});
 
+	it('marks a grant dormant when its agent is disabled (#1345), leaving working rows unmarked', async () => {
+		// The API annotates each grant with the bound agent's lifecycle
+		// status; a disabled agent leaves the grant ACTIVE but dormant — the
+		// row must say so instead of reading as a working connection.
+		seedOauthGrants([
+			{ id: 'ocg_dormant_1', client_name: 'Dormant Client', agent_status: 'disabled' },
+		]);
+		renderCard({ agentId: 'agnt_active_1', agentName: 'support-agent' });
+
+		const dormantRow = (await screen.findByText('Dormant Client')).closest('li');
+		expect(dormantRow).not.toBeNull();
+		// Disable/Enable vocabulary, with the way back named in the tooltip.
+		expect(within(dormantRow as HTMLElement).getByText('Agent disabled')).toBeInTheDocument();
+		expect(
+			within(dormantRow as HTMLElement).getByText(
+				/Enable the agent to restore the connection/,
+			),
+		).toBeInTheDocument();
+
+		// The working connection (Cursor → an active agent) carries no chip.
+		const workingRow = (await screen.findByText('Cursor')).closest('li');
+		expect(workingRow).not.toBeNull();
+		expect(
+			within(workingRow as HTMLElement).queryByText(/Agent disabled/),
+		).not.toBeInTheDocument();
+	});
+
 	it('revokes a grant through the confirm dialog and drops the row', async () => {
 		const user = userEvent.setup();
 		renderCard({ agentId: 'agnt_active_1', agentName: 'support-agent' });

--- a/ui/src/modules/agents/api/client.ts
+++ b/ui/src/modules/agents/api/client.ts
@@ -950,6 +950,7 @@ function grantToEntity(r: OAuthGrantResponse): OAuthGrantEntity {
 		clientOrigin: r.client_origin ?? null,
 		userId: r.user_id,
 		agentId: r.agent_id,
+		agentStatus: r.agent_status ?? null,
 		scopes: r.scopes,
 		status: r.status,
 		createdAt: r.created_at,

--- a/ui/src/modules/agents/api/types.ts
+++ b/ui/src/modules/agents/api/types.ts
@@ -290,6 +290,12 @@ export interface OAuthGrantEntity {
 	clientOrigin: string | null;
 	userId: string;
 	agentId: string;
+	/**
+	 * Lifecycle state of the bound agent (#1345): a grant on a non-active
+	 * agent stays `active` but is DORMANT — no token resolves until the agent
+	 * is enabled again. Null when the API omitted the annotation.
+	 */
+	agentStatus: string | null;
 	scopes: string[];
 	status: string;
 	createdAt: string;

--- a/ui/src/modules/agents/components/detail/ConnectedClientsCard.tsx
+++ b/ui/src/modules/agents/components/detail/ConnectedClientsCard.tsx
@@ -32,6 +32,7 @@ import {
 	Dialog,
 	EmptyState,
 	ErrorAlert,
+	GrantAgentStatusChip,
 	LoadingState,
 	SegmentedToggle,
 	Tooltip,
@@ -136,6 +137,14 @@ export function ConnectedClientsCard({
 											{grant.status === 'revoked' && (
 												<Badge variant="danger">Revoked</Badge>
 											)}
+											{/* #1345: the agent was disabled after this
+											    consent — the grant stands but is dormant,
+											    so the row must not read as a working
+											    connection. */}
+											<GrantAgentStatusChip
+												grantStatus={grant.status}
+												agentStatus={grant.agentStatus}
+											/>
 										</p>
 										{grant.clientOrigin && (
 											<p className="text-muted-foreground truncate font-mono text-xs">

--- a/ui/src/modules/agents/mocks/handlers.ts
+++ b/ui/src/modules/agents/mocks/handlers.ts
@@ -105,6 +105,8 @@ interface OAuthGrantRow {
 	client_origin: string | null;
 	user_id: string;
 	agent_id: string;
+	/** Lifecycle state of the bound agent (#1345) — non-active means dormant. */
+	agent_status: string;
 	scopes: string[];
 	status: 'active' | 'revoked';
 	created_at: string;
@@ -382,6 +384,7 @@ export function resetAgentsStore(): void {
 			client_origin: 'http://localhost:33418',
 			user_id: 'usr_admin_1',
 			agent_id: 'agnt_active_1',
+			agent_status: 'active',
 			scopes: ['apis:read', 'capabilities:execute'],
 			status: 'active',
 			created_at: now(-45),
@@ -396,6 +399,7 @@ export function resetAgentsStore(): void {
 			client_origin: 'https://old.example.com',
 			user_id: 'usr_departed_owner',
 			agent_id: 'agnt_active_1',
+			agent_status: 'active',
 			scopes: ['apis:read'],
 			status: 'revoked',
 			created_at: now(-600),
@@ -419,6 +423,7 @@ export function seedOauthGrants(rows: Array<Partial<OAuthGrantRow> & { id: strin
 			client_origin: 'https://seeded.example.com',
 			user_id: 'usr_admin_1',
 			agent_id: 'agnt_active_1',
+			agent_status: 'active',
 			scopes: ['apis:read'],
 			status: 'active',
 			created_at: now(-45),

--- a/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
+++ b/ui/src/modules/settings/__tests__/OAuthClientsSection.test.tsx
@@ -360,6 +360,46 @@ describe('OAuth clients surface (via SettingsPage)', () => {
 		await checkA11y(document.body);
 	});
 
+	it('marks a dormant grant (#1345): the disabled-agent row carries the chip, working rows none, and the roster count excludes it', async () => {
+		const user = userEvent.setup();
+		renderSettingsPage();
+		await screen.findByText('Internal Dashboard');
+
+		// The roster's grant count is HONEST: three active grant rows exist,
+		// but the dormant one (agent disabled) is no working connection → 2.
+		expect(
+			screen.getByRole('button', { name: 'View grants for Internal Dashboard' }),
+		).toHaveTextContent('2');
+
+		await user.click(
+			screen.getByRole('button', { name: 'View details for Internal Dashboard' }),
+		);
+		const sheet = await screen.findByTestId('sheet-primitive');
+
+		// The dormant grant row (Nightly Reporter was disabled after consent):
+		// the muted chip, plus the tooltip copy explaining the dormancy and
+		// why the active count excludes it — Disable/Enable vocabulary.
+		const dormantRow = (await within(sheet).findByText('Nightly Reporter')).closest('li');
+		expect(dormantRow).not.toBeNull();
+		expect(within(dormantRow as HTMLElement).getByText('Agent disabled')).toBeInTheDocument();
+		expect(
+			within(dormantRow as HTMLElement).getByText(
+				/no tokens are issued while the agent is disabled, and active-connection counts exclude it/,
+			),
+		).toBeInTheDocument();
+
+		// Working connections (active grant, active agent) carry no chip.
+		const workingRow = (await within(sheet).findByText('Invoice Bot')).closest('li');
+		expect(workingRow).not.toBeNull();
+		expect(
+			within(workingRow as HTMLElement).queryByText(/Agent disabled/),
+		).not.toBeInTheDocument();
+
+		// The opened sheet with the dormancy chip stays axe-clean (body portal).
+		await settleHeader();
+		await checkA11y(document.body);
+	});
+
 	it("offers Enable in a zombie's detail sheet (recovery from its own console)", async () => {
 		const user = userEvent.setup();
 		renderSettingsPage();

--- a/ui/src/modules/settings/components/ClientDetailSheet.tsx
+++ b/ui/src/modules/settings/components/ClientDetailSheet.tsx
@@ -27,6 +27,7 @@ import {
 	Dialog,
 	EmptyRow,
 	ErrorAlert,
+	GrantAgentStatusChip,
 	LoadingState,
 	SegmentedToggle,
 	SheetPrimitive,
@@ -155,6 +156,15 @@ function GrantsSection({ client }: { client: OAuthClient }) {
 											{grant.status === 'revoked' && (
 												<Badge variant="danger">Revoked</Badge>
 											)}
+											{/* #1345: an active grant on a non-active
+											    agent is dormant — mark it so the row
+											    explains why it isn't a working
+											    connection (and why the roster's
+											    active-grant count excludes it). */}
+											<GrantAgentStatusChip
+												grantStatus={grant.status}
+												agentStatus={grant.agent_status}
+											/>
 										</p>
 										<div className="mt-1.5 flex flex-wrap gap-1">
 											{grant.scopes.length > 0 ? (

--- a/ui/src/modules/settings/mocks/handlers.ts
+++ b/ui/src/modules/settings/mocks/handlers.ts
@@ -42,6 +42,8 @@ interface OAuthGrantAdminRow {
 	client_name: string | null;
 	client_origin: string | null;
 	agent_id: string;
+	/** Lifecycle state of the bound agent (#1345) — non-active means dormant. */
+	agent_status: string;
 	user_id: string;
 	scopes: string[];
 	status: 'active' | 'revoked';
@@ -186,6 +188,7 @@ export function resetSettingsStore(): void {
 			client_name: 'Internal Dashboard',
 			client_origin: 'https://app.example.com',
 			agent_id: 'invoice-bot',
+			agent_status: 'active',
 			user_id: 'usr_admin_1',
 			scopes: ['apis:read'],
 			status: 'active',
@@ -202,6 +205,7 @@ export function resetSettingsStore(): void {
 			client_name: 'Internal Dashboard',
 			client_origin: 'https://app.example.com',
 			agent_id: 'support-triage',
+			agent_status: 'active',
 			user_id: 'usr_other_1',
 			scopes: ['apis:read', 'executions:read'],
 			status: 'active',
@@ -217,6 +221,7 @@ export function resetSettingsStore(): void {
 			client_name: 'Internal Dashboard',
 			client_origin: 'https://app.example.com',
 			agent_id: 'invoice-bot',
+			agent_status: 'active',
 			user_id: 'usr_admin_1',
 			scopes: ['apis:read'],
 			status: 'revoked',
@@ -224,6 +229,25 @@ export function resetSettingsStore(): void {
 			created_at: now(-200),
 			revoked_at: now(-100),
 			last_used_at: now(-150),
+		},
+		// DORMANT grant (#1345): the row stays active (disable is reversible;
+		// the standing consent survives) but its agent was disabled, so no
+		// token resolves and `active_grant_count` excludes it. The detail
+		// sheet must mark it rather than let it read as a working connection.
+		{
+			id: 'ocg_4',
+			oauth_client_id: 'oc_dashboard',
+			client_name: 'Internal Dashboard',
+			client_origin: 'https://app.example.com',
+			agent_id: 'nightly-reporter',
+			agent_status: 'disabled',
+			user_id: 'usr_admin_1',
+			scopes: ['apis:read'],
+			status: 'active',
+			can_revoke: true,
+			created_at: now(-70),
+			revoked_at: null,
+			last_used_at: now(-2000),
 		},
 	];
 	// Decision history for the seeded rows: the denied client carries its
@@ -259,12 +283,19 @@ function genId(prefix: string): string {
 	return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
-/** `active_grant_count` is computed on the read path, like the backend. */
+/**
+ * `active_grant_count` is computed on the read path, like the backend — and
+ * honestly (#1345): grants whose agent is non-active are dormant, so they
+ * don't count as working connections.
+ */
 function withGrantCount(row: OAuthClientRow): OAuthClientRow {
 	return {
 		...row,
 		active_grant_count: oauthGrants.filter(
-			(g) => g.oauth_client_id === row.client_id && g.status === 'active',
+			(g) =>
+				g.oauth_client_id === row.client_id &&
+				g.status === 'active' &&
+				g.agent_status === 'active',
 		).length,
 	};
 }

--- a/ui/src/shared/ui/GrantAgentStatusChip.tsx
+++ b/ui/src/shared/ui/GrantAgentStatusChip.tsx
@@ -1,0 +1,51 @@
+/**
+ * GrantAgentStatusChip — the dormant-connection marker on a consent→agent
+ * grant row (#1345). Disabling an agent keeps its grants `active` (disable is
+ * reversible, so the standing consent survives), but no token resolves while
+ * the agent is non-active and client-level active-grant counts exclude the
+ * row. The API annotates each grant with `agent_status` so listings can tell
+ * a working connection from a dormant one; this chip renders that annotation.
+ *
+ * Lives in `shared/` because two sibling modules render grant rows (the
+ * agents module's "Connected clients" card and the settings module's
+ * client-detail Grants panel) and modules never import each other. The
+ * agent-status language is not re-derived: label text comes from the shared
+ * actor-status vocabulary (`STATUS_LABELS` / `toActorStatus` — the
+ * status-and-filter rule).
+ */
+import { STATUS_LABELS, toActorStatus } from '@/shared/ui/ActorStatusBadge';
+import { Tooltip } from '@/shared/ui/Tooltip';
+
+export interface GrantAgentStatusChipProps {
+	/** The grant's own lifecycle status (`active` | `revoked`). */
+	grantStatus: string;
+	/** The bound agent's lifecycle status, when the API annotated the row. */
+	agentStatus?: string | null;
+}
+
+/**
+ * Muted chip ("Agent disabled", "Agent archived", …) on an active grant whose
+ * agent is non-active, with a tooltip explaining the dormancy. Renders
+ * nothing on a working connection, on a revoked row (its own Revoked badge
+ * already explains it), or when the API omitted the annotation.
+ */
+export function GrantAgentStatusChip({ grantStatus, agentStatus }: GrantAgentStatusChipProps) {
+	if (grantStatus !== 'active' || agentStatus == null) return null;
+	const status = toActorStatus(agentStatus);
+	if (status === 'active') return null;
+	const label = STATUS_LABELS[status].toLowerCase();
+	return (
+		<Tooltip
+			content={
+				`This grant is dormant: no tokens are issued while the agent is ${label}, ` +
+				'and active-connection counts exclude it.' +
+				// Disable/Enable vocabulary: the reversible arm names its way back.
+				(status === 'disabled' ? ' Enable the agent to restore the connection.' : '')
+			}
+		>
+			<span className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 font-mono text-xs">
+				Agent {label}
+			</span>
+		</Tooltip>
+	);
+}

--- a/ui/src/shared/ui/__tests__/GrantAgentStatusChip.test.tsx
+++ b/ui/src/shared/ui/__tests__/GrantAgentStatusChip.test.tsx
@@ -1,0 +1,50 @@
+import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
+import { GrantAgentStatusChip } from '@/shared/ui/GrantAgentStatusChip';
+
+describe('GrantAgentStatusChip', () => {
+	it('marks an active grant on a disabled agent as dormant, with the why in the tooltip', async () => {
+		const { container } = renderWithProviders(
+			<GrantAgentStatusChip grantStatus="active" agentStatus="disabled" />,
+		);
+		// Disable/Enable vocabulary — never "deactivated".
+		expect(screen.getByText('Agent disabled')).toBeInTheDocument();
+		// The tooltip explains the dormancy AND why active counts exclude it,
+		// naming Enable as the way back (the reversible arm).
+		expect(
+			screen.getByText(
+				/no tokens are issued while the agent is disabled, and active-connection counts exclude it\. Enable the agent to restore the connection\./,
+			),
+		).toBeInTheDocument();
+		await checkA11y(container);
+	});
+
+	it('labels other non-active lifecycle states from the shared vocabulary', () => {
+		renderWithProviders(<GrantAgentStatusChip grantStatus="active" agentStatus="archived" />);
+		expect(screen.getByText('Agent archived')).toBeInTheDocument();
+		// Archive is not the reversible arm — no Enable hint.
+		expect(screen.queryByText(/Enable the agent/)).not.toBeInTheDocument();
+	});
+
+	it('renders nothing for a working connection (agent active)', () => {
+		renderWithProviders(<GrantAgentStatusChip grantStatus="active" agentStatus="active" />);
+		expect(screen.queryByText(/Agent /)).not.toBeInTheDocument();
+	});
+
+	it('renders nothing when the API omitted the annotation', () => {
+		renderWithProviders(<GrantAgentStatusChip grantStatus="active" agentStatus={null} />);
+		renderWithProviders(<GrantAgentStatusChip grantStatus="active" />);
+		expect(screen.queryByText(/Agent /)).not.toBeInTheDocument();
+	});
+
+	it('renders nothing on a revoked grant — its own badge already explains it', () => {
+		renderWithProviders(<GrantAgentStatusChip grantStatus="revoked" agentStatus="disabled" />);
+		expect(screen.queryByText('Agent disabled')).not.toBeInTheDocument();
+	});
+
+	it('normalizes an unknown agent status through the shared vocabulary (→ archived)', () => {
+		renderWithProviders(
+			<GrantAgentStatusChip grantStatus="active" agentStatus="totally-unknown" />,
+		);
+		expect(screen.getByText('Agent archived')).toBeInTheDocument();
+	});
+});

--- a/ui/src/shared/ui/index.ts
+++ b/ui/src/shared/ui/index.ts
@@ -167,6 +167,9 @@ export {
 } from '@/shared/ui/ActorStatusBadge';
 export type { ActorStatus } from '@/shared/ui/ActorStatusBadge';
 
+export { GrantAgentStatusChip } from '@/shared/ui/GrantAgentStatusChip';
+export type { GrantAgentStatusChipProps } from '@/shared/ui/GrantAgentStatusChip';
+
 export { ScopePicker } from '@/shared/ui/ScopePicker';
 export type { ScopePickerProps } from '@/shared/ui/ScopePicker';
 export { ScopeGroup } from '@/shared/ui/ScopeGroup';


### PR DESCRIPTION
## Summary

#1345 keeps a grant `active` (dormant) when its agent is disabled and annotates grant listings with `agent_status`, but the UI never consumed the field — a dormant grant still read as a working connection, and nothing explained why the roster's active-grant count excluded it. This PR picks up that handoff: grant rows now carry a muted "Agent disabled" (/ archived / …) chip, with a tooltip explaining the dormancy and the count exclusion.

## Changes

- `ui`: new shared primitive `GrantAgentStatusChip` (`src/shared/ui/`) — renders a muted chip on an ACTIVE grant whose agent is non-active, nothing otherwise. Labels come from the shared actor-status vocabulary (`STATUS_LABELS`/`toActorStatus`, status-and-filter rule); copy uses the Disable/Enable vocabulary ("Agent disabled", "Enable the agent to restore the connection" — never "deactivated"). Shared because both grant surfaces live in sibling modules that must agree.
- `ui` (settings): `ClientDetailSheet`'s Grants panel renders the chip from the wire `agent_status` (`OAuthGrantAdminResponse` is used directly there — no entity mapping layer to extend).
- `ui` (agents): `grantToEntity` now maps `agent_status → agentStatus` on `OAuthGrantEntity` (the exact gap flagged in the #1345 review — the field was dead payload), and `ConnectedClientsCard` renders the chip.
- `ui` (mocks): grant fixtures carry `agent_status`; the settings store gains a dormant seed grant (disabled agent) and computes `active_grant_count` honestly (dormant grants excluded), mirroring the #1345 backend.
- Out of scope: no backend/spec change (the generated client already carries the field on main — codegen is drift-free), and no new roster column — dormancy is a per-grant annotation, not a client-level state.

## Risk & rollback

- Low risk: presentational only — no API calls, auth surface, or mutation paths change; the chip renders nothing when `agent_status` is absent (older payloads degrade to today's behaviour).
- Revert the squash commit to roll back.

## Test plan

- New `GrantAgentStatusChip` suite (browser-mode vitest + axe): disabled → chip + tooltip, archived label, active/absent/revoked → nothing, unknown status normalizes via the shared vocabulary.
- `OAuthClientsSection.test.tsx` (page-level, via `SettingsPage`): dormant grant row shows "Agent disabled" + tooltip copy, working rows show none, roster grant count excludes the dormant row (2 of 3 active rows), axe on the open sheet.
- `ConnectedClientsCard.test.tsx`: dormant seeded grant shows the chip + Enable hint; the active-agent row shows none.
- Gates run in `ui/`: `npm run lint:fix` ✓, `npm run build` ✓, `npm run test:run` ✓ (132 files, 1223 tests passed), `npm run codegen` ✓ (no diff).

## Review guide

- Start with `src/shared/ui/GrantAgentStatusChip.tsx` (the whole behaviour); the two render sites and the entity mapping are one-liners; the rest is fixtures/tests.

Follow-up to #1345 (review flagged: "the UI does not render agent_status yet"). Builds on #1318/#1346 vocabulary.

Made with [Cursor](https://cursor.com)