### PR TITLE
chore(deps): bump brace-expansion for GHSA-mh99-v99m-4gvg / GHSA-rgw5-rvv9-x895

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3781,9 +3781,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4785,9 +4785,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## What

Lockfile-only transitive bump of both `brace-expansion` lineages in `ui/package-lock.json`:

- `1.1.x` → **1.1.18** (via `eslint-plugin-jsx-a11y` → `minimatch@3`)
- `5.0.x` → **5.0.9** (via `eslint-plugin-import-x` / `typescript-eslint` → `minimatch@10`)

## Why

High-severity DoS advisories: [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (unbounded expansion length → OOM crash) and [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (unbounded intermediate arrays bypassing the CVE-2026-14257 mitigation). Follow-up to #1356, which closed the js-yaml alert and surfaced this one.

All parents allow the patched versions, so no manifest or override changes — the diff is 12 lockfile lines, applied with `npx npm@11 audit fix` to avoid npm 10's lockfile-metadata churn.

## Verification

- `npm audit` → **0 vulnerabilities**
- `npm ls brace-expansion` → only 1.1.18 / 5.0.9
- `npm run lint` clean on tracked files, `npm run build` passes
- `npm run test:run` → 132 files, **1223/1223** browser-mode tests pass

Made with [Cursor](https://cursor.com)