### PR TITLE
feat(control): toolkit flattening, verified export, and the 6b acknowledgement sentinel (theme 5 phase 6a)

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -104,9 +104,53 @@ the Deprecations table.
   (`broker.direct_bindings_enabled: false`) and is removed in Phase 6b —
   adopt the credential headers now.
 - **Toolkit tables are still present.** The stored toolkit rows (bindings,
-  keys) survive this release; they are dropped in Phase 6b. The Phase 6a
-  export/acknowledge runbook — how to export the legacy toolkit data and
-  acknowledge the drop — lands in a release **before** the tables are removed.
+  keys) survive this release; they are dropped in Phase 6b. Before that
+  release you must run the Phase 6a export/flatten/acknowledge runbook below
+  — the Phase-6b drop migrations refuse to run until the acknowledgement is
+  on record.
+
+### Phase 6a runbook: export, flatten, verify, acknowledge
+
+Run these against **production data** (all commands read/write the live
+control + admin databases configured for the process). Order matters.
+
+1. **Export first**: `jentic_one export-toolkits --out toolkit-export.json`.
+   The file captures all five legacy tables (`toolkits`, `toolkit_keys`,
+   `toolkit_credential_bindings`, `toolkit_permission_rules`,
+   `agent_toolkit_bindings`) with row counts and dialect-neutral values. It
+   embeds key hash digests — store it like a secrets backup.
+2. *(Optional)* preview: `jentic_one flatten-toolkits --diff-only --report
+   preview.jsonl` writes the report without touching either database.
+3. **Flatten**: `jentic_one flatten-toolkits --report flatten.jsonl`. Every
+   `(agent, credential)` pair reachable through a toolkit gains a direct
+   binding carrying the pair's rules. Read the report: `rule_conflict` lines
+   are pairs whose toolkit paths disagreed — they were bound **default-deny**
+   (the safer outcome) and need a rules decision from you;
+   `inactive_toolkit_binding` lines are live access you may have believed
+   disabled (an inactive toolkit never gated bound agents) — they were
+   migrated, review them; `pooled_rule_drift` lines are pairs whose effective
+   rules narrowed from vendor-pooled to per-pair; `active_toolkit_key` lines
+   want `retire-toolkit-keys` (or a revoke) before 6b.
+4. **Double-run-and-diff** (the concurrency check — binds racing step 3 are
+   possible since OSS cannot quiesce the bind endpoints): run
+   `jentic_one flatten-toolkits` again and confirm it reports **zero
+   creations**. If it created rows, repeat until a run creates nothing.
+5. **Verify**: `jentic_one flatten-toolkits --verify` — recomputes the legacy
+   pair set and fails unless every pair exists as a direct binding (extra
+   hand-created bindings are fine). Rule-list divergence is reported, not
+   fatal.
+6. **Acknowledge**: `jentic_one flatten-toolkits --verify --acknowledge` —
+   records the sentinel row (`toolkit_flattening_acks`, control DB) that the
+   Phase-6b drop migrations require. It is refused unless the verification
+   passes in that same invocation.
+
+**Rollback after Phase 6b** is two steps, not one: downgrade the drop
+migrations **and then** `jentic_one export-toolkits --import
+toolkit-export.json`. A migration `downgrade()` recreates empty tables — it
+cannot restore rows — and restoring the toolkit path with empty
+`toolkit_permission_rules` is a **total default-deny authorization outage**
+for every agent on the legacy path. Do not flip
+`broker.direct_bindings_enabled` back off without re-importing.
 
 ## Deprecations
 

--- a/src/jentic_one/__main__.py
+++ b/src/jentic_one/__main__.py
@@ -24,6 +24,8 @@ from jentic_one.admin.services.errors import (
 )
 from jentic_one.auth.web.app import install_on_app as _install_auth_verifier
 from jentic_one.control.services.key_retirement import KeyRetirementService
+from jentic_one.control.services.toolkit_export import ToolkitExportError, ToolkitExportService
+from jentic_one.control.services.toolkit_flattening import Finding, ToolkitFlatteningService
 from jentic_one.shared.config import AppConfig, load_config
 from jentic_one.shared.context import Context
 from jentic_one.shared.logging import configure_logging
@@ -326,6 +328,124 @@ async def _retire_toolkit_keys(*, owner_email: str | None) -> int:
     return 0
 
 
+def _write_report(findings: list[Finding], report_path: str | None) -> None:
+    """Emit one JSON line per finding, to ``report_path`` or stdout."""
+    if report_path is None:
+        for finding in findings:
+            print(json.dumps(finding.as_dict()), flush=True)
+        return
+    with open(report_path, "w", encoding="utf-8") as fh:
+        for finding in findings:
+            fh.write(json.dumps(finding.as_dict()) + "\n")
+
+
+async def _flatten_toolkits(
+    *,
+    diff_only: bool,
+    report_path: str | None,
+    verify: bool,
+    acknowledge: bool,
+) -> int:
+    """Run the theme-5 Phase 6a flattening job (or its verify mode).
+
+    Default mode derives direct agent↔credential bindings from the toolkit
+    graph (idempotent — re-run and confirm zero creations, the
+    double-run-and-diff check). ``--verify`` runs the R-02 queries instead;
+    ``--verify --acknowledge`` additionally writes the sentinel row Phase
+    6b's drop migrations require. One JSONL report line per finding.
+    """
+    config = load_config()
+    configure_logging(config)
+
+    async with Context(config, allowed_dbs={"admin", "control"}) as ctx:
+        svc = ToolkitFlatteningService(ctx)
+        if verify:
+            result = await svc.verify(acknowledge=acknowledge)
+            _write_report(result.findings, report_path)
+            print(
+                f"==> verify {'PASSED' if result.passed else 'FAILED'}: "
+                f"{result.legacy_pair_count} legacy pair(s), "
+                f"{result.direct_binding_count} direct binding(s), "
+                f"{result.missing_pair_count} missing, "
+                f"{len(result.findings)} report line(s).",
+                file=sys.stderr,
+                flush=True,
+            )
+            if acknowledge:
+                print(
+                    "==> acknowledgement recorded — Phase 6b drops are unblocked."
+                    if result.acknowledged
+                    else "==> acknowledgement REFUSED: verification failed; run "
+                    "flatten-toolkits first, then re-verify.",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            return 0 if result.passed else 1
+
+        run = await svc.run(diff_only=diff_only)
+        _write_report(run.findings, report_path)
+        verb = "would create" if diff_only else "created"
+        print(
+            f"==> {run.pairs_total} legacy pair(s): {verb} {run.created} binding(s), "
+            f"{run.already_present} already present, {len(run.findings)} report line(s).",
+            file=sys.stderr,
+            flush=True,
+        )
+        if not diff_only:
+            print(
+                "==> Re-run this command and confirm it reports zero creations "
+                "(double-run-and-diff), then run with --verify.",
+                file=sys.stderr,
+                flush=True,
+            )
+    return 0
+
+
+async def _export_toolkits(*, out_path: str | None, import_path: str | None) -> int:
+    """Export the five legacy toolkit tables, or re-import an export file."""
+    config = load_config()
+    configure_logging(config)
+
+    async with Context(config, allowed_dbs={"admin", "control"}) as ctx:
+        svc = ToolkitExportService(ctx)
+        if import_path is not None:
+            try:
+                with open(import_path, encoding="utf-8") as fh:
+                    document = json.load(fh)
+            except (OSError, json.JSONDecodeError) as exc:
+                print(f"error: cannot read {import_path}: {exc}", file=sys.stderr)
+                return 2
+            try:
+                outcome = await svc.import_document(document)
+            except ToolkitExportError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+            for table in sorted(outcome.inserted):
+                print(
+                    f"==> {table}: {outcome.inserted[table]} inserted, "
+                    f"{outcome.skipped_existing[table]} already present.",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            return 0
+
+        document = await svc.export()
+        assert out_path is not None  # argparse enforces the either/or
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump(document, fh)
+            fh.write("\n")
+        counts = ", ".join(
+            f"{table}={body['row_count']}" for table, body in document["tables"].items()
+        )
+        print(
+            f"==> exported to {out_path} ({counts}). The file embeds key hash "
+            "digests — store it like a secrets backup.",
+            file=sys.stderr,
+            flush=True,
+        )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Dispatch CLI subcommands. With no subcommand, run the server."""
     parser = argparse.ArgumentParser(prog="jentic_one", description="jentic-one service CLI.")
@@ -367,6 +487,57 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
 
+    flatten = sub.add_parser(
+        "flatten-toolkits",
+        help=(
+            "Derive direct agent-credential bindings from the toolkit graph "
+            "(theme-5 Phase 6a; idempotent, operator-invoked)."
+        ),
+    )
+    flatten.add_argument(
+        "--diff-only",
+        action="store_true",
+        help="Report what a run would create without writing anything.",
+    )
+    flatten.add_argument(
+        "--report",
+        metavar="PATH",
+        help="Write the JSONL report here instead of stdout.",
+    )
+    flatten.add_argument(
+        "--verify",
+        action="store_true",
+        help=(
+            "Run the verification queries instead of flattening: every legacy "
+            "(agent, credential) pair must exist as a direct binding."
+        ),
+    )
+    flatten.add_argument(
+        "--acknowledge",
+        action="store_true",
+        help=(
+            "With --verify: record the operator acknowledgement that gates the "
+            "Phase-6b drop migrations. Refused unless the verification passes "
+            "in this same invocation."
+        ),
+    )
+
+    export_toolkits = sub.add_parser(
+        "export-toolkits",
+        help=(
+            "Export the five legacy toolkit tables to a re-importable JSON file "
+            "(theme-5 Phase 6a; the only row-restoring rollback after Phase 6b)."
+        ),
+    )
+    export_group = export_toolkits.add_mutually_exclusive_group(required=True)
+    export_group.add_argument("--out", metavar="PATH", help="Write the export file here.")
+    export_group.add_argument(
+        "--import",
+        dest="import_path",
+        metavar="PATH",
+        help="Re-import a previously exported file (idempotent by row id).",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "create-admin":
@@ -389,6 +560,23 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "retire-toolkit-keys":
         return asyncio.run(_retire_toolkit_keys(owner_email=args.owner))
+
+    if args.command == "flatten-toolkits":
+        if args.acknowledge and not args.verify:
+            flatten.error("--acknowledge requires --verify (it records a passed verification)")
+        if args.diff_only and args.verify:
+            flatten.error("--diff-only and --verify are mutually exclusive")
+        return asyncio.run(
+            _flatten_toolkits(
+                diff_only=args.diff_only,
+                report_path=args.report,
+                verify=args.verify,
+                acknowledge=args.acknowledge,
+            )
+        )
+
+    if args.command == "export-toolkits":
+        return asyncio.run(_export_toolkits(out_path=args.out, import_path=args.import_path))
 
     _serve()
     return 0

--- a/src/jentic_one/control/core/schema/__init__.py
+++ b/src/jentic_one/control/core/schema/__init__.py
@@ -18,6 +18,7 @@ from jentic_one.control.core.schema.permission_rule_sets import (
 from jentic_one.control.core.schema.sigv4_credentials import Sigv4Credential
 from jentic_one.control.core.schema.token_value_credentials import TokenValueCredential
 from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
+from jentic_one.control.core.schema.toolkit_flattening_acks import ToolkitFlatteningAck
 from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
 from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
 from jentic_one.control.core.schema.toolkits import Toolkit
@@ -40,6 +41,7 @@ __all__ = [
     "TokenValueCredential",
     "Toolkit",
     "ToolkitCredentialBinding",
+    "ToolkitFlatteningAck",
     "ToolkitKey",
     "ToolkitPermissionRule",
 ]

--- a/src/jentic_one/control/core/schema/toolkit_flattening_acks.py
+++ b/src/jentic_one/control/core/schema/toolkit_flattening_acks.py
@@ -1,0 +1,55 @@
+"""ToolkitFlatteningAck ORM model — the Phase-6a acknowledgement sentinel.
+
+Theme-5 Phase 6b's drop migrations destroy the five legacy toolkit tables.
+That is only safe once an operator has run the Phase-6a flattening job
+against the *production* data, its verification queries passed (every legacy
+``(agent, credential)`` pair exists as a direct ``agent_credential_bindings``
+row), and the operator explicitly acknowledged the result. This table records
+exactly that: one row per acknowledged verification run, written **only** by
+``jentic_one flatten-toolkits --verify --acknowledge`` and only when the
+verification passed in that same invocation.
+
+Phase 6b's drop migrations must ``SELECT count(*) FROM
+toolkit_flattening_acks`` and **raise** — not skip — when the table is empty
+(guard-and-raise, mirroring the enterprise FK-ordering guard). The row
+carries the counts the verification printed and the tool version that
+produced them, so the migration note can cite them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from jentic_one.shared.db.base import AuditableMixin, ControlBase
+from jentic_one.shared.db.ids import generate_ksuid
+from jentic_one.shared.db.types import UTCDateTime
+
+
+class ToolkitFlatteningAck(AuditableMixin, ControlBase):
+    """One acknowledged Phase-6a verification run (see module docstring)."""
+
+    __tablename__ = "toolkit_flattening_acks"
+
+    id: Mapped[str] = mapped_column(
+        String(30),
+        primary_key=True,
+        default=lambda: generate_ksuid("tfa"),
+        server_default=func.generate_ksuid("tfa"),
+    )
+    #: When the operator acknowledged (the --acknowledge invocation's clock).
+    acknowledged_at: Mapped[datetime] = mapped_column(UTCDateTime(), nullable=False)
+    #: count(distinct (agent_id, credential_id)) over the legacy toolkit join
+    #: (agent_toolkit_bindings ⋈ toolkit_credential_bindings, dangling rows
+    #: excluded) at verification time.
+    legacy_pair_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    #: count(*) from agent_credential_bindings at verification time.
+    direct_binding_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    #: Number of report findings the verification emitted (rule mismatches
+    #: and the like — informational, not blocking).
+    report_finding_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    #: jentic-one package version that ran the verification.
+    tool_version: Mapped[str] = mapped_column(String(50), nullable=False)

--- a/src/jentic_one/control/repos/toolkit_export_repo.py
+++ b/src/jentic_one/control/repos/toolkit_export_repo.py
@@ -1,0 +1,104 @@
+"""Repository for the theme-5 Phase 6a toolkit export/import job (P-01).
+
+Control-side inserts go through the ORM models (Python-side KSUID defaults
+are irrelevant here — exported rows carry their original ids), so one code
+path serves both dialects. The admin-side ``agent_toolkit_bindings`` table
+is raw SQL for the same module-boundary reason as
+``FlatteningAdminRepository``.
+
+Import is idempotent by primary key: rows whose id already exists are
+skipped, so a re-run after a partial failure (control committed, admin
+crashed) completes the missing side without duplicating the other.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
+from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
+from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
+from jentic_one.control.core.schema.toolkits import Toolkit
+from jentic_one.control.repos.toolkit_flattening_repo import _bind_ts
+
+_CONTROL_MODELS: dict[str, type[Any]] = {
+    "toolkits": Toolkit,
+    "toolkit_keys": ToolkitKey,
+    "toolkit_credential_bindings": ToolkitCredentialBinding,
+    "toolkit_permission_rules": ToolkitPermissionRule,
+}
+
+
+class ExportControlRepository:
+    """Control-DB export/import statements — flush-only, never commits."""
+
+    @staticmethod
+    async def existing_ids(session: AsyncSession, table: str) -> set[str]:
+        model = _CONTROL_MODELS[table]
+        result = await session.execute(select(model.id))
+        return {str(i) for i in result.scalars().all()}
+
+    @staticmethod
+    async def insert_rows(session: AsyncSession, table: str, rows: list[dict[str, Any]]) -> None:
+        """Insert exported rows verbatim (ids, timestamps, and all)."""
+        model = _CONTROL_MODELS[table]
+        for row in rows:
+            session.add(model(**row))
+        await session.flush()
+
+
+_LIST_ATB_FULL = text(
+    "SELECT id, agent_id, toolkit_id, bound_at, created_at, updated_at, created_by"
+    " FROM agent_toolkit_bindings ORDER BY id"
+)
+
+_LIST_ATB_IDS = text("SELECT id FROM agent_toolkit_bindings")
+
+_INSERT_ATB_FULL = text(
+    "INSERT INTO agent_toolkit_bindings"
+    " (id, agent_id, toolkit_id, bound_at, created_at, updated_at, created_by)"
+    " VALUES (:id, :agent_id, :toolkit_id, :bound_at, :created_at, :updated_at, :created_by)"
+)
+
+
+class ExportAdminRepository:
+    """Admin-DB export/import statements for ``agent_toolkit_bindings``."""
+
+    @staticmethod
+    async def list_rows(session: AsyncSession) -> list[Any]:
+        """Every binding row, raw (the service owns serialization)."""
+        return list((await session.execute(_LIST_ATB_FULL)).all())
+
+    @staticmethod
+    async def existing_ids(session: AsyncSession) -> set[str]:
+        result = await session.execute(_LIST_ATB_IDS)
+        return {str(i) for i in result.scalars().all()}
+
+    @staticmethod
+    async def insert_row(
+        session: AsyncSession,
+        *,
+        id: str,
+        agent_id: str,
+        toolkit_id: str,
+        bound_at: dt.datetime,
+        created_at: dt.datetime,
+        updated_at: dt.datetime,
+        created_by: str | None,
+    ) -> None:
+        await session.execute(
+            _INSERT_ATB_FULL,
+            {
+                "id": id,
+                "agent_id": agent_id,
+                "toolkit_id": toolkit_id,
+                "bound_at": _bind_ts(session, bound_at),
+                "created_at": _bind_ts(session, created_at),
+                "updated_at": _bind_ts(session, updated_at),
+                "created_by": created_by,
+            },
+        )

--- a/src/jentic_one/control/repos/toolkit_flattening_repo.py
+++ b/src/jentic_one/control/repos/toolkit_flattening_repo.py
@@ -1,0 +1,256 @@
+"""Repositories for the theme-5 Phase 6a toolkit-flattening job.
+
+Two halves, mirroring the Phase-4 key-retirement seam
+(``control/repos/key_retirement_repo.py``):
+
+- :class:`FlatteningControlRepository` — ORM reads over the control-DB
+  legacy tables (``toolkits``, ``toolkit_credential_bindings``,
+  ``toolkit_permission_rules``, ``toolkit_keys``), the direct-model rule
+  tables the verification compares against, and the acknowledgement
+  sentinel insert.
+- :class:`FlatteningAdminRepository` — raw-SQL statements against the
+  **admin** DB (``agent_toolkit_bindings`` reads, actor existence checks,
+  ``agent_credential_bindings`` reads/inserts, scope-grant reads). The
+  control module must not import admin ORM models, so — like
+  ``KeyRetirementRepository`` — every admin-side statement is raw SQL.
+
+Timestamps crossing the raw-SQL seam are normalized by ``_as_utc``: asyncpg
+returns aware datetimes, aiosqlite returns naive strings; both sides of the
+job need aware-UTC values. Writes bind naive-UTC strings on SQLite (matching
+SQLAlchemy's own storage format so ORM reads keep parsing) and aware
+datetimes on Postgres.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from jentic_one.control.core.schema.agent_permission_rules import AgentPermissionRule
+from jentic_one.control.core.schema.credentials import Credential
+from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
+from jentic_one.control.core.schema.toolkit_flattening_acks import ToolkitFlatteningAck
+from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
+from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
+from jentic_one.control.core.schema.toolkits import Toolkit
+from jentic_one.shared.db.ids import generate_ksuid
+
+#: Provenance stamp for every row the flattening job derives — mirrors the
+#: Phase-4 ``system:theme5-key-retirement`` convention.
+SYSTEM_ACTOR = "system:theme5-flattening"
+
+
+def _as_utc(value: dt.datetime | str | None) -> dt.datetime | None:
+    """Normalize a raw-SQL timestamp to an aware-UTC datetime.
+
+    asyncpg returns aware datetimes; aiosqlite returns the naive string
+    SQLAlchemy stored. Naive values are assumed UTC (the ``UTCDateTime``
+    write-side convention).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = dt.datetime.fromisoformat(value)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.UTC)
+    return value.astimezone(dt.UTC)
+
+
+def _bind_ts(session: AsyncSession, value: dt.datetime) -> dt.datetime | str:
+    """Bind parameter form of a timestamp for raw SQL on this session's dialect.
+
+    SQLite gets the naive-UTC string format SQLAlchemy itself stores (so ORM
+    reads keep parsing the column); Postgres gets the aware datetime.
+    """
+    if session.get_bind().dialect.name == "sqlite":
+        return value.astimezone(dt.UTC).replace(tzinfo=None).strftime("%Y-%m-%d %H:%M:%S.%f")
+    return value
+
+
+class FlatteningControlRepository:
+    """Control-DB reads for the flattening job — flush-only, never commits."""
+
+    @staticmethod
+    async def list_toolkits(session: AsyncSession) -> list[Toolkit]:
+        result = await session.execute(select(Toolkit).order_by(Toolkit.id))
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def list_credential_bindings(session: AsyncSession) -> list[ToolkitCredentialBinding]:
+        result = await session.execute(
+            select(ToolkitCredentialBinding).order_by(ToolkitCredentialBinding.id)
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def list_permission_rules(session: AsyncSession) -> list[ToolkitPermissionRule]:
+        """Every legacy rule row, in per-pair evaluation order.
+
+        Ordered ``(toolkit_id, credential_id, is_system, sequence)`` — the
+        same order ``ToolkitPermissionRepository.list_rules`` serves a single
+        pair in, so grouping by pair preserves evaluation order.
+        """
+        result = await session.execute(
+            select(ToolkitPermissionRule).order_by(
+                ToolkitPermissionRule.toolkit_id,
+                ToolkitPermissionRule.credential_id,
+                ToolkitPermissionRule.is_system.asc(),
+                ToolkitPermissionRule.sequence.asc(),
+            )
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def list_toolkit_keys(session: AsyncSession) -> list[ToolkitKey]:
+        result = await session.execute(select(ToolkitKey).order_by(ToolkitKey.id))
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def list_credentials(session: AsyncSession) -> list[Credential]:
+        result = await session.execute(select(Credential).order_by(Credential.id))
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def list_inline_rules(
+        session: AsyncSession, *, agent_id: str, credential_id: str
+    ) -> list[AgentPermissionRule]:
+        """A direct binding's inline rules, in evaluation order (verification read)."""
+        result = await session.execute(
+            select(AgentPermissionRule)
+            .where(
+                AgentPermissionRule.agent_id == agent_id,
+                AgentPermissionRule.credential_id == credential_id,
+            )
+            .order_by(
+                AgentPermissionRule.is_system.asc(),
+                AgentPermissionRule.sequence.asc(),
+            )
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def record_acknowledgement(
+        session: AsyncSession,
+        *,
+        acknowledged_at: dt.datetime,
+        legacy_pair_count: int,
+        direct_binding_count: int,
+        report_finding_count: int,
+        tool_version: str,
+    ) -> ToolkitFlatteningAck:
+        """Insert the Phase-6b gate row — only call after a passed verification."""
+        ack = ToolkitFlatteningAck(
+            acknowledged_at=acknowledged_at,
+            legacy_pair_count=legacy_pair_count,
+            direct_binding_count=direct_binding_count,
+            report_finding_count=report_finding_count,
+            tool_version=tool_version,
+            created_by=SYSTEM_ACTOR,
+        )
+        session.add(ack)
+        await session.flush()
+        return ack
+
+
+_LIST_AGENT_TOOLKIT_BINDINGS = text(
+    "SELECT id, agent_id, toolkit_id, bound_at FROM agent_toolkit_bindings ORDER BY id"
+)
+
+_LIST_CREDENTIAL_BINDING_PAIRS = text(
+    "SELECT agent_id, credential_id, rule_set_id FROM agent_credential_bindings"
+)
+
+_COUNT_CREDENTIAL_BINDINGS = text("SELECT count(*) AS n FROM agent_credential_bindings")
+
+_LIST_AGENT_IDS = text("SELECT id FROM agents")
+
+_LIST_SERVICE_ACCOUNT_IDS = text("SELECT id FROM service_accounts")
+
+_LIST_SCOPES_FOR_ACTORS = text(
+    "SELECT actor_id, scope FROM actor_scope_grants ORDER BY actor_id, scope"
+)
+
+_INSERT_CREDENTIAL_BINDING = text(
+    "INSERT INTO agent_credential_bindings"
+    " (id, agent_id, credential_id, rule_set_id, bound_at, created_by)"
+    " VALUES (:id, :agent_id, :credential_id, :rule_set_id, :bound_at, :created_by)"
+    " ON CONFLICT (agent_id, credential_id) DO NOTHING"
+)
+
+
+class FlatteningAdminRepository:
+    """Admin-DB statements for the flattening job — raw SQL, flush-only."""
+
+    @staticmethod
+    async def list_agent_toolkit_bindings(
+        session: AsyncSession,
+    ) -> list[tuple[str, str, str, dt.datetime | None]]:
+        """Every legacy actor↔toolkit binding: (id, agent_id, toolkit_id, bound_at)."""
+        rows = (await session.execute(_LIST_AGENT_TOOLKIT_BINDINGS)).all()
+        return [(str(r.id), str(r.agent_id), str(r.toolkit_id), _as_utc(r.bound_at)) for r in rows]
+
+    @staticmethod
+    async def list_direct_binding_pairs(
+        session: AsyncSession,
+    ) -> dict[tuple[str, str], str | None]:
+        """Existing direct bindings: {(agent_id, credential_id): rule_set_id}."""
+        rows = (await session.execute(_LIST_CREDENTIAL_BINDING_PAIRS)).all()
+        return {
+            (str(r.agent_id), str(r.credential_id)): (
+                str(r.rule_set_id) if r.rule_set_id is not None else None
+            )
+            for r in rows
+        }
+
+    @staticmethod
+    async def count_direct_bindings(session: AsyncSession) -> int:
+        row = (await session.execute(_COUNT_CREDENTIAL_BINDINGS)).one()
+        return int(row.n)
+
+    @staticmethod
+    async def list_actor_ids(session: AsyncSession) -> set[str]:
+        """Every id an ``agent_toolkit_bindings.agent_id`` may legitimately hold."""
+        agents = (await session.execute(_LIST_AGENT_IDS)).scalars().all()
+        service_accounts = (await session.execute(_LIST_SERVICE_ACCOUNT_IDS)).scalars().all()
+        return {str(i) for i in agents} | {str(i) for i in service_accounts}
+
+    @staticmethod
+    async def list_scopes_by_actor(session: AsyncSession) -> dict[str, list[str]]:
+        """All scope grants grouped by actor id (converted-identity report read)."""
+        rows = (await session.execute(_LIST_SCOPES_FOR_ACTORS)).all()
+        scopes: dict[str, list[str]] = {}
+        for row in rows:
+            scopes.setdefault(str(row.actor_id), []).append(str(row.scope))
+        return scopes
+
+    @staticmethod
+    async def insert_credential_binding(
+        session: AsyncSession,
+        *,
+        agent_id: str,
+        credential_id: str,
+        rule_set_id: str | None,
+        bound_at: dt.datetime,
+    ) -> str:
+        """Insert one derived direct binding; return its id.
+
+        Idempotent via the natural unique constraint
+        (``uq_agent_credential_bindings_agent_credential``) — the service
+        checks pair existence first, ON CONFLICT DO NOTHING is the belt for
+        a bind racing the job (double-run-and-diff catches the rules side).
+        """
+        binding_id = generate_ksuid("acb")
+        await session.execute(
+            _INSERT_CREDENTIAL_BINDING,
+            {
+                "id": binding_id,
+                "agent_id": agent_id,
+                "credential_id": credential_id,
+                "rule_set_id": rule_set_id,
+                "bound_at": _bind_ts(session, bound_at),
+                "created_by": SYSTEM_ACTOR,
+            },
+        )
+        return binding_id

--- a/src/jentic_one/control/services/toolkit_export.py
+++ b/src/jentic_one/control/services/toolkit_export.py
@@ -1,0 +1,247 @@
+"""Theme-5 Phase 6a — verified toolkit export/import (P-01).
+
+Exports all five legacy toolkit tables — ``toolkits``, ``toolkit_keys``,
+``toolkit_credential_bindings``, ``toolkit_permission_rules`` (control DB)
+and ``agent_toolkit_bindings`` (admin DB) — to one self-describing JSON
+document the **same job re-imports** (``export-toolkits --import``). This is
+the only row-restoring rollback path once Phase 6b drops the tables: a
+migration ``downgrade()`` recreates empty schemas, and a rules-empty restore
+is a total default-deny authorization outage, so the runbook is *downgrade
+the drops, then re-import this file*.
+
+Format (schema_version 1): dialect-neutral JSON — KSUID strings, ISO-8601
+timestamps (aware UTC), booleans, JSON lists, nulls — with per-table row
+counts so a truncated file fails validation instead of silently restoring a
+subset. The file embeds key hash digests (``hashed_key``, ``lookup_hash``);
+treat it like a secrets backup.
+
+Import is idempotent by primary key (rows whose id exists are skipped), so a
+re-run after a partial failure — control committed, admin crashed — completes
+the missing side without duplicating the other.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from typing import Any
+
+import structlog
+
+from jentic_one import __version__
+from jentic_one.control.repos.toolkit_export_repo import (
+    ExportAdminRepository,
+    ExportControlRepository,
+)
+from jentic_one.control.repos.toolkit_flattening_repo import FlatteningControlRepository
+from jentic_one.shared.context import Context
+
+logger = structlog.get_logger(__name__)
+
+EXPORT_FORMAT = "jentic-one-toolkit-export"
+SCHEMA_VERSION = 1
+
+#: Exported columns per table, fixed per schema_version — a column added
+#: later bumps the version rather than silently changing the file shape.
+_COLUMNS: dict[str, tuple[str, ...]] = {
+    "toolkits": ("id", "name", "description", "active", "created_at", "updated_at", "created_by"),
+    "toolkit_keys": (
+        "id",
+        "toolkit_id",
+        "label",
+        "allowed_ips",
+        "revoked",
+        "key_preview",
+        "hashed_key",
+        "lookup_hash",
+        "last_used_at",
+        "migrated_actor_id",
+        "created_at",
+        "updated_at",
+        "created_by",
+    ),
+    "toolkit_credential_bindings": (
+        "id",
+        "toolkit_id",
+        "credential_id",
+        "bound_at",
+        "created_at",
+        "updated_at",
+        "created_by",
+    ),
+    "toolkit_permission_rules": (
+        "id",
+        "toolkit_id",
+        "credential_id",
+        "effect",
+        "methods",
+        "path",
+        "match_mode",
+        "operations",
+        "is_system",
+        "comment",
+        "sequence",
+        "created_at",
+        "updated_at",
+        "created_by",
+    ),
+    "agent_toolkit_bindings": (
+        "id",
+        "agent_id",
+        "toolkit_id",
+        "bound_at",
+        "created_at",
+        "updated_at",
+        "created_by",
+    ),
+}
+
+_DATETIME_COLUMNS = frozenset({"created_at", "updated_at", "bound_at", "last_used_at"})
+
+#: Control-table import order — parents before FK children.
+_CONTROL_TABLE_ORDER = (
+    "toolkits",
+    "toolkit_keys",
+    "toolkit_credential_bindings",
+    "toolkit_permission_rules",
+)
+
+
+def _serialize(table: str, row: Any) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for column in _COLUMNS[table]:
+        value = getattr(row, column)
+        if isinstance(value, dt.datetime):
+            if value.tzinfo is None:  # raw-SQL SQLite reads come back naive UTC
+                value = value.replace(tzinfo=dt.UTC)
+            value = value.astimezone(dt.UTC).isoformat()
+        elif isinstance(value, str) and column in _DATETIME_COLUMNS:
+            parsed = dt.datetime.fromisoformat(value)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=dt.UTC)
+            value = parsed.astimezone(dt.UTC).isoformat()
+        out[column] = value
+    return out
+
+
+def _deserialize(table: str, row: dict[str, Any]) -> dict[str, Any]:
+    unexpected = set(row) - set(_COLUMNS[table])
+    if unexpected:
+        raise ToolkitExportError(f"{table}: unexpected columns {sorted(unexpected)}")
+    out: dict[str, Any] = {}
+    for column in _COLUMNS[table]:
+        value = row.get(column)
+        if column in _DATETIME_COLUMNS and isinstance(value, str):
+            parsed = dt.datetime.fromisoformat(value)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=dt.UTC)
+            value = parsed.astimezone(dt.UTC)
+        out[column] = value
+    return out
+
+
+class ToolkitExportError(ValueError):
+    """A malformed or version-mismatched export document."""
+
+
+@dataclass
+class ImportOutcome:
+    """Per-table row counts of one import run."""
+
+    inserted: dict[str, int] = field(default_factory=dict)
+    skipped_existing: dict[str, int] = field(default_factory=dict)
+
+
+class ToolkitExportService:
+    """Exports and re-imports the five doomed toolkit tables."""
+
+    def __init__(self, ctx: Context) -> None:
+        self._ctx = ctx
+
+    async def export(self) -> dict[str, Any]:
+        """Read both databases and return the schema-versioned document."""
+        async with self._ctx.control_db.session() as session:
+            control_rows: dict[str, list[Any]] = {
+                "toolkits": await FlatteningControlRepository.list_toolkits(session),
+                "toolkit_keys": await FlatteningControlRepository.list_toolkit_keys(session),
+                "toolkit_credential_bindings": (
+                    await FlatteningControlRepository.list_credential_bindings(session)
+                ),
+                "toolkit_permission_rules": (
+                    await FlatteningControlRepository.list_permission_rules(session)
+                ),
+            }
+        async with self._ctx.admin_db.session() as session:
+            admin_rows = await ExportAdminRepository.list_rows(session)
+
+        tables: dict[str, dict[str, Any]] = {}
+        for table, rows in {**control_rows, "agent_toolkit_bindings": admin_rows}.items():
+            serialized = [_serialize(table, row) for row in rows]
+            tables[table] = {"row_count": len(serialized), "rows": serialized}
+
+        logger.info(
+            "toolkit_export",
+            **{table: body["row_count"] for table, body in tables.items()},
+        )
+        return {
+            "format": EXPORT_FORMAT,
+            "schema_version": SCHEMA_VERSION,
+            "exported_at": dt.datetime.now(dt.UTC).isoformat(),
+            "tool_version": __version__,
+            "tables": tables,
+        }
+
+    async def import_document(self, document: dict[str, Any]) -> ImportOutcome:
+        """Re-insert an exported document's rows (idempotent by primary key)."""
+        self._validate(document)
+        tables = document["tables"]
+        outcome = ImportOutcome()
+
+        async with self._ctx.control_db.transaction() as session:
+            for table in _CONTROL_TABLE_ORDER:
+                rows = [_deserialize(table, row) for row in tables[table]["rows"]]
+                existing = await ExportControlRepository.existing_ids(session, table)
+                missing = [row for row in rows if row["id"] not in existing]
+                await ExportControlRepository.insert_rows(session, table, missing)
+                outcome.inserted[table] = len(missing)
+                outcome.skipped_existing[table] = len(rows) - len(missing)
+
+        async with self._ctx.admin_db.transaction() as session:
+            table = "agent_toolkit_bindings"
+            rows = [_deserialize(table, row) for row in tables[table]["rows"]]
+            existing = await ExportAdminRepository.existing_ids(session)
+            inserted = 0
+            for row in rows:
+                if row["id"] in existing:
+                    continue
+                await ExportAdminRepository.insert_row(session, **row)
+                inserted += 1
+            outcome.inserted[table] = inserted
+            outcome.skipped_existing[table] = len(rows) - inserted
+
+        logger.info("toolkit_import", inserted=outcome.inserted, skipped=outcome.skipped_existing)
+        return outcome
+
+    @staticmethod
+    def _validate(document: dict[str, Any]) -> None:
+        if document.get("format") != EXPORT_FORMAT:
+            raise ToolkitExportError(
+                f"not a {EXPORT_FORMAT} document (format={document.get('format')!r})"
+            )
+        if document.get("schema_version") != SCHEMA_VERSION:
+            raise ToolkitExportError(
+                f"unsupported schema_version {document.get('schema_version')!r}; "
+                f"this build reads version {SCHEMA_VERSION}"
+            )
+        tables = document.get("tables")
+        if not isinstance(tables, dict):
+            raise ToolkitExportError("missing tables object")
+        for table in _COLUMNS:
+            body = tables.get(table)
+            if not isinstance(body, dict) or not isinstance(body.get("rows"), list):
+                raise ToolkitExportError(f"missing table {table!r}")
+            if body.get("row_count") != len(body["rows"]):
+                raise ToolkitExportError(
+                    f"{table}: row_count {body.get('row_count')!r} does not match "
+                    f"{len(body['rows'])} rows — truncated or edited file"
+                )

--- a/src/jentic_one/control/services/toolkit_flattening.py
+++ b/src/jentic_one/control/services/toolkit_flattening.py
@@ -1,0 +1,730 @@
+"""Theme-5 Phase 6a — the toolkit-flattening job (no drops).
+
+Derives direct ``agent_credential_bindings`` rows (plus shared
+``permission_rule_sets``) from the legacy toolkit graph: every
+``(agent, credential)`` pair reachable via ``agent_toolkit_bindings ⋈
+toolkit_credential_bindings`` gains a direct binding carrying the pair's
+effective rules from ``toolkit_permission_rules``. Output is shaped exactly
+like a hand-created binding (same tables, same rule-set indirection), so the
+broker's direct path serves flattened and hand-made pairs identically.
+
+Semantics for the two ways the legacy model cannot be flattened soundly
+(theme plan, hard problem 2):
+
+- **Same-pair rule conflicts** — a pair reachable via two toolkits whose
+  per-pair rule lists diverge has no correct automatic merge (ordered
+  first-match-wins lists). The job prefers the SAFER outcome: the binding is
+  created **default-deny** (no rule set, no inline rules) and a
+  ``rule_conflict`` report line embeds every contributing list verbatim for
+  the operator to resolve.
+- **Pooled-vs-per-pair drift** — the legacy broker pooled rules per
+  ``(toolkit, api_vendor)``, so a vendor-wide rule authored on one binding
+  also governed sibling same-vendor credentials. The direct model is strictly
+  per-pair. The job writes the per-pair list (the target model) and emits a
+  ``pooled_rule_drift`` line wherever the pooled list differs, embedding both
+  lists verbatim.
+
+Ordering and idempotency: rules are written **control-first**, bindings
+**admin-last**, so a crash mid-run leaves orphan rule sets — never a live
+rule-less binding — and a re-run skips pairs that already exist (the natural
+``UNIQUE (agent_id, credential_id)`` on the binding). Quiescing bind/unbind
+is not practical in OSS, so concurrency is handled by double-run-and-diff:
+run the job, run it again, and assert the second run reports zero creations
+(``--diff-only`` previews without writing).
+
+Bindings reachable only through **inactive** toolkits are live access on the
+legacy path (``toolkits.active`` never gated bound agents) — they are
+migrated like any other pair AND reported loudly, never skipped.
+
+Operator-invoked only (``jentic_one flatten-toolkits``): unlike the Phase-4
+key retirement there is no startup one-shot, because Phase 6b's drops are
+gated on an explicit operator acknowledgement (``--verify --acknowledge``
+writes the ``toolkit_flattening_acks`` sentinel row 6b's migrations check).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from jentic_one import __version__
+from jentic_one.control.repos.permission_rule_set_repo import PermissionRuleSetRepository
+from jentic_one.control.repos.toolkit_flattening_repo import (
+    SYSTEM_ACTOR,
+    FlatteningAdminRepository,
+    FlatteningControlRepository,
+)
+from jentic_one.shared.audit import record_audit
+from jentic_one.shared.context import Context
+from jentic_one.shared.models.audit import AuditAction, AuditTargetType
+
+if TYPE_CHECKING:
+    from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
+
+logger = structlog.get_logger(__name__)
+
+#: ``audit_entries.actor_type`` value for job-derived writes. Not a member of
+#: ``ActorType`` (jobs are not authenticated actors); the audit read surface
+#: treats the column as an opaque string.
+_AUDIT_ACTOR_TYPE = "system:job"
+
+#: The only scope a converted ``jntc_live_`` holder should carry (Phase 4).
+_EXECUTE_SCOPE = "capabilities:execute"
+
+
+def _iso(value: dt.datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _rule_row(rule: ToolkitPermissionRule | Any) -> dict[str, Any]:
+    """One legacy rule row, verbatim — report lines must survive the drop."""
+    return {
+        "id": rule.id,
+        "toolkit_id": rule.toolkit_id,
+        "credential_id": rule.credential_id,
+        "effect": rule.effect,
+        "methods": rule.methods,
+        "path": rule.path,
+        "match_mode": rule.match_mode,
+        "operations": rule.operations,
+        "is_system": rule.is_system,
+        "comment": rule.comment,
+        "sequence": rule.sequence,
+        "created_at": _iso(rule.created_at),
+        "created_by": rule.created_by,
+    }
+
+
+def _rule_semantics(rule: Any) -> tuple[Any, ...]:
+    """The fields rule evaluation reads — the equality key for conflict checks."""
+    return (
+        rule.effect,
+        tuple(rule.methods) if rule.methods is not None else None,
+        rule.path,
+        rule.match_mode,
+        tuple(rule.operations) if rule.operations is not None else None,
+    )
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One JSONL report line: a category plus its category-specific payload."""
+
+    category: str
+    detail: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"category": self.category, **self.detail}
+
+
+@dataclass
+class FlatteningRunResult:
+    """Outcome of one flattening run (or ``--diff-only`` preview)."""
+
+    diff_only: bool
+    pairs_total: int = 0
+    created: int = 0
+    already_present: int = 0
+    findings: list[Finding] = field(default_factory=list)
+
+
+@dataclass
+class VerificationResult:
+    """Outcome of ``--verify`` (R-02): counts, coverage, and report lines."""
+
+    passed: bool
+    legacy_pair_count: int
+    direct_binding_count: int
+    missing_pair_count: int
+    findings: list[Finding] = field(default_factory=list)
+    acknowledged: bool = False
+
+
+@dataclass
+class _Path:
+    """One toolkit route from an agent to a credential."""
+
+    toolkit_id: str
+    toolkit_name: str
+    toolkit_active: bool
+    atb_id: str
+    tcb_id: str
+    bound_at: dt.datetime | None  # max(atb.bound_at, tcb.bound_at) for this path
+    rules: list[Any]  # per-pair ToolkitPermissionRule rows, evaluation order
+    pooled_rules: list[Any]  # (toolkit, vendor) pooled rows, broker order
+
+
+@dataclass
+class _Snapshot:
+    """Everything the job reads, loaded once per run from both databases."""
+
+    toolkits: dict[str, Any]
+    credentials: dict[str, Any]
+    pair_rules: dict[tuple[str, str], list[Any]]
+    pooled_rules: dict[tuple[str, str], list[Any]]
+    tcb_rows: list[Any]
+    atb_rows: list[tuple[str, str, str, dt.datetime | None]]
+    toolkit_keys: list[Any]
+    actor_ids: set[str]
+    existing_pairs: dict[tuple[str, str], str | None]
+    scopes_by_actor: dict[str, list[str]]
+
+
+@dataclass
+class _DerivedPair:
+    """One (agent, credential) pair with every toolkit path that reaches it."""
+
+    agent_id: str
+    credential_id: str
+    paths: list[_Path] = field(default_factory=list)
+
+    @property
+    def conflicting(self) -> bool:
+        """True when the contributing per-pair rule lists diverge."""
+        distinct = {tuple(_rule_semantics(r) for r in p.rules) for p in self.paths}
+        return len(distinct) > 1
+
+    @property
+    def target_rules(self) -> list[Any]:
+        """The rule list the direct binding gets: the identical contributors'
+        list, or empty (default-deny, the safer outcome) on conflict."""
+        if self.conflicting:
+            return []
+        return self.paths[0].rules
+
+    @property
+    def source_path(self) -> _Path:
+        """Deterministic provenance path: the lowest toolkit id."""
+        return min(self.paths, key=lambda p: p.toolkit_id)
+
+    @property
+    def bound_at(self) -> dt.datetime:
+        """max(source rows' timestamps) across every contributing path."""
+        stamps = [p.bound_at for p in self.paths if p.bound_at is not None]
+        return max(stamps) if stamps else dt.datetime.now(dt.UTC)
+
+
+def _rule_set_name(toolkit_id: str, credential_id: str) -> str:
+    """Deterministic per-source-pair name — the job's control-side idempotency key."""
+    return f"theme5-flattening:{toolkit_id}:{credential_id}"
+
+
+class ToolkitFlatteningService:
+    """Orchestrates the flattening run across the control and admin databases."""
+
+    def __init__(self, ctx: Context) -> None:
+        self._ctx = ctx
+
+    async def _load_snapshot(self) -> _Snapshot:
+        """One coherent read of both databases (torn reads against live binds
+        are handled by the double-run-and-diff runbook, not by locking)."""
+        async with self._ctx.control_db.session() as control_session:
+            toolkits = await FlatteningControlRepository.list_toolkits(control_session)
+            credentials = await FlatteningControlRepository.list_credentials(control_session)
+            tcb_rows = await FlatteningControlRepository.list_credential_bindings(control_session)
+            rules = await FlatteningControlRepository.list_permission_rules(control_session)
+            toolkit_keys = await FlatteningControlRepository.list_toolkit_keys(control_session)
+
+        async with self._ctx.admin_db.session() as admin_session:
+            atb_rows = await FlatteningAdminRepository.list_agent_toolkit_bindings(admin_session)
+            actor_ids = await FlatteningAdminRepository.list_actor_ids(admin_session)
+            existing_pairs = await FlatteningAdminRepository.list_direct_binding_pairs(
+                admin_session
+            )
+            scopes_by_actor = await FlatteningAdminRepository.list_scopes_by_actor(admin_session)
+
+        toolkit_map = {t.id: t for t in toolkits}
+        credential_map = {c.id: c for c in credentials}
+
+        pair_rules: dict[tuple[str, str], list[Any]] = {}
+        for rule in rules:  # repo orders (toolkit, credential, is_system, sequence)
+            pair_rules.setdefault((rule.toolkit_id, rule.credential_id), []).append(rule)
+
+        # The legacy broker pool: rules of every *bound* same-vendor pair of
+        # the toolkit, ordered by sequence alone (list_rules_for_vendor's
+        # ORDER BY — ties across sibling credentials interleave, which is
+        # faithful to what the broker evaluated).
+        bound_pairs = {(b.toolkit_id, b.credential_id) for b in tcb_rows}
+        pooled_rules: dict[tuple[str, str], list[Any]] = {}
+        for (toolkit_id, credential_id), rows in pair_rules.items():
+            if (toolkit_id, credential_id) not in bound_pairs:
+                continue
+            credential = credential_map.get(credential_id)
+            if credential is None:
+                continue
+            pooled_rules.setdefault((toolkit_id, credential.api_vendor), []).extend(rows)
+        for pool in pooled_rules.values():
+            pool.sort(key=lambda r: (r.sequence, r.id))
+
+        return _Snapshot(
+            toolkits=toolkit_map,
+            credentials=credential_map,
+            pair_rules=pair_rules,
+            pooled_rules=pooled_rules,
+            tcb_rows=tcb_rows,
+            atb_rows=atb_rows,
+            toolkit_keys=toolkit_keys,
+            actor_ids=actor_ids,
+            existing_pairs=existing_pairs,
+            scopes_by_actor=scopes_by_actor,
+        )
+
+    @staticmethod
+    def _derive_pairs(
+        snapshot: _Snapshot, findings: list[Finding]
+    ) -> dict[tuple[str, str], _DerivedPair]:
+        """Join atb ⋈ tcb in the app layer, reporting dangling rows as found."""
+        tcb_by_toolkit: dict[str, list[Any]] = {}
+        for tcb in snapshot.tcb_rows:
+            if tcb.credential_id not in snapshot.credentials:
+                findings.append(
+                    Finding(
+                        "dangling_reference",
+                        {
+                            "table": "toolkit_credential_bindings",
+                            "row_id": tcb.id,
+                            "toolkit_id": tcb.toolkit_id,
+                            "missing": "credential",
+                            "missing_id": tcb.credential_id,
+                        },
+                    )
+                )
+                continue
+            if tcb.toolkit_id not in snapshot.toolkits:
+                findings.append(
+                    Finding(
+                        "dangling_reference",
+                        {
+                            "table": "toolkit_credential_bindings",
+                            "row_id": tcb.id,
+                            "credential_id": tcb.credential_id,
+                            "missing": "toolkit",
+                            "missing_id": tcb.toolkit_id,
+                        },
+                    )
+                )
+                continue
+            tcb_by_toolkit.setdefault(tcb.toolkit_id, []).append(tcb)
+
+        pairs: dict[tuple[str, str], _DerivedPair] = {}
+        for atb_id, agent_id, toolkit_id, atb_bound_at in snapshot.atb_rows:
+            toolkit = snapshot.toolkits.get(toolkit_id)
+            if toolkit is None:
+                findings.append(
+                    Finding(
+                        "dangling_reference",
+                        {
+                            "table": "agent_toolkit_bindings",
+                            "row_id": atb_id,
+                            "agent_id": agent_id,
+                            "missing": "toolkit",
+                            "missing_id": toolkit_id,
+                        },
+                    )
+                )
+                continue
+            if agent_id not in snapshot.actor_ids:
+                findings.append(
+                    Finding(
+                        "dangling_reference",
+                        {
+                            "table": "agent_toolkit_bindings",
+                            "row_id": atb_id,
+                            "toolkit_id": toolkit_id,
+                            "missing": "actor",
+                            "missing_id": agent_id,
+                        },
+                    )
+                )
+                continue
+            for tcb in tcb_by_toolkit.get(toolkit_id, []):
+                credential = snapshot.credentials[tcb.credential_id]
+                stamps = [s for s in (atb_bound_at, tcb.bound_at) if s is not None]
+                pair = pairs.setdefault(
+                    (agent_id, tcb.credential_id),
+                    _DerivedPair(agent_id=agent_id, credential_id=tcb.credential_id),
+                )
+                pair.paths.append(
+                    _Path(
+                        toolkit_id=toolkit_id,
+                        toolkit_name=toolkit.name,
+                        toolkit_active=toolkit.active,
+                        atb_id=atb_id,
+                        tcb_id=tcb.id,
+                        bound_at=max(stamps) if stamps else None,
+                        rules=snapshot.pair_rules.get((toolkit_id, tcb.credential_id), []),
+                        pooled_rules=snapshot.pooled_rules.get(
+                            (toolkit_id, credential.api_vendor), []
+                        ),
+                    )
+                )
+        return pairs
+
+    @staticmethod
+    def _hygiene_findings(snapshot: _Snapshot, findings: list[Finding]) -> None:
+        """Report categories independent of the pair derivation."""
+        for key in snapshot.toolkit_keys:
+            # Hash material (hashed_key, lookup_hash) stays out of the report.
+            if not key.revoked and key.migrated_actor_id is None:
+                findings.append(
+                    Finding(
+                        "active_toolkit_key",
+                        {
+                            "key_id": key.id,
+                            "toolkit_id": key.toolkit_id,
+                            "label": key.label,
+                            "key_preview": key.key_preview,
+                            "last_used_at": _iso(key.last_used_at),
+                            "created_at": _iso(key.created_at),
+                            "remediation": "run `jentic_one retire-toolkit-keys` (or revoke)",
+                        },
+                    )
+                )
+            if key.migrated_actor_id is not None:
+                scopes = snapshot.scopes_by_actor.get(key.migrated_actor_id, [])
+                excess = sorted(s for s in scopes if s != _EXECUTE_SCOPE)
+                if excess:
+                    findings.append(
+                        Finding(
+                            "scope_exceeds_execute",
+                            {
+                                "service_account_id": key.migrated_actor_id,
+                                "key_id": key.id,
+                                "toolkit_id": key.toolkit_id,
+                                "scopes": sorted(scopes),
+                                "excess_scopes": excess,
+                            },
+                        )
+                    )
+
+    @staticmethod
+    def _pair_findings(pair: _DerivedPair, findings: list[Finding]) -> None:
+        """Conflict / drift / inactive-path report lines for one pair."""
+        for path in pair.paths:
+            if not path.toolkit_active:
+                detail = {
+                    "agent_id": pair.agent_id,
+                    "credential_id": pair.credential_id,
+                    "toolkit_id": path.toolkit_id,
+                    "toolkit_name": path.toolkit_name,
+                    "agent_toolkit_binding_id": path.atb_id,
+                    "toolkit_credential_binding_id": path.tcb_id,
+                    "note": (
+                        "LIVE access through an inactive toolkit — toolkits.active never "
+                        "gated bound agents; migrated, not skipped"
+                    ),
+                }
+                findings.append(Finding("inactive_toolkit_binding", detail))
+                logger.warning("toolkit_flattening_inactive_toolkit_binding", **detail)
+            # Drift: the pooled (toolkit, vendor) list the legacy broker
+            # evaluated is not the per-pair list the direct model enforces.
+            if [r.id for r in path.pooled_rules] != [r.id for r in path.rules]:
+                findings.append(
+                    Finding(
+                        "pooled_rule_drift",
+                        {
+                            "agent_id": pair.agent_id,
+                            "credential_id": pair.credential_id,
+                            "toolkit_id": path.toolkit_id,
+                            "per_pair_rules": [_rule_row(r) for r in path.rules],
+                            "pooled_rules": [_rule_row(r) for r in path.pooled_rules],
+                        },
+                    )
+                )
+        if pair.conflicting:
+            findings.append(
+                Finding(
+                    "rule_conflict",
+                    {
+                        "agent_id": pair.agent_id,
+                        "credential_id": pair.credential_id,
+                        "resolution": "default_deny",
+                        "contributing": [
+                            {
+                                "toolkit_id": path.toolkit_id,
+                                "toolkit_name": path.toolkit_name,
+                                "rules": [_rule_row(r) for r in path.rules],
+                            }
+                            for path in pair.paths
+                        ],
+                    },
+                )
+            )
+
+    async def run(self, *, diff_only: bool = False) -> FlatteningRunResult:
+        """Flatten the toolkit graph (or preview it with ``diff_only``)."""
+        snapshot = await self._load_snapshot()
+        result = FlatteningRunResult(diff_only=diff_only)
+        self._hygiene_findings(snapshot, result.findings)
+        pairs = self._derive_pairs(snapshot, result.findings)
+        result.pairs_total = len(pairs)
+
+        to_create: list[_DerivedPair] = []
+        for key in sorted(pairs):
+            pair = pairs[key]
+            self._pair_findings(pair, result.findings)
+            if key in snapshot.existing_pairs:
+                result.already_present += 1
+            else:
+                to_create.append(pair)
+
+        creation_category = "binding_would_create" if diff_only else "binding_created"
+
+        # Rules control-first: a crash after this transaction leaves inert
+        # orphan rule sets, never a live rule-less binding.
+        rule_set_ids: dict[tuple[str, str], str | None] = {}
+        if not diff_only:
+            async with self._ctx.control_db.transaction() as control_session:
+                for pair in to_create:
+                    if not pair.target_rules:
+                        rule_set_ids[(pair.agent_id, pair.credential_id)] = None
+                        continue
+                    rule_set_ids[(pair.agent_id, pair.credential_id)] = await self._ensure_rule_set(
+                        control_session, pair
+                    )
+
+        # Bindings admin-last, audit in the same transaction.
+        for pair in to_create:
+            source = pair.source_path
+            rule_set_id = rule_set_ids.get((pair.agent_id, pair.credential_id))
+            detail: dict[str, Any] = {
+                "agent_id": pair.agent_id,
+                "credential_id": pair.credential_id,
+                "rule_set_name": (
+                    _rule_set_name(source.toolkit_id, pair.credential_id)
+                    if pair.target_rules
+                    else None
+                ),
+                "rule_count": len(pair.target_rules),
+                "default_deny": not pair.target_rules,
+                "bound_at": _iso(pair.bound_at),
+                "via_toolkit_ids": sorted(p.toolkit_id for p in pair.paths),
+                "source_agent_toolkit_binding_ids": sorted(p.atb_id for p in pair.paths),
+                "source_toolkit_credential_binding_ids": sorted(p.tcb_id for p in pair.paths),
+            }
+            if not diff_only:
+                async with self._ctx.admin_db.transaction() as admin_session:
+                    binding_id = await FlatteningAdminRepository.insert_credential_binding(
+                        admin_session,
+                        agent_id=pair.agent_id,
+                        credential_id=pair.credential_id,
+                        rule_set_id=rule_set_id,
+                        bound_at=pair.bound_at,
+                    )
+                    await record_audit(
+                        admin_session,
+                        action=AuditAction.GRANT,
+                        target_type=AuditTargetType.CREDENTIAL_BINDING,
+                        target_id=binding_id,
+                        actor_type=_AUDIT_ACTOR_TYPE,
+                        actor_id=SYSTEM_ACTOR,
+                        target_parent_id=pair.agent_id,
+                        reason="theme5_flattening",
+                        after=detail,
+                        origin=None,
+                    )
+                detail["binding_id"] = binding_id
+                detail["rule_set_id"] = rule_set_id
+            result.created += 1
+            result.findings.append(Finding(creation_category, detail))
+            logger.info("toolkit_flattening_binding", diff_only=diff_only, **detail)
+
+        logger.info(
+            "toolkit_flattening_run",
+            diff_only=diff_only,
+            pairs_total=result.pairs_total,
+            created=result.created,
+            already_present=result.already_present,
+            findings=len(result.findings),
+        )
+        return result
+
+    @staticmethod
+    async def _ensure_rule_set(
+        # ``Any`` because the arch rule forbids sqlalchemy imports in control
+        # services (tests/arch/test_no_direct_db.py); the repos it's passed to
+        # type it as AsyncSession.
+        session: Any,
+        pair: _DerivedPair,
+    ) -> str:
+        """Copy the pair's effective rules into a shared rule set.
+
+        Named per source ``(toolkit, credential)`` so every agent flattened
+        off the same toolkit pair shares one set, and a re-run reuses it. An
+        existing set is never overwritten (operator edits win).
+        """
+        name = _rule_set_name(pair.source_path.toolkit_id, pair.credential_id)
+        existing = await PermissionRuleSetRepository.get_by_name(session, name)
+        if existing is not None:
+            return existing.id
+        rule_set = await PermissionRuleSetRepository.create(
+            session,
+            name=name,
+            description=(
+                f"Rules of toolkit {pair.source_path.toolkit_id} / credential "
+                f"{pair.credential_id}, copied by the theme-5 Phase 6a flattening job"
+            ),
+            created_by=SYSTEM_ACTOR,
+        )
+        await PermissionRuleSetRepository.replace_user_rules(
+            session,
+            rule_set.id,
+            [
+                {
+                    "effect": rule.effect,
+                    "methods": rule.methods,
+                    "path": rule.path,
+                    "match_mode": rule.match_mode,
+                    "operations": rule.operations,
+                    "comment": rule.comment,
+                }
+                for rule in pair.target_rules
+            ],
+            created_by=SYSTEM_ACTOR,
+        )
+        return rule_set.id
+
+    async def verify(self, *, acknowledge: bool = False) -> VerificationResult:
+        """Run the R-02 verification queries; optionally write the 6b gate row.
+
+        Passes iff every legacy ``(agent, credential)`` pair exists as a
+        direct binding — extra hand-created direct pairs are fine (upgraded
+        installs kept binding post-Phase-1). Per-pair rule-list divergence is
+        a report entry, not a failure. The acknowledgement sentinel is
+        written only when ``acknowledge`` is set AND this verification
+        passed — never from any other code path.
+        """
+        snapshot = await self._load_snapshot()
+        findings: list[Finding] = []
+        self._hygiene_findings(snapshot, findings)
+        pairs = self._derive_pairs(snapshot, findings)
+
+        missing = [key for key in sorted(pairs) if key not in snapshot.existing_pairs]
+        for agent_id, credential_id in missing:
+            pair = pairs[(agent_id, credential_id)]
+            findings.append(
+                Finding(
+                    "verify_missing_binding",
+                    {
+                        "agent_id": agent_id,
+                        "credential_id": credential_id,
+                        "via_toolkit_ids": sorted(p.toolkit_id for p in pair.paths),
+                    },
+                )
+            )
+
+        async with self._ctx.control_db.session() as control_session:
+            for key in sorted(pairs):
+                if key in snapshot.existing_pairs:
+                    await self._compare_pair_rules(
+                        control_session,
+                        pairs[key],
+                        rule_set_id=snapshot.existing_pairs[key],
+                        findings=findings,
+                    )
+
+        result = VerificationResult(
+            passed=not missing,
+            legacy_pair_count=len(pairs),
+            direct_binding_count=len(snapshot.existing_pairs),
+            missing_pair_count=len(missing),
+            findings=findings,
+        )
+        findings.append(
+            Finding(
+                "verify_summary",
+                {
+                    "passed": result.passed,
+                    "legacy_pair_count": result.legacy_pair_count,
+                    "direct_binding_count": result.direct_binding_count,
+                    "missing_pair_count": result.missing_pair_count,
+                    "tool_version": __version__,
+                },
+            )
+        )
+        logger.info(
+            "toolkit_flattening_verify",
+            passed=result.passed,
+            legacy_pair_count=result.legacy_pair_count,
+            direct_binding_count=result.direct_binding_count,
+            missing_pair_count=result.missing_pair_count,
+        )
+
+        if acknowledge and result.passed:
+            async with self._ctx.control_db.transaction() as control_session:
+                ack = await FlatteningControlRepository.record_acknowledgement(
+                    control_session,
+                    acknowledged_at=dt.datetime.now(dt.UTC),
+                    legacy_pair_count=result.legacy_pair_count,
+                    direct_binding_count=result.direct_binding_count,
+                    report_finding_count=len(result.findings),
+                    tool_version=__version__,
+                )
+                ack_id = ack.id
+            result.acknowledged = True
+            logger.info("toolkit_flattening_acknowledged", ack_id=ack_id)
+        elif acknowledge:
+            logger.warning(
+                "toolkit_flattening_acknowledge_refused",
+                detail="verification failed; sentinel not written",
+                missing_pair_count=result.missing_pair_count,
+            )
+        return result
+
+    @staticmethod
+    async def _compare_pair_rules(
+        # ``Any`` for the same arch-rule reason as ``_ensure_rule_set``.
+        control_session: Any,
+        pair: _DerivedPair,
+        *,
+        rule_set_id: str | None,
+        findings: list[Finding],
+    ) -> None:
+        """Ordered rule-list equality for one pair (report entry on mismatch).
+
+        Expected is what the flattening semantics produce (the identical
+        contributors' list, or empty on conflict); actual is the direct
+        binding's effective list — its rule set when it has one, its inline
+        ``agent_permission_rules`` otherwise.
+        """
+        if rule_set_id is not None:
+            actual_rules: list[Any] = await PermissionRuleSetRepository.list_rules(
+                control_session, rule_set_id
+            )
+        else:
+            actual_rules = await FlatteningControlRepository.list_inline_rules(
+                control_session, agent_id=pair.agent_id, credential_id=pair.credential_id
+            )
+        expected = [_rule_semantics(r) for r in pair.target_rules]
+        actual = [_rule_semantics(r) for r in actual_rules]
+        if expected == actual:
+            return
+        findings.append(
+            Finding(
+                "verify_rule_mismatch",
+                {
+                    "agent_id": pair.agent_id,
+                    "credential_id": pair.credential_id,
+                    "rule_set_id": rule_set_id,
+                    "legacy_conflict": pair.conflicting,
+                    "expected_rules": [_rule_row(r) for r in pair.target_rules],
+                    "actual_rules": [
+                        {
+                            "id": r.id,
+                            "effect": r.effect,
+                            "methods": r.methods,
+                            "path": r.path,
+                            "match_mode": r.match_mode,
+                            "operations": r.operations,
+                            "is_system": r.is_system,
+                            "comment": r.comment,
+                            "sequence": r.sequence,
+                        }
+                        for r in actual_rules
+                    ],
+                },
+            )
+        )

--- a/src/jentic_one/migrations/control/versions/u2c3d4e5f6a7_add_toolkit_flattening_acks.py
+++ b/src/jentic_one/migrations/control/versions/u2c3d4e5f6a7_add_toolkit_flattening_acks.py
@@ -1,0 +1,72 @@
+"""add toolkit_flattening_acks
+
+Theme-5 Phase 6a: the acknowledgement sentinel gating the Phase-6b drops.
+One row per acknowledged verification run of the flattening job, written
+only by ``jentic_one flatten-toolkits --verify --acknowledge`` when the
+verification passed in that same invocation. Phase 6b's drop migrations
+must count this table and **raise** when it is empty (guard-and-raise) —
+dropping the toolkit tables with no acknowledged flatten on record risks a
+total default-deny authorization outage for every legacy-bound agent.
+
+Revision ID: u2c3d4e5f6a7
+Revises: t1b2c3d4e5f6
+Create Date: 2026-09-11
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "u2c3d4e5f6a7"  # pragma: allowlist secret
+down_revision: str | None = "t1b2c3d4e5f6"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pg = op.get_bind().dialect.name == "postgresql"
+    op.create_table(
+        "toolkit_flattening_acks",
+        sa.Column(
+            "id",
+            sa.String(30),
+            # Postgres generates the ksuid server-side; SQLite has no such
+            # function, so inserts there must go through the ORM model, whose
+            # Python-side default (generate_ksuid("tfa")) supplies the id.
+            server_default=sa.func.generate_ksuid("tfa") if pg else None,
+            nullable=False,
+        ),
+        sa.Column("acknowledged_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("legacy_pair_count", sa.Integer, nullable=False),
+        sa.Column("direct_binding_count", sa.Integer, nullable=False),
+        sa.Column("report_finding_count", sa.Integer, nullable=False),
+        sa.Column("tool_version", sa.String(50), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("created_by", sa.String(255), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_toolkit_flattening_acks_created_at", "toolkit_flattening_acks", ["created_at"]
+    )
+    op.create_index(
+        "ix_toolkit_flattening_acks_created_by", "toolkit_flattening_acks", ["created_by"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_toolkit_flattening_acks_created_by", table_name="toolkit_flattening_acks")
+    op.drop_index("ix_toolkit_flattening_acks_created_at", table_name="toolkit_flattening_acks")
+    op.drop_table("toolkit_flattening_acks")

--- a/tests/integration/control/test_toolkit_export.py
+++ b/tests/integration/control/test_toolkit_export.py
@@ -1,0 +1,230 @@
+"""Integration tests for the theme-5 Phase 6a toolkit export/import job (P-01).
+
+Round-trips the five doomed tables: seed → export → simulate the Phase-6b
+drop (delete every row) → import → deep equality of a fresh export against
+the original document. Also covers import idempotency (partial-failure
+re-run) and the self-describing-format validation.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from sqlalchemy import delete, text
+
+from jentic_one.control.core.schema.credentials import Credential
+from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
+from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
+from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
+from jentic_one.control.core.schema.toolkits import Toolkit
+from jentic_one.control.services.toolkit_export import (
+    ToolkitExportError,
+    ToolkitExportService,
+)
+from jentic_one.shared.context import Context
+from jentic_one.shared.db.session import DatabaseSession
+
+pytestmark = pytest.mark.integration
+
+_TABLES = (
+    "toolkits",
+    "toolkit_keys",
+    "toolkit_credential_bindings",
+    "toolkit_permission_rules",
+    "agent_toolkit_bindings",
+)
+
+_BOUND_AT = dt.datetime(2026, 3, 1, 8, 30, tzinfo=dt.UTC)
+
+
+@pytest.fixture()
+async def clean_tables(
+    control_db: DatabaseSession, admin_db: DatabaseSession
+) -> AsyncGenerator[None, None]:
+    """Wipe the five exported tables (the job exports them whole)."""
+
+    async def _cleanup() -> None:
+        async with control_db.session() as session:
+            await session.execute(delete(ToolkitPermissionRule))
+            await session.execute(delete(ToolkitKey))
+            await session.execute(delete(ToolkitCredentialBinding))
+            await session.execute(delete(Toolkit))
+            await session.execute(text("DELETE FROM credentials WHERE id LIKE 'cred_extest%'"))
+            await session.commit()
+        async with admin_db.session() as session:
+            await session.execute(text("DELETE FROM agent_toolkit_bindings"))
+            await session.commit()
+
+    await _cleanup()
+    yield
+    await _cleanup()
+
+
+async def _seed(control_db: DatabaseSession, admin_db: DatabaseSession) -> None:
+    """A row in every exported table, exercising the awkward value shapes:
+    JSON lists, NULLs, booleans, and explicit timestamps."""
+    async with control_db.session() as session:
+        session.add(Toolkit(id="tk_extest_1", name="ex-toolkit", description=None, active=False))
+        session.add(
+            Credential(
+                id="cred_extest_1",
+                type="token_value",
+                name="ex-cred",
+                api_vendor="extest.local",
+            )
+        )
+        await session.flush()
+        session.add(
+            ToolkitKey(
+                id="ck_extest_1",
+                toolkit_id="tk_extest_1",
+                hashed_key="argon2-extest",
+                key_preview="jntc_live_ex...",
+                lookup_hash="extest-lookup",
+                allowed_ips=["10.0.0.1", "10.0.0.2"],
+                revoked=True,
+                migrated_actor_id="sva_extest_1",
+                last_used_at=_BOUND_AT,
+                created_by="usr_extest",
+            )
+        )
+        session.add(
+            ToolkitCredentialBinding(
+                id="tcb_extest_1",
+                toolkit_id="tk_extest_1",
+                credential_id="cred_extest_1",
+                bound_at=_BOUND_AT,
+            )
+        )
+        session.add(
+            ToolkitPermissionRule(
+                id="tpr_extest_1",
+                toolkit_id="tk_extest_1",
+                credential_id="cred_extest_1",
+                effect="allow",
+                methods=["GET", "POST"],
+                path="/v1/.*",
+                match_mode="regex",
+                operations=None,
+                sequence=0,
+                comment="ex-rule",
+            )
+        )
+        await session.commit()
+    async with admin_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO agent_toolkit_bindings (id, agent_id, toolkit_id, bound_at,"
+                " created_by) VALUES (:id, 'agnt_extest_1', 'tk_extest_1', :bound_at,"
+                " 'usr_extest')"
+            ),
+            {
+                "id": "atb_extest_1",
+                "bound_at": _BOUND_AT.replace(tzinfo=None).strftime("%Y-%m-%d %H:%M:%S.%f")
+                if admin_db.backend.dialect_name == "sqlite"
+                else _BOUND_AT,
+            },
+        )
+        await session.commit()
+
+
+async def _simulate_drop(control_db: DatabaseSession, admin_db: DatabaseSession) -> None:
+    """Delete every row from the five tables — the closest a test can get to
+    the Phase-6b drop without running migrations mid-session."""
+    async with control_db.session() as session:
+        await session.execute(delete(ToolkitPermissionRule))
+        await session.execute(delete(ToolkitKey))
+        await session.execute(delete(ToolkitCredentialBinding))
+        await session.execute(delete(Toolkit))
+        await session.commit()
+    async with admin_db.session() as session:
+        await session.execute(text("DELETE FROM agent_toolkit_bindings"))
+        await session.commit()
+
+
+def _comparable(document: dict[str, Any]) -> dict[str, Any]:
+    """The invariant part of an export document (drops the run timestamp)."""
+    return {key: value for key, value in document.items() if key != "exported_at"}
+
+
+async def test_export_import_round_trip_deep_equality(
+    integration_context: Context,
+    control_db: DatabaseSession,
+    admin_db: DatabaseSession,
+    clean_tables: None,
+) -> None:
+    """seed → export → drop → import → a fresh export equals the original."""
+    await _seed(control_db, admin_db)
+    service = ToolkitExportService(integration_context)
+
+    document = await service.export()
+    assert document["format"] == "jentic-one-toolkit-export"
+    assert document["schema_version"] == 1
+    assert {t: document["tables"][t]["row_count"] for t in _TABLES} == {
+        "toolkits": 1,
+        "toolkit_keys": 1,
+        "toolkit_credential_bindings": 1,
+        "toolkit_permission_rules": 1,
+        "agent_toolkit_bindings": 1,
+    }
+    # Dialect-neutral values: ISO timestamps, JSON lists, real booleans.
+    key_row = document["tables"]["toolkit_keys"]["rows"][0]
+    assert key_row["allowed_ips"] == ["10.0.0.1", "10.0.0.2"]
+    assert key_row["revoked"] is True
+    assert dt.datetime.fromisoformat(key_row["last_used_at"]) == _BOUND_AT
+    atb_row = document["tables"]["agent_toolkit_bindings"]["rows"][0]
+    assert dt.datetime.fromisoformat(atb_row["bound_at"]) == _BOUND_AT
+
+    await _simulate_drop(control_db, admin_db)
+    assert _comparable(await service.export())["tables"] != document["tables"]
+
+    outcome = await service.import_document(document)
+    assert outcome.inserted == dict.fromkeys(_TABLES, 1)
+    assert outcome.skipped_existing == dict.fromkeys(_TABLES, 0)
+
+    assert _comparable(await service.export()) == _comparable(document)
+
+
+async def test_import_is_idempotent_by_row_id(
+    integration_context: Context,
+    control_db: DatabaseSession,
+    admin_db: DatabaseSession,
+    clean_tables: None,
+) -> None:
+    """Re-importing over existing rows skips them all (partial-failure re-run)."""
+    await _seed(control_db, admin_db)
+    service = ToolkitExportService(integration_context)
+    document = await service.export()
+
+    outcome = await service.import_document(document)
+
+    assert outcome.inserted == dict.fromkeys(_TABLES, 0)
+    assert outcome.skipped_existing == dict.fromkeys(_TABLES, 1)
+    assert _comparable(await service.export()) == _comparable(document)
+
+
+async def test_import_rejects_malformed_documents(
+    integration_context: Context,
+    clean_tables: None,
+) -> None:
+    """The self-describing header is validated before any write."""
+    service = ToolkitExportService(integration_context)
+    document = await service.export()
+
+    with pytest.raises(ToolkitExportError, match="not a jentic-one-toolkit-export"):
+        await service.import_document({**document, "format": "something-else"})
+    with pytest.raises(ToolkitExportError, match="unsupported schema_version"):
+        await service.import_document({**document, "schema_version": 99})
+
+    truncated = {
+        **document,
+        "tables": {
+            **document["tables"],
+            "toolkits": {"row_count": 5, "rows": document["tables"]["toolkits"]["rows"]},
+        },
+    }
+    with pytest.raises(ToolkitExportError, match="row_count"):
+        await service.import_document(truncated)

--- a/tests/integration/control/test_toolkit_flattening.py
+++ b/tests/integration/control/test_toolkit_flattening.py
@@ -1,0 +1,550 @@
+"""Integration tests for the theme-5 Phase 6a toolkit-flattening job.
+
+Runs ``ToolkitFlatteningService`` against real control + admin databases,
+seeded with the plan's R-01 awkward shapes: the same ``(agent, credential)``
+pair reachable via two toolkits with divergent rules, same-vendor pooled
+rules whose per-pair replay differs, an inactive toolkit with bound agents,
+dangling ids on both sides of the cross-DB join, a live ``jntc_live_`` key
+row, a converted identity whose scopes exceed ``capabilities:execute``, and
+two same-named same-API credentials. The same suite runs on SQLite (via
+``JENTIC_TEST_BACKEND=sqlite``) and Postgres — the dual-dialect invariance
+check.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from sqlalchemy import delete, select, text
+
+from jentic_one.control.core.schema.credentials import Credential
+from jentic_one.control.core.schema.permission_rule_sets import (
+    PermissionRuleSet,
+    PermissionRuleSetRule,
+)
+from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
+from jentic_one.control.core.schema.toolkit_flattening_acks import ToolkitFlatteningAck
+from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
+from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
+from jentic_one.control.core.schema.toolkits import Toolkit
+from jentic_one.control.services.toolkit_flattening import Finding, ToolkitFlatteningService
+from jentic_one.shared.context import Context
+from jentic_one.shared.db.session import DatabaseSession
+
+pytestmark = pytest.mark.integration
+
+_OWNER = "usr_fltest_owner"
+_AGENT_A = "agnt_fltest_a"
+_AGENT_B = "agnt_fltest_b"
+_GHOST_AGENT = "agnt_fltest_ghost"
+_MIGRATED_SVA = "sva_fltest_migr"
+
+_TK_A = "tk_fltest_a"
+_TK_B = "tk_fltest_b"
+_TK_INACTIVE = "tk_fltest_inact"
+_TK_GHOST = "tk_fltest_ghost"
+
+_CRED_ONE = "cred_fltest_one"
+_CRED_TWO = "cred_fltest_two"
+_CRED_DUP1 = "cred_fltest_dup1"
+_CRED_DUP2 = "cred_fltest_dup2"
+
+_ATB_BOUND_AT = dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC)
+_TCB_BOUND_AT = dt.datetime(2026, 2, 1, 12, 0, tzinfo=dt.UTC)
+
+#: Every (agent, credential) pair the seed graph derives.
+_EXPECTED_PAIRS = {
+    (_AGENT_A, _CRED_ONE),  # via tk_a AND tk_b, divergent rules → conflict
+    (_AGENT_A, _CRED_TWO),  # via tk_a only, rule-less pair with pooled drift
+    (_AGENT_A, _CRED_DUP1),  # same-named same-API twins (multi-account)
+    (_AGENT_A, _CRED_DUP2),
+    (_AGENT_B, _CRED_TWO),  # via the INACTIVE toolkit — migrated + loud
+}
+
+
+@pytest.fixture()
+async def clean_tables(
+    control_db: DatabaseSession, admin_db: DatabaseSession
+) -> AsyncGenerator[None, None]:
+    """Remove every row this module seeds or the job creates, before and after.
+
+    The job scans the whole toolkit graph and the whole binding table, so the
+    legacy control tables and ``agent_toolkit_bindings`` are wiped outright
+    (the key-retirement suite sets the precedent for whole-table wipes on
+    job-scanned tables); everything else is cleaned by this module's
+    prefixes.
+    """
+
+    async def _cleanup() -> None:
+        async with control_db.session() as session:
+            await session.execute(delete(ToolkitPermissionRule))
+            await session.execute(delete(ToolkitKey))
+            await session.execute(delete(ToolkitCredentialBinding))
+            await session.execute(delete(Toolkit))
+            await session.execute(delete(ToolkitFlatteningAck))
+            await session.execute(
+                text("DELETE FROM permission_rule_sets WHERE name LIKE 'theme5-flattening:%'")
+            )
+            await session.execute(text("DELETE FROM credentials WHERE id LIKE 'cred_fltest%'"))
+            await session.commit()
+        async with admin_db.session() as session:
+            await session.execute(text("DELETE FROM agent_toolkit_bindings"))
+            await session.execute(
+                text(
+                    "DELETE FROM agent_credential_bindings WHERE agent_id LIKE 'agnt_fltest%'"
+                    " OR created_by = 'system:theme5-flattening'"
+                )
+            )
+            await session.execute(
+                text("DELETE FROM actor_scope_grants WHERE actor_id LIKE 'sva_fltest%'")
+            )
+            await session.execute(
+                text("DELETE FROM audit_entries WHERE actor_id = 'system:theme5-flattening'")
+            )
+            await session.execute(text("DELETE FROM service_accounts WHERE id LIKE 'sva_fltest%'"))
+            await session.execute(text("DELETE FROM agents WHERE id LIKE 'agnt_fltest%'"))
+            await session.execute(text("DELETE FROM users WHERE id = :owner"), {"owner": _OWNER})
+            await session.commit()
+
+    await _cleanup()
+    yield
+    await _cleanup()
+
+
+async def _seed_graph(control_db: DatabaseSession, admin_db: DatabaseSession) -> None:
+    """Seed the full R-01 awkward-shape fixture (see module docstring)."""
+    async with control_db.session() as session:
+        session.add(Toolkit(id=_TK_A, name="fl-toolkit-a", active=True, created_by=_OWNER))
+        session.add(Toolkit(id=_TK_B, name="fl-toolkit-b", active=True, created_by=_OWNER))
+        session.add(
+            Toolkit(id=_TK_INACTIVE, name="fl-toolkit-inact", active=False, created_by=_OWNER)
+        )
+        for cred_id, name in (
+            (_CRED_ONE, "fl-cred-one"),
+            (_CRED_TWO, "fl-cred-two"),
+            # Two same-named same-API credentials (multi-account twins).
+            (_CRED_DUP1, "fl-dup"),
+            (_CRED_DUP2, "fl-dup"),
+        ):
+            session.add(
+                Credential(
+                    id=cred_id,
+                    type="token_value",
+                    name=name,
+                    api_vendor="fltest.local",
+                    api_name="fl-api",
+                    created_by=_OWNER,
+                )
+            )
+        await session.flush()
+        for toolkit_id, cred_id in (
+            (_TK_A, _CRED_ONE),
+            (_TK_A, _CRED_TWO),
+            (_TK_B, _CRED_ONE),
+            (_TK_B, _CRED_DUP1),
+            (_TK_B, _CRED_DUP2),
+            (_TK_INACTIVE, _CRED_TWO),
+        ):
+            session.add(
+                ToolkitCredentialBinding(
+                    toolkit_id=toolkit_id,
+                    credential_id=cred_id,
+                    bound_at=_TCB_BOUND_AT,
+                    created_by=_OWNER,
+                )
+            )
+        # Divergent per-pair rules for (agent_a, cred_one)'s two paths, and
+        # the same-vendor pooled shape: (tk_a, cred_one) has rules while
+        # (tk_a, cred_two) has none, so cred_two's legacy pooled list
+        # borrowed cred_one's rules — per-pair replay differs.
+        rules = [
+            (_TK_A, _CRED_ONE, "allow", "/repos/.*", 0),
+            (_TK_A, _CRED_ONE, "deny", "/admin/.*", 1),
+            (_TK_B, _CRED_ONE, "deny", "/repos/.*", 0),
+            (_TK_INACTIVE, _CRED_TWO, "allow", "/inactive/.*", 0),
+        ]
+        for toolkit_id, cred_id, effect, path, sequence in rules:
+            session.add(
+                ToolkitPermissionRule(
+                    toolkit_id=toolkit_id,
+                    credential_id=cred_id,
+                    effect=effect,
+                    path=path,
+                    match_mode="regex",
+                    sequence=sequence,
+                    created_by=_OWNER,
+                )
+            )
+        # A live (unrevoked, unmigrated) jntc_live_ key, and a migrated one
+        # whose successor actor carries scopes beyond capabilities:execute.
+        session.add(
+            ToolkitKey(
+                id="ck_fltest_live",
+                toolkit_id=_TK_A,
+                hashed_key="argon2-fltest",
+                key_preview="jntc_live_fl...",
+                lookup_hash="fltest-lookup-live",
+                label="fl-live-key",
+                created_by=_OWNER,
+            )
+        )
+        session.add(
+            ToolkitKey(
+                id="ck_fltest_migr",
+                toolkit_id=_TK_A,
+                hashed_key="argon2-fltest-2",
+                key_preview="jntc_live_fm...",
+                lookup_hash="fltest-lookup-migr",
+                label="fl-migrated-key",
+                revoked=True,
+                migrated_actor_id=_MIGRATED_SVA,
+                created_by=_OWNER,
+            )
+        )
+        await session.commit()
+
+    async with admin_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO users (id, email, first_name, last_name)"
+                " VALUES (:id, 'fltest-owner@test.local', 'Fl', 'Owner')"
+            ),
+            {"id": _OWNER},
+        )
+        for agent_id, name in ((_AGENT_A, "fl-agent-a"), (_AGENT_B, "fl-agent-b")):
+            await session.execute(
+                text(
+                    "INSERT INTO agents (id, name, registered_by, status)"
+                    " VALUES (:id, :name, :owner, 'approved')"
+                ),
+                {"id": agent_id, "name": name, "owner": _OWNER},
+            )
+        await session.execute(
+            text(
+                "INSERT INTO service_accounts"
+                " (id, name, description, owner_id, registered_by, status, created_by)"
+                " VALUES (:id, 'toolkit-key:ck_fltest_migr', 'fl', :owner, :owner, 'active',"
+                " :owner)"
+            ),
+            {"id": _MIGRATED_SVA, "owner": _OWNER},
+        )
+        for i, scope in enumerate(("capabilities:execute", "agents:read")):
+            await session.execute(
+                text(
+                    "INSERT INTO actor_scope_grants"
+                    " (id, actor_id, actor_type, scope, granted_by, created_by)"
+                    " VALUES (:id, :actor, 'service_account', :scope, :owner, :owner)"
+                ),
+                {"id": f"asg_fltest_{i}", "actor": _MIGRATED_SVA, "scope": scope, "owner": _OWNER},
+            )
+        bindings = [
+            ("atb_fltest_1", _AGENT_A, _TK_A),
+            ("atb_fltest_2", _AGENT_A, _TK_B),
+            ("atb_fltest_3", _AGENT_B, _TK_INACTIVE),
+            # Dangling on both axes of the cross-DB join.
+            ("atb_fltest_4", _AGENT_A, _TK_GHOST),
+            ("atb_fltest_5", _GHOST_AGENT, _TK_A),
+        ]
+        for atb_id, agent_id, toolkit_id in bindings:
+            await session.execute(
+                text(
+                    "INSERT INTO agent_toolkit_bindings"
+                    " (id, agent_id, toolkit_id, bound_at, created_by)"
+                    " VALUES (:id, :agent, :toolkit, :bound_at, :owner)"
+                ),
+                {
+                    "id": atb_id,
+                    "agent": agent_id,
+                    "toolkit": toolkit_id,
+                    "bound_at": _ATB_BOUND_AT.replace(tzinfo=None).strftime("%Y-%m-%d %H:%M:%S.%f")
+                    if admin_db.backend.dialect_name == "sqlite"
+                    else _ATB_BOUND_AT,
+                    "owner": _OWNER,
+                },
+            )
+        await session.commit()
+
+
+def _by_category(findings: list[Finding]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for finding in findings:
+        grouped.setdefault(finding.category, []).append(finding.detail)
+    return grouped
+
+
+async def _direct_bindings(admin_db: DatabaseSession) -> dict[tuple[str, str], Any]:
+    async with admin_db.session() as session:
+        rows = (
+            await session.execute(
+                text(
+                    "SELECT agent_id, credential_id, rule_set_id, bound_at, created_by, suspended"
+                    " FROM agent_credential_bindings WHERE agent_id LIKE 'agnt_fltest%'"
+                )
+            )
+        ).all()
+    return {(row.agent_id, row.credential_id): row for row in rows}
+
+
+def _as_dt(value: Any) -> dt.datetime:
+    """Normalize a raw-SQL timestamp (str on SQLite, datetime on Postgres)."""
+    parsed: dt.datetime = dt.datetime.fromisoformat(value) if isinstance(value, str) else value
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+async def test_flattening_creates_all_pairs_with_expected_semantics(
+    integration_context: Context,
+    control_db: DatabaseSession,
+    admin_db: DatabaseSession,
+    clean_tables: None,
+) -> None:
+    """One run migrates every reachable pair — conflicts default-deny, the
+    inactive-toolkit pair included, provenance stamped — and reports every
+    R-01 shape in its category."""
+    await _seed_graph(control_db, admin_db)
+
+    result = await ToolkitFlatteningService(integration_context).run()
+
+    assert result.pairs_total == len(_EXPECTED_PAIRS)
+    assert result.created == len(_EXPECTED_PAIRS)
+    assert result.already_present == 0
+
+    bindings = await _direct_bindings(admin_db)
+    assert set(bindings) == _EXPECTED_PAIRS
+    for row in bindings.values():
+        assert row.created_by == "system:theme5-flattening"
+        assert not row.suspended
+        # max(source rows' timestamps): the tcb stamp (2026-02) beats the atb (2026-01).
+        assert _as_dt(row.bound_at) == _TCB_BOUND_AT
+
+    # The conflicting pair and the rule-less pairs bind default-deny (no set).
+    for pair in _EXPECTED_PAIRS - {(_AGENT_B, _CRED_TWO)}:
+        assert bindings[pair].rule_set_id is None, pair
+    # The inactive-toolkit pair carries its copied rule set.
+    inactive_set_id = bindings[(_AGENT_B, _CRED_TWO)].rule_set_id
+    assert inactive_set_id is not None
+    async with control_db.session() as session:
+        rule_set = await session.get(PermissionRuleSet, inactive_set_id)
+        assert rule_set is not None
+        assert rule_set.name == f"theme5-flattening:{_TK_INACTIVE}:{_CRED_TWO}"
+        copied = (
+            (
+                await session.execute(
+                    select(PermissionRuleSetRule)
+                    .where(PermissionRuleSetRule.rule_set_id == inactive_set_id)
+                    .order_by(PermissionRuleSetRule.sequence)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert [(r.effect, r.path) for r in copied] == [("allow", "/inactive/.*")]
+
+    report = _by_category(result.findings)
+    assert len(report["binding_created"]) == len(_EXPECTED_PAIRS)
+
+    # Same-pair conflict: both contributing lists embedded verbatim.
+    (conflict,) = report["rule_conflict"]
+    assert (conflict["agent_id"], conflict["credential_id"]) == (_AGENT_A, _CRED_ONE)
+    assert conflict["resolution"] == "default_deny"
+    contributing = {c["toolkit_id"]: c["rules"] for c in conflict["contributing"]}
+    assert [(r["effect"], r["path"]) for r in contributing[_TK_A]] == [
+        ("allow", "/repos/.*"),
+        ("deny", "/admin/.*"),
+    ]
+    assert [(r["effect"], r["path"]) for r in contributing[_TK_B]] == [("deny", "/repos/.*")]
+
+    # Pooled-vs-per-pair drift: the rule-less same-vendor siblings that used
+    # to borrow pooled rules (cred_two via tk_a; both dup twins via tk_b).
+    drifted = {
+        (d["agent_id"], d["credential_id"], d["toolkit_id"]) for d in report["pooled_rule_drift"]
+    }
+    assert drifted == {
+        (_AGENT_A, _CRED_TWO, _TK_A),
+        (_AGENT_A, _CRED_DUP1, _TK_B),
+        (_AGENT_A, _CRED_DUP2, _TK_B),
+    }
+    for drift in report["pooled_rule_drift"]:
+        assert drift["per_pair_rules"] == []
+        assert drift["pooled_rules"], "the borrowed pooled list must be embedded"
+
+    (inactive,) = report["inactive_toolkit_binding"]
+    assert (inactive["agent_id"], inactive["toolkit_id"]) == (_AGENT_B, _TK_INACTIVE)
+
+    dangling = {(d["missing"], d["missing_id"]) for d in report["dangling_reference"]}
+    assert dangling == {("toolkit", _TK_GHOST), ("actor", _GHOST_AGENT)}
+    # Dangling rows derive no binding.
+    assert not any(agent == _GHOST_AGENT for agent, _ in bindings)
+
+    (live_key,) = report["active_toolkit_key"]
+    assert live_key["key_id"] == "ck_fltest_live"
+    assert "hashed_key" not in live_key and "lookup_hash" not in live_key
+
+    (scopes,) = report["scope_exceeds_execute"]
+    assert scopes["service_account_id"] == _MIGRATED_SVA
+    assert scopes["excess_scopes"] == ["agents:read"]
+
+    # One audit entry per derived binding, system-actor attributed.
+    async with admin_db.session() as session:
+        audit_rows = (
+            await session.execute(
+                text(
+                    "SELECT target_id, target_parent_id FROM audit_entries"
+                    " WHERE actor_id = 'system:theme5-flattening'"
+                    " AND target_type = 'credential_binding' AND action = 'grant'"
+                )
+            )
+        ).all()
+    assert len(audit_rows) == len(_EXPECTED_PAIRS)
+
+
+async def test_second_run_and_diff_only_create_nothing(
+    integration_context: Context,
+    control_db: DatabaseSession,
+    admin_db: DatabaseSession,
+    clean_tables: None,
+) -> None:
+    """Double-run-and-diff: a second run (and a diff-only pass) report zero
+    creations and duplicate no rows."""
+    await _seed_graph(control_db, admin_db)
+    service = ToolkitFlatteningService(integration_context)
+
+    first = await service.run()
+    second = await service.run()
+    diff = await service.run(diff_only=True)
+
+    assert first.created == len(_EXPECTED_PAIRS)
+    assert second.created == 0
+    assert second.already_present == len(_EXPECTED_PAIRS)
+    assert diff.created == 0
+    assert not any(f.category == "binding_created" for f in second.findings)
+    assert not any(f.category == "binding_would_create" for f in diff.findings)
+    assert len(await _direct_bindings(admin_db)) == len(_EXPECTED_PAIRS)
+    async with control_db.session() as session:
+        rule_sets = (
+            (
+                await session.execute(
+                    select(PermissionRuleSet).where(
+                        PermissionRuleSet.name.like("theme5-flattening:%")
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rule_sets) == 1  # only the inactive-toolkit pair has rules
+
+
+async def test_diff_only_previews_without_writing(
+    integration_context: Context,
+    control_db: DatabaseSession,
+    admin_db: DatabaseSession,
+    clean_tables: None,
+) -> None:
+    """--diff-only reports what a run WOULD create and touches neither DB."""
+    await _seed_graph(control_db, admin_db)
+
+    result = await ToolkitFlatteningService(integration_context).run(diff_only=True)
+
+    assert result.diff_only
+    assert result.created == len(_EXPECTED_PAIRS)
+    report = _by_category(result.findings)
+    assert len(report["binding_would_create"]) == len(_EXPECTED_PAIRS)
+    assert "binding_created" not in report
+    assert await _direct_bindings(admin_db) == {}
+    async with control_db.session() as session:
+        rule_sets = (
+            (
+                await session.execute(
+                    select(PermissionRuleSet).where(
+                        PermissionRuleSet.name.like("theme5-flattening:%")
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert rule_sets == []
+
+
+async def _ack_rows(control_db: DatabaseSession) -> list[ToolkitFlatteningAck]:
+    async with control_db.session() as session:
+        return list((await session.execute(select(ToolkitFlatteningAck))).scalars().all())
+
+
+async def test_verify_gates_acknowledgement_on_coverage(
+    integration_context: Context,
+    control_db: DatabaseSession,
+    admin_db: DatabaseSession,
+    clean_tables: None,
+) -> None:
+    """--verify fails (and --acknowledge is refused, writing no sentinel)
+    until the flatten has run; afterwards it passes and the acknowledgement
+    records the counts 6b will cite."""
+    await _seed_graph(control_db, admin_db)
+    service = ToolkitFlatteningService(integration_context)
+
+    before = await service.verify(acknowledge=True)
+    assert not before.passed
+    assert before.missing_pair_count == len(_EXPECTED_PAIRS)
+    assert not before.acknowledged
+    assert await _ack_rows(control_db) == []
+    missing = {
+        (d.detail["agent_id"], d.detail["credential_id"])
+        for d in before.findings
+        if d.category == "verify_missing_binding"
+    }
+    assert missing == _EXPECTED_PAIRS
+
+    await service.run()
+
+    after = await service.verify(acknowledge=True)
+    assert after.passed
+    assert after.legacy_pair_count == len(_EXPECTED_PAIRS)
+    assert after.missing_pair_count == 0
+    assert after.acknowledged
+    (ack,) = await _ack_rows(control_db)
+    assert ack.legacy_pair_count == len(_EXPECTED_PAIRS)
+    assert ack.direct_binding_count >= len(_EXPECTED_PAIRS)
+    assert ack.report_finding_count == len(after.findings)
+    assert ack.tool_version
+    assert ack.created_by == "system:theme5-flattening"
+
+
+async def test_verify_reports_rule_mismatch_without_failing(
+    integration_context: Context,
+    control_db: DatabaseSession,
+    admin_db: DatabaseSession,
+    clean_tables: None,
+) -> None:
+    """Per-pair rule-list divergence is a report entry, not a verify failure."""
+    await _seed_graph(control_db, admin_db)
+    service = ToolkitFlatteningService(integration_context)
+    await service.run()
+
+    # An operator empties the flattened rule set post-run.
+    async with control_db.session() as session:
+        await session.execute(
+            delete(PermissionRuleSetRule).where(
+                PermissionRuleSetRule.rule_set_id.in_(
+                    select(PermissionRuleSet.id).where(
+                        PermissionRuleSet.name.like("theme5-flattening:%")
+                    )
+                )
+            )
+        )
+        await session.commit()
+
+    result = await service.verify()
+
+    assert result.passed
+    mismatches = [f.detail for f in result.findings if f.category == "verify_rule_mismatch"]
+    assert [(m["agent_id"], m["credential_id"]) for m in mismatches] == [(_AGENT_B, _CRED_TWO)]
+    assert [(r["effect"], r["path"]) for r in mismatches[0]["expected_rules"]] == [
+        ("allow", "/inactive/.*")
+    ]
+    assert mismatches[0]["actual_rules"] == []

--- a/tests/unit/test_cli_flattening.py
+++ b/tests/unit/test_cli_flattening.py
@@ -1,0 +1,62 @@
+"""Unit tests for the ``flatten-toolkits`` / ``export-toolkits`` CLI glue.
+
+The jobs themselves are covered by the control integration suites
+(``test_toolkit_flattening.py`` / ``test_toolkit_export.py``); this file pins
+the CLI-specific seam — flag validation (``--acknowledge`` requires
+``--verify``; ``--diff-only`` and ``--verify`` are exclusive; export needs
+exactly one of ``--out``/``--import``) and the JSONL report writer — with no
+database.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from jentic_one import __main__ as cli
+from jentic_one.control.services.toolkit_flattening import Finding
+
+
+def _expect_usage_error(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(argv)
+    assert excinfo.value.code == 2
+
+
+def test_acknowledge_without_verify_is_a_usage_error() -> None:
+    """The sentinel records a *passed verification* — bare --acknowledge is refused."""
+    _expect_usage_error(["flatten-toolkits", "--acknowledge"])
+
+
+def test_diff_only_and_verify_are_mutually_exclusive() -> None:
+    _expect_usage_error(["flatten-toolkits", "--diff-only", "--verify"])
+
+
+def test_export_requires_exactly_one_of_out_and_import(tmp_path: Path) -> None:
+    _expect_usage_error(["export-toolkits"])
+    _expect_usage_error(
+        ["export-toolkits", "--out", str(tmp_path / "a.json"), "--import", str(tmp_path / "a.json")]
+    )
+
+
+def test_write_report_emits_one_json_line_per_finding(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    findings = [
+        Finding("rule_conflict", {"agent_id": "agnt_1", "credential_id": "cred_1"}),
+        Finding("active_toolkit_key", {"key_id": "ck_1"}),
+    ]
+
+    report_path = tmp_path / "report.jsonl"
+    cli._write_report(findings, str(report_path))
+    lines = [json.loads(line) for line in report_path.read_text().splitlines()]
+    assert lines == [
+        {"category": "rule_conflict", "agent_id": "agnt_1", "credential_id": "cred_1"},
+        {"category": "active_toolkit_key", "key_id": "ck_1"},
+    ]
+
+    cli._write_report(findings, None)
+    stdout_lines = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert stdout_lines == lines


### PR DESCRIPTION
## Theme 5, Phase 6a — flattening + report (no drops)

Stacked on #1359 (phase 5d). Part of the theme-5 toolkit removal (plan: jentic-one-plans `themes/theme-5-remove-toolkits.md`). **Nothing is dropped here** — this ships the operator tooling that Phase 6b's drop migrations are gated on.

### `jentic-one flatten-toolkits [--diff-only] [--report PATH] [--verify] [--acknowledge]`
- Derives direct `agent_credential_bindings` (+ `permission_rule_sets`) from the toolkit graph: rules **control-first**, binding **admin-last** (a crash leaves orphan rule sets, never a rule-less live binding). Idempotent via the pair unique constraint + `ON CONFLICT DO NOTHING`; `--diff-only` previews with zero writes (double-run-and-diff is the concurrency answer per plan hard problem 2).
- **Same-pair rule conflicts** (one pair reachable via two toolkits with divergent rules): the binding is created **default-deny** — the safer outcome — with a `rule_conflict` report line embedding every contributing rule list verbatim.
- **Pooled-vs-per-pair drift** (vendor-pooled legacy evaluation no longer borrowing sibling rules): report-only `pooled_rule_drift` lines; what's written stays per-pair.
- **Inactive-toolkit bindings are live access on the legacy path**: migrated AND loudly reported, never skipped. Dangling references reported and excluded.
- Provenance: `bound_at = max(source rows)`, `created_by = system:theme5-flattening`, one audit entry per derived binding carrying both source-row id lists.
- Report categories: `rule_conflict`, `pooled_rule_drift`, `inactive_toolkit_binding`, `dangling_reference`, `active_toolkit_key`, `scope_exceeds_execute` — JSONL, contributing rows embedded verbatim so the report survives the drop.

### `--verify` + `--acknowledge` (R-02, the 6b gate)
- Verify: every legacy `(agent, credential)` pair from the toolkit join exists as a direct binding (hand-made extras fine); per-pair rule equality mismatches are report entries, not failures. Exit 1 on failure.
- Acknowledge: refused unless verification passed **in the same invocation**; writes a `toolkit_flattening_acks` sentinel row (new control migration `u2c3d4e5f6a7`) recording counts + tool version. **6b's drop migrations must raise when this table is empty.**

### `jentic-one export-toolkits (--out | --import)` (P-01)
- Schema-versioned document covering all five doomed tables; import validates format/version/row-counts and inserts missing-by-id in FK order (partial-failure re-run safe).
- `releasing.md` runbook: **rollback after 6b = downgrade the drops + re-import** — `downgrade()` cannot restore rows, and a rules-empty restore is a total default-deny authorization outage.

### Fixtures (R-01)
The awkward-shapes seed the success criteria name: divergent-rule dual-path pair, pooled-drift siblings + same-named credential twins, inactive-toolkit binding, ghost toolkit/actor rows, an unmigrated live `jntc_live_` key, an over-scoped converted identity — each pinned to its report category, dual-dialect (SQLite ORM + Postgres).

### Validation
- mypy ✓ · ruff ✓ · unit 3360 ✓ · arch 295 ✓
- integration: SQLite 822 ✓ · Postgres 1154 ✓
- new migration downgrade→upgrade round-trip ✓ · live CLI smoke of all four modes ✓

Made with [Cursor](https://cursor.com)